### PR TITLE
fix(a11y): screen reader accessibility for settings and history views

### DIFF
--- a/doc/plans/2026-04-09-a11y-settings-history-design.md
+++ b/doc/plans/2026-04-09-a11y-settings-history-design.md
@@ -1,0 +1,74 @@
+# Accessibility: Settings & History Views — Design
+
+## Problem
+
+GH #93 tracks screen reader accessibility for Bridge.app. Onboarding, scan, import, landing, and dashboard views are done. Settings and shot history remain — both have zero Semantics widgets. This blocks closing #93.
+
+## Approach
+
+Apply the same patterns established in dashboard a11y work (commit 5387fed):
+- `Semantics(explicitChildNodes: true)` on container sections
+- `MergeSemantics` on label+control / label+value pairs
+- `Semantics(button: true, label: '...')` + `ExcludeSemantics` on interactive elements
+- `Semantics(header: true)` on section headings
+- Contextual labels including live state values
+
+## Settings View (`lib/src/settings/settings_view.dart`)
+
+### Sections
+Wrap each `_SettingsSection` / `ShadCard` with `Semantics(explicitChildNodes: true, label: 'Section name')`.
+
+### Label+control pairs
+Wrap each `_SettingRow` with `MergeSemantics` so label and control announce as one (e.g., "Theme, Dark").
+
+### Navigation buttons
+`ShadButton.outline` items navigating to sub-pages get `Semantics(button: true, label: 'Configure [feature] settings')` with `ExcludeSemantics` on children.
+
+### Dropdowns
+Wrap `DropdownButton` with `Semantics` including current value (e.g., "Gateway mode, Full").
+
+### Switches
+ShadSwitch has `label`/`sublabel`. Wrap with `MergeSemantics` to unify announcement.
+
+### Icon-only buttons
+Add `Semantics(button: true, label: '...')`.
+
+## History View (`lib/src/history_feature/history_feature.dart`)
+
+### List items
+Wrap each shot card in `Semantics(button: true, label: 'Shot on [date], [coffee], [dose]g in, [yield]g out, [duration]')` with `ExcludeSemantics` on children.
+
+### Search bar
+Add semantic label describing purpose.
+
+### Result count
+Announce as status when search changes.
+
+### Detail view sections
+Section headers: `Semantics(header: true)`. Section containers: `Semantics(explicitChildNodes: true, label: '...')`.
+
+### Stat cards
+`MergeSemantics` on each `_StatCard` (label+value).
+
+### Detail rows
+`MergeSemantics` on each `_DetailRow` (label+value).
+
+### Action buttons
+`Semantics(button: true, label: 'Edit shot notes')`, `'Repeat this shot'`, `'Delete this shot'`.
+
+### Chart
+Wrap `ShotChart` in `Semantics(label: 'Shot chart summary: [duration], peak pressure, peak flow, final weight')`. Exclude chart internals from semantics — fl_chart tooltips aren't SR-accessible.
+
+### Decorative icons
+Wrap in `ExcludeSemantics`.
+
+## Out of scope
+
+- Streamline.js skin `role="button"` fix (separate workstream)
+- Dialog a11y (TalkBack node merging — tracked separately)
+- Scan step status announcements (tracked separately)
+- Chart data table alternative (not needed for Approach B)
+
+## Testing
+
+Deploy to device, verify with TalkBack that all interactive elements are discoverable, labeled, and activatable via double-tap.

