### PR TITLE
Embedded skin view on Windows

### DIFF
--- a/lib/src/home_feature/widgets/quick_settings_widget.dart
+++ b/lib/src/home_feature/widgets/quick_settings_widget.dart
@@ -53,7 +53,7 @@ class QuickSettingsWidget extends StatefulWidget {
                 height: 220,
                 // width: 220,
                 child: PrettyQrView.data(
-                  data: 'http://$deviceIp:3000',
+                  data: 'http://$deviceIp:3000/?_=${DateTime.now().millisecondsSinceEpoch}',
                   decoration: PrettyQrDecoration(
                     quietZone: PrettyQrQuietZone.standard,
                     shape: PrettyQrSquaresSymbol(
@@ -199,14 +199,12 @@ class _QuickSettingsState extends State<QuickSettingsWidget> {
                       child: Text("Open", overflow: TextOverflow.ellipsis),
                       onPressed: () async {
                         // On supported platforms (iOS, Android, macOS), use in-app WebView
-                        if (Platform.isIOS ||
-                            Platform.isAndroid ||
-                            Platform.isMacOS) {
-                          Navigator.of(context).pushNamed(SkinView.routeName);
-                        } else {
+                        if (Platform.isLinux) {
                           // On other platforms, open in external browser
                           final url = Uri.parse('http://localhost:3000?_=${DateTime.now().millisecondsSinceEpoch}');
                           await launchUrl(url);
+                        } else {
+                          Navigator.of(context).pushNamed(SkinView.routeName);
                         }
                       },
                     ),

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -190,7 +190,7 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
     } else if (Platform.isMacOS) {
       instructions = 'Press ⌘D or use View → Back to Dashboard to return';
     } else if (Platform.isWindows) {
-      instructions = 'Press Ctrl+ESC to return to Dashboard';
+      instructions = 'Press Alt+Backspace to return to Dashboard';
     } else {
       // Fallback for other platforms
       instructions = 'Use back navigation to return to Dashboard';

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -498,7 +498,7 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
     if (Platform.isWindows) {
       return CallbackShortcuts(
         bindings: {
-          const SingleActivator(LogicalKeyboardKey.escape, control: true): () {
+          const SingleActivator(LogicalKeyboardKey.backspace, alt: true): () {
             Navigator.of(context).pop();
           },
         },

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -189,6 +189,8 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
       instructions = 'Use system back button to return to Dashboard';
     } else if (Platform.isMacOS) {
       instructions = 'Press ⌘D or use View → Back to Dashboard to return';
+    } else if (Platform.isWindows) {
+      instructions = 'Press Ctrl+ESC to return to Dashboard';
     } else {
       // Fallback for other platforms
       instructions = 'Use back navigation to return to Dashboard';
@@ -338,12 +340,13 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
                   ElevatedButton.icon(
                     icon: const Icon(Icons.download),
                     label: const Text('Install WebView2'),
-                    onPressed: () => launchUrl(
-                      Uri.parse(
-                        'https://go.microsoft.com/fwlink/p/?LinkId=2124703',
-                      ),
-                      mode: LaunchMode.externalApplication,
-                    ),
+                    onPressed:
+                        () => launchUrl(
+                          Uri.parse(
+                            'https://go.microsoft.com/fwlink/p/?LinkId=2124703',
+                          ),
+                          mode: LaunchMode.externalApplication,
+                        ),
                   ),
               ],
             ),
@@ -492,6 +495,21 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
       );
     }
 
+    if (Platform.isWindows) {
+      return CallbackShortcuts(
+        bindings: {
+          const SingleActivator(LogicalKeyboardKey.escape, control: true): () {
+            Navigator.of(context).pop();
+          },
+        },
+        child: _buildWebViewStack(),
+      );
+    }
+
+    return _buildWebViewStack();
+  }
+
+  Widget _buildWebViewStack() {
     return Stack(
       children: [
         InAppWebView(


### PR DESCRIPTION
Adds support for exiting the in app webview on Windows, by pressing alt+backspace.