### PR TITLE
Add entitlements when notarizing macOS app (#38)

### DIFF
--- a/.github/workflows/develop-builds.yml
+++ b/.github/workflows/develop-builds.yml
@@ -117,6 +117,7 @@ jobs:
           APP="build/macos/Build/Products/Release/Streamline-Bridge.app"
           codesign --deep --force \
             --options runtime \
+            --entitlements macos/Runner/Release.entitlements \
             --sign "Developer ID Application" \
             "$APP"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,7 @@ jobs:
           APP="build/macos/Build/Products/Release/Streamline-Bridge.app"
           codesign --deep --force \
             --options runtime \
+            --entitlements macos/Runner/Release.entitlements \
             --sign "Developer ID Application" \
             "$APP"
 


### PR DESCRIPTION
the correct entitlements were skipped when signing the app for macOS notarization.

closes #38 