--- a/doc/plans/2026-04-09-a11y-settings-history.md
+++ b/doc/plans/2026-04-09-a11y-settings-history.md
@@ -1,0 +1,415 @@
+# A11Y Settings & History Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add comprehensive screen reader (TalkBack) accessibility to the Settings and History views, matching the quality of the existing dashboard a11y work.
+
+**Architecture:** Apply existing patterns — `Semantics(explicitChildNodes: true)` on sections, `MergeSemantics` on label+control pairs, `Semantics(button: true)` with `ExcludeSemantics` on interactive elements. No new widgets or abstractions needed.
+
+**Tech Stack:** Flutter Semantics API, existing shadcn_ui widgets
+
+**Subagent structure:** 2 agents per view (4 total). Settings: helper widgets + sections. History: list view + detail view.
+
+---
+
+### Task 1: Settings — Annotate helper widgets (`_SettingsSection`, `_SettingRow`, `_InfoRow`)
+
+**Files:**
+- Modify: `lib/src/settings/settings_view.dart:1179-1301`
+
+**Step 1: Add `Semantics(explicitChildNodes: true)` to `_SettingsSection`**
+
+Wrap the `ShadCard` return in `_SettingsSection.build()` (line 1196) with:
+```dart
+return Semantics(
+  explicitChildNodes: true,
+  label: title,
+  child: ShadCard(
+    // ... existing code
+  ),
+);
+```
+
+Also wrap the info `IconButton` (line 1214) with `Semantics(button: true, label: 'Learn more about $title')` and `ExcludeSemantics` on the child icon.
+
+**Step 2: Add `MergeSemantics` to `_SettingRow`**
+
+Wrap the `Padding` return in `_SettingRow.build()` (line 1249) with `MergeSemantics`:
+```dart
+return MergeSemantics(
+  child: Padding(
+    // ... existing code
+  ),
+);
+```
+
+This merges the label text and the control widget so TalkBack announces them together (e.g., "Theme, Dark Theme").
+
+**Step 3: Add `MergeSemantics` to `_InfoRow`**
+
+Same pattern for `_InfoRow.build()` (line 1277):
+```dart
+return MergeSemantics(
+  child: Padding(
+    // ... existing code
+  ),
+);
+```
+
+**Step 4: Run `flutter analyze`**
+
+Run: `flutter analyze lib/src/settings/settings_view.dart`
+Expected: No new warnings
+
+**Step 5: Commit**
+
+```
+git add lib/src/settings/settings_view.dart
+git commit -m "fix(a11y): add semantics to settings helper widgets"
+```
+
+---
+
+### Task 2: Settings — Annotate section builders
+
+**Files:**
+- Modify: `lib/src/settings/settings_view.dart:134-710`
+
+**Step 1: Annotate Battery section (lines 201-256)**
+
+This section doesn't use `_SettingsSection`, it's a raw `ShadCard`. Wrap it:
+```dart
+return Semantics(
+  explicitChildNodes: true,
+  label: 'Battery & Charging',
+  child: ShadCard(
+    // ... existing
+  ),
+);
+```
+
+Wrap the "Configure" `ShadButton.outline` (line 241) with:
+```dart
+Semantics(
+  button: true,
+  label: 'Configure battery and charging settings',
+  child: ExcludeSemantics(
+    child: ShadButton.outline(
+      // ... existing
+    ),
+  ),
+),
+```
+
+**Step 2: Annotate Presence section (lines 271-335)**
+
+Same pattern — raw `ShadCard`, wrap with `Semantics(explicitChildNodes: true, label: 'Presence & Sleep')`.
+
+Wrap "Configure" button with `Semantics(button: true, label: 'Configure presence and sleep settings, currently $subtitle')`.
+
+**Step 3: Annotate Device Management section (lines 337-433)**
+
+Wrap with `Semantics(explicitChildNodes: true, label: 'Device Management')`.
+
+Wrap "Configure" button (line 385) with `Semantics(button: true, label: 'Configure device management, machine: ${machineName ?? "Not set"}, scale: ${scaleName ?? "Not set"}')`.
+
+Wrap each `ShadSwitch` for simulated devices (line 414) with `MergeSemantics`.
+
+**Step 4: Annotate Data Management section (lines 435-491)**
+
+Wrap with `Semantics(explicitChildNodes: true, label: 'Data Management')`.
+
+Wrap "Configure" button (line 471) with `Semantics(button: true, label: 'Configure data management')`.
+
+**Step 5: Annotate WebUI section (lines 537-583)**
+
+`_SettingsSection` wrapper already gets semantics from Task 1. Additional:
+
+- Wrap the skin selector dropdown with `Semantics(label: 'Selected skin')` — the `MergeSemantics` from `_SettingRow` will merge label + dropdown.
+- Wrap "Start WebUI Server" button (line 550) with `Semantics(button: true, label: 'Start WebUI server')`.
+- Wrap "Open UI in browser" button (line 559) with `Semantics(button: true, label: 'Open web interface in browser')`.
+- Wrap "Stop WebUI Server" button (line 565) with `Semantics(button: true, label: 'Stop WebUI server')`.
+- Wrap "Check for Skin Updates" button (line 577) with `Semantics(button: true, label: 'Check for skin updates')`.
+
+**Step 6: Annotate Advanced section (lines 585-672)**
+
+`_SettingsSection` wrapper handles section semantics. Additional:
+
+- The `ShadSwitch` for automatic updates (line 606) — wrap with `MergeSemantics`.
+- Update available banner (line 622-648) — wrap with `Semantics(label: 'Update available: ${widget.updateCheckService?.availableUpdate?.version}')`.
+- Wrap "Plugins" button (line 654) with `Semantics(button: true, label: 'Open plugins settings')`.
+- Wrap "Check for updates" button (line 658) with `Semantics(button: true, label: 'Check for app updates')`.
+- Wrap "Exit" button (line 665) with `Semantics(button: true, label: 'Exit Streamline-Bridge application')`.
+
+**Step 7: Annotate About section (lines 674-710)**
+
+`_SettingsSection` wrapper handles section semantics. Additional:
+
+- Wrap "View GPL v3 License" button (line 702) with `Semantics(button: true, label: 'View GPL version 3 license')`.
+
+**Step 8: Run `flutter analyze`**
+
+Run: `flutter analyze lib/src/settings/settings_view.dart`
+Expected: No new warnings
+
+**Step 9: Commit**
+
+```
+git add lib/src/settings/settings_view.dart
+git commit -m "fix(a11y): add semantics to all settings sections"
+```
+
+---
+
+### Task 3: History — Annotate list view (left column)
+
+**Files:**
+- Modify: `lib/src/history_feature/history_feature.dart:105-364`
+
+**Step 1: Annotate search bar (line 125)**
+
+Add a `Semantics` label to the `SearchBar`:
+```dart
+Semantics(
+  label: 'Search shot history',
+  child: SearchBar(
+    controller: _searchController,
+    hintText: "Search by coffee, roaster, profile, grinder, or notes...",
+  ),
+),
+```
+
+**Step 2: Annotate result count (line 129-138)**
+
+Wrap the result count text with `Semantics(liveRegion: true)` so TalkBack announces search result changes:
+```dart
+Semantics(
+  liveRegion: true,
+  child: Padding(
+    padding: const EdgeInsets.only(top: 4.0, left: 8.0),
+    child: Text(
+      "Found ${_shots.length} shot${_shots.length == 1 ? '' : 's'}",
+      // ... existing style
+    ),
+  ),
+),
+```
+
+**Step 3: Annotate list items (lines 153-357)**
+
+Wrap each list item's `Padding` (line 153) with `Semantics` and `ExcludeSemantics`:
+
+```dart
+return Semantics(
+  button: true,
+  selected: isSelected,
+  label: _shotListItemLabel(record, durationSeconds),
+  child: ExcludeSemantics(
+    child: Padding(
+      // ... existing TapRegion code
+    ),
+  ),
+);
+```
+
+Add helper method to build the label:
+```dart
+String _shotListItemLabel(ShotRecord record, int durationSeconds) {
+  final parts = <String>[record.shotTime()];
+  if (record.workflow.context?.coffeeName != null) {
+    parts.add(record.workflow.context!.coffeeName!);
+  }
+  if (record.workflow.context?.coffeeRoaster != null) {
+    parts.add('by ${record.workflow.context!.coffeeRoaster!}');
+  }
+  parts.add(record.workflow.profile.title);
+  if (record.workflow.context?.targetDoseWeight != null) {
+    parts.add('${record.workflow.context!.targetDoseWeight!}g in');
+  }
+  if (record.workflow.context?.targetYield != null) {
+    parts.add('${record.workflow.context!.targetYield!}g out');
+  }
+  parts.add('${durationSeconds}s');
+  return parts.join(', ');
+}
+```
+
+**Step 4: Run `flutter analyze`**
+
+Run: `flutter analyze lib/src/history_feature/history_feature.dart`
+Expected: No new warnings
+
+**Step 5: Commit**
+
+```
+git add lib/src/history_feature/history_feature.dart
+git commit -m "fix(a11y): add semantics to history list view"
+```
+
+---
+
+### Task 4: History — Annotate detail view (right column)
+
+**Files:**
+- Modify: `lib/src/history_feature/history_feature.dart:366-883`
+
+**Step 1: Annotate action buttons (lines 417-453)**
+
+Wrap each button with `Semantics(button: true)` + `ExcludeSemantics`:
+
+```dart
+Semantics(
+  button: true,
+  label: 'Edit shot notes',
+  child: ExcludeSemantics(
+    child: ShadButton.outline(/* existing */),
+  ),
+),
+Semantics(
+  button: true,
+  label: 'Repeat this shot with same workflow settings',
+  child: ExcludeSemantics(
+    child: ShadButton(/* existing */),
+  ),
+),
+Semantics(
+  button: true,
+  label: 'Delete this shot',
+  child: ExcludeSemantics(
+    child: ShadButton.destructive(/* existing */),
+  ),
+),
+```
+
+**Step 2: Annotate stat cards (lines 459-490)**
+
+Wrap each `_StatCard` with `MergeSemantics`. Modify `_StatCard.build()` (line 820):
+```dart
+@override
+Widget build(BuildContext context) {
+  return MergeSemantics(
+    child: Semantics(
+      label: '$label: $value',
+      child: ExcludeSemantics(
+        child: ShadCard(
+          // ... existing code
+        ),
+      ),
+    ),
+  );
+}
+```
+
+**Step 3: Annotate detail sections (Coffee, Equipment, Notes, Additional Info)**
+
+Add `Semantics(header: true)` to each section title Row (lines 499-509, 546-556, 589-599, 619-629).
+
+Wrap each section title `Text` with:
+```dart
+Semantics(
+  header: true,
+  child: Text(
+    "Coffee Details",
+    // ... existing style
+  ),
+),
+```
+
+Wrap section `ShadCard` containers with `Semantics(explicitChildNodes: true, label: 'section name')`.
+
+**Step 4: Annotate `_DetailRow`**
+
+Modify `_DetailRow.build()` (line 858) to wrap with `MergeSemantics`:
+```dart
+@override
+Widget build(BuildContext context) {
+  return MergeSemantics(
+    child: Padding(
+      // ... existing code
+    ),
+  );
+}
+```
+
+**Step 5: Annotate chart section (lines 679-696)**
+
+Wrap the "Shot Profile" heading text (line 682) with `Semantics(header: true)`.
+
+Wrap the `ShotChart` SizedBox (line 689) with a descriptive `Semantics` and exclude the chart:
+```dart
+Semantics(
+  label: _chartSummaryLabel(record),
+  child: ExcludeSemantics(
+    child: SizedBox(
+      height: 500,
+      child: ShotChart(/* existing */),
+    ),
+  ),
+),
+```
+
+Add helper method:
+```dart
+String _chartSummaryLabel(ShotRecord record) {
+  final duration = record.measurements.isNotEmpty
+      ? record.measurements.last.machine.timestamp.difference(record.timestamp)
+      : Duration.zero;
+  final parts = <String>['Shot profile chart'];
+  parts.add('duration ${duration.inSeconds} seconds');
+  if (record.measurements.isNotEmpty) {
+    final maxPressure = record.measurements
+        .map((m) => m.machine.groupPressure)
+        .reduce((a, b) => a > b ? a : b);
+    parts.add('peak pressure ${maxPressure.toStringAsFixed(1)} bar');
+    final maxFlow = record.measurements
+        .map((m) => m.machine.groupFlow)
+        .reduce((a, b) => a > b ? a : b);
+    parts.add('peak flow ${maxFlow.toStringAsFixed(1)} millilitres per second');
+  }
+  return parts.join(', ');
+}
+```
+
+**Step 6: Annotate "No shot selected" placeholder (line 372)**
+
+```dart
+Center(child: Semantics(
+  label: 'No shot selected. Select a shot from the list on the left.',
+  child: ExcludeSemantics(child: Text("No shot selected")),
+)),
+```
+
+**Step 7: Run `flutter analyze`**
+
+Run: `flutter analyze lib/src/history_feature/history_feature.dart`
+Expected: No new warnings
+
+**Step 8: Run full test suite**
+
+Run: `flutter test`
+Expected: All tests pass
+
+**Step 9: Commit**
+
+```
+git add lib/src/history_feature/history_feature.dart
+git commit -m "fix(a11y): add semantics to history detail view"
+```
+
+---
+
+### Task 5: Final verification
+
+**Step 1: Run `flutter analyze` on full project**
+
+Run: `flutter analyze`
+Expected: No new warnings related to our changes
+
+**Step 2: Run `flutter test`**
+
+Run: `flutter test`
+Expected: All tests pass
+
+**Step 3: Commit any remaining fixes**
+
+If analyze or tests revealed issues, fix and commit.

