### PR TITLE
use primary color for QR foreground

### DIFF
--- a/lib/src/home_feature/widgets/quick_settings_widget.dart
+++ b/lib/src/home_feature/widgets/quick_settings_widget.dart
@@ -54,9 +54,12 @@ class QuickSettingsWidget extends StatefulWidget {
                 // width: 220,
                 child: PrettyQrView.data(
                   data: 'http://$deviceIp:3000',
-                  decoration: const PrettyQrDecoration(
+                  decoration: PrettyQrDecoration(
                     quietZone: PrettyQrQuietZone.standard,
-                    shape: PrettyQrSquaresSymbol(unifiedFinderPattern: true),
+                    shape: PrettyQrSquaresSymbol(
+                      unifiedFinderPattern: true,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
                     // shape: PrettyQrShape.custom(
                     //   PrettyQrSquaresSymbol(),
                     //   finderPattern: PrettyQrSmoothSymbol(),


### PR DESCRIPTION
Previously, black color was used for displaying webUI QR code. Switched to foreground color so that it can change, depending on the system theme, if needed.