### PR TITLE
Fix DE1 BLE disconnect during wake: hold scale snapshot WS open

### DIFF
--- a/assets/api/websocket_v1.yml
+++ b/assets/api/websocket_v1.yml
@@ -39,11 +39,19 @@ channels:
       waterLevelsMessage:
         $ref: '#/components/messages/WaterLevels'
   ScaleSnapshot:
-    description: Real-time scale weight and battery data.
+    description: >
+      Real-time scale weight and battery data. The socket is held open across
+      scale connect/disconnect cycles — clients should not reconnect on scale
+      disconnect. On open and on every scale connection-state change the
+      server emits a status frame (`{"status":"connected"}` or
+      `{"status":"disconnected"}`). Snapshot frames (see ScaleSnapshot
+      schema) are only sent while a scale is connected.
     address: ws/v1/scale/snapshot
     messages:
       scaleSnapshotMessage:
         $ref: '#/components/messages/ScaleSnapshot'
+      scaleStatusMessage:
+        $ref: '#/components/messages/ScaleStatus'
   MachineRaw:
     description: Real-time raw BLE data from machine (read/write/notify).
     address: ws/v1/machine/raw
@@ -174,6 +182,11 @@ components:
       title: Scale Snapshot
       payload:
         $ref: '#/components/schemas/ScaleSnapshot'
+    ScaleStatus:
+      name: ScaleStatus
+      title: Scale connection status
+      payload:
+        $ref: '#/components/schemas/ScaleStatus'
     MachineSnapshot:
       name: MachineSnapshot
       title: Machine Snapshot
@@ -255,6 +268,16 @@ components:
           type: integer
           nullable: true
           description: Timer elapsed time in milliseconds. Null if scale doesn't support timers or timer hasn't been started.
