### PR TITLE
chore(comms): log swallowed catches in comms-critical paths

### DIFF
--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -537,15 +537,20 @@ class ConnectionManager {
     if (earlyMachineConnect != null) {
       try {
         await earlyMachineConnect;
-      } catch (_) {
-        // connectMachine already handled the error and updated status
+      } catch (e, st) {
+        // connectMachine already emitted machineConnectFailed and
+        // _connectMachineTracked recorded the outcome on the tracker.
+        // If an error still slipped out, log for diagnostics.
+        _log.fine('Early machine connect slipped past tracker', e, st);
       }
     }
 
     if (earlyScaleConnect != null) {
       try {
         await earlyScaleConnect;
-      } catch (_) {}
+      } catch (e, st) {
+        _log.fine('Early scale connect slipped past tracker', e, st);
+      }
     }
 
     // Collect found devices

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -481,7 +481,9 @@ class UnifiedDe1Transport {
       try {
         // Don't await — BLE stack may be unresponsive
         _transport.disconnect();
-      } catch (_) {}
+      } catch (e, st) {
+        _log.fine('transport.disconnect() during BLE recovery failed', e, st);
+      }
       return false;
     }
   }

--- a/lib/src/services/ble/linux_ble_discovery_service.dart
+++ b/lib/src/services/ble/linux_ble_discovery_service.dart
@@ -378,7 +378,9 @@ class LinuxBleDiscoveryService extends BleDiscoveryService {
       _log.warning("Refresh scan failed: $e");
       try {
         await FlutterBluePlus.stopScan();
-      } catch (_) {}
+      } catch (e, st) {
+        _log.fine('stopScan after failed refresh scan errored', e, st);
+      }
     }
   }
 

--- a/lib/src/services/ble/linux_blue_plus_transport.dart
+++ b/lib/src/services/ble/linux_blue_plus_transport.dart
@@ -151,7 +151,9 @@ class LinuxBluePlusTransport implements BLETransport {
       _log.warning("Pre-connect cache refresh scan failed: $e");
       try {
         await FlutterBluePlus.stopScan();
-      } catch (_) {}
+      } catch (e, st) {
+        _log.fine('stopScan after failed cache refresh errored', e, st);
+      }
     }
   }
 


### PR DESCRIPTION
## What

Replaces five nested `} catch (_) {}` blocks in comms-critical defensive/cleanup paths with `} catch (e, st) { _log.fine(...); }`.

Sites:
- `connection_manager.dart:540` (earlyMachineConnect seatbelt)
- `connection_manager.dart:548` (earlyScaleConnect seatbelt)
- `unified_de1_transport.dart` (BLE recovery disconnect cleanup)
- `linux_blue_plus_transport.dart` (stopScan after failed cache refresh)
- `linux_ble_discovery_service.dart` (stopScan after failed refresh scan)

## Why

Resolves comms-harden #26. These are defensive catches on paths where the primary failure is already logged upstream at warning level, so `fine` keeps the diagnostics available without adding warning-level noise in normal operation.

Scope deliberately narrow. 15 other `} catch (_) {}` sites in scale implementations, serial services, and webserver handlers are out of Phase 1 — they'll be swept in a later observability pass.

## Test plan

- No behavior change; no new tests.
- `flutter test`: 951 pass, 2 skip (unchanged).
- `flutter analyze`: clean on changed files (one pre-existing unused-element warning in `linux_ble_discovery_service.dart` is unrelated).