### PR TITLE
Fix CI build number: use full git history

### DIFF
--- a/.github/workflows/develop-builds.yml
+++ b/.github/workflows/develop-builds.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -18,7 +20,7 @@ jobs:
           channel: 'stable'
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -35,7 +37,7 @@ jobs:
           echo "${{ secrets.ANDROID_KEYSTORE_B64 }}" | base64 --decode > android/app/debug.keystore
 
       - name: Cache Flutter & Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.pub-cache
@@ -71,7 +73,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install automake and libtool
         run: brew install automake libtool
@@ -182,7 +186,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install GTK+ 3.0
         run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev
@@ -222,7 +228,9 @@ jobs:
     runs-on: ubuntu-22.04-arm     # ARM64 hosted runner label
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install GTK+ 3.0
         run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev
@@ -265,7 +273,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -18,7 +20,7 @@ jobs:
           channel: 'stable'
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -35,7 +37,7 @@ jobs:
           echo "${{ secrets.ANDROID_KEYSTORE_B64 }}" | base64 --decode > android/app/debug.keystore
 
       - name: Cache Flutter & Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.pub-cache
@@ -83,7 +85,10 @@ jobs:
   build-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -198,7 +203,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install GTK+ 3.0
         run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev
@@ -249,7 +256,9 @@ jobs:
     runs-on: ubuntu-22.04-arm
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install GTK+ 3.0
         run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev
@@ -303,7 +312,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -354,7 +365,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Get version from tag
         id: version
@@ -372,7 +385,7 @@ jobs:
         run: ls -R release-artifacts
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             release-artifacts/android-apk/*


### PR DESCRIPTION
## Summary
- Add `fetch-depth: 0` to all `actions/checkout` steps so `git rev-list --count HEAD` returns the real commit count instead of `1` (shallow clone default)
- Bump all GitHub Actions to latest major versions (checkout v4, setup-java v4, cache v4, action-gh-release v2)

## Context
The v0.5.0 release builds all had build number `1` because GitHub Actions does a shallow clone by default.

## Test plan
- [ ] Merge, tag `v0.5.0` again (or `v0.5.1`), verify build number is ~950+ in the release artifacts


🤖 Generated with [Claude Code](https://claude.com/claude-code)