### PR TITLE
chore: update docs and MCP server for post-v0.5.4 changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ The MCP server in `packages/mcp-server/` bridges Claude to the Flutter app's RES
 - **RxDart:** Controllers use `BehaviorSubject` for state broadcasting
 - **Async init:** Services/controllers have `initialize()` methods called from `main.dart`
 - **Logging:** `package:logging`, configured in `main.dart`. Logs to `~/Download/REA1/log.txt` (Android) or app documents dir (other platforms)
-- **Foreground service:** Android uses `ForegroundTaskService` to maintain BLE in background
+- **Foreground service:** Android uses `ForegroundTaskService` to maintain BLE in background. Auto-stops after a 5-minute grace period when the machine disconnects; auto-restarts on reconnect. Shows connection state in the notification.
 - **StreamBuilder patterns:**
   - Check both `hasData` AND `data != null` for nullable streams (e.g., `De1Interface?`)
   - Use explicit type parameters: `StreamBuilder<De1Interface?>`

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3392,6 +3392,10 @@ components:
           minimum: 0
           maximum: 1439
           description: Morning time in minutes since midnight
+        lowBatteryBrightnessLimit:
+          type: boolean
+          nullable: true
+          description: When enabled and battery drops below 30%, screen brightness is capped at 20. Only effective on platforms with battery monitoring.
 
     ReaSettings:
       type: object
@@ -3456,6 +3460,9 @@ components:
           minimum: 0
           maximum: 1439
           description: Morning time in minutes since midnight (e.g., 420 = 07:00)
