### PR TITLE
fix: prevent update snackbar stacking and add version skip (#28)

### DIFF
--- a/lib/src/settings/settings_service.dart
+++ b/lib/src/settings/settings_service.dart
@@ -160,6 +160,18 @@ class SettingsService {
   Future<void> setTelemetryConsentDialogShown(bool value) async {
     await prefs.setBool(SettingsKeys.telemetryConsentDialogShown.name, value);
   }
+
+  Future<String?> skippedVersion() async {
+    return await prefs.getString(SettingsKeys.skippedVersion.name);
+  }
+
+  Future<void> setSkippedVersion(String? version) async {
+    if (version == null) {
+      await prefs.remove(SettingsKeys.skippedVersion.name);
+    } else {
+      await prefs.setString(SettingsKeys.skippedVersion.name, version);
+    }
+  }
 }
 
 enum SettingsKeys {
@@ -179,6 +191,7 @@ enum SettingsKeys {
   telemetryConsent,
   telemetryPromptShown,
   telemetryConsentDialogShown,
+  skippedVersion,
 }
 
 /// Position options for the skin view exit button


### PR DESCRIPTION
- Clear existing snackbars before showing new ones to prevent stacking
- Add close icon to snackbar; dismissing skips the version permanently
- Persist skipped version in SharedPreferences so it survives restarts
- Show initial update notification on startup after widget tree is built
- Handle macOS `hidden` lifecycle state (Cmd+H) in addition to `paused`
- Shorten update check interval to 1 min when simulate=1

closes #28 