### PR TITLE
docs: correct log location in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ Driving a running Flutter app (start, stop, hot reload, curl, websocat) is docum
 
 - **RxDart:** Controllers use `BehaviorSubject` for state broadcasting
 - **Async init:** Services/controllers have `initialize()` methods called from `main.dart`
-- **Logging:** `package:logging`, configured in `main.dart`. Logs to `~/Download/REA1/log.txt` (Android) or app documents dir (other platforms)
+- **Logging:** `package:logging`, configured in `main.dart`. File log lives under `getApplicationDocumentsDirectory()/log.txt` (plus rotated `log.txt.1..3`) — app-private on every platform. On Android retrieve with `adb shell run-as net.tadel.reaprime cat app_flutter/log.txt` (or use `adb logcat` for live output). The legacy `~/Download/REA1/log.txt` path from older Android builds is obsolete and no longer written.
 - **Foreground service:** Android uses `ForegroundTaskService` to maintain BLE in background. Auto-stops after a 5-minute grace period when the machine disconnects; auto-restarts on reconnect. Shows connection state in the notification.
 - **StreamBuilder patterns:**
   - Check both `hasData` AND `data != null` for nullable streams (e.g., `De1Interface?`)


### PR DESCRIPTION
## What

Replaces the stale `~/Download/REA1/log.txt` reference in `CLAUDE.md` with the current app-documents path plus the `adb shell run-as` invocation to retrieve it on Android.

## Why

The old external-storage path hasn't been written for a while and misled the Phase 1 smoke test until we traced `main.dart`. The current file lives under app-private scoped storage at `/data/user/0/net.tadel.reaprime/app_flutter/log.txt`.

`doc/DeviceManagement.md:704` was already correct (`<app_documents>/log.txt`); only `CLAUDE.md` needed updating. Archived plan docs left untouched — they're historical.

## Test plan

Doc-only. No code change.