--- a/lib/src/history_feature/history_feature.dart
+++ b/lib/src/history_feature/history_feature.dart
@@ -101,7 +101,16 @@ class _HistoryFeatureState extends State<HistoryFeature> {
     if (record.workflow.context?.targetYield != null) {
       parts.add('${record.workflow.context!.targetYield!}g out');
     }
+    if (record.workflow.context?.grinderModel != null) {
+      final grinder = record.workflow.context!.grinderModel!;
+      final setting = record.workflow.context?.grinderSetting;
+      parts.add(setting != null ? '$grinder at $setting' : grinder);
+    }
     parts.add('${durationSeconds}s');
+    if (record.annotations?.espressoNotes != null &&
+        record.annotations!.espressoNotes!.isNotEmpty) {
+      parts.add('has notes');
+    }
     return parts.join(', ');
   }
 
@@ -195,14 +204,14 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                   button: true,
                   selected: isSelected,
                   label: _shotListItemLabel(record, durationSeconds),
-                  onTap: () => _selectShot(record),
                   child: ExcludeSemantics(
                     child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
-                  child: TapRegion(
-                    onTapUpInside: (_) {
+                  child: InkWell(
+                    onTap: () {
                       _selectShot(record);
                     },
+                    borderRadius: BorderRadius.circular(8),
                     child: Container(
                       decoration: BoxDecoration(
                         color: isSelected
@@ -770,7 +779,7 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                         value: entry.value.toString(),
                         context: context,
                       );
-                    }).toList(),
+                    }),
                   ],
                 ),
               ),
@@ -828,20 +837,6 @@ class _HistoryFeatureState extends State<HistoryFeature> {
       builder: (context) => ShadDialog(
         title: Text('Edit Shot'),
         description: Text('Update shot notes'),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 20),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              ShadInput(
-                controller: notesController,
-                placeholder: const Text('Add notes about this shot...'),
-                maxLines: 5,
-              ),
-            ],
-          ),
-        ),
         actions: [
           ShadButton.outline(
             child: const Text('Cancel'),
@@ -858,6 +853,7 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                   annotations: updatedAnnotations,
                 );
                 await widget.persistenceController.updateShot(updatedShot);
+                if (!context.mounted) return;
                 Navigator.of(context).pop();
                 if (!mounted) return;
                 setState(() {
@@ -865,7 +861,7 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                 });
               } catch (e) {
                 _log.severe("Failed to update shot", e);
-                // Show error toast
+                if (!context.mounted) return;
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(content: Text('Failed to update shot: $e')),
                 );
