### PR TITLE
fix: guard profile upload against firmware race

### DIFF
--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -288,6 +288,13 @@ class UnifiedDe1 implements De1Interface {
   @override
   Future<void> setProfile(Profile profile) async {
     await _sendProfile(profile);
+    // Guard against firmware ProfileDownloadInProgress race: the DE1 writes
+    // the shot descriptor to internal flash inside APIView::write for the
+    // final frame and tail, and only clears ProfileDownloadInProgress when
+    // that flash write returns. If a state=espresso request hits the
+    // firmware task loop before the flag clears, doEspresso() aborts to
+    // HeaterDown and the shot ends after preinfuse. See BC 9788201734.
+    await Future.delayed(const Duration(milliseconds: 500));
   }
 
   @override


### PR DESCRIPTION
## What
- Add 500 ms delay at the end of `UnifiedDe1.setProfile` after `_sendProfile` completes.

## Why
DE1 firmware sets `ProfileDownloadInProgress` when the header is written and clears it only after the final frame + tail are committed to internal flash. A state=espresso request racing the flash write hits `doEspresso()` with the flag still set and aborts straight to HeaterDown — shots end after preinfuse. Reproduced on a Linux station; the added delay closes the window. Inline comment documents the firmware path.