### PR TITLE
fix(de1): idempotent initRawStream unblocks reconnect (comms-harden #3)

### DIFF
--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -231,6 +231,12 @@ class UnifiedDe1 implements De1Interface {
 
   final StreamController<De1RawMessage> _rawInputController =
       StreamController();
+
+  /// Guards `initRawStream()` against a second `.listen()` on the
+  /// single-subscription `_rawInputController`. Without this, a
+  /// reconnect on the same `UnifiedDe1` instance throws
+  /// `Bad state: Stream has already been listened to.` See comms-harden #3.
+  bool _rawStreamInitialized = false;
   @override
   void sendRawMessage(De1RawMessage message) {
     _rawInputController.add(message);

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.raw.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.raw.dart
@@ -2,6 +2,8 @@ part of 'unified_de1.dart';
 
 extension UnifiedDe1Raw on UnifiedDe1 {
   void initRawStream() {
+    if (_rawStreamInitialized) return;
+    _rawStreamInitialized = true;
     _rawInputController.stream.listen((data) async {
       if (data.operation == De1RawOperationType.notify) {
         _log.fine("Ignoring ${data.operation.name}");

--- a/test/models/device/unified_de1_reconnect_test.dart
+++ b/test/models/device/unified_de1_reconnect_test.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+import 'package:reaprime/src/models/device/transport/serial_port.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// Regression coverage for comms-harden #3 — `UnifiedDe1.initRawStream`
+/// must be idempotent across reconnects.
+///
+/// Before the fix, `_rawInputController` was a single-subscription
+/// `StreamController` and `initRawStream()` called `.listen(...)` once
+/// per `onConnect()`. The second reconnect against the same `UnifiedDe1`
+/// instance threw `Bad state: Stream has already been listened to.`,
+/// wedging the machine at `disconnected` for the rest of the app session.
+///
+/// Confirmed on real hardware during the Phase 1 smoke test
+/// (see doc/plans/comms-harden.md and the Phase 1 smoke report).
+///
+/// After the fix, `initRawStream()` is guarded with a one-shot flag so
+/// the listener is attached only once regardless of how many reconnects
+/// cycle through the same instance.
+
+class _QuietSerialTransport extends SerialTransport {
+  final _connState =
+      BehaviorSubject<ConnectionState>.seeded(ConnectionState.connected);
+
+  @override
+  String get id => 'reconnect-test-de1';
+
+  @override
+  String get name => 'ReconnectTestDe1';
+
+  @override
+  Stream<ConnectionState> get connectionState => _connState.stream;
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Stream<String> get readStream => const Stream.empty();
+
+  @override
+  Stream<Uint8List> get rawStream => const Stream.empty();
+
+  @override
+  Future<void> writeHexCommand(Uint8List command) async {}
+
+  @override
+  Future<void> writeCommand(String command) async {}
+
+  void dispose() {
+    _connState.close();
+  }
+}
+
+void main() {
+  group('UnifiedDe1 reconnect (comms-harden #3)', () {
+    test(
+        'initRawStream is idempotent — calling it twice does not throw',
+        () {
+      final transport = _QuietSerialTransport();
+      final de1 = UnifiedDe1(transport: transport);
+
+      expect(() => de1.initRawStream(), returnsNormally);
+      expect(
+        () => de1.initRawStream(),
+        returnsNormally,
+        reason:
+            'second call simulates a reconnect; must not throw '
+            '"Bad state: Stream has already been listened to."',
+      );
+
+      transport.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## What

Guards `UnifiedDe1Raw.initRawStream()` with a one-shot `_rawStreamInitialized` flag so the listener attaches only once per `UnifiedDe1` instance.

## Why

`_rawInputController` is a single-subscription `StreamController`. Before this fix, every `onConnect()` called `initRawStream()` which called `.listen()` on it — so the second reconnect against the same instance threw `Bad state: Stream has already been listened to.`, wedging the machine at `disconnected` until app restart.

Confirmed on real hardware during the Phase 1 smoke test. A single disconnect → reconnect cycle reproduces it every time with the current code.

Minimal fix (Option B from the hardening plan). The broader broadcast-controller + proper dispose cleanup (Option A) is deferred to Phase 5 together with the other resource-safety items (`_nativeConnectionSub`, `ScaleController.dispose`, etc).

## Test plan

- New `test/models/device/unified_de1_reconnect_test.dart`: calls `initRawStream()` twice on the same instance; red against pre-fix code (reproduces the exact real-hardware throw), green after.
- `flutter test`: 952 pass (1 new), 2 skip.
- `flutter analyze`: clean on changed files.
- Real-hardware retest pending once merged — should let a disconnect/reconnect cycle succeed.