@@ -873,6 +869,20 @@ class _HistoryFeatureState extends State<HistoryFeature> {
             },
           ),
         ],
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              ShadInput(
+                controller: notesController,
+                placeholder: const Text('Add notes about this shot...'),
+                maxLines: 5,
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }
@@ -893,12 +903,15 @@ class _HistoryFeatureState extends State<HistoryFeature> {
             onPressed: () async {
               try {
                 await widget.persistenceController.deleteShot(record.id);
+                if (!context.mounted) return;
                 Navigator.of(context).pop();
+                if (!mounted) return;
                 setState(() {
                   _selectedShot = null;
                 });
               } catch (e) {
                 _log.severe("Failed to delete shot", e);
+                if (!context.mounted) return;
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(content: Text('Failed to delete shot: $e')),
                 );

--- a/lib/src/history_feature/history_feature.dart
+++ b/lib/src/history_feature/history_feature.dart
@@ -86,6 +86,44 @@ class _HistoryFeatureState extends State<HistoryFeature> {
     }
   }
 
+  String _shotListItemLabel(ShotRecord record, int durationSeconds) {
+    final parts = <String>[record.shotTime()];
+    if (record.workflow.context?.coffeeName != null) {
+      parts.add(record.workflow.context!.coffeeName!);
+    }
+    if (record.workflow.context?.coffeeRoaster != null) {
+      parts.add('by ${record.workflow.context!.coffeeRoaster!}');
+    }
+    parts.add(record.workflow.profile.title);
+    if (record.workflow.context?.targetDoseWeight != null) {
+      parts.add('${record.workflow.context!.targetDoseWeight!}g in');
+    }
+    if (record.workflow.context?.targetYield != null) {
+      parts.add('${record.workflow.context!.targetYield!}g out');
+    }
+    parts.add('${durationSeconds}s');
+    return parts.join(', ');
+  }
+
+  String _chartSummaryLabel(ShotRecord record) {
+    final duration = record.measurements.isNotEmpty
+        ? record.measurements.last.machine.timestamp.difference(record.timestamp)
+        : Duration.zero;
+    final parts = <String>['Shot profile chart'];
+    parts.add('duration ${duration.inSeconds} seconds');
+    if (record.measurements.isNotEmpty) {
+      final maxPressure = record.measurements
+          .map((m) => m.machine.pressure)
+          .reduce((a, b) => a > b ? a : b);
+      parts.add('peak pressure ${maxPressure.toStringAsFixed(1)} bar');
+      final maxFlow = record.measurements
+          .map((m) => m.machine.flow)
+          .reduce((a, b) => a > b ? a : b);
+      parts.add('peak flow ${maxFlow.toStringAsFixed(1)} millilitres per second');
+    }
+    return parts.join(', ');
+  }
+
   @override
   void dispose() {
     _shotsSubscription.cancel();
@@ -127,12 +165,15 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                   hintText: "Search by coffee, roaster, profile, grinder, or notes...",
                 ),
                 if (_searchController.text.isNotEmpty)
-                  Padding(
-                    padding: const EdgeInsets.only(top: 4.0, left: 8.0),
-                    child: Text(
-                      "Found ${_shots.length} shot${_shots.length == 1 ? '' : 's'}",
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
+                  Semantics(
+                    liveRegion: true,
+                    child: Padding(
+                      padding: const EdgeInsets.only(top: 4.0, left: 8.0),
+                      child: Text(
+                        "Found ${_shots.length} shot${_shots.length == 1 ? '' : 's'}",
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                        ),
                       ),
                     ),
                   ),
@@ -150,7 +191,13 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                     : Duration.zero;
                 final durationSeconds = duration.inSeconds;
                 
-                return Padding(
+                return Semantics(
+                  button: true,
+                  selected: isSelected,
+                  label: _shotListItemLabel(record, durationSeconds),
+                  onTap: () => _selectShot(record),
+                  child: ExcludeSemantics(
+                    child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
                   child: TapRegion(
                     onTapUpInside: (_) {
@@ -158,8 +205,8 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                     },
                     child: Container(
                       decoration: BoxDecoration(
-                        color: isSelected 
-                            ? Theme.of(context).colorScheme.primaryContainer.withOpacity(0.3)
+                        color: isSelected
+                            ? Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.3)
                             : null,
                         border: isSelected
                             ? Border.all(
@@ -201,12 +248,12 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                             ],
                           ),
                           const SizedBox(height: 8),
-                          
+
                           // Coffee and roaster
                           if (record.workflow.context?.coffeeName != null) ...[
                             Row(
                               children: [
-                                Icon(Icons.coffee, size: 14, color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6)),
+                                Icon(Icons.coffee, size: 14, color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6)),
                                 const SizedBox(width: 4),
                                 Expanded(
                                   child: Text(
@@ -226,7 +273,7 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                                 child: Text(
                                   record.workflow.context!.coffeeRoaster!,
                                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                    color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                                    color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
                                   ),
                                   maxLines: 1,
                                   overflow: TextOverflow.ellipsis,
@@ -234,11 +281,11 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                               ),
                             const SizedBox(height: 6),
                           ],
-                          
+
                           // Profile name
                           Row(
                             children: [
-                              Icon(Icons.dashboard_customize, size: 14, color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6)),
+                              Icon(Icons.dashboard_customize, size: 14, color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6)),
                               const SizedBox(width: 4),
                               Expanded(
                                 child: Text(
@@ -251,12 +298,12 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                             ],
                           ),
                           const SizedBox(height: 6),
-                          
+
                           // Dose ratio
                           if (record.workflow.context?.targetDoseWeight != null) ...[
                             Row(
                               children: [
-                                Icon(Icons.scale, size: 14, color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6)),
+                                Icon(Icons.scale, size: 14, color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6)),
                                 const SizedBox(width: 4),
                                 Text(
                                   "${record.workflow.context!.targetDoseWeight!}g → ${record.workflow.context?.targetYield ?? 0}g",
@@ -269,20 +316,20 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                                   Text(
                                     "(1:${record.workflow.context!.ratio!.toStringAsFixed(1)})",
                                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                      color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                                      color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
                                     ),
                                   ),
                                 ],
                               ],
                             ),
                           ],
-                          
+
                           // Grinder info
                           if (record.workflow.context?.grinderModel != null || record.workflow.context?.grinderSetting != null) ...[
                             const SizedBox(height: 6),
                             Row(
                               children: [
-                                Icon(Icons.settings, size: 14, color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6)),
+                                Icon(Icons.settings, size: 14, color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6)),
                                 const SizedBox(width: 4),
                                 Expanded(
                                   child: Text(
@@ -295,7 +342,7 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                               ],
                             ),
                           ],
-                          
+
                           // Notes preview
                           if (record.annotations?.espressoNotes != null && record.annotations!.espressoNotes!.isNotEmpty) ...[
                             const SizedBox(height: 8),
@@ -308,7 +355,7 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                               child: Row(
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                  Icon(Icons.note, size: 12, color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6)),
+                                  Icon(Icons.note, size: 12, color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6)),
                                   const SizedBox(width: 4),
                                   Expanded(
                                     child: Text(
@@ -324,7 +371,7 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                               ),
                             ),
                           ],
-                          
+
                           // Metadata tags
                           if (record.annotations?.extras != null && record.annotations!.extras!['tags'] != null) ...[
                             const SizedBox(height: 6),
@@ -354,6 +401,8 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                       ),
                     ),
                   ),
+                ),
+                  ),
                 );
               },
             ),
@@ -369,7 +418,12 @@ class _HistoryFeatureState extends State<HistoryFeature> {
       child:
           _selectedShot != null
               ? shotDetail(context, _selectedShot!)
-              : Center(child: Text("No shot selected")),
+              : Center(
+                  child: Semantics(
+                    label: 'No shot selected, select a shot from the list',
+                    child: ExcludeSemantics(child: Text("No shot selected")),
+                  ),
+                ),
     );
   }
 
@@ -404,7 +458,7 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                       Text(
                         record.shotTime(),
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
+                          color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
                         ),
                       ),
                     ],
@@ -414,40 +468,58 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                   spacing: 8,
                   runSpacing: 8,
                   children: [
-                    ShadButton.outline(
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(Icons.edit, size: 16),
-                          SizedBox(width: 4),
-                          Text("Edit"),
-                        ],
+                    Semantics(
+                      button: true,
+                      label: 'Edit shot notes',
+                      child: ExcludeSemantics(
+                        child: ShadButton.outline(
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(Icons.edit, size: 16),
+                              SizedBox(width: 4),
+                              Text("Edit"),
+                            ],
+                          ),
+                          onPressed: () => _showEditDialog(context, record),
+                        ),
                       ),
-                      onPressed: () => _showEditDialog(context, record),
                     ),
-                    ShadButton(
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(Icons.replay, size: 16),
-                          SizedBox(width: 4),
-                          Text("Repeat"),
-                        ],
+                    Semantics(
+                      button: true,
+                      label: 'Repeat this shot',
+                      child: ExcludeSemantics(
+                        child: ShadButton(
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(Icons.replay, size: 16),
+                              SizedBox(width: 4),
+                              Text("Repeat"),
+                            ],
+                          ),
+                          onPressed: () {
+                            widget.workflowController.setWorkflow(record.workflow.copyWith());
+                          },
+                        ),
                       ),
-                      onPressed: () {
-                        widget.workflowController.setWorkflow(record.workflow.copyWith());
-                      },
                     ),
-                    ShadButton.destructive(
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(Icons.delete, size: 16),
-                          SizedBox(width: 4),
-                          Text("Delete"),
-                        ],
+                    Semantics(
+                      button: true,
+                      label: 'Delete this shot',
+                      child: ExcludeSemantics(
+                        child: ShadButton.destructive(
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(Icons.delete, size: 16),
+                              SizedBox(width: 4),
+                              Text("Delete"),
+                            ],
+                          ),
+                          onPressed: () => _confirmDelete(context, record),
+                        ),
                       ),
-                      onPressed: () => _confirmDelete(context, record),
                     ),
                   ],
                 ),
