### PR TITLE
fix: harden webui zip extraction against Win32 filenames and per-skin failures

### DIFF
--- a/lib/src/webui_support/webui_storage.dart
+++ b/lib/src/webui_support/webui_storage.dart
@@ -9,6 +9,7 @@ import 'package:archive/archive_io.dart';
 import 'package:path/path.dart' as p;
 import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/webui_support/webui_zip_support.dart';
 
 /// REA metadata for tracking WebUI skin source and version
 class WebUIReaMetadata {
@@ -909,17 +910,28 @@ class WebUIStorage {
       }
     }
 
-    // Install bundled skin zips from assets/bundled_skins/
+    // Install bundled skin zips from assets/bundled_skins/.
+    //
+    // The outer try only covers the manifest load. Each skin install runs
+    // inside installBundledSkinList, which isolates per-skin failures so one
+    // bad zip cannot silently drop every later bundled skin (issue #148).
+    List<String> skinIds;
     try {
       final manifestString =
           await rootBundle.loadString('assets/bundled_skins/manifest.json');
-      final skinIds = (jsonDecode(manifestString) as List).cast<String>();
+      skinIds = (jsonDecode(manifestString) as List).cast<String>();
+    } catch (e, st) {
+      _log.warning('Failed to load bundled skins manifest', e, st);
+      return;
+    }
 
-      for (final skinId in skinIds) {
+    await installBundledSkinList(
+      skinIds,
+      (skinId) async {
         final destDir = Directory('${_webUIDir.path}/$skinId');
         if (destDir.existsSync() && destDir.listSync().isNotEmpty) {
           _log.fine('Bundled skin already exists: $skinId');
-          continue;
+          return;
         }
 
         // Load zip from assets and extract
@@ -934,10 +946,9 @@ class WebUIStorage {
         } finally {
           if (tempFile.existsSync()) await tempFile.delete();
         }
-      }
-    } catch (e) {
-      _log.fine('No bundled skin zips found in assets: $e');
-    }
+      },
+      log: _log,
+    );
   }
 
   /// Copy an entire asset folder to a destination path
