### PR TITLE
fix: WebView cache/SW cleanup and fullscreen on Android

### DIFF
--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -36,7 +36,6 @@ class SkinView extends StatefulWidget {
 
 class _SkinViewState extends State<SkinView> {
   final _log = Logger('SkinView');
-  InAppWebViewController? _controller;
   bool _isLoading = true;
   bool _isCheckingCompatibility = true;
   String? _errorMessage;
@@ -420,7 +419,6 @@ class _SkinViewState extends State<SkinView> {
           initialSettings: _settings,
           onWebViewCreated: (controller) {
             _log.info('InAppWebView created');
-            _controller = controller;
           },
           onLoadStart: (controller, url) {
             _log.info('Page started loading: $url');


### PR DESCRIPTION
## Summary

- Fix white screen when switching skins: stale service workers cached assets from the previous skin and served them even after the server switched to a different skin directory. Bypassed via cache-busting query param on the initial URL.
- Clear HTTP cache before each SkinView load to prevent stale asset serving
- Immersive fullscreen on Android/iOS when viewing skins (hides status bar and nav bar)
- Removed unused `_controller` field

## Root cause

Skins register service workers that cache their HTML/CSS/JS in CacheStorage. When switching skins, the old SW intercepts the initial `/` request and returns cached HTML referencing assets that don't exist in the new skin's directory — causing 404s with `text/plain` MIME type, which strict MIME checking rejects → white screen.

Approaches tried that didn't work:
- `clearAllCache()` — only clears HTTP cache, not SW CacheStorage
- `WebStorageManager.deleteAllData()` — doesn't clear CacheStorage on Android
- `ServiceWorkerController.setCacheMode(LOAD_NO_CACHE)` — only affects network fetch cache mode, not the SW's internal `caches.match()` logic
- `loadData` with `baseUrl` to unregister SWs — `InvalidStateError`, documents loaded via `loadData` can't access SW API

What works: `?_=<timestamp>` on the initial URL. The SW cache matches on exact URL, so `/?_=123` doesn't match cached `/` and falls through to the network.

## Test plan

- [x] Android: load skin → switch to different skin → switch back → no white screen
- [x] macOS: same skin switching cycle works
- [x] `flutter analyze` clean
- [x] 812 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)