@@ -491,19 +563,24 @@ class _HistoryFeatureState extends State<HistoryFeature> {
             SizedBox(height: 20),
             
             // Coffee details section
-            ShadCard(
+            Semantics(
+              explicitChildNodes: true,
+              child: ShadCard(
               padding: EdgeInsets.all(16),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Row(
                     children: [
-                      Icon(Icons.coffee, size: 20),
+                      ExcludeSemantics(child: Icon(Icons.coffee, size: 20)),
                       SizedBox(width: 8),
-                      Text(
-                        "Coffee Details",
-                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
+                      Semantics(
+                        header: true,
+                        child: Text(
+                          "Coffee Details",
+                          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
                       ),
                     ],
@@ -535,22 +612,28 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                 ],
               ),
             ),
+            ),
             SizedBox(height: 16),
-            
+
             // Equipment section
-            ShadCard(
+            Semantics(
+              explicitChildNodes: true,
+              child: ShadCard(
               padding: EdgeInsets.all(16),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Row(
                     children: [
-                      Icon(Icons.settings, size: 20),
+                      ExcludeSemantics(child: Icon(Icons.settings, size: 20)),
                       SizedBox(width: 8),
-                      Text(
-                        "Equipment",
-                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
+                      Semantics(
+                        header: true,
+                        child: Text(
+                          "Equipment",
+                          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
                       ),
                     ],
@@ -577,23 +660,29 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                 ],
               ),
             ),
+            ),
             
             // Notes section
             if (record.annotations?.espressoNotes != null && record.annotations!.espressoNotes!.isNotEmpty) ...[
               SizedBox(height: 16),
-              ShadCard(
+              Semantics(
+                explicitChildNodes: true,
+                child: ShadCard(
                 padding: EdgeInsets.all(16),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Row(
                       children: [
-                        Icon(Icons.note, size: 20),
+                        ExcludeSemantics(child: Icon(Icons.note, size: 20)),
                         SizedBox(width: 8),
-                        Text(
-                          "Notes",
-                          style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                            fontWeight: FontWeight.bold,
+                        Semantics(
+                          header: true,
+                          child: Text(
+                            "Notes",
+                            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
                           ),
                         ),
                       ],
@@ -606,24 +695,30 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                   ],
                 ),
               ),
+              ),
             ],
             
             // Extras section
             if (record.annotations?.extras != null && record.annotations!.extras!.isNotEmpty) ...[
               SizedBox(height: 16),
-              ShadCard(
+              Semantics(
+                explicitChildNodes: true,
+                child: ShadCard(
                 padding: EdgeInsets.all(16),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Row(
                       children: [
-                        Icon(Icons.label, size: 20),
+                        ExcludeSemantics(child: Icon(Icons.label, size: 20)),
                         SizedBox(width: 8),
-                        Text(
-                          "Additional Info",
-                          style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                            fontWeight: FontWeight.bold,
+                        Semantics(
+                          header: true,
+                          child: Text(
+                            "Additional Info",
+                            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
                           ),
                         ),
                       ],
@@ -633,35 +728,40 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                       if (entry.key == 'tags' && entry.value is List) {
                         return Padding(
                           padding: EdgeInsets.only(bottom: 8),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                "Tags:",
-                                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                  color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
-                                ),
-                              ),
-                              SizedBox(height: 4),
-                              Wrap(
-                                spacing: 6,
-                                runSpacing: 6,
+                          child: Semantics(
+                            label: 'Tags: ${(entry.value as List).join(", ")}',
+                            child: ExcludeSemantics(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                  for (var tag in (entry.value as List))
-                                    Container(
-                                      padding: EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-                                      decoration: BoxDecoration(
-                                        color: Theme.of(context).colorScheme.tertiaryContainer,
-                                        borderRadius: BorderRadius.circular(16),
-                                      ),
-                                      child: Text(
-                                        tag.toString(),
-                                        style: Theme.of(context).textTheme.bodySmall,
-                                      ),
+                                  Text(
+                                    "Tags:",
+                                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                      color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
                                     ),
+                                  ),
+                                  SizedBox(height: 4),
+                                  Wrap(
+                                    spacing: 6,
+                                    runSpacing: 6,
+                                    children: [
+                                      for (var tag in (entry.value as List))
+                                        Container(
+                                          padding: EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                                          decoration: BoxDecoration(
+                                            color: Theme.of(context).colorScheme.tertiaryContainer,
+                                            borderRadius: BorderRadius.circular(16),
+                                          ),
+                                          child: Text(
+                                            tag.toString(),
+                                            style: Theme.of(context).textTheme.bodySmall,
+                                          ),
+                                        ),
+                                    ],
+                                  ),
                                 ],
                               ),
-                            ],
+                            ),
                           ),
                         );
                       }
@@ -674,24 +774,33 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                   ],
                 ),
               ),
+              ),
             ],
             
             SizedBox(height: 20),
             
             // Chart section
-            Text(
-              "Shot Profile",
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
+            Semantics(
+              header: true,
+              child: Text(
+                "Shot Profile",
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
             SizedBox(height: 12),
-            SizedBox(
-              height: 500,
-              child: ShotChart(
-                key: ValueKey(record.id),
-                shotSnapshots: record.measurements,
-                shotStartTime: record.timestamp,
+            Semantics(
+              label: _chartSummaryLabel(record),
+              child: ExcludeSemantics(
+                child: SizedBox(
+                  height: 500,
+                  child: ShotChart(
+                    key: ValueKey(record.id),
+                    shotSnapshots: record.measurements,
+                    shotStartTime: record.timestamp,
+                  ),
+                ),
               ),
             ),
             
@@ -701,7 +810,7 @@ class _HistoryFeatureState extends State<HistoryFeature> {
               child: Text(
                 "Shot ID: ${record.id}",
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                  color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
                 ),
               ),
             ),
@@ -818,26 +927,31 @@ class _StatCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ShadCard(
-      padding: EdgeInsets.all(12),
-      child: Column(
-        children: [
-          Icon(icon, size: 24, color: Theme.of(context).colorScheme.primary),
-          SizedBox(height: 8),
-          Text(
-            value,
-            style: Theme.of(context).textTheme.titleLarge?.copyWith(
-              fontWeight: FontWeight.bold,
-            ),
+    return Semantics(
+      label: '$label: $value',
+      child: ExcludeSemantics(
+        child: ShadCard(
+          padding: EdgeInsets.all(12),
+          child: Column(
+            children: [
+              Icon(icon, size: 24, color: Theme.of(context).colorScheme.primary),
+              SizedBox(height: 8),
+              Text(
+                value,
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              SizedBox(height: 4),
+              Text(
+                label,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                ),
+              ),
+            ],
           ),
-          SizedBox(height: 4),
-          Text(
-            label,
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }
@@ -856,27 +970,29 @@ class _DetailRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 8.0),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SizedBox(
-            width: 100,
-            child: Text(
-              "$label:",
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
+    return MergeSemantics(
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 8.0),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: 100,
+              child: Text(
+                "$label:",
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                ),
               ),
             ),
-          ),
-          Expanded(
-            child: Text(
-              value,
-              style: Theme.of(context).textTheme.bodyMedium,
+            Expanded(
+              child: Text(
+                value,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/home_feature/tiles/history_tile.dart
+++ b/lib/src/home_feature/tiles/history_tile.dart
@@ -85,7 +85,10 @@ class _HistoryTileState extends State<HistoryTile> {
   @override
   Widget build(BuildContext context) {
     if (_currentShot == null) {
-      return Text("No shots yet.");
+      return Semantics(
+        label: 'No shots recorded yet',
+        child: ExcludeSemantics(child: Text("No shots yet.")),
+      );
     }
     return _body(context);
   }
@@ -96,26 +99,25 @@ class _HistoryTileState extends State<HistoryTile> {
     var canGoForward = _currentIndex > 0; // toward newer
     return Semantics(
       explicitChildNodes: true,
-      label: 'Shot history',
       child: Column(
       children: [
         Text(shot.shotTime()),
         Semantics(
           button: true,
-          label:
-              'View shot details for ${shot.workflow.profile.title} at ${shot.shotTime()}',
-          child: TapRegion(
-            child: ExcludeSemantics(child: _shotDetails(context, shot)),
-            onTapInside: (cb) {
-              Navigator.pushNamed(
-                context,
-                HistoryFeature.routeName,
-                arguments: jsonEncode(shot.toJson()),
-              );
-            },
+          label: _shotLabel(shot),
+          child: ExcludeSemantics(
+            child: InkWell(
+              onTap: () {
+                Navigator.pushNamed(
+                  context,
+                  HistoryFeature.routeName,
+                  arguments: jsonEncode(shot.toJson()),
+                );
+              },
+              child: _shotDetails(context, shot),
+            ),
           ),
         ),
-        _shotSummary(shot),
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
@@ -166,7 +168,7 @@ class _HistoryTileState extends State<HistoryTile> {
     );
   }
 
-  Widget _shotSummary(ShotRecord shot) {
+  String _shotLabel(ShotRecord shot) {
     final doseIn =
         shot.annotations?.actualDoseWeight ??
         shot.workflow.context?.targetDoseWeight;
@@ -176,6 +178,8 @@ class _HistoryTileState extends State<HistoryTile> {
         shot.measurements.last.scale?.weight ??
         0.0;
     final parts = <String>[
+      'View shot details',
+      shot.shotTime(),
       shot.workflow.profile.title,
       if (doseIn != null)
         '${doseIn.toStringAsFixed(1)} to ${yield_.toStringAsFixed(1)} grams',
@@ -184,10 +188,7 @@ class _HistoryTileState extends State<HistoryTile> {
       if (shot.workflow.context?.grinderModel != null)
         shot.workflow.context!.grinderModel!,
     ];
-    return Semantics(
-      label: parts.join(', '),
-      child: const SizedBox.shrink(),
-    );
+    return parts.join(', ');
   }
 
   Widget _shotDetails(BuildContext context, ShotRecord shot) {

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -161,96 +161,107 @@ class _SettingsViewState extends State<SettingsView>
       description: 'Configure how external clients can control the machine',
       onInfoPressed: () => showGatewayModeInfoDialog(context),
       children: [
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'Gateway Mode',
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    fontWeight: FontWeight.w500,
+        MergeSemantics(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Gateway Mode',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w500,
+                    ),
+              ),
+              const SizedBox(height: 8),
+              DropdownButton<GatewayMode>(
+                isExpanded: true,
+                value: widget.controller.gatewayMode,
+                onChanged: (v) {
+                  if (v != null) widget.controller.updateGatewayMode(v);
+                },
+                items: const [
+                  DropdownMenuItem(
+                    value: GatewayMode.full,
+                    child: Text('Full (Rea has no control)'),
                   ),
-            ),
-            const SizedBox(height: 8),
-            DropdownButton<GatewayMode>(
-              isExpanded: true,
-              value: widget.controller.gatewayMode,
-              onChanged: (v) {
-                if (v != null) widget.controller.updateGatewayMode(v);
-              },
-              items: const [
-                DropdownMenuItem(
-                  value: GatewayMode.full,
-                  child: Text('Full (Rea has no control)'),
-                ),
-                DropdownMenuItem(
-                  value: GatewayMode.tracking,
-                  child: Text('Tracking (Rea will stop shot if target weight is reached)'),
-                ),
-                DropdownMenuItem(
-                  value: GatewayMode.disabled,
-                  child: Text('Disabled (Rea has full control)'),
-                ),
-              ],
-            ),
-          ],
+                  DropdownMenuItem(
+                    value: GatewayMode.tracking,
+                    child: Text('Tracking (Rea will stop shot if target weight is reached)'),
+                  ),
+                  DropdownMenuItem(
+                    value: GatewayMode.disabled,
+                    child: Text('Disabled (Rea has full control)'),
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ],
     );
   }
 
   Widget _buildBatterySection() {
-    return ShadCard(
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              const Icon(Icons.battery_charging_full_outlined, size: 20),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  'Battery & Charging',
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 4),
-          Text(
-            'Smart charging and night mode settings',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
-                ),
-          ),
-          const SizedBox(height: 16),
-          Text(
-            'Mode: ${_chargingModeLabel(widget.controller.chargingMode)}',
-            style: Theme.of(context).textTheme.bodyMedium,
-          ),
-          if (widget.controller.nightModeEnabled) ...[
-            const SizedBox(height: 4),
-            Text(
-              'Night mode enabled',
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-          ],
-          const SizedBox(height: 12),
-          ShadButton.outline(
-            onPressed: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (_) => BatteryChargingSettingsPage(
-                    controller: widget.controller,
+    return Semantics(
+      explicitChildNodes: true,
+      child: ShadCard(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.battery_charging_full_outlined, size: 20),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Battery & Charging',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
                   ),
                 ),
-              );
-            },
-            child: const Text('Configure'),
-          ),
-        ],
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Smart charging and night mode settings',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                  ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Mode: ${_chargingModeLabel(widget.controller.chargingMode)}',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            if (widget.controller.nightModeEnabled) ...[
+              const SizedBox(height: 4),
+              Text(
+                'Night mode enabled',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+            const SizedBox(height: 12),
+            Semantics(
+              button: true,
+              label: 'Configure battery and charging settings',
+              child: ExcludeSemantics(
+                child: ShadButton.outline(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => BatteryChargingSettingsPage(
+                          controller: widget.controller,
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('Configure'),
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -281,55 +292,64 @@ class _SettingsViewState extends State<SettingsView>
       subtitle = 'Enabled, no sleep timeout';
     }
 
-    return ShadCard(
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              const Icon(Icons.schedule_outlined, size: 20),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  'Presence & Sleep',
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 4),
-          Text(
-            'Automatic sleep and scheduled wake settings',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context)
-                      .colorScheme
-                      .onSurface
-                      .withValues(alpha: 0.7),
-                ),
-          ),
-          const SizedBox(height: 16),
-          Text(
-            subtitle,
-            style: Theme.of(context).textTheme.bodyMedium,
-          ),
-          const SizedBox(height: 12),
-          ShadButton.outline(
-            onPressed: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (_) => PresenceSettingsPage(
-                    controller: widget.controller,
-                    keepAwakeUntil: widget.presenceController.keepAwakeUntil,
+    return Semantics(
+      explicitChildNodes: true,
+      child: ShadCard(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.schedule_outlined, size: 20),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Presence & Sleep',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
                   ),
                 ),
-              );
-            },
-            child: const Text('Configure'),
-          ),
-        ],
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Automatic sleep and scheduled wake settings',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.7),
+                  ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              subtitle,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 12),
+            Semantics(
+              button: true,
+              label: 'Configure presence and sleep settings',
+              child: ExcludeSemantics(
+                child: ShadButton.outline(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => PresenceSettingsPage(
+                          controller: widget.controller,
+                          keepAwakeUntil: widget.presenceController.keepAwakeUntil,
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('Configure'),
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -342,150 +362,170 @@ class _SettingsViewState extends State<SettingsView>
     final machineName = _resolveDeviceName(machineId);
     final scaleName = _resolveDeviceName(scaleId);
 
-    return ShadCard(
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              const Icon(Icons.devices_outlined, size: 20),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  'Device Management',
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 4),
-          Text(
-            'Configure preferred auto-connect devices',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context)
-                      .colorScheme
-                      .onSurface
-                      .withValues(alpha: 0.7),
-                ),
-          ),
-          const SizedBox(height: 16),
-          Text(
-            'Machine: ${machineName ?? "Not set"}',
-            style: Theme.of(context).textTheme.bodyMedium,
-          ),
-          const SizedBox(height: 4),
-          Text(
-            'Scale: ${scaleName ?? "Not set"}',
-            style: Theme.of(context).textTheme.bodyMedium,
-          ),
-          const SizedBox(height: 12),
-          ShadButton.outline(
-            onPressed: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (_) => DeviceManagementPage(
-                    settingsController: widget.controller,
-                    deviceController: widget.deviceController,
+    return Semantics(
+      explicitChildNodes: true,
+      child: ShadCard(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.devices_outlined, size: 20),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Device Management',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
                   ),
                 ),
-              );
-            },
-            child: const Text('Configure'),
-          ),
-          const Divider(height: 32),
-          Text(
-            'Simulated Devices',
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.w500,
-                ),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            'Select which simulated devices appear in scan results',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
-                ),
-          ),
-          const SizedBox(height: 8),
-          for (final type in SimulatedDevicesTypes.values)
-            ShadSwitch(
-              value: widget.controller.simulatedDevices.contains(type),
-              onChanged: (v) async {
-                final current = Set<SimulatedDevicesTypes>.from(
-                  widget.controller.simulatedDevices,
-                );
-                if (v) {
-                  current.add(type);
-                } else {
-                  current.remove(type);
-                }
-                _log.info("simulated devices: $current");
-                await widget.controller.setSimulatedDevices(current);
-              },
-              label: Text(type.name[0].toUpperCase() + type.name.substring(1)),
+              ],
             ),
-        ],
+            const SizedBox(height: 4),
+            Text(
+              'Configure preferred auto-connect devices',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.7),
+                  ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Machine: ${machineName ?? "Not set"}',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Scale: ${scaleName ?? "Not set"}',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 12),
+            Semantics(
+              button: true,
+              label: 'Configure preferred devices',
+              child: ExcludeSemantics(
+                child: ShadButton.outline(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => DeviceManagementPage(
+                          settingsController: widget.controller,
+                          deviceController: widget.deviceController,
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('Configure'),
+                ),
+              ),
+            ),
+            const Divider(height: 32),
+            Text(
+              'Simulated Devices',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w500,
+                  ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Select which simulated devices appear in scan results',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                  ),
+            ),
+            const SizedBox(height: 8),
+            for (final type in SimulatedDevicesTypes.values)
+              MergeSemantics(
+                child: ShadSwitch(
+                  value: widget.controller.simulatedDevices.contains(type),
+                  onChanged: (v) async {
+                    final current = Set<SimulatedDevicesTypes>.from(
+                      widget.controller.simulatedDevices,
+                    );
+                    if (v) {
+                      current.add(type);
+                    } else {
+                      current.remove(type);
+                    }
+                    _log.info("simulated devices: $current");
+                    await widget.controller.setSimulatedDevices(current);
+                  },
+                  label: Text(type.name[0].toUpperCase() + type.name.substring(1)),
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }
 
   Widget _buildDataManagementSection() {
-    return ShadCard(
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              const Icon(Icons.storage_outlined, size: 20),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  'Data Management',
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 4),
-          Text(
-            'Export, import, and backup your data',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context)
-                      .colorScheme
-                      .onSurface
-                      .withValues(alpha: 0.7),
-                ),
-          ),
-          const SizedBox(height: 16),
-          Text(
-            'Backup, restore, and privacy settings',
-            style: Theme.of(context).textTheme.bodyMedium,
-          ),
-          const SizedBox(height: 12),
-          ShadButton.outline(
-            onPressed: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (_) => DataManagementPage(
-                    controller: widget.controller,
-                    persistenceController: widget.persistenceController,
-                    profileStorageService: widget.profileStorageService,
-                    beanStorageService: widget.beanStorageService,
-                    grinderStorageService: widget.grinderStorageService,
-                    workflowController: widget.workflowController,
+    return Semantics(
+      explicitChildNodes: true,
+      child: ShadCard(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.storage_outlined, size: 20),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Data Management',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
                   ),
                 ),
-              );
-            },
-            child: const Text('Configure'),
-          ),
-        ],
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Export, import, and backup your data',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.7),
+                  ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Backup, restore, and privacy settings',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 12),
+            Semantics(
+              button: true,
+              label: 'Configure data management',
+              child: ExcludeSemantics(
+                child: ShadButton.outline(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => DataManagementPage(
+                          controller: widget.controller,
+                          persistenceController: widget.persistenceController,
+                          profileStorageService: widget.profileStorageService,
+                          beanStorageService: widget.beanStorageService,
+                          grinderStorageService: widget.grinderStorageService,
+                          workflowController: widget.workflowController,
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('Configure'),
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -518,16 +558,22 @@ class _SettingsViewState extends State<SettingsView>
             style: Theme.of(context).textTheme.bodySmall,
           ),
           const SizedBox(height: 8),
-          ShadButton.outline(
-            onPressed: () async {
-              final result =
-                  await Permission.manageExternalStorage.request();
-              if (result.isPermanentlyDenied) {
-                await openAppSettings();
-              }
-              await _checkStoragePermission();
-            },
-            child: const Text('Grant Storage Access'),
+          Semantics(
+            button: true,
+            label: 'Grant full storage access',
+            child: ExcludeSemantics(
+              child: ShadButton.outline(
+                onPressed: () async {
+                  final result =
+                      await Permission.manageExternalStorage.request();
+                  if (result.isPermanentlyDenied) {
+                    await openAppSettings();
+                  }
+                  await _checkStoragePermission();
+                },
+                child: const Text('Grant Storage Access'),
+              ),
+            ),
           ),
         ],
       ),
@@ -547,35 +593,59 @@ class _SettingsViewState extends State<SettingsView>
         _buildStoragePermissionRow(),
         const Divider(height: 24),
         if (!widget.webUIService.isServing)
-          ShadButton(
-            onPressed: _startSelectedSkin,
-            child: const Text("Start WebUI Server"),
+          Semantics(
+            button: true,
+            label: 'Start web interface server',
+            child: ExcludeSemantics(
+              child: ShadButton(
+                onPressed: _startSelectedSkin,
+                child: const Text("Start WebUI Server"),
+              ),
+            ),
           )
         else
           Wrap(
             spacing: 12,
             runSpacing: 12,
             children: [
-              ShadButton(
-                onPressed: () async {
-                  await launchUrl(Uri.parse('http://localhost:3000'));
-                },
-                child: const Text("Open UI in browser"),
+              Semantics(
+                button: true,
+                label: 'Open web interface in browser',
+                child: ExcludeSemantics(
+                  child: ShadButton(
+                    onPressed: () async {
+                      await launchUrl(Uri.parse('http://localhost:3000'));
+                    },
+                    child: const Text("Open UI in browser"),
+                  ),
+                ),
               ),
-              ShadButton.destructive(
-                onPressed: () async {
-                  await widget.webUIService.stopServing();
-                  setState(() {});
-                },
-                child: const Text("Stop WebUI Server"),
+              Semantics(
+                button: true,
+                label: 'Stop web interface server',
+                child: ExcludeSemantics(
+                  child: ShadButton.destructive(
+                    onPressed: () async {
+                      await widget.webUIService.stopServing();
+                      setState(() {});
+                    },
+                    child: const Text("Stop WebUI Server"),
+                  ),
+                ),
               ),
             ],
           ),
         if (!BuildInfo.appStore) ...[
           const Divider(height: 24),
-          ShadButton.outline(
-            onPressed: () => _checkForSkinUpdates(context),
-            child: const Text("Check for Skin Updates"),
+          Semantics(
+            button: true,
+            label: 'Check for skin updates',
+            child: ExcludeSemantics(
+              child: ShadButton.outline(
+                onPressed: () => _checkForSkinUpdates(context),
+                child: const Text("Check for Skin Updates"),
+              ),
+            ),
           ),
         ],
       ],
@@ -603,19 +673,21 @@ class _SettingsViewState extends State<SettingsView>
           ),
         ),
         const Divider(height: 24),
-        ShadSwitch(
-          value: widget.controller.automaticUpdateCheck,
-          onChanged: (v) async {
-            await widget.controller.setAutomaticUpdateCheck(v);
-            if (v) {
-              await widget.updateCheckService?.enableAutomaticChecks();
-            } else {
-              await widget.updateCheckService?.disableAutomaticChecks();
-            }
-          },
-          label: const Text("Automatic update checks"),
-          sublabel: const Text(
-            "Check for updates every 12 hours",
+        MergeSemantics(
+          child: ShadSwitch(
+            value: widget.controller.automaticUpdateCheck,
+            onChanged: (v) async {
+              await widget.controller.setAutomaticUpdateCheck(v);
+              if (v) {
+                await widget.updateCheckService?.enableAutomaticChecks();
+              } else {
+                await widget.updateCheckService?.disableAutomaticChecks();
+              }
+            },
+            label: const Text("Automatic update checks"),
+            sublabel: const Text(
+              "Check for updates every 12 hours",
+            ),
           ),
         ),
         const SizedBox(height: 16),
@@ -650,21 +722,39 @@ class _SettingsViewState extends State<SettingsView>
           spacing: 12,
           runSpacing: 12,
           children: [
-            ShadButton.outline(
-              onPressed: () => Navigator.of(context).pushNamed(PluginsSettingsView.routeName),
-              child: const Text("Plugins"),
+            Semantics(
+              button: true,
+              label: 'Open plugins settings',
+              child: ExcludeSemantics(
+                child: ShadButton.outline(
+                  onPressed: () => Navigator.of(context).pushNamed(PluginsSettingsView.routeName),
+                  child: const Text("Plugins"),
+                ),
+              ),
             ),
-            ShadButton.outline(
-              onPressed: () => _checkForUpdates(context),
-              child: const Text("Check for updates"),
+            Semantics(
+              button: true,
+              label: 'Check for app updates',
+              child: ExcludeSemantics(
+                child: ShadButton.outline(
+                  onPressed: () => _checkForUpdates(context),
+                  child: const Text("Check for updates"),
+                ),
+              ),
             ),
           ],
         ),
         if (!BuildInfo.appStore) ...[
           const Divider(height: 24),
-          ShadButton.destructive(
-            onPressed: () => _exitApp(),
-            child: const Text("Exit Streamline-Bridge"),
+          Semantics(
+            button: true,
+            label: 'Exit Streamline-Bridge',
+            child: ExcludeSemantics(
+              child: ShadButton.destructive(
+                onPressed: () => _exitApp(),
+                child: const Text("Exit Streamline-Bridge"),
+              ),
+            ),
           ),
         ],
       ],
@@ -699,11 +789,17 @@ class _SettingsViewState extends State<SettingsView>
           style: Theme.of(context).textTheme.bodySmall,
         ),
         const SizedBox(height: 12),
-        ShadButton.outline(
-          onPressed: () async {
-            await launchUrl(Uri.parse('https://www.gnu.org/licenses/gpl-3.0.html'));
-          },
-          child: const Text('View GPL v3 License'),
+        Semantics(
+          button: true,
+          label: 'View GPL version 3 license',
+          child: ExcludeSemantics(
+            child: ShadButton.outline(
+              onPressed: () async {
+                await launchUrl(Uri.parse('https://www.gnu.org/licenses/gpl-3.0.html'));
+              },
+              child: const Text('View GPL v3 License'),
+            ),
+          ),
         ),
       ],
     );
@@ -756,6 +852,7 @@ class _SettingsViewState extends State<SettingsView>
                     child: IconButton(
                       padding: EdgeInsets.zero,
                       iconSize: 16,
+                      tooltip: 'Remove ${skin.name}',
                       icon: const Icon(Icons.delete_outline),
                       onPressed: () async {
                         // Close the dropdown first
@@ -1193,43 +1290,52 @@ class _SettingsSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ShadCard(
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(icon, size: 20),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  title,
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
-                ),
-              ),
-              if (onInfoPressed != null)
-                IconButton(
-                  icon: const Icon(Icons.info_outline, size: 18),
-                  onPressed: onInfoPressed,
-                  tooltip: 'Learn more',
-                ),
-            ],
-          ),
-          if (description != null) ...[
-            const SizedBox(height: 4),
-            Text(
-              description!,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
+    return Semantics(
+      explicitChildNodes: true,
+      child: ShadCard(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(icon, size: 20),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    title,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
                   ),
+                ),
+                if (onInfoPressed != null)
+                  Semantics(
+                    button: true,
+                    label: 'Learn more about $title',
+                    child: ExcludeSemantics(
+                      child: IconButton(
+                        icon: const Icon(Icons.info_outline, size: 18),
+                        onPressed: onInfoPressed,
+                        tooltip: 'Learn more',
+                      ),
+                    ),
+                  ),
+              ],
             ),
+            if (description != null) ...[
+              const SizedBox(height: 4),
+              Text(
+                description!,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                    ),
+              ),
+            ],
+            const SizedBox(height: 16),
+            ...children,
           ],
-          const SizedBox(height: 16),
-          ...children,
-        ],
+        ),
       ),
     );
   }
@@ -1246,21 +1352,23 @@ class _SettingRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 12.0),
-      child: Row(
-        children: [
-          SizedBox(
-            width: 140,
-            child: Text(
-              label,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    fontWeight: FontWeight.w500,
-                  ),
+    return MergeSemantics(
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 12.0),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 140,
+              child: Text(
+                label,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w500,
+                    ),
+              ),
             ),
-          ),
-          Expanded(child: child),
-        ],
+            Expanded(child: child),
+          ],
+        ),
       ),
     );
   }
@@ -1274,27 +1382,29 @@ class _InfoRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 8.0),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SizedBox(
-            width: 80,
-            child: Text(
-              '$label:',
-              style: Theme.of(context).textTheme.bodySmall,
+    return MergeSemantics(
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 8.0),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: 80,
+              child: Text(
+                '$label:',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
             ),
-          ),
-          Expanded(
-            child: Text(
-              value,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    fontFamily: 'monospace',
-                  ),
+            Expanded(
+              child: Text(
+                value,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontFamily: 'monospace',
+                    ),
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -1299,7 +1299,7 @@ class _SettingsSection extends StatelessWidget {
           children: [
             Row(
               children: [
-                Icon(icon, size: 20),
+                ExcludeSemantics(child: Icon(icon, size: 20)),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(


### PR DESCRIPTION
## Summary

- Add comprehensive TalkBack/screen reader + keyboard accessibility to Settings view, History view, and dashboard History tile
- Replace `TapRegion` with `InkWell` for keyboard Tab navigation in history list items and dashboard tile
- Clean all `withOpacity` deprecation warnings and async context lint issues in `history_feature.dart`

### Settings view
- `Semantics(explicitChildNodes: true)` on all sections (both `_SettingsSection` and raw `ShadCard` sections)
- `MergeSemantics` on all label+control pairs (`_SettingRow`, `_InfoRow`, switches, gateway dropdown)
- `Semantics(button: true)` with `ExcludeSemantics` on all buttons (Configure, Start/Stop WebUI, Plugins, Check for updates, Exit, Grant storage, View license)
- `ExcludeSemantics` on all decorative icons
- Tooltip on skin delete button for accessibility

### History view
- List items: contextual labels (time, coffee, roaster, profile, dose, yield, grinder, duration, notes hint), keyboard-focusable via `InkWell`
- Search: result count as `liveRegion` for TalkBack announcements
- Detail view: section headers, `explicitChildNodes` on sections, `MergeSemantics` on stat cards and detail rows
- Chart: text summary label (duration, peak pressure, peak flow) with `ExcludeSemantics` on the visual chart
- Tags grouped into single semantic label
- Action buttons (Edit, Repeat, Delete) labeled
- Empty states ("No shot selected") wrapped with descriptive labels

### Dashboard history tile
- Shot chart area keyboard-focusable via `InkWell`
- Shot summary merged into button label (was invisible `SizedBox.shrink`)
- "No shots yet" empty state wrapped with Semantics

Reviewed through 2 full review cycles (4 independent reviewers per cycle) + final arbiter pass.

## Test plan

- [x] `flutter analyze` — zero issues on all modified files
- [x] `flutter test` — 847 tests pass
- [ ] TalkBack verification on Android device
- [x] Keyboard navigation verification on macOS (Tab through settings, history list, detail view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)