### PR TITLE
fix: default smart charging off, import from de1app (#145)

### DIFF
--- a/doc/plans/archive/smart-charging-defaults/2026-04-13-smart-charging-defaults-and-import.md
+++ b/doc/plans/archive/smart-charging-defaults/2026-04-13-smart-charging-defaults-and-import.md
@@ -1,0 +1,91 @@
+# Smart Charging: default off + import from de1app
+
+Tracks: [tadelv/reaprime#145](https://github.com/tadelv/reaprime/issues/145)
+
+## Problem
+
+tobbenb installed 0.5.11 on a Teclast tablet with a battery mod (no physical battery — relies on USB-powered operation). On first launch Bridge imported de1app settings, then after ~2 minutes the smart-charging logic cut USB power and the tablet shut down. There was no way to find and disable the setting fast enough.
+
+Two issues on the Bridge side:
+
+1. **Default is wrong for the battery-mod population.** `settings_service.dart:299` returns `ChargingMode.balanced` when no value is stored. For tablets without a battery, *any* mode other than `disabled` can brick the tablet when it hits the hysteresis low-water mark.
+2. **de1app's `smart_battery_charging` is not imported.** Users who already configured smart charging correctly in de1app (disabled, or longevity/high-availability) have to redo it in Bridge. A tablet that was happily running with de1app's `smart_battery_charging 0` lands in Bridge with `balanced` and starts cycling.
+
+A third item — making the smart-charging settings visible in the Streamline.js skin — is out of scope (lives in `allofmeng/streamline_project`).
+
+## Scope
+
+In-scope (this PR, Bridge only):
+
+1. Flip the default in `SettingsService.chargingMode()` from `balanced` to `disabled`.
+2. Parse `smart_battery_charging` out of `settings.tdb` and apply it during onboarding import, with the mapping below.
+
+Out of scope:
+
+- Streamline.js skin exposure of smart charging settings.
+- Changes to the smart charging logic itself (`charging_logic.dart`).
+- Changes to the Battery & Charging settings UI.
+- Migration of existing installs already storing `balanced` — those users already went through onboarding and (presumably) their tablets survived, so we don't want to change their behavior out from under them. Only the default-for-new-installs changes.
+
+## Mapping
+
+| de1app `smart_battery_charging` | Bridge `ChargingMode` |
+|---|---|
+| `0` | `disabled` |
+| `1` | `longevity` |
+| `2` | `highAvailability` |
+| missing / unrecognized | *no change* (don't touch the stored value) |
+
+No de1app analog for Bridge's `balanced` mode. We lose nothing — de1app simply never produced a setting that would map there.
+
+Rationale for leaving unrecognized values alone: the user may have already configured Bridge; the import pipeline in general prefers "overlay de1app values where present" rather than "reset to defaults."
+
+## Files
+
+### Modify
+
+- **`lib/src/settings/settings_service.dart`** — line 299, change `ChargingMode.balanced.name` → `ChargingMode.disabled.name`, and the fallback on line 301 → `ChargingMode.disabled`.
+- **`lib/src/import/parsers/settings_tdb_parser.dart`**
+  - Add nullable `ChargingMode? chargingMode` field to `SettingsTdbResult` (and constructor, `isEmpty` check).
+  - In `SettingsTdbParser.parse()`, read `data['smart_battery_charging']`, map via a private helper, return the result.
+- **`lib/src/import/de1app_importer.dart`** — in Phase 5 (settings import, ~line 348) call `settingsController!.setChargingMode(settings.chargingMode!)` when non-null.
+
+### Tests — modify
+
+- **`test/import/settings_tdb_parser_test.dart`**
+  - `smart_battery_charging 0` → `ChargingMode.disabled`
+  - `smart_battery_charging 1` → `ChargingMode.longevity`
+  - `smart_battery_charging 2` → `ChargingMode.highAvailability`
+  - `smart_battery_charging 99` → `null` (unknown, don't touch)
+  - missing key → `null`
+  - `isEmpty` still `true` when only `smart_battery_charging` is absent and all other fields are null
+- **`test/import/de1app_importer_test.dart`** — extend an existing settings-import test to assert the mapped value was applied via `SettingsController`.
+- **New test** in `test/settings/settings_service_test.dart` (or whichever existing file covers defaults) asserting the fresh-install default is `ChargingMode.disabled`. If no such file exists, add one — small scope, targeted.
+
+## Non-goals / explicitly not changing
+
+- **`de1_skin_settings.tcl` in de1app** — not ours.
+- **tobbenb's "clicking the row only opens fan setting" bug** — per triage, that's a Streamline.js skin issue (the current user's skin), not Bridge. Out of scope for this PR.
+- **Migration for existing Bridge installs** — if someone already has `chargingMode = balanced` stored, we leave it. Default-flip only affects users with no stored value.
+
+## Test plan
+
+1. `flutter test test/import/settings_tdb_parser_test.dart`
+2. `flutter test test/import/de1app_importer_test.dart`
+3. `flutter test test/settings/` (or full settings suite)
+4. `flutter test` (full suite before PR)
+5. `flutter analyze` — no new warnings
+6. Manual / MCP: start fresh-install simulated app (`app_start` with wiped prefs), check `settings_get` → `chargingMode: disabled`. Not strictly required given unit coverage, but a nice confidence pass.
+
+## Rollout / risk
+
+Low risk. Two surgical changes:
+
+- Default flip: only affects users on first onboarding of a Bridge build that ships this change. Existing users with stored `chargingMode` are untouched.
+- Import: additive — new code path only runs when `settings.tdb` has `smart_battery_charging` and the import pipeline decides to apply settings (same guard as all other imported fields).
+
+The de1app Samsung auto-reset-to-0 quirk is not relevant: by the time we're reading `settings.tdb`, de1app has already written whatever value it ended up with. We parse what's on disk.
+
+## Open questions
+
+None blocking. One judgement call logged in the mapping table: `balanced` has no de1app analog; we accept that and do nothing if de1app's value doesn't map cleanly.

--- a/lib/src/import/de1app_importer.dart
+++ b/lib/src/import/de1app_importer.dart
@@ -384,6 +384,13 @@ class De1appImporter {
                 .setSleepTimeoutMinutes(settings.sleepTimeoutMinutes!);
           }
 
+          // Charging mode — map from de1app's smart_battery_charging enum.
+          // Unknown values leave the current Bridge setting untouched (see
+          // SettingsTdbParser._parseChargingMode).
+          if (settings.chargingMode != null) {
+            await settingsController!.setChargingMode(settings.chargingMode!);
+          }
+
           // Preferred device IDs (Android only — BLE IDs are MAC addresses)
           if (Platform.isAndroid) {
             if (settings.machineBluetoothAddress != null) {

--- a/lib/src/import/parsers/settings_tdb_parser.dart
+++ b/lib/src/import/parsers/settings_tdb_parser.dart
@@ -1,4 +1,5 @@
 import 'package:reaprime/src/import/parsers/tcl_parser.dart';
+import 'package:reaprime/src/settings/charging_mode.dart';
 
 /// Parsed result from a de1app `settings.tdb` file.
 ///
@@ -14,6 +15,7 @@ class SettingsTdbResult {
   // Settings
   final bool? keepScaleOn;
   final int? sleepTimeoutMinutes;
+  final ChargingMode? chargingMode;
 
   // Workflow context
   final double? doseWeight;
@@ -44,6 +46,7 @@ class SettingsTdbResult {
     this.keepAwakeForMinutes,
     this.keepScaleOn,
     this.sleepTimeoutMinutes,
+    this.chargingMode,
     this.doseWeight,
     this.grinderSetting,
     this.grinderModel,
@@ -68,6 +71,7 @@ class SettingsTdbResult {
       keepAwakeForMinutes == null &&
       keepScaleOn == null &&
       sleepTimeoutMinutes == null &&
+      chargingMode == null &&
       doseWeight == null &&
       grinderSetting == null &&
       grinderModel == null &&
@@ -141,6 +145,7 @@ class SettingsTdbParser {
       keepAwakeForMinutes: keepAwakeFor,
       keepScaleOn: _parseBool(data['keep_scale_on']),
       sleepTimeoutMinutes: sleepTimeoutMinutes,
+      chargingMode: _parseChargingMode(data['smart_battery_charging']),
       doseWeight: doseWeight,
       grinderSetting: grinderSetting,
       grinderModel: grinderModel,
@@ -161,6 +166,30 @@ class SettingsTdbParser {
   static bool? _parseBool(dynamic value) {
     if (value == null) return null;
     return value.toString() == '1';
+  }
+
+  /// Maps de1app's `smart_battery_charging` integer enum to Bridge's
+  /// [ChargingMode]. Unknown values return null so the caller leaves the
+  /// existing Bridge setting untouched.
+  ///
+  /// de1app values:
+  /// - `0` → off (USB charger always on) → [ChargingMode.disabled]
+  /// - `1` → longevity (55-65%) → [ChargingMode.longevity]
+  /// - `2` → high availability (90-95%) → [ChargingMode.highAvailability]
+  ///
+  /// de1app has no analog for [ChargingMode.balanced].
+  static ChargingMode? _parseChargingMode(dynamic value) {
+    if (value == null) return null;
+    switch (value.toString()) {
+      case '0':
+        return ChargingMode.disabled;
+      case '1':
+        return ChargingMode.longevity;
+      case '2':
+        return ChargingMode.highAvailability;
+      default:
+        return null;
+    }
   }
 
   static int? _parseInt(dynamic value) {

--- a/lib/src/settings/settings_service.dart
+++ b/lib/src/settings/settings_service.dart
@@ -296,9 +296,9 @@ class SharedPreferencesSettingsService extends SettingsService {
   Future<ChargingMode> chargingMode() async {
     return ChargingModeFromString.fromString(
           await prefs.getString(SettingsKeys.chargingMode.name) ??
-              ChargingMode.balanced.name,
+              ChargingMode.disabled.name,
         ) ??
-        ChargingMode.balanced;
+        ChargingMode.disabled;
   }
 
   @override

--- a/test/data_export/settings_export_section_test.dart
+++ b/test/data_export/settings_export_section_test.dart
@@ -47,7 +47,7 @@ void main() {
       expect(settings['volumeFlowMultiplier'], equals(0.3));
       expect(settings['scalePowerMode'], equals('disabled'));
       expect(settings['automaticUpdateCheck'], isTrue);
-      expect(settings['chargingMode'], equals('balanced'));
+      expect(settings['chargingMode'], equals('disabled'));
       expect(settings['nightModeEnabled'], isFalse);
       expect(settings['nightModeSleepTime'], equals(1320));
       expect(settings['nightModeMorningTime'], equals(420));

--- a/test/helpers/mock_settings_service.dart
+++ b/test/helpers/mock_settings_service.dart
@@ -24,7 +24,7 @@ class MockSettingsService extends SettingsService {
   bool _telemetryPromptShown = true; // skip prompt in tests
   bool _telemetryConsentDialogShown = true; // skip dialog in tests
   String? _skippedVersion;
-  ChargingMode _chargingMode = ChargingMode.balanced;
+  ChargingMode _chargingMode = ChargingMode.disabled;
   bool _nightModeEnabled = false;
   int _nightModeSleepTime = 1320;
   int _nightModeMorningTime = 420;

--- a/test/import/de1app_importer_test.dart
+++ b/test/import/de1app_importer_test.dart
@@ -14,6 +14,7 @@ import 'package:reaprime/src/services/storage/bean_storage_service.dart';
 import 'package:reaprime/src/services/storage/grinder_storage_service.dart';
 import 'package:reaprime/src/services/storage/profile_storage_service.dart';
 import 'package:reaprime/src/services/storage/storage_service.dart';
+import 'package:reaprime/src/settings/charging_mode.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/settings/scale_power_mode.dart';
 
@@ -508,7 +509,8 @@ void main() {
           'water_temperature 80\n'
           'water_volume 200\n'
           'flush_flow 4.5\n'
-          'flush_seconds 8\n',
+          'flush_seconds 8\n'
+          'smart_battery_charging 2\n',
         );
 
         // Create a workflow with defaults so it can be updated
@@ -601,6 +603,13 @@ void main() {
         final rinse = storage._currentWorkflow!.rinseData;
         expect(rinse.flow, equals(4.5));
         expect(rinse.duration, equals(8));
+      });
+
+      test('maps smart_battery_charging 2 → highAvailability', () {
+        expect(
+          settingsController.chargingMode,
+          equals(ChargingMode.highAvailability),
+        );
       });
 
       test('has no errors', () {

--- a/test/import/settings_tdb_parser_test.dart
+++ b/test/import/settings_tdb_parser_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/import/parsers/settings_tdb_parser.dart';
+import 'package:reaprime/src/settings/charging_mode.dart';
 
 void main() {
   group('SettingsTdbParser', () {
@@ -170,6 +171,43 @@ water_volume 200
       });
     });
 
+    group('charging mode', () {
+      test('smart_battery_charging 0 → disabled', () {
+        final result =
+            SettingsTdbParser.parse('smart_battery_charging 0\n');
+        expect(result.chargingMode, ChargingMode.disabled);
+      });
+
+      test('smart_battery_charging 1 → longevity', () {
+        final result =
+            SettingsTdbParser.parse('smart_battery_charging 1\n');
+        expect(result.chargingMode, ChargingMode.longevity);
+      });
+
+      test('smart_battery_charging 2 → highAvailability', () {
+        final result =
+            SettingsTdbParser.parse('smart_battery_charging 2\n');
+        expect(result.chargingMode, ChargingMode.highAvailability);
+      });
+
+      test('unknown value returns null (leave Bridge setting untouched)', () {
+        final result =
+            SettingsTdbParser.parse('smart_battery_charging 99\n');
+        expect(result.chargingMode, isNull);
+      });
+
+      test('missing key returns null', () {
+        final result = SettingsTdbParser.parse('');
+        expect(result.chargingMode, isNull);
+      });
+
+      test('chargingMode alone makes isEmpty false', () {
+        final result =
+            SettingsTdbParser.parse('smart_battery_charging 0\n');
+        expect(result.isEmpty, false);
+      });
+    });
+
     group('rinse settings', () {
       test('parses rinse flow and duration', () {
         final content = '''
@@ -191,6 +229,7 @@ flush_seconds 10
         expect(result.keepAwakeForMinutes, isNull);
         expect(result.keepScaleOn, isNull);
         expect(result.sleepTimeoutMinutes, isNull);
+        expect(result.chargingMode, isNull);
         expect(result.doseWeight, isNull);
         expect(result.grinderSetting, isNull);
         expect(result.grinderModel, isNull);


### PR DESCRIPTION
## What

- Flip fresh-install default `ChargingMode` from `balanced` to `disabled`.
- Import de1app's `smart_battery_charging` from `settings.tdb` during onboarding. Mapping: `0` → `disabled`, `1` → `longevity`, `2` → `highAvailability`; unknown/missing preserves existing Bridge setting.

## Why

tobbenb ([#145](https://github.com/tadelv/reaprime/issues/145)) installed 0.5.11 on a Teclast tablet with a battery mod (no physical battery). Bridge defaulted to `balanced`, the smart-charging hysteresis cut USB power at the low-water mark, and the tablet shut down before the setting could be found. Flipping the default and importing the user's de1app choice removes the footgun for battery-mod tablets and avoids making users reconfigure what they already set in de1app.

Streamline.js skin exposure of the setting is out of scope — tracked separately in `allofmeng/streamline_project`.