+    ScaleStatus:
+      type: object
+      description: >
+        Connection status frame emitted by ws/v1/scale/snapshot when the
+        socket opens and whenever scale connection state changes. Clients
+        should keep the socket open across disconnected periods.
+      properties:
+        status:
+          type: string
+          enum: [connected, disconnected]
     MachineSnapshot:
       type: object
       properties:

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -219,7 +219,7 @@ All WebSocket endpoints are on port 8080 at `/ws/v1/...`. See [`assets/api/webso
 | Path | Description | Data |
 |------|-------------|------|
 | `/ws/v1/machine/snapshot` | Machine state stream (~10Hz) | Temps, pressures, flow, state |
-| `/ws/v1/scale/snapshot` | Scale weight/flow stream | Weight, flow, battery |
+| `/ws/v1/scale/snapshot` | Scale weight/flow stream. Stays open across scale disconnects; emits `{"status":"connected"\|"disconnected"}` frames on state change. | Weight, flow, battery |
 | `/ws/v1/machine/shot-settings` | Shot settings changes | Target temp, volume, weight |
 | `/ws/v1/machine/water-levels` | Water level changes | Current/limit levels |
 | `/ws/v1/machine/raw` | Raw BLE characteristic data | Hex-encoded bytes |

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -1652,7 +1652,20 @@ ws.onmessage = (event) => {
 
 **Update Frequency:** Variable (based on scale model, typically 5-10 Hz)
 
-**Message Format:**
+**Connection lifecycle:** The socket is held open across scale
+connect/disconnect cycles. Do not reconnect the WebSocket when the scale
+disconnects — the server will resume streaming automatically once a scale
+connects. On open and on every scale connection-state transition the
+server emits a status frame:
+
+```json
+{ "status": "connected" }
+```
+```json
+{ "status": "disconnected" }
+```
+
+**Snapshot message format** (sent only while a scale is connected):
 ```json
 {
   "timestamp": "2026-02-06T10:30:45.123Z",
@@ -1660,6 +1673,9 @@ ws.onmessage = (event) => {
   "batteryLevel": 85
 }
 ```
+
+Client code should branch on the presence of a `status` field vs. a
+`weight` field.
 
 ### 3. Shot Settings Stream
 

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -154,6 +154,11 @@ class UnifiedDe1Transport {
   }
 
   Future<void> disconnect() async {
+    _log.warning(
+      'disconnect() called by app code',
+      null,
+      StackTrace.current,
+    );
     switch (transportType) {
       case TransportType.serial:
         if (_transport is! SerialTransport) {

--- a/lib/src/services/ble/android_blue_plus_transport.dart
+++ b/lib/src/services/ble/android_blue_plus_transport.dart
@@ -54,6 +54,13 @@ class AndroidBluePlusTransport implements BLETransport {
     // Forward native connection state to our subject
     _nativeConnectionSub?.cancel();
     _nativeConnectionSub = _device.connectionState.listen((state) {
+      if (state == BluetoothConnectionState.disconnected) {
+        final reason = _device.disconnectReason;
+        _log.warning(
+          'Native disconnect: platform=${reason?.platform} '
+          'code=${reason?.code} description=${reason?.description}',
+        );
+      }
       _connectionStateSubject.add(
         state == BluetoothConnectionState.connected
             ? device.ConnectionState.connected
@@ -126,6 +133,11 @@ class AndroidBluePlusTransport implements BLETransport {
 
   @override
   Future<void> disconnect() async {
+    _log.warning(
+      'disconnect() called by app code',
+      null,
+      StackTrace.current,
+    );
     try {
       await _device.disconnect(queue: false, timeout: 5);
     } catch (e) {

--- a/lib/src/services/webserver/scale_handler.dart
+++ b/lib/src/services/webserver/scale_handler.dart
@@ -51,26 +51,55 @@ class ScaleHandler {
 
   _handleSnapshot(WebSocketChannel socket, String? protocol) async {
     _log.fine("handling websocket connection");
-    Scale scale;
-    try {
-      scale = _controller.connectedScale();
-    } catch (e) {
-      socket.sink.add(jsonEncode({'error': 'No scale connected'}));
-      socket.sink.close();
-      return;
-    }
-    var sub = scale.currentSnapshot.listen((snapshot) {
+
+    StreamSubscription<ScaleSnapshot>? snapshotSub;
+
+    void sendStatus(String status) {
       try {
-        var json = jsonEncode(snapshot.toJson());
-        socket.sink.add(json);
-      } catch (e, st) {
-        _log.severe("failed to send: ", e, st);
+        socket.sink.add(jsonEncode({'status': status}));
+      } catch (_) {}
+    }
+
+    void attachSnapshots() {
+      snapshotSub?.cancel();
+      snapshotSub = null;
+      final Scale scale;
+      try {
+        scale = _controller.connectedScale();
+      } catch (e) {
+        _log.warning('connected state reported but no scale: $e');
+        return;
+      }
+      snapshotSub = scale.currentSnapshot.listen((snapshot) {
+        try {
+          socket.sink.add(jsonEncode(snapshot.toJson()));
+        } catch (e, st) {
+          _log.severe("failed to send: ", e, st);
+        }
+      });
+    }
+
+    final connSub = _controller.connectionState.listen((state) {
+      if (state == ConnectionState.connected) {
+        sendStatus('connected');
+        attachSnapshots();
+      } else {
+        snapshotSub?.cancel();
+        snapshotSub = null;
+        sendStatus('disconnected');
       }
     });
+
     socket.stream.listen(
       (e) {},
-      onDone: () => sub.cancel(),
-      onError: (e, st) => sub.cancel(),
+      onDone: () {
+        connSub.cancel();
+        snapshotSub?.cancel();
+      },
+      onError: (e, st) {
+        connSub.cancel();
+        snapshotSub?.cancel();
+      },
     );
   }
 }

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -4,7 +4,7 @@ import 'dart:math';
 import 'dart:typed_data';
 import 'dart:collection';
 import 'package:collection/collection.dart';
-import 'package:flutter/material.dart' hide Router, Visibility;
+import 'package:flutter/material.dart' hide Router, Visibility, ConnectionState;
 import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';


### PR DESCRIPTION
## What
- Hold `/ws/v1/scale/snapshot` open across scale connect/disconnect cycles; emit `{"status":"connected"|"disconnected"}` frames on state change instead of refusing the socket when no scale is connected.
- Add diagnostic logging of the flutter_blue_plus `DisconnectReason` and app-initiated `disconnect()` call sites on both `AndroidBluePlusTransport` and `UnifiedDe1Transport`.
- Update `assets/api/websocket_v1.yml`, `doc/Api.md`, and `doc/Skins.md` for the new lifecycle.

## Why
Every machine wake-from-sleep triggers a 15s scale-only BLE scan. During that window the scale WS is "not connected", so skin clients (passione reproduces reliably) reconnect ~1 Hz. On Teclast M50 Mini (Android 9) that CPU churn plus the unfiltered BLE scan starved the Android BLE stack enough to drop the DE1 link — confirmed on-device as `LINK_SUPERVISION_TIMEOUT` (GATT error code 8) via the new logging. Holding the WS open removes the reconnect-loop CPU load source; the new logging stays in place to attribute any future drops.

Verified on m50mini.home: passione + wake + scale scan no longer drops the DE1 link.