### PR TITLE
docs: streamline and reorganize CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@
 
 Streamline-Bridge (formerly REA/ReaPrime/R1) is a Flutter gateway app for Decent Espresso machines. Connects to DE1 machines and scales via BLE/USB, exposing REST (port 8080) and WebSocket APIs. Includes a JavaScript plugin system. Primary platform: Android (DE1 tablet), also macOS, Linux, Windows, iOS. Note: the rename is in progress — code, repo, and file references may still use the old names.
 
+**Reference implementation:** The original Decent Espresso app at `github.com/decentespresso/de1app` is the authoritative source for DE1 protocol behavior, BLE characteristics, and machine state logic. Consult it when implementation details are unclear. Note: Streamline-Bridge uses its own JSON profile format — the TCL-based profile format in de1app is not authoritative for profiles here.
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## Summary

- **Reduced CLAUDE.md from 375 to ~160 lines** by removing duplication with `doc/` files
- **Renamed project reference** to Streamline-Bridge (formerly REA/ReaPrime/R1)
- **Added workflow rules:** verification loop, plans in `doc/plans/`, branching guidance
- **Added de1app as reference** for DE1 protocol/BLE/state (not profiles — we use JSON, not TCL)
- **Removed redundant Code Style section** (duplicated Design Principles and Conventions)
- **Cleaned up `.claude/memory/`** — deleted 5 stale implementation notes from January

## Test plan

- [ ] Verify CLAUDE.md reads correctly and all `doc/` references are valid
- [ ] Confirm no critical project context was lost in the streamlining

🤖 Generated with [Claude Code](https://claude.com/claude-code)