### PR TITLE
fix: flutter_inappwebview on Windows

### DIFF
--- a/.github/workflows/develop-builds.yml
+++ b/.github/workflows/develop-builds.yml
@@ -5,9 +5,24 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Platform to build (push to main always builds all)'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - android
+          - macos
+          - linux
+          - raspberrypi
+          - ios
+          - windows
 
 jobs:
   build-android:
+    if: github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'android'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -71,6 +86,7 @@ jobs:
           path: build/app/outputs/flutter-apk/app-release.apk
 
   build-macos:
+    if: github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'macos'
     runs-on: macos-latest
     steps:
       - name: Check out repository
@@ -202,6 +218,7 @@ jobs:
           path: streamline-bridge-macos-develop.zip
 
   build-linux:
+    if: github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'linux'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -244,6 +261,7 @@ jobs:
 
   build-raspberrypi:
     name: Build for Raspberry Pi (ARM64 / Pi 4+)
+    if: github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'raspberrypi'
     runs-on: ubuntu-22.04-arm     # ARM64 hosted runner label
     steps:
       - name: Check out repository
@@ -289,6 +307,7 @@ jobs:
           path: build/linux/arm64/release/bundle
 
   build-ios:
+    if: github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'ios'
     runs-on: macos-latest
     steps:
       - name: Check out repository
@@ -422,6 +441,7 @@ jobs:
       # TestFlight upload is only done in release builds (release.yml)
 
   build-windows:
+    if: github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'windows'
     runs-on: windows-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/develop-builds.yml
+++ b/.github/workflows/develop-builds.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build-android:

--- a/lib/src/services/webview_compatibility_checker.dart
+++ b/lib/src/services/webview_compatibility_checker.dart
@@ -35,6 +35,7 @@ enum CompatibilityIssue {
   oldAndroidVersion,
   webViewRenderingFailed,
   webViewNotAvailable,
+  webView2RuntimeMissing,
 }
 
 /// Checks if the device's WebView implementation is compatible with SkinView
@@ -61,6 +62,11 @@ class WebViewCompatibilityChecker {
       return _cachedResult!;
     }
 
+    if (Platform.isWindows) {
+      _cachedResult = await _checkWindowsWebView2Runtime();
+      return _cachedResult!;
+    }
+
     if (!Platform.isAndroid) {
       _log.info('Non-Android platform - WebView is compatible');
       _cachedResult = const CompatibilityResult.compatible();
@@ -80,6 +86,41 @@ class WebViewCompatibilityChecker {
     final runtimeCheckResult = await _testWebViewRendering();
     _cachedResult = runtimeCheckResult;
     return _cachedResult!;
+  }
+
+  /// Checks if the WebView2 Runtime is installed on Windows.
+  ///
+  /// Returns compatible if `WebViewEnvironment.getAvailableVersion()`
+  /// reports a non-null version. Returns an incompatible result with
+  /// `webView2RuntimeMissing` otherwise so the UI can prompt the user
+  /// to install it.
+  ///
+  /// WebView2 Runtime ships with Windows 11 but may be missing on
+  /// Windows 10 installations.
+  static Future<CompatibilityResult> _checkWindowsWebView2Runtime() async {
+    _log.info('Checking WebView2 Runtime availability on Windows...');
+    try {
+      final version = await WebViewEnvironment.getAvailableVersion().timeout(
+        const Duration(seconds: 5),
+        onTimeout: () => null,
+      );
+      if (version == null) {
+        _log.warning('WebView2 Runtime not found on this system');
+        return CompatibilityResult.incompatible(
+          'Microsoft Edge WebView2 Runtime is not installed. '
+          'Install it from https://go.microsoft.com/fwlink/p/?LinkId=2124703',
+          CompatibilityIssue.webView2RuntimeMissing,
+        );
+      }
+      _log.info('WebView2 Runtime available: $version');
+      return const CompatibilityResult.compatible();
+    } catch (e, stackTrace) {
+      _log.severe('Failed to probe WebView2 Runtime', e, stackTrace);
+      return CompatibilityResult.incompatible(
+        'Could not verify WebView2 Runtime: $e',
+        CompatibilityIssue.webView2RuntimeMissing,
+      );
+    }
   }
 
   /// Checks device manufacturer, model, and Android version

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -102,8 +102,18 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
     // Clear HTTP cache. Note: this does NOT clear service worker
     // CacheStorage on Android — the SW is bypassed via a cache-
     // busting query param on the initial URL instead.
-    await InAppWebViewController.clearAllCache();
-    _log.fine('WebView cache cleared');
+    //
+    // Skipped on Windows: flutter_inappwebview_windows has no native
+    // handler for clearAllCache, and awaiting it hangs SkinView on
+    // "Checking compatibility...".
+    if (!Platform.isWindows) {
+      try {
+        await InAppWebViewController.clearAllCache();
+        _log.fine('WebView cache cleared');
+      } catch (e, st) {
+        _log.warning('clearAllCache failed, continuing', e, st);
+      }
+    }
 
     final result = await WebViewCompatibilityChecker.checkCompatibility();
 

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -261,6 +261,14 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
         description =
             'Unable to initialize WebView on your device.\n\n${result.reason}';
         break;
+      case CompatibilityIssue.webView2RuntimeMissing:
+        icon = Icons.download;
+        iconColor = Colors.orange;
+        title = 'WebView2 Runtime Missing';
+        description =
+            'Microsoft Edge WebView2 Runtime is required to display the '
+            'skin on Windows. Install it and restart the app.';
+        break;
       default:
         icon = Icons.info;
         iconColor = Colors.blue;
@@ -326,6 +334,17 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
                     );
                   },
                 ),
+                if (result.issue == CompatibilityIssue.webView2RuntimeMissing)
+                  ElevatedButton.icon(
+                    icon: const Icon(Icons.download),
+                    label: const Text('Install WebView2'),
+                    onPressed: () => launchUrl(
+                      Uri.parse(
+                        'https://go.microsoft.com/fwlink/p/?LinkId=2124703',
+                      ),
+                      mode: LaunchMode.externalApplication,
+                    ),
+                  ),
               ],
             ),
             Row(


### PR DESCRIPTION
## What
- Skip `InAppWebViewController.clearAllCache()` on Windows — `flutter_inappwebview_windows` has no native handler for it and the awaited call hangs `SkinView` on "Checking compatibility...".
- Probe `WebViewEnvironment.getAvailableVersion()` on Windows from `WebViewCompatibilityChecker` with a 5s timeout. Show a dedicated "WebView2 Runtime Missing" screen + direct install button when the runtime is absent.
- Add `workflow_dispatch` with a `platform` input to `develop-builds.yml` so a single platform (e.g. `windows`) can be built on demand without spending runner minutes on the others.

## Why
Enabling the in-app webview on Windows left users stuck on a blank "Checking compatibility..." screen. Two root causes: a hanging `clearAllCache()` call, and no feedback when the WebView2 Runtime is missing on Windows 10 systems. The workflow changes make it easy to build and test Windows artifacts from a Mac.