### PR TITLE
test(comms): Phase 0 regression coverage

### DIFF
--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -331,6 +331,64 @@ void main() {
         });
       });
 
+      // Gap A — comms-harden #4: after a scale connect failure, a
+      // subsequent connect() must re-attempt the scale. Current code
+      // happens to pass this because _scaleConnected is guarded behind
+      // a successful `await scaleController.connectToScale(...)`, but
+      // the invariant must survive the Phase 2 state-derivation
+      // refactor. These tests pin the contract.
+      //
+      // See: doc/plans/comms-harden.md #4,
+      //      doc/plans/comms-phase-0-1.md Gap A.
+      group('scale failure recovery (comms-harden #4)', () {
+        test('after scaleOnly connect fails, next connect retries scale',
+            () async {
+          mockScaleController.shouldFailConnect = true;
+
+          final scale = TestScale(deviceId: 'scale-1');
+          mockScanner.addDevice(scale);
+          await Future.delayed(Duration.zero);
+
+          await connectionManager.connect(scaleOnly: true);
+          await Future.delayed(Duration.zero);
+          expect(mockScaleController.connectCalls, hasLength(1),
+              reason: 'first scaleOnly attempt should call connectToScale');
+
+          mockScaleController.shouldFailConnect = false;
+          await connectionManager.connect(scaleOnly: true);
+          await Future.delayed(Duration.zero);
+
+          expect(mockScaleController.connectCalls, hasLength(2),
+              reason:
+                  'scale must be retried after a prior failed scaleOnly connect');
+        });
+
+        test(
+            'after full connect fails on scale phase, next scaleOnly retries',
+            () async {
+          mockScaleController.shouldFailConnect = true;
+
+          final fakeDe1 = _FakeDe1(deviceId: 'de1');
+          final scale = TestScale(deviceId: 'scale-1');
+          mockScanner.addDevice(fakeDe1);
+          mockScanner.addDevice(scale);
+          await Future.delayed(Duration.zero);
+
+          await connectionManager.connect();
+          await Future.delayed(Duration.zero);
+          expect(mockScaleController.connectCalls, hasLength(1),
+              reason: 'full connect reaches scale phase on first attempt');
+
+          mockScaleController.shouldFailConnect = false;
+          await connectionManager.connect(scaleOnly: true);
+          await Future.delayed(Duration.zero);
+
+          expect(mockScaleController.connectCalls, hasLength(2),
+              reason:
+                  'scale phase must retry after a prior full-connect failure');
+        });
+      });
+
       group('early-stop', () {
         test(
             'both preferred set and both connected → calls stopScan',

--- a/test/controllers/de1_controller_test.dart
+++ b/test/controllers/de1_controller_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+
+/// Gap E — regression coverage for comms-harden #5 (shot-settings debounce
+/// races disconnect).
+///
+/// `De1Controller._shotSettingsUpdate` schedules a 100 ms debounce timer
+/// that calls `_processShotSettingsUpdate`. Once the timer fires, its async
+/// body awaits a chain of `connectedDe1().getSteamFlow()` / `getFlushFlow()`
+/// / etc. If the DE1 disconnects mid-chain, `_de1` is nulled by
+/// `_onDisconnect()` and subsequent `connectedDe1()` calls throw the raw
+/// string `"De1 not connected yet"` — unhandled, leaking as an async error
+/// from the timer.
+///
+/// Phase 1 PR 3 replaces the raw string with `DeviceNotConnectedException`.
+/// Phase 5 (#5 proper) adds generation-token guards so the running debounce
+/// body bails out cleanly on disconnect.
+///
+/// When the fix lands:
+///   1. Remove the `skip:` arguments.
+///   2. Implement the test body using `runZonedGuarded` (or a test binding
+///      error hook) to catch async errors from the timer body.
+///   3. Fire `_shotSettingsUpdate`, immediately disconnect, advance time
+///      past the 100 ms debounce, and assert no unhandled exception was
+///      emitted.
+///
+/// See: doc/plans/comms-harden.md #5,
+///      doc/plans/comms-phase-0-1.md Gap E.
+void main() {
+  group('shot-settings debounce race (comms-harden #5)', () {
+    test(
+      'disconnect during debounce does not leak an unhandled async error',
+      () async {
+        fail('pending Phase 5 fix for #5');
+      },
+      skip: 'pending fix for comms-harden #5 — see doc/plans/comms-phase-0-1.md',
+    );
+  });
+}

--- a/test/controllers/device_controller_test.dart
+++ b/test/controllers/device_controller_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+
+/// Gap F — regression coverage for comms-harden #20 (disconnect detection
+/// keyed on `device.name` instead of `deviceId`).
+///
+/// `DeviceController._previousDeviceNames` and `_disconnectedAt` are keyed
+/// by `device.name`. Two devices sharing an advertised name (e.g. two DE1s
+/// on the same bench) will have their reconnect-tracking cross-attributed.
+/// A device whose firmware changes its advertised name is also never
+/// cleaned up from `_disconnectedAt` (mitigated by the 24 h cleanup, but
+/// the semantics are still wrong).
+///
+/// Phase 6 switches the key from `name` to `deviceId`. When that lands:
+///   1. Remove the `skip:` argument.
+///   2. Build a `DeviceController` over a stubbed `DeviceDiscoveryService`
+///      that emits two devices with the same `name` but different
+///      `deviceId`s. Disconnect one. Assert the other remains tracked as
+///      connected, and that `_disconnectedAt` only records the one that
+///      actually left.
+///
+/// A migration audit is required before the fix lands because persisted
+/// preference keys may depend on `name` — see `comms-harden.md` landmine.
+///
+/// See: doc/plans/comms-harden.md #20,
+///      doc/plans/comms-phase-0-1.md Gap F.
+void main() {
+  group('disconnect tracking keys (comms-harden #20)', () {
+    test(
+      'two devices with same name but different IDs do not collide',
+      () async {
+        fail('pending Phase 6 fix for #20');
+      },
+      skip:
+          'pending fix for comms-harden #20 — see doc/plans/comms-phase-0-1.md',
+    );
+  });
+}

--- a/test/models/device/unified_de1_mmr_test.dart
+++ b/test/models/device/unified_de1_mmr_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+
+/// Gap C — regression coverage for comms-harden #2 (MMR read timeout).
+///
+/// `_mmrRead` in `unified_de1.mmr.dart` currently wraps
+/// `_mmr.firstWhere(...)` without a timeout. A single dropped MMR notify
+/// from the DE1 (firmware glitch, BLE drop between write and notify) during
+/// `onConnect()` leaves the Future pending forever, permanently wedging
+/// `ConnectionManager._isConnecting`.
+///
+/// Phase 1 PR 3 introduces `MmrTimeoutException` in `lib/src/models/errors.dart`
+/// and wraps the `firstWhere` with `.timeout(const Duration(seconds: 2), ...)`.
+///
+/// When PR 3 lands:
+///   1. Remove the `skip:` arguments below.
+///   2. Implement the test bodies using a fake `DataTransport` that feeds
+///      `UnifiedDe1Transport._mmrSubject` without ever matching the request.
+///   3. Drive the timeout via `package:fake_async`.
+///
+/// See: doc/plans/comms-harden.md #2,
+///      doc/plans/comms-phase-0-1.md PR 3 / Gap C.
+void main() {
+  group('_mmrRead timeout (comms-harden #2)', () {
+    test(
+      'throws MmrTimeoutException when no matching response arrives',
+      () async {
+        fail('pending Phase 1 PR 3 — MmrTimeoutException not yet defined');
+      },
+      skip: 'pending fix for comms-harden #2 — see doc/plans/comms-phase-0-1.md',
+    );
+
+    test(
+      '_unpackMMRInt throws a bounded error (not RangeError) on empty buffer',
+      () async {
+        fail('pending Phase 1 PR 3 — empty-buffer guard not yet added');
+      },
+      skip: 'pending fix for comms-harden #2 — see doc/plans/comms-phase-0-1.md',
+    );
+  });
+}


### PR DESCRIPTION
## What

Adds four regression tests that pin behavior ahead of the Phase 2 state-derivation refactor. One group is live (Gap A, passes today); three are skipped placeholders that activate as their respective fix PRs land.

- **Gap A** (`comms-harden.md` #4): scale failure recovery — two live tests.
- **Gap C** (#2): MMR read timeout — skipped, activates in PR 3.
- **Gap E** (#5): shot-settings debounce race — skipped, activates in Phase 5.
- **Gap F** (#20): disconnect tracking keyed on `deviceId` — skipped, activates in Phase 6.

## Why

Phase 0 of the connectivity hardening roadmap (`doc/plans/comms-harden.md`, `doc/plans/comms-phase-0-1.md`). Establishes a baseline so the larger Phase 2 refactor can't silently regress these invariants.

Targets `integration/comms-harden` per the integration-branch strategy; will merge to `main` as part of the cumulative hardening work.

## Test plan

- `flutter test` — 942 passing, 4 skipped (ours), no regressions.
- `flutter analyze` — no issues on new/modified files.