### PR TITLE
feat(sb-dev): real-hardware mode + Android adb forward

### DIFF
--- a/.agents/skills/streamline-bridge/SKILL.md
+++ b/.agents/skills/streamline-bridge/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: streamline-bridge
-description: Use when touching the Flutter app, its REST/WebSocket API, profiles, shots, or simulated devices, or whenever exercising a code change against a running Streamline Bridge instance. Covers the dev loop (sb-dev start/reload/stop), REST calls via curl, WebSocket streams via websocat, and smoke-test verification.
+description: Use when touching the Flutter app, its REST/WebSocket API, profiles, shots, simulated devices, or real BLE/USB hardware via an Android tablet or desktop, or whenever exercising a code change against a running Streamline Bridge instance. Covers the dev loop (sb-dev start/reload/stop in simulate or real-hardware mode), REST calls via curl, WebSocket streams via websocat, and smoke-test verification.
 ---
 
 # Streamline Bridge — agent skill
 
-This skill covers driving a running Streamline Bridge Flutter app in simulate mode from the shell: REST via `curl`, WebSocket via `websocat`, and lifecycle (start, stop, reload, logs) via `scripts/sb-dev.sh`. It's written for any agent that can read markdown and execute shell commands — Claude Code, Cursor, Codex, Windsurf, humans — and deliberately avoids agent-specific mechanisms like MCP tools or slash commands.
+This skill covers driving a running Streamline Bridge Flutter app from the shell — simulate mode by default, real hardware via `--real` (+ `--adb-forward` for Android). It exposes REST via `curl`, WebSocket via `websocat`, and lifecycle (start, stop, reload, logs) via `scripts/sb-dev.sh`. Written for any agent that can read markdown and execute shell commands — Claude Code, Cursor, Codex, Windsurf, humans — and deliberately avoids agent-specific mechanisms like MCP tools or slash commands.
 
 The skill lives under `.agents/skills/streamline-bridge/` following the [agentskills.io](https://agentskills.io) cross-client convention. Any compliant client will auto-discover it. Claude Code also loads it via a forwarder at `.claude/skills/streamline-bridge/SKILL.md`.
 
@@ -44,8 +44,20 @@ Hard dependencies on `PATH`:
 
 ## Quick start
 
+Simulate mode (default — no hardware needed):
+
 ```bash
 scripts/sb-dev.sh start --connect-machine MockDe1
+curl -sf http://localhost:8080/api/v1/devices | jq .
+scripts/sb-dev.sh stop
+```
+
+Real hardware on an Android tablet (adb serial from `flutter devices`):
+
+```bash
+scripts/sb-dev.sh start \
+  --platform 8734SCCFAC00000747 --real --adb-forward \
+  --connect-machine DE1
 curl -sf http://localhost:8080/api/v1/devices | jq .
 scripts/sb-dev.sh stop
 ```

--- a/.agents/skills/streamline-bridge/lifecycle.md
+++ b/.agents/skills/streamline-bridge/lifecycle.md
@@ -1,6 +1,6 @@
 # sb-dev lifecycle
 
-`scripts/sb-dev.sh` is a POSIX Bash helper that drives `flutter run` in simulate mode for development work. It owns the flutter child process, exposes hot reload / hot restart / cold restart, and tails the combined log — replacing the old MCP lifecycle tools (`app_start`, `app_stop`, etc). It targets macOS and Linux contributors. Windows users should run `flutter run --dart-define=simulate=1` directly in a terminal and skip this file.
+`scripts/sb-dev.sh` is a POSIX Bash helper that drives `flutter run` for development work. By default it injects `--dart-define=simulate=1` for MockDe1/MockScale; `--real` opts out to exercise real BLE or USB devices. It owns the flutter child process, exposes hot reload / hot restart / cold restart, and tails the combined log — replacing the old MCP lifecycle tools (`app_start`, `app_stop`, etc). It targets macOS and Linux contributors. Windows users should run `flutter run` directly (add `--dart-define=simulate=1` for simulate mode) and skip this file.
 
 ## Prerequisites
 
@@ -18,17 +18,27 @@ All commands are run from the repo root as `scripts/sb-dev.sh <cmd>`.
 
 ### `start`
 
-Spawns `flutter run` via `./flutter_with_commit.sh run` with `--dart-define=simulate=1` always injected, waits up to 120s for `GET /api/v1/devices` to respond, then (if `--connect-machine` was passed) scans and waits up to 30s for the named device to report `connected`.
+Spawns `flutter run` via `./flutter_with_commit.sh run`, waits up to 120s for `GET /api/v1/devices` to respond, then (if `--connect-machine` was passed) scans and waits up to 30s for the named device to report `connected`. `--dart-define=simulate=1` is injected by default — add `--real` for real hardware.
 
 Flags:
 
-- `--platform <name>` — forwarded as `-d <name>` to flutter (`macos`, `linux`, `chrome`, etc).
-- `--connect-machine <id>` — sets `--dart-define=preferredMachineId=<id>` and triggers a post-boot scan loop. Use `MockDe1` in simulate mode.
-- `--connect-scale <id>` — sets `--dart-define=preferredScaleId=<id>`. Use `MockScale`. Note: the scale's REST `name` field is `"Mock Scale"` (with space); the flag takes the dart-define identifier without a space.
+- `--platform <id>` — forwarded as `-d <id>` to flutter (`macos`, `linux`, `chrome`, or an Android adb serial like `8734SCCFAC00000747`).
+- `--connect-machine <name|id>` — sets `--dart-define=preferredMachineId=<value>` and triggers a post-boot scan loop. Simulate: `MockDe1`. Real BLE: the advertised name (`DE1`) or the MAC (`D9:11:0B:E6:9F:86`) — the scan loop matches either.
+- `--connect-scale <name|id>` — same semantics for the scale. Simulate example: `MockScale` (note the REST `name` field is `"Mock Scale"` with a space; the flag takes the dart-define identifier without one).
+- `--real` — skip injecting `--dart-define=simulate=1`. Mock device registration is compiled out, so only real transports (BLE, USB serial, HDS) will discover devices.
+- `--adb-forward` — before spawning flutter, run `adb forward tcp:$PORT tcp:$PORT` so the readiness check and all `curl` calls against `localhost:$PORT` reach the REST server on an Android device. Removed on `stop`.
 - `--dart-define key=val` — repeatable passthrough for extra defines.
 
 ```bash
+# Simulate (default)
 scripts/sb-dev.sh start --connect-machine MockDe1 --connect-scale MockScale
+
+# Real hardware on an Android tablet (adb serial from `flutter devices`)
+scripts/sb-dev.sh start \
+  --platform 8734SCCFAC00000747 \
+  --real \
+  --adb-forward \
+  --connect-machine DE1
 ```
 
 ### `stop`
@@ -95,6 +105,7 @@ Everything sb-dev owns lives under `$SB_RUNTIME_DIR` (default `/tmp/streamline-b
 - `stdin` — named pipe; flutter's stdin reads from it (`r`, `R`, `q` are written here)
 - `flutter.log` — combined stdout + stderr
 - `last-flags` — the flags from the most recent `start`, used by `restart`
+- `adb-forwarded` — touched when `start --adb-forward` installed a forward; `stop` removes the forward iff this marker is present
 
 `SB_HOST` and `SB_PORT` override the host/port used for `curl` checks (default `localhost:8080`).
 

--- a/.agents/skills/streamline-bridge/simulated-devices.md
+++ b/.agents/skills/streamline-bridge/simulated-devices.md
@@ -1,6 +1,6 @@
 # Simulated devices
 
-Streamline Bridge ships with in-process mock implementations of its supported devices so you can develop and run tests without a real DE1 or scale on hand. Simulate mode is deterministic, CI-friendly, and enabled via `--dart-define=simulate=1` (all mocks), a comma-delimited subset like `--dart-define=simulate=machine,scale`, or the in-app Settings UI toggle (`SimulatedDevicesTypes` — machine, scale, sensor). `sb-dev start` always injects `--dart-define=simulate=1`.
+Streamline Bridge ships with in-process mock implementations of its supported devices so you can develop and run tests without a real DE1 or scale on hand. Simulate mode is deterministic, CI-friendly, and enabled via `--dart-define=simulate=1` (all mocks), a comma-delimited subset like `--dart-define=simulate=machine,scale`, or the in-app Settings UI toggle (`SimulatedDevicesTypes` — machine, scale, sensor). `sb-dev start` injects `--dart-define=simulate=1` by default; pass `--real` to opt out and run against real hardware (see `lifecycle.md`).
 
 ## Available mocks
 

--- a/scripts/sb-dev.sh
+++ b/scripts/sb-dev.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # sb-dev.sh — Streamline Bridge dev-session manager
 #
-# Manages a `flutter run` process for simulate-mode development.
-# See .agents/skills/streamline-bridge/lifecycle.md for the full reference.
+# Manages a `flutter run` process for simulate-mode development by default,
+# with opt-in flags for running against real hardware (including Android
+# devices via adb port forwarding). See
+# .agents/skills/streamline-bridge/lifecycle.md for the full reference.
 #
 # Runtime state lives under $SB_RUNTIME_DIR (default /tmp/streamline-bridge-$USER).
 
@@ -14,6 +16,7 @@ HOLDER_PIDFILE="$RUNTIME_DIR/holder.pid"
 STDIN_FIFO="$RUNTIME_DIR/stdin"
 LOGFILE="$RUNTIME_DIR/flutter.log"
 FLAGSFILE="$RUNTIME_DIR/last-flags"
+ADB_FORWARD_MARK="$RUNTIME_DIR/adb-forwarded"
 HOST="${SB_HOST:-localhost}"
 PORT="${SB_PORT:-8080}"
 BASE_URL="http://$HOST:$PORT"
@@ -31,7 +34,8 @@ usage() {
 sb-dev.sh — Streamline Bridge dev-session manager
 
 Usage:
-  sb-dev start [--platform macos] [--connect-machine MockDe1] [--connect-scale MockScale] [--dart-define k=v]
+  sb-dev start [--platform <id>] [--connect-machine <name|id>] [--connect-scale <name|id>]
+               [--real] [--adb-forward] [--dart-define k=v]
   sb-dev stop
   sb-dev restart           — cold restart with the same flags as the last start
   sb-dev reload            — hot reload (preserves app state)
@@ -39,6 +43,18 @@ Usage:
   sb-dev status            — pid + http reachability + devices
   sb-dev logs [-n 50] [--filter text]
   sb-dev help
+
+Flags:
+  --platform <id>          Flutter device id (`-d` passthrough). Examples: macos,
+                           linux, chrome, or an Android adb serial like 8734SCCFAC00000747.
+  --connect-machine <v>    Match by device name OR id; used as preferredMachineId.
+                           Simulate: MockDe1. Real BLE: DE1 (name) or D9:11:… (MAC).
+  --connect-scale <v>      Same semantics for the scale.
+  --real                   Do NOT inject --dart-define=simulate=1. Use real BLE/USB.
+  --adb-forward            Run `adb forward tcp:$PORT tcp:$PORT` on start so host
+                           localhost:$PORT reaches the REST server on an Android
+                           device. Removed on stop.
+  --dart-define k=v        Extra --dart-define passed to flutter (repeatable).
 
 Env:
   SB_RUNTIME_DIR  runtime state directory (default: /tmp/streamline-bridge-$USER)
@@ -75,12 +91,15 @@ wait_ready() {
 }
 
 connect_machine() {
-  local name="$1" start
+  local needle="$1" start
   start=$(date +%s)
-  # Re-scan each iteration: early post-boot scans can return empty (simulate
-  # service may not have populated yet), so we retry within the 30s window
-  # rather than trusting a single scan result. Each scan call blocks until
+  # Re-scan each iteration: early post-boot scans can return empty
+  # (simulate service may not have populated yet, and real BLE scans
+  # take ~15 s), so we retry within the 30 s window rather than trusting
+  # a single scan result. Each scan call blocks until
   # ConnectionManager.connect() completes, so the loop self-paces.
+  # Match by either device name or id so callers can pass "DE1" or a
+  # BLE MAC like "D9:11:0B:E6:9F:86" against real hardware.
   while (( $(date +%s) - start < 30 )); do
     curl -sf "$BASE_URL/api/v1/devices/scan?connect=true" >/dev/null || {
       echo "Scan request failed" >&2
@@ -89,14 +108,18 @@ connect_machine() {
     local devices
     devices=$(curl -sf "$BASE_URL/api/v1/devices" || echo "[]")
     if printf '%s' "$devices" \
-         | jq -e --arg name "$name" '.[] | select(.name == $name and .state == "connected")' \
+         | jq -e --arg needle "$needle" '
+             .[] | select(
+               (.name == $needle or .id == $needle)
+               and .state == "connected"
+             )' \
            >/dev/null 2>&1; then
-      echo "Connected to $name"
+      echo "Connected to $needle"
       return 0
     fi
     sleep 1
   done
-  echo "Timed out waiting for $name to connect" >&2
+  echo "Timed out waiting for $needle to connect" >&2
   return 1
 }
 
@@ -108,6 +131,7 @@ start_cmd() {
   fi
 
   local platform="" machine="" scale=""
+  local real=0 adb_forward=0
   local -a extra_defines=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -120,6 +144,10 @@ start_cmd() {
       --connect-scale)
         [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; return 2; }
         scale="$2"; shift 2 ;;
+      --real)
+        real=1; shift ;;
+      --adb-forward)
+        adb_forward=1; shift ;;
       --dart-define)
         [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; return 2; }
         extra_defines+=("--dart-define=$2"); shift 2 ;;
@@ -132,10 +160,28 @@ start_cmd() {
     [[ -n "$platform" ]] && printf '%s\n' "--platform $platform"
     [[ -n "$machine" ]] && printf '%s\n' "--connect-machine $machine"
     [[ -n "$scale" ]] && printf '%s\n' "--connect-scale $scale"
+    [[ "$real" -eq 1 ]] && printf '%s\n' "--real"
+    [[ "$adb_forward" -eq 1 ]] && printf '%s\n' "--adb-forward"
     for d in "${extra_defines[@]}"; do printf '%s\n' "--dart-define ${d#--dart-define=}"; done
   } > "$FLAGSFILE"
 
-  local -a defines=("--dart-define=simulate=1")
+  # Set up adb port forwarding before spawning flutter so readiness
+  # checks against $BASE_URL work immediately after the app binds 8080.
+  if [[ "$adb_forward" -eq 1 ]]; then
+    if ! command -v adb >/dev/null 2>&1; then
+      echo "error: --adb-forward requires adb on PATH" >&2
+      return 1
+    fi
+    if ! adb forward "tcp:$PORT" "tcp:$PORT" >/dev/null; then
+      echo "error: adb forward tcp:$PORT tcp:$PORT failed" >&2
+      return 1
+    fi
+    : > "$ADB_FORWARD_MARK"
+    echo "adb forward tcp:$PORT -> device tcp:$PORT"
+  fi
+
+  local -a defines=()
+  [[ "$real" -eq 0 ]] && defines+=("--dart-define=simulate=1")
   [[ -n "$machine" ]] && defines+=("--dart-define=preferredMachineId=$machine")
   [[ -n "$scale" ]] && defines+=("--dart-define=preferredScaleId=$scale")
   defines+=("${extra_defines[@]}")
@@ -175,6 +221,14 @@ cleanup_runtime() {
   if [[ -f "$HOLDER_PIDFILE" ]]; then
     kill "$(cat "$HOLDER_PIDFILE")" 2>/dev/null || true
     rm -f "$HOLDER_PIDFILE"
+  fi
+  # Best-effort: remove the adb forward we installed on start. Ignore
+  # errors (adb may be gone, device detached, etc).
+  if [[ -f "$ADB_FORWARD_MARK" ]]; then
+    if command -v adb >/dev/null 2>&1; then
+      adb forward --remove "tcp:$PORT" 2>/dev/null || true
+    fi
+    rm -f "$ADB_FORWARD_MARK"
   fi
   rm -f "$PIDFILE" "$STDIN_FIFO"
 }


### PR DESCRIPTION
## What

Two new `sb-dev start` flags + matching skill doc updates:

- `--real` — skip `--dart-define=simulate=1`, so only real BLE/USB transports discover devices.
- `--adb-forward` — install `adb forward tcp:$PORT tcp:$PORT` on start; remove it on stop via a runtime marker file.

`connect_machine` scan loop now matches by device name **or** id, so `--connect-machine DE1` (advertised name) or `--connect-machine D9:11:0B:E6:9F:86` (MAC) both work against real hardware.

Skill docs (`SKILL.md`, `lifecycle.md`, `simulated-devices.md`) updated — new Android-tablet quick-start example, flags documented, "always injects simulate" rephrased to "injects by default".

## Why

The Phase 1 smoke test on real DE1 hardware had to bypass sb-dev because simulate=1 is always injected. The manual workflow (`flutter_with_commit.sh run -d <serial>` + separate `adb forward` + manual cleanup) is error-prone and not repeatable — and this project has to smoke-test reconnect/connect flows against real hardware before every structural refactor in the connectivity layer (Phase 2 onwards).

## Test plan

- `bash -n scripts/sb-dev.sh`: syntax OK.
- `scripts/sb-dev.sh help`: help text includes the new flags.
- Simulate-mode backward compat: `sb-dev start --platform macos --connect-machine MockDe1` boots; MockDe1 + Mock Scale both report `connected`; clean `sb-dev stop`.
- Real-hardware path tested manually during the Phase 1 smoke with the underlying commands (`adb forward tcp:8080 tcp:8080`, no `simulate=1`, `--platform <serial>`); this PR just wraps that same sequence.