@@ -1070,20 +1081,19 @@ class WebUIStorage {
       final zipFile = File(zipPath);
       final bytes = await zipFile.readAsBytes();
       final archive = ZipDecoder().decodeBytes(bytes);
-      
-      // Extract files to temp directory
-      for (final file in archive) {
-        final filename = file.name;
-        final filePath = '${tempDir.path}/$filename';
-        
-        if (file.isFile) {
-          final outFile = File(filePath);
-          outFile.createSync(recursive: true);
-          outFile.writeAsBytesSync(file.content as List<int>);
-        } else {
-          Directory(filePath).createSync(recursive: true);
-        }
-      }
+
+      // Extract files to temp directory. On Windows we sanitise filenames
+      // to dodge the Win32-reserved chars; on macOS/Linux we leave them
+      // alone so skins that legitimately use characters like `:` in
+      // filenames keep working. Per-entry failures are isolated so a
+      // single bad entry can't abort the whole install (issue #147). The
+      // helper logs each skipped entry, so we don't repeat that here.
+      extractArchiveToDirectory(
+        archive,
+        tempDir,
+        sanitize: Platform.isWindows,
+        log: _log,
+      );
 
       // Find the actual content directory
       // (GitHub zips have a root folder like "repo-main/")

--- a/lib/src/webui_support/webui_zip_support.dart
+++ b/lib/src/webui_support/webui_zip_support.dart
@@ -1,0 +1,149 @@
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+
+/// Pure helpers backing [WebUIStorage] zip handling.
+///
+/// Extracted from `webui_storage.dart` so the bug-prone bits (Win32 filename
+/// handling, per-iteration error isolation) can be unit-tested without
+/// standing up the full storage + asset bundle stack.
+///
+/// Issues this file addresses:
+///   - https://github.com/tadelv/reaprime/issues/147
+///     `_installFromZip` crashed on Windows-reserved filename chars.
+///   - https://github.com/tadelv/reaprime/issues/148
+///     `_copyBundledSkins` silently skipped every later bundled skin if any
+///     earlier one threw.
+
+/// Characters Win32 forbids in path components: `<>:"|?*`.
+final _win32ReservedChars = RegExp(r'[<>:"|?*]');
+
+/// Sanitises a single zip entry path so it is safe to write on every host
+/// OS — most importantly Windows, which rejects the chars in
+/// [_win32ReservedChars] and silently strips trailing dots / spaces from path
+/// segments.
+///
+/// Forward-slash separators are preserved; each segment between separators is
+/// sanitised independently. The function is intentionally lossless about
+/// non-reserved bytes (including non-ASCII), so localised filenames survive
+/// untouched.
+String sanitizeZipEntryPath(String entryName) {
+  if (entryName.isEmpty) return entryName;
+  final segments = entryName.split('/');
+  final sanitised = segments.map((segment) {
+    var s = segment.replaceAll(_win32ReservedChars, '_');
+    // Win32 silently drops trailing dots and spaces from path components;
+    // strip them so what we ask for is what we get on disk.
+    while (s.isNotEmpty && (s.endsWith('.') || s.endsWith(' '))) {
+      s = s.substring(0, s.length - 1);
+    }
+    return s;
+  }).join('/');
+  return sanitised;
+}
+
+/// Result of extracting an [Archive] to disk.
+class ExtractionResult {
+  /// Number of file entries written successfully.
+  final int extracted;
+
+  /// Number of file entries that failed to write and were skipped.
+  final int skipped;
+
+  const ExtractionResult({required this.extracted, required this.skipped});
+}
+
+/// Extracts every entry of [archive] under [destDir], isolating per-entry
+/// failures so a single bad entry cannot abort the whole extraction.
+///
+/// When [sanitize] is true, each entry path is run through
+/// [sanitizeZipEntryPath] first — callers set this on Windows, where the
+/// raw filename would otherwise be rejected by the OS. On macOS and Linux
+/// filenames like `2025:bad.json` are valid and we leave them alone, so
+/// skins that legitimately use them keep working.
+///
+/// Each failed entry is logged at [Level.WARNING] (when [log] is supplied)
+/// and counted in [ExtractionResult.skipped]. Successful entries are counted
+/// in [ExtractionResult.extracted]. Directory entries are created but not
+/// counted in either total — only file writes affect the counters.
+ExtractionResult extractArchiveToDirectory(
+  Archive archive,
+  Directory destDir, {
+  required bool sanitize,
+  Logger? log,
+}) {
+  var extracted = 0;
+  var skipped = 0;
+
+  for (final entry in archive) {
+    final originalName = entry.name;
+    final safeName =
+        sanitize ? sanitizeZipEntryPath(originalName) : originalName;
+
+    if (safeName != originalName) {
+      log?.fine(
+        'Sanitised zip entry name: "$originalName" -> "$safeName"',
+      );
+    }
+
+    if (safeName.isEmpty) {
+      skipped += entry.isFile ? 1 : 0;
+      log?.warning(
+        'Skipping zip entry with empty path after sanitisation: '
+        '"$originalName"',
+      );
+      continue;
+    }
+
+    final outPath = p.join(destDir.path, safeName);
+
+    try {
+      if (entry.isFile) {
+        final outFile = File(outPath);
+        outFile.parent.createSync(recursive: true);
+        outFile.writeAsBytesSync(entry.content as List<int>);
+        extracted++;
+      } else {
+        Directory(outPath).createSync(recursive: true);
+      }
+    } catch (e, st) {
+      skipped += entry.isFile ? 1 : 0;
+      log?.warning(
+        'Failed to extract zip entry "$originalName" '
+        '(sanitised to "$safeName"); skipping',
+        e,
+        st,
+      );
+    }
+  }
+
+  return ExtractionResult(extracted: extracted, skipped: skipped);
+}
+
+/// Iterates [skinIds], calling [installOne] for each one in order. Each
+/// iteration is isolated: if [installOne] throws, the failure is logged at
+/// [Level.WARNING] (when [log] is supplied) and the loop continues with the
+/// next id.
+///
+/// This is the primary fix for issue #148: the previous loop wrapped the
+/// whole iteration in one `try/catch` and broke out on the first failure,
+/// silently dropping every later skin.
+Future<void> installBundledSkinList(
+  List<String> skinIds,
+  Future<void> Function(String skinId) installOne, {
+  Logger? log,
+}) async {
+  for (final skinId in skinIds) {
+    try {
+      await installOne(skinId);
+    } catch (e, st) {
+      log?.warning(
+        'Failed to install bundled skin "$skinId"',
+        e,
+        st,
+      );
+    }
+  }
+}

--- a/test/webui_zip_support_test.dart
+++ b/test/webui_zip_support_test.dart
@@ -1,0 +1,286 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+import 'package:reaprime/src/webui_support/webui_zip_support.dart';
+
+/// Tests for the pure helpers that back WebUIStorage zip handling.
+///
+/// Covers:
+///   - sanitizeZipEntryPath (issue #147 — Win32-reserved chars)
+///   - extractArchiveToDirectory (issue #147 — per-entry error isolation)
+///   - installBundledSkinList (issue #148 — per-skin loop continuation)
+void main() {
+  group('sanitizeZipEntryPath', () {
+    test('leaves a normal filename unchanged', () {
+      expect(sanitizeZipEntryPath('style.css'), 'style.css');
+    });
+
+    test('leaves a nested normal path unchanged', () {
+      expect(
+        sanitizeZipEntryPath('assets/images/logo.png'),
+        'assets/images/logo.png',
+      );
+    });
+
+    test('replaces a colon in a filename with underscore', () {
+      // The exact shape that crashed Nils B on Windows (#147).
+      expect(
+        sanitizeZipEntryPath('shots/2025-09-12T16:04:38.049213.json'),
+        'shots/2025-09-12T16_04_38.049213.json',
+      );
+    });
+
+    test('replaces all Win32-reserved chars in a segment', () {
+      expect(
+        sanitizeZipEntryPath('a<b>c:d"e|f?g*h.txt'),
+        'a_b_c_d_e_f_g_h.txt',
+      );
+    });
+
+    test('preserves forward-slash path separators between segments', () {
+      expect(
+        sanitizeZipEntryPath('dir/sub:dir/file:name.txt'),
+        'dir/sub_dir/file_name.txt',
+      );
+    });
+
+    test('strips trailing dots from each path segment', () {
+      // Win32 silently drops trailing dots from path components; force them
+      // out so later reads resolve the same path we wrote. Embedded dots
+      // (e.g. `file.tar.gz`) are valid and must survive untouched.
+      expect(
+        sanitizeZipEntryPath('weird./file.tar.gz'),
+        'weird/file.tar.gz',
+      );
+      expect(
+        sanitizeZipEntryPath('trailing.../normal.txt'),
+        'trailing/normal.txt',
+      );
+    });
+
+    test('strips trailing spaces from each path segment', () {
+      expect(
+        sanitizeZipEntryPath('dir /file.txt '),
+        'dir/file.txt',
+      );
+    });
+
+    test('leaves an empty string as empty', () {
+      expect(sanitizeZipEntryPath(''), '');
+    });
+  });
+
+  group('extractArchiveToDirectory', () {
+    late Directory tempDir;
+    late Logger testLog;
+    late List<LogRecord> logged;
+
+    setUp(() {
+      tempDir = Directory.systemTemp
+          .createTempSync('reaprime_zip_support_test_');
+      testLog = Logger.detached('ExtractTest');
+      logged = <LogRecord>[];
+      testLog.onRecord.listen(logged.add);
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    test('extracts a single file with its content intact', () {
+      final archive = Archive()
+        ..addFile(ArchiveFile.string('hello.txt', 'hi'));
+
+      final result = extractArchiveToDirectory(archive, tempDir, sanitize: true, log: testLog);
+
+      expect(result.extracted, 1);
+      expect(result.skipped, 0);
+      final extracted = File(p.join(tempDir.path, 'hello.txt'));
+      expect(extracted.existsSync(), isTrue);
+      expect(extracted.readAsStringSync(), 'hi');
+    });
+
+    test('creates nested directories for a file inside a sub-path', () {
+      final archive = Archive()
+        ..addFile(ArchiveFile.string('a/b/c.txt', 'deep'));
+
+      final result = extractArchiveToDirectory(archive, tempDir, sanitize: true, log: testLog);
+
+      expect(result.extracted, 1);
+      final extracted = File(p.join(tempDir.path, 'a', 'b', 'c.txt'));
+      expect(extracted.existsSync(), isTrue);
+      expect(extracted.readAsStringSync(), 'deep');
+    });
+
+    test('sanitises a filename containing Win32-reserved chars', () {
+      // Regression for #147: ISO-timestamp filename crashed extraction.
+      final archive = Archive()
+        ..addFile(
+          ArchiveFile.string(
+            'shots/2025-09-12T16:04:38.049213.json',
+            jsonEncode({'ok': true}),
+          ),
+        );
+
+      final result = extractArchiveToDirectory(archive, tempDir, sanitize: true, log: testLog);
+
+      expect(result.extracted, 1);
+      expect(result.skipped, 0);
+      final sanitised = File(
+        p.join(tempDir.path, 'shots', '2025-09-12T16_04_38.049213.json'),
+      );
+      expect(sanitised.existsSync(), isTrue);
+      expect(jsonDecode(sanitised.readAsStringSync()), {'ok': true});
+      // Original name must NOT exist — if it did, sanitisation is a no-op.
+      expect(
+        File(p.join(tempDir.path, 'shots', '2025-09-12T16:04:38.049213.json'))
+            .existsSync(),
+        isFalse,
+      );
+    });
+
+    test('still extracts remaining entries when one entry is pathological',
+        () {
+      final archive = Archive()
+        ..addFile(ArchiveFile.string('good_before.txt', 'first'))
+        ..addFile(ArchiveFile.string('shots/2025:bad.json', 'middle'))
+        ..addFile(ArchiveFile.string('good_after.txt', 'last'));
+
+      final result = extractArchiveToDirectory(archive, tempDir, sanitize: true, log: testLog);
+
+      // All three should land on disk; the middle one is sanitised, not
+      // skipped.
+      expect(result.extracted, 3);
+      expect(result.skipped, 0);
+      expect(File(p.join(tempDir.path, 'good_before.txt')).existsSync(),
+          isTrue);
+      expect(File(p.join(tempDir.path, 'good_after.txt')).existsSync(),
+          isTrue);
+      expect(
+        File(p.join(tempDir.path, 'shots', '2025_bad.json')).existsSync(),
+        isTrue,
+      );
+    });
+
+    test('handles an empty archive', () {
+      final result = extractArchiveToDirectory(
+        Archive(),
+        tempDir,
+        sanitize: true,
+        log: testLog,
+      );
+      expect(result.extracted, 0);
+      expect(result.skipped, 0);
+    });
+
+    test(
+      'leaves entry names untouched when sanitize is false (POSIX hosts)',
+      () {
+        // On macOS/Linux, a filename containing `:` is valid — we want it
+        // written as-is so skins that intentionally use such filenames keep
+        // working. On Windows the OS would reject it; we gate sanitisation
+        // at the caller with Platform.isWindows, so this test is only
+        // meaningful on POSIX hosts.
+        final archive = Archive()
+          ..addFile(
+            ArchiveFile.string('shots/2025-09-12T16:04:38.json', 'ok'),
+          );
+
+        final result = extractArchiveToDirectory(
+          archive,
+          tempDir,
+          sanitize: false,
+          log: testLog,
+        );
+
+        expect(result.extracted, 1);
+        expect(result.skipped, 0);
+        final asWritten = File(
+          p.join(tempDir.path, 'shots', '2025-09-12T16:04:38.json'),
+        );
+        expect(asWritten.existsSync(), isTrue);
+        expect(asWritten.readAsStringSync(), 'ok');
+      },
+      testOn: '!windows',
+    );
+  });
+
+  group('installBundledSkinList', () {
+    late Logger testLog;
+    late List<LogRecord> logged;
+
+    setUp(() {
+      testLog = Logger.detached('InstallListTest');
+      logged = <LogRecord>[];
+      testLog.onRecord.listen(logged.add);
+    });
+
+    test('calls installOne for every skin id when all succeed', () async {
+      final calls = <String>[];
+      await installBundledSkinList(
+        ['a', 'b', 'c'],
+        (id) async => calls.add(id),
+        log: testLog,
+      );
+      expect(calls, ['a', 'b', 'c']);
+      expect(
+        logged.where((r) => r.level >= Level.WARNING),
+        isEmpty,
+        reason: 'successful installs should not warn',
+      );
+    });
+
+    test(
+      'continues after a failure and still attempts later skins (issue #148)',
+      () async {
+        final calls = <String>[];
+        await installBundledSkinList(
+          ['first', 'boom', 'third'],
+          (id) async {
+            calls.add(id);
+            if (id == 'boom') throw StateError('simulated install failure');
+          },
+          log: testLog,
+        );
+        expect(calls, ['first', 'boom', 'third']);
+        // The failure must be surfaced at warning level so users and logs
+        // notice — the original bug hid it at fine.
+        final warnings =
+            logged.where((r) => r.level >= Level.WARNING).toList();
+        expect(warnings, hasLength(1));
+        expect(warnings.single.message, contains('boom'));
+      },
+    );
+
+    test('attempts every skin when every install throws', () async {
+      final calls = <String>[];
+      await installBundledSkinList(
+        ['x', 'y', 'z'],
+        (id) async {
+          calls.add(id);
+          throw StateError('always fails');
+        },
+        log: testLog,
+      );
+      expect(calls, ['x', 'y', 'z']);
+      expect(
+        logged.where((r) => r.level >= Level.WARNING).length,
+        3,
+      );
+    });
+
+    test('does nothing for an empty list', () async {
+      final calls = <String>[];
+      await installBundledSkinList(
+        const [],
+        (id) async => calls.add(id),
+        log: testLog,
+      );
+      expect(calls, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## What

- Sanitise Win32-reserved chars (`<>:"|?*`) and trailing dots/spaces in zip entry paths when extracting on Windows; isolate per-entry failures so one bad entry can't abort the install.
- Replace the single outer try/catch in `_copyBundledSkins` with per-skin error isolation so one failing bundled skin no longer silently drops every later skin in the loop.

## Why

Fixes #147 — a skin with an ISO-timestamp filename (`2025-09-12T16:04:38.json`) crashed `_installFromZip` on the first `:` with Win32 errno 123, and nothing installed. Reported by Nils B on Basecamp, 2026-04-11.

Fixes #148 — same report surfaced that the bundled-skin loop was catching at `fine` level and breaking out on the first failure, silently dropping every later bundled skin. Not Windows-specific; any extraction failure had the same effect on every OS.

Logic is extracted into a new pure helper file (`lib/src/webui_support/webui_zip_support.dart`) so both bugs get direct unit-test coverage, including the pathological-filename regression and the loop-continuation behaviour.