### PR TITLE
Propagate git tag version to all native platforms

### DIFF
--- a/flutter_with_commit.sh
+++ b/flutter_with_commit.sh
@@ -32,6 +32,13 @@ else
   VERSION="${TAG#v}"
 fi
 
+# --- Build number from commit count (monotonically increasing) ---
+BUILD_NUMBER=$(git rev-list --count HEAD 2>/dev/null || echo "1")
+
+# --- Build name: semver part only (strip pre-release suffix for native platforms) ---
+# e.g. "1.2.3-beta.1" -> build-name "1.2.3", but VERSION dart-define keeps the full string
+BUILD_NAME="${VERSION%%-*}"
+
 # --- Command required ---
 if [ $# -lt 1 ]; then
   echo "Usage: $0 <flutter command> [arguments...]"
@@ -54,11 +61,14 @@ if [ "$COMMAND" = "build" ]; then
     REMAINDER=("${EXTRA_ARGS[@]:1}")
 
     flutter build "$TARGET" \
+      --build-name="$BUILD_NAME" \
+      --build-number="$BUILD_NUMBER" \
       --dart-define=COMMIT="$COMMIT" \
       --dart-define=COMMIT_SHORT="$COMMIT_SHORT" \
       --dart-define=BRANCH="$BRANCH" \
       --dart-define=BUILD_TIME="$BUILD_TIME" \
       --dart-define=VERSION="$VERSION" \
+      --dart-define=BUILD_NUMBER="$BUILD_NUMBER" \
       "${FEEDBACK_TOKEN_DEFINE[@]}" \
       "${REMAINDER[@]}"
 
@@ -72,5 +82,6 @@ flutter "$COMMAND" \
   --dart-define=BRANCH="$BRANCH" \
   --dart-define=BUILD_TIME="$BUILD_TIME" \
   --dart-define=VERSION="$VERSION" \
+  --dart-define=BUILD_NUMBER="$BUILD_NUMBER" \
   "${FEEDBACK_TOKEN_DEFINE[@]}" \
   "${EXTRA_ARGS[@]}"

--- a/lib/build_info.dart
+++ b/lib/build_info.dart
@@ -5,4 +5,8 @@ class BuildInfo {
   static const String branch = String.fromEnvironment('BRANCH', defaultValue: 'unknown');
   static const String buildTime = String.fromEnvironment('BUILD_TIME', defaultValue: 'unknown'); // ISO8601
   static const String version = String.fromEnvironment('VERSION', defaultValue: '0.0.0-dev');
+  static const String buildNumber = String.fromEnvironment('BUILD_NUMBER', defaultValue: '0');
+
+  /// Full version string including build number (e.g., "1.2.3+456")
+  static String get fullVersion => '$version+$buildNumber';
 }

--- a/lib/src/services/feedback_service.dart
+++ b/lib/src/services/feedback_service.dart
@@ -96,7 +96,7 @@ class FeedbackService {
   String _collectSystemInfo() {
     final info = StringBuffer();
     info.writeln('**System Information:**');
-    info.writeln('- App Version: ${BuildInfo.version}');
+    info.writeln('- App Version: ${BuildInfo.version} (build ${BuildInfo.buildNumber})');
     info.writeln('- Commit: ${BuildInfo.commitShort}');
     info.writeln('- Branch: ${BuildInfo.branch}');
     info.writeln('- Platform: ${Platform.operatingSystem}');

--- a/lib/src/services/webserver/data_export_handler.dart
+++ b/lib/src/services/webserver/data_export_handler.dart
@@ -30,6 +30,7 @@ class DataExportHandler {
       final metadata = {
         'formatVersion': _currentFormatVersion,
         'appVersion': BuildInfo.version,
+        'buildNumber': BuildInfo.buildNumber,
         'commitSha': BuildInfo.commitShort,
         'branch': BuildInfo.branch,
         'exportTimestamp': DateTime.now().toUtc().toIso8601String(),

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -576,6 +576,7 @@ class _SettingsViewState extends State<SettingsView> {
       description: 'Version and build information',
       children: [
         _InfoRow('Version', BuildInfo.version),
+        _InfoRow('Build', BuildInfo.buildNumber),
         _InfoRow('Commit', BuildInfo.commitShort),
         _InfoRow('Branch', BuildInfo.branch),
         const Divider(height: 24),


### PR DESCRIPTION
## Summary
- Propagate git tag version to Android, iOS, macOS, Windows, and Linux native build systems via `--build-name` and `--build-number` flags
- Use `git rev-list --count HEAD` for monotonically increasing build numbers (required by Play Store and App Store)
- Expose build number in-app via `BuildInfo.buildNumber`

## Changes
- **`flutter_with_commit.sh`** — compute `BUILD_NUMBER` (commit count) and `BUILD_NAME` (semver without pre-release suffix), pass `--build-name`/`--build-number` to `flutter build`, pass `BUILD_NUMBER` as dart-define
- **`lib/build_info.dart`** — add `buildNumber` field and `fullVersion` getter
- **`lib/src/settings/settings_view.dart`** — show build number in About section
- **`lib/src/services/feedback_service.dart`** — include build number in feedback reports
- **`lib/src/services/webserver/data_export_handler.dart`** — include `buildNumber` in export metadata

## Context
Previously, only the in-app version display used the git tag (via `--dart-define=VERSION`). All native platform versions were stuck at `1.0.0+1` from `pubspec.yaml`. Now all platforms get the correct version at build time without modifying `pubspec.yaml`.

Pre-release version comparison enhancement tracked in #82.

## Test plan
- [x] Verify `./flutter_with_commit.sh build apk --release` produces APK with correct `versionName` and `versionCode`
- [x] Verify Settings > About shows version and build number
- [x] Verify feedback reports include build number


🤖 Generated with [Claude Code](https://claude.com/claude-code)