### PR TITLE
Dual Y-axes for shot chart and realtime screen scalability

### DIFF
--- a/lib/src/history_feature/history_feature.dart
+++ b/lib/src/history_feature/history_feature.dart
@@ -747,10 +747,13 @@ class _HistoryFeatureState extends State<HistoryFeature> {
               ),
             ),
             SizedBox(height: 12),
-            ShotChart(
-              key: ValueKey(record.id),
-              shotSnapshots: record.measurements,
-              shotStartTime: record.timestamp,
+            SizedBox(
+              height: 500,
+              child: ShotChart(
+                key: ValueKey(record.id),
+                shotSnapshots: record.measurements,
+                shotStartTime: record.timestamp,
+              ),
             ),
             
             SizedBox(height: 16),

--- a/lib/src/realtime_shot_feature/realtime_shot_feature.dart
+++ b/lib/src/realtime_shot_feature/realtime_shot_feature.dart
@@ -80,9 +80,11 @@ class _RealtimeShotFeatureState extends State<RealtimeShotFeature> {
             mainAxisAlignment: MainAxisAlignment.start,
             children: <Widget>[
               _shotStats(context),
-              ShotChart(
-                shotSnapshots: _shotSnapshots,
-                shotStartTime: _shotController.shotStartTime,
+              Flexible(
+                child: ShotChart(
+                  shotSnapshots: _shotSnapshots,
+                  shotStartTime: _shotController.shotStartTime,
+                ),
               ),
               _buttons(context),
             ],

--- a/lib/src/realtime_steam_feature/realtime_steam_feature.dart
+++ b/lib/src/realtime_steam_feature/realtime_steam_feature.dart
@@ -144,9 +144,11 @@ class _RealtimeSteamFeatureState extends State<RealtimeSteamFeature> {
             mainAxisAlignment: MainAxisAlignment.start,
             children: <Widget>[
               _steamStats(context),
-              ShotChart(
-                shotSnapshots: _steamSnapshots,
-                shotStartTime: _steamStartTime ?? DateTime.now(),
+              Flexible(
+                child: ShotChart(
+                  shotSnapshots: _steamSnapshots,
+                  shotStartTime: _steamStartTime ?? DateTime.now(),
+                ),
               ),
               Row(
                 spacing: 16.0,

--- a/lib/src/util/shot_chart.dart
+++ b/lib/src/util/shot_chart.dart
@@ -18,21 +18,36 @@ class ShotChart extends StatefulWidget {
   State<ShotChart> createState() => _ShotChartState();
 }
 
+class _LineInfo {
+  final String label;
+  final String unit;
+  final bool isTemp;
+
+  const _LineInfo(this.label, this.unit, {this.isTemp = false});
+}
+
 class _ShotChartState extends State<ShotChart> {
-  late List<LineChartBarData> _bars;
+  static const double _leftMaxY = 11.0;
+  static const double _tempMaxY = 160.0;
+  static const double _tempScale = _leftMaxY / _tempMaxY;
+
+  static const List<_LineInfo> _lineInfo = [
+    _LineInfo('Flow', 'ml/s'),
+    _LineInfo('Pressure', 'bar'),
+    _LineInfo('Target flow', 'ml/s'),
+    _LineInfo('Target pressure', 'bar'),
+    _LineInfo('Group temp', '°C', isTemp: true),
+    _LineInfo('Mix temp', '°C', isTemp: true),
+    _LineInfo('Target group temp', '°C', isTemp: true),
+    _LineInfo('Target mix temp', '°C', isTemp: true),
+    _LineInfo('Steam temp', '°C', isTemp: true),
+    // Scale lines (weight, weight flow) are appended dynamically
+  ];
 
   @override
   void dispose() {
-    // Forces repaint boundaries to drop cached layers
-    _bars = [];
     PaintingBinding.instance.imageCache.clearLiveImages();
     super.dispose();
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _rebuildBars();
   }
 
   @override
@@ -40,39 +55,70 @@ class _ShotChartState extends State<ShotChart> {
     return _shotChart(context);
   }
 
-  @override
-  void didUpdateWidget(covariant ShotChart oldWidget) {
-    super.didUpdateWidget(oldWidget);
-
-    // Rebuild ONLY if the shot actually changed
-    if (!identical(oldWidget.shotSnapshots, widget.shotSnapshots) ||
-        oldWidget.shotStartTime != widget.shotStartTime) {
-      _rebuildBars();
-    }
-  }
-
-  void _rebuildBars() {
-    _bars = _shotChartData();
-  }
-
-  Padding _shotChart(BuildContext context) {
+  Widget _shotChart(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(16.0),
-      child: SizedBox(
-        height: 500,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxHeight: 500),
         child: RepaintBoundary(
           child: LineChart(
             LineChartData(
               lineBarsData: _shotChartData(),
               minY: 0,
-              maxY: 11,
-              titlesData: _titles(context), // clipData: FlClipData.all(),
+              maxY: _leftMaxY,
+              titlesData: _titles(context),
+              lineTouchData: _touchData(context),
             ),
             duration:
                 widget.isLiveShot ? Duration(milliseconds: 300) : Duration.zero,
-            // curve: Curves.fastLinearToSlowEaseIn,
           ),
         ),
+      ),
+    );
+  }
+
+  List<_LineInfo> get _allLineInfo {
+    final info = List<_LineInfo>.from(_lineInfo);
+    if (widget.shotSnapshots.firstOrNull?.scale != null) {
+      info.add(const _LineInfo('Weight', 'g'));
+      info.add(const _LineInfo('Weight flow', 'g/s'));
+    }
+    return info;
+  }
+
+  LineTouchData _touchData(BuildContext context) {
+    return LineTouchData(
+      touchTooltipData: LineTouchTooltipData(
+        tooltipBorderRadius: BorderRadius.circular(8),
+        maxContentWidth: 200,
+        fitInsideHorizontally: true,
+        fitInsideVertically: true,
+        getTooltipItems: (touchedSpots) {
+          final allInfo = _allLineInfo;
+          return touchedSpots.map((spot) {
+            final idx = spot.barIndex;
+            final color = spot.bar.color ?? Colors.blue;
+
+            if (idx < allInfo.length) {
+              final info = allInfo[idx];
+              final value = info.isTemp
+                  ? (spot.y / _tempScale).toStringAsFixed(1)
+                  : spot.y.toStringAsFixed(1);
+              return LineTooltipItem(
+                '${info.label}: $value ${info.unit}',
+                TextStyle(
+                  color: color,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                ),
+              );
+            }
+            return LineTooltipItem(
+              spot.y.toStringAsFixed(1),
+              TextStyle(color: color, fontSize: 12),
+            );
+          }).toList();
+        },
       ),
     );
   }
@@ -80,11 +126,50 @@ class _ShotChartState extends State<ShotChart> {
   FlTitlesData _titles(BuildContext context) {
     return FlTitlesData(
       topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
-      leftTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+      leftTitles: AxisTitles(
+        sideTitles: SideTitles(
+          showTitles: true,
+          reservedSize: 32,
+          interval: 2,
+          getTitlesWidget: (value, meta) {
+            if (value == meta.max || value == meta.min) {
+              return const SizedBox.shrink();
+            }
+            return SideTitleWidget(
+              meta: meta,
+              child: Text(
+                value.toInt().toString(),
+                style: Theme.of(context).textTheme.labelSmall,
+              ),
+            );
+          },
+        ),
+      ),
+      rightTitles: AxisTitles(
+        sideTitles: SideTitles(
+          showTitles: true,
+          reservedSize: 40,
+          interval: 2,
+          getTitlesWidget: (value, meta) {
+            if (value == meta.max || value == meta.min) {
+              return const SizedBox.shrink();
+            }
+            final tempValue = (value / _tempScale).round();
+            return SideTitleWidget(
+              meta: meta,
+              child: Text(
+                '$tempValue°',
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: Colors.red.shade300,
+                ),
+              ),
+            );
+          },
+        ),
+      ),
       bottomTitles: AxisTitles(
         sideTitles: SideTitles(
           showTitles: true,
-          //interval: 5,
           getTitlesWidget:
               (value, meta) => _buildBottomTitle(value, meta, context),
         ),
@@ -97,18 +182,15 @@ class _ShotChartState extends State<ShotChart> {
     String text;
 
     if (value / 1000 < 60) {
-      // For less than 60 seconds, show ticks every 5 seconds with just seconds.
       if (value.toInt() % 1000 == 0) {
         text = '$seconds s';
       } else {
-        return Container(); // return an empty widget for non-tick values
+        return Container();
       }
     } else if (value / 1000 <= 120) {
-      // For 60 seconds or more, display minutes and seconds.
       final int minutes = seconds ~/ 60;
       final int remainingSeconds = seconds % 60;
       if (seconds % 15 == 0) {
-        // Format the seconds with two digits.
         text = '$minutes:${remainingSeconds.toString().padLeft(2, '0')}';
       } else {
         return Container();
@@ -121,7 +203,6 @@ class _ShotChartState extends State<ShotChart> {
         return Container();
       }
     }
-    // Style the text as needed.
     return SideTitleWidget(
       meta: meta,
       space: 8.0,
@@ -131,6 +212,7 @@ class _ShotChartState extends State<ShotChart> {
 
   List<LineChartBarData> _shotChartData() {
     return [
+      // Flow (actual)
       LineChartBarData(
         dotData: FlDotData(show: false),
         spots:
@@ -141,6 +223,7 @@ class _ShotChartState extends State<ShotChart> {
                 )
                 .toList(),
       ),
+      // Pressure (actual)
       LineChartBarData(
         color: Colors.green,
         dotData: FlDotData(show: false),
@@ -154,6 +237,7 @@ class _ShotChartState extends State<ShotChart> {
                 )
                 .toList(),
       ),
+      // Flow (target)
       LineChartBarData(
         dotData: FlDotData(show: false),
         dashArray: [5, 5],
@@ -167,6 +251,7 @@ class _ShotChartState extends State<ShotChart> {
                 )
                 .toList(),
       ),
+      // Pressure (target)
       LineChartBarData(
         color: Colors.green,
         dashArray: [5, 5],
@@ -181,6 +266,7 @@ class _ShotChartState extends State<ShotChart> {
                 )
                 .toList(),
       ),
+      // Group temperature (actual) — right axis scale
       LineChartBarData(
         color: Colors.red,
         dotData: FlDotData(show: false),
@@ -189,11 +275,12 @@ class _ShotChartState extends State<ShotChart> {
                 .map(
                   (e) => FlSpot(
                     _timestamp(e.machine.timestamp),
-                    e.machine.groupTemperature / 10.0,
+                    e.machine.groupTemperature * _tempScale,
                   ),
                 )
                 .toList(),
       ),
+      // Mix temperature (actual) — right axis scale
       LineChartBarData(
         color: Colors.orange,
         dotData: FlDotData(show: false),
@@ -202,11 +289,12 @@ class _ShotChartState extends State<ShotChart> {
                 .map(
                   (e) => FlSpot(
                     _timestamp(e.machine.timestamp),
-                    e.machine.mixTemperature / 10.0,
+                    e.machine.mixTemperature * _tempScale,
                   ),
                 )
                 .toList(),
       ),
+      // Group temperature (target) — right axis scale
       LineChartBarData(
         color: Colors.red,
         dashArray: [5, 5],
@@ -216,11 +304,12 @@ class _ShotChartState extends State<ShotChart> {
                 .map(
                   (e) => FlSpot(
                     _timestamp(e.machine.timestamp),
-                    e.machine.targetGroupTemperature / 10.0,
+                    e.machine.targetGroupTemperature * _tempScale,
                   ),
                 )
                 .toList(),
       ),
+      // Mix temperature (target) — right axis scale
       LineChartBarData(
         color: Colors.orange,
         dashArray: [5, 5],
@@ -230,7 +319,21 @@ class _ShotChartState extends State<ShotChart> {
                 .map(
                   (e) => FlSpot(
                     _timestamp(e.machine.timestamp),
-                    e.machine.targetMixTemperature / 10.0,
+                    e.machine.targetMixTemperature * _tempScale,
+                  ),
+                )
+                .toList(),
+      ),
+      // Steam temperature — right axis scale
+      LineChartBarData(
+        color: Colors.deepOrange,
+        dotData: FlDotData(show: false),
+        spots:
+            widget.shotSnapshots
+                .map(
+                  (e) => FlSpot(
+                    _timestamp(e.machine.timestamp),
+                    e.machine.steamTemperature * _tempScale,
                   ),
                 )
                 .toList(),


### PR DESCRIPTION
## Summary
- **Dual Y-axes on ShotChart:** Left axis for flow/pressure (0–11), right axis for temperature (0–160°C) with proper scaling — replaces the old `/10.0` hack
- **Steam temperature line** added (deep orange) — visible in both shot and steam realtime screens
- **Flexible chart height** in realtime features using `Flexible` + `ConstrainedBox(maxHeight: 500)` so the chart adapts to smaller screens
- **Custom tooltips** with labeled values, correct units, line-matched colors, and constrained inside chart bounds
- History feature retains fixed 500px chart height

## Test plan
- [x] Verified lines draw correctly during simulated espresso shot
- [x] Verified chart scales to screen size on realtime screens
- [x] Verified tooltip hover shows labeled values with correct units
- [x] Verified tooltips stay within chart bounds
- [x] All 467 tests pass, `flutter analyze` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)