+        lowBatteryBrightnessLimit:
+          type: boolean
+          description: When enabled and battery drops below 30%, screen brightness is capped at 20. Only effective on platforms with battery monitoring.
         chargingState:
           $ref: '#/components/schemas/ChargingState'
 

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -734,8 +734,12 @@ void _handleSnapshot(MachineSnapshot snapshot) {
 Use simulated devices for testing without hardware:
 
 ```bash
-flutter run --dart-define=simulate=1
+flutter run --dart-define=simulate=1              # Simulate all devices
+flutter run --dart-define=simulate=machine         # Simulate machine only
+flutter run --dart-define=simulate=machine,scale   # Simulate machine and scale
 ```
+
+Supported types: `machine`, `scale`, `sensor` (comma-separated).
 
 Or toggle in Settings UI → Simulated Devices
 
@@ -853,10 +857,9 @@ _log.info('Found serial ports: $ports');
 - `lib/src/services/simulated_device_service.dart` - Testing mocks
 
 ### Device Implementations
-- `lib/src/models/device/impl/de1/` - DE1 BLE machines
-- `lib/src/models/device/impl/serial_de1/` - DE1 Serial machines
-- `lib/src/models/device/impl/unified_de1/` - Unified DE1 interface
+- `lib/src/models/device/impl/de1/` - DE1 machines (BLE + Serial, unified interface in `unified_de1/`)
 - `lib/src/models/device/impl/decent_scale/` - Decent Scale (BLE + Serial)
+- `lib/src/models/device/impl/acaia/` - Acaia scales (unified: IPS protocol for older ACAIA/PROCH, Pyxis protocol for Lunar/Pearl/Pyxis, auto-detected at connect time)
 - `lib/src/models/device/impl/felicita/` - Felicita Arc scale
 - `lib/src/models/device/impl/bookoo/` - Bookoo Miniscale
 - `lib/src/models/device/impl/mock_de1/` - Mock DE1 for testing

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -1210,6 +1210,7 @@ GET /api/v1/settings
 - `volumeFlowMultiplier`: Multiplier for projected volume calculation (default: 0.3)
 - `scalePowerMode`: Automatic scale power management (`disabled`, `displayOff`, `disconnect`)
 - `preferredMachineId`: Device ID for auto-connect on startup
+- `lowBatteryBrightnessLimit` (boolean): When enabled, caps brightness at 20 when battery drops below 30%
 
 **Gateway Modes:**
 - `disabled`: No gateway features

--- a/packages/mcp-server/src/bridge/rest-client.ts
+++ b/packages/mcp-server/src/bridge/rest-client.ts
@@ -50,7 +50,7 @@ export class RestClient {
 
   async isReachable(): Promise<boolean> {
     try {
-      await this.get("/api/v1/machine/state");
+      await this.get("/api/v1/info");
       return true;
     } catch {
       return false;

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -21,6 +21,7 @@ import { WsClient } from "./bridge/ws-client.js";
 import { registerStreamingTools } from "./tools/streaming.js";
 import { registerDataSyncTools } from "./tools/data-sync.js";
 import { registerInfoTools } from "./tools/info.js";
+import { registerDisplayTools } from "./tools/display.js";
 import { registerStaticResources } from "./resources/static-docs.js";
 import { registerLiveResources } from "./resources/live-state.js";
 
@@ -63,6 +64,7 @@ export function createServer(config: ServerConfig) {
   registerGrinderTools(server, restClient);
   registerDataSyncTools(server, restClient);
   registerInfoTools(server, restClient);
+  registerDisplayTools(server, restClient);
 
   const appManager = new AppManager({
     flutterCmd: config.flutterCmd,

--- a/packages/mcp-server/src/tools/display.ts
+++ b/packages/mcp-server/src/tools/display.ts
@@ -1,0 +1,43 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { RestClient } from "../bridge/rest-client.js";
+
+export function registerDisplayTools(server: McpServer, rest: RestClient) {
+  server.registerTool("display_get", {
+    title: "Get Display State",
+    description: "Get current display state including brightness, wake lock status, and low battery brightness cap.",
+    inputSchema: z.object({}),
+  }, async () => {
+    const data = await rest.get("/api/v1/display");
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  });
+
+  server.registerTool("display_set_brightness", {
+    title: "Set Display Brightness",
+    description: "Set screen brightness (0-100). May be capped by low battery brightness limit if active.",
+    inputSchema: z.object({
+      brightness: z.number().int().min(0).max(100).describe("Brightness level (0-100)"),
+    }),
+  }, async ({ brightness }) => {
+    const data = await rest.put("/api/v1/display/brightness", { brightness });
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  });
+
+  server.registerTool("display_wakelock_request", {
+    title: "Request Wake Lock",
+    description: "Request a wake lock to keep the screen on.",
+    inputSchema: z.object({}),
+  }, async () => {
+    const data = await rest.post("/api/v1/display/wakelock", {});
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  });
+
+  server.registerTool("display_wakelock_release", {
+    title: "Release Wake Lock",
+    description: "Release the wake lock, allowing the screen to turn off normally.",
+    inputSchema: z.object({}),
+  }, async () => {
+    const data = await rest.delete("/api/v1/display/wakelock");
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  });
+}

--- a/packages/mcp-server/src/tools/settings.ts
+++ b/packages/mcp-server/src/tools/settings.ts
@@ -14,7 +14,7 @@ export function registerSettingsTools(server: McpServer, rest: RestClient) {
 
   server.registerTool("settings_update", {
     title: "Update Settings",
-    description: "Update app settings (gateway mode, log level, multipliers, etc.).",
+    description: "Update app settings (gateway mode, log level, multipliers, scale power mode, charging mode, night mode, lowBatteryBrightnessLimit, etc.).",
     inputSchema: z.object({
       settings: z.record(z.unknown()),
     }),


### PR DESCRIPTION
## Summary
- Fix stale device implementation paths and add Acaia scale entry in DeviceManagement.md
- Add granular simulate flags (`machine`, `scale`, `sensor`) to DeviceManagement.md
- Add `lowBatteryBrightnessLimit` to OpenAPI spec (`ReaSettings` + `ReaSettingsRequest`) and Skins.md
- Document foreground service grace-period auto-stop behavior in CLAUDE.md
- Add MCP display tools (`display_get`, `display_set_brightness`, `display_wakelock_request`, `display_wakelock_release`)
- Fix MCP `isReachable()` to use `/api/v1/info` instead of `/api/v1/machine/state` (was returning false without a connected machine)
- Expand MCP `settings_update` description to mention newer fields

## Test plan
- [x] MCP server builds clean (`npm run build`)
- [x] `flutter analyze` passes
- [ ] Verify MCP display tools work against running app (`app_start` + `display_get`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)