### PR TITLE
feat(comms): scan API returns ScanResult with partial-failure semantics

### DIFF
--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -474,28 +474,13 @@ class ConnectionManager {
       }
     });
 
-    // Run full unfiltered scan. Classify any throw from scan-start
-    // into bluetoothPermissionDenied or scanFailed. Both are sticky
-    // errors — they survive phase transitions and only clear when the
-    // environment recovers (see the success path below).
+    // Run full unfiltered scan. The scanner awaits every service's scan
+    // and returns a ScanResult carrying per-service failures; only a
+    // catastrophic, scan-wide error throws out of the Future. Classify
+    // any such throw into bluetoothPermissionDenied or scanFailed —
+    // both are sticky errors that survive phase transitions.
     try {
-      // Start the scan and subscribe to scanningStream concurrently so we
-      // can race the "scanning started" signal against an error from
-      // scanForDevices() (which may reject asynchronously on permission /
-      // adapter failures). Without the race, awaiting scanForDevices first
-      // would miss the scanning=true emission, and awaiting the stream
-      // first would hang if the scan never started.
-      final scanFuture = deviceScanner.scanForDevices();
-      // Swallow a late rejection from scanFuture if the stream wins the
-      // race — otherwise Future.any leaves it as an unhandled async error.
-      // A real classify-and-emit still fires via the catch below because
-      // scanFuture rejects BEFORE firstWhere sees scanning=true in that
-      // failure case; this only guards the already-started path.
-      scanFuture.catchError((_) {});
-      await Future.any<Object?>([
-        deviceScanner.scanningStream.firstWhere((s) => s),
-        scanFuture,
-      ]);
+      await deviceScanner.scanForDevices();
     } catch (e) {
       sub.cancel();
       final kind = _classifyScanError(e);
@@ -517,21 +502,22 @@ class ConnectionManager {
       ));
       return;
     }
+    sub.cancel();
 
-    // Past this point, scan actually started. Sticky-error environmental
-    // recovery: a successful scan-start means permission and scan
-    // subsystems are working again. Clear any sticky scan-related error
-    // that was hanging on — _publishStatus' gatekeeper would preserve
-    // it otherwise.
+    // Sticky-error environmental recovery: reaching a completed scan
+    // means permission and scan subsystems are working again. Clear
+    // any sticky scan-related error that was hanging on — the
+    // _publishStatus gatekeeper would preserve it otherwise.
+    //
+    // TODO(comms-phase-2 PR B): consult scanResult.failedServices to
+    // surface per-transport failures (e.g. BLE permission denied while
+    // serial succeeded). Deferred to the error-path unification pass.
     final prevErr = currentStatus.error;
     if (prevErr != null &&
         (prevErr.kind == ConnectionErrorKind.scanFailed ||
             prevErr.kind == ConnectionErrorKind.bluetoothPermissionDenied)) {
       _clearError();
     }
-
-    await deviceScanner.scanningStream.firstWhere((s) => !s);
-    sub.cancel();
 
     // Wait for early connections to finish if started
     if (earlyMachineConnect != null) {

--- a/lib/src/controllers/device_controller.dart
+++ b/lib/src/controllers/device_controller.dart
@@ -96,56 +96,86 @@ class DeviceController implements DeviceScanner {
     // This avoids competing BLE scans that interfere with each other.
   }
 
-  Future<void> scanForDevices() async {
+  /// In-flight scan Future so concurrent callers share a single scan
+  /// cycle instead of kicking off parallel scans that would interfere
+  /// with each other at the BLE layer.
+  Future<ScanResult>? _inFlightScan;
+
+  @override
+  Future<ScanResult> scanForDevices() {
+    return _inFlightScan ??= _runScan().whenComplete(() {
+      _inFlightScan = null;
+    });
+  }
+
+  Future<ScanResult> _runScan() async {
     _scanningStream.add(true);
-    // throw out disconnected/discovered devices (keep connected and connecting)
-    for (final entry in _devices.entries) {
-      final devices = entry.value;
-      final toRemove = <Device>[];
-      for (final device in devices) {
-        final state = await device.connectionState.first
-            .timeout(const Duration(seconds: 2),
-                onTimeout: () => ConnectionState.disconnected);
-        if (state != ConnectionState.connected &&
-            state != ConnectionState.connecting) {
-          toRemove.add(device);
+    final start = DateTime.now();
+    try {
+      // Throw out disconnected/discovered devices (keep connected and connecting).
+      for (final entry in _devices.entries) {
+        final devices = entry.value;
+        final toRemove = <Device>[];
+        for (final device in devices) {
+          final state = await device.connectionState.first.timeout(
+            const Duration(seconds: 2),
+            onTimeout: () => ConnectionState.disconnected,
+          );
+          if (state != ConnectionState.connected &&
+              state != ConnectionState.connecting) {
+            toRemove.add(device);
+          }
+        }
+        for (final device in toRemove) {
+          devices.remove(device);
         }
       }
-      for (final device in toRemove) {
-        devices.remove(device);
-      }
-    }
-    // Sync the disconnect-detection baseline with the cleaned list so that
-    // service emissions arriving during the scan don't see false diffs.
-    _previousDeviceNames.clear();
-    _previousDeviceNames.addAll(devices.map((d) => d.name));
-    _deviceStream.add(devices);
-    // Scan all services in parallel
-    final completer = Completer();
-    try {
-      completer.complete(
-        Future.wait(
-          _services.map((service) async {
-            try {
-              _log.fine("starting scan for $service");
-              await service.scanForDevices();
-            } catch (e, st) {
-              _log.warning("Service $service failed to scan:", e, st);
-            }
-          }),
-        ),
+      // Sync the disconnect-detection baseline with the cleaned list so
+      // that service emissions arriving during the scan don't see false
+      // diffs.
+      _previousDeviceNames.clear();
+      _previousDeviceNames.addAll(devices.map((d) => d.name));
+      _deviceStream.add(devices);
+
+      // Run every service's scan in parallel and capture per-service
+      // failures in the result rather than torpedoing the whole scan.
+      // A user with BLE permission denied but a USB DE1 connected still
+      // gets their machine back from the serial service.
+      final failures = <ServiceScanFailure>[];
+      await Future.wait(
+        _services.map((service) async {
+          try {
+            _log.fine("starting scan for $service");
+            await service.scanForDevices();
+          } catch (e, st) {
+            _log.warning("Service $service failed to scan:", e, st);
+            failures.add(
+              ServiceScanFailure(
+                serviceName: service.runtimeType.toString(),
+                error: e,
+                stackTrace: st,
+              ),
+            );
+          }
+        }),
+      );
+
+      _log.info("current devices: $devices");
+      // Settle delay before flipping scanningStream so downstream UI
+      // observers see a stable "scanning" period rather than a
+      // zero-duration flicker when services resolve synchronously.
+      // Preserved from the pre-PR-A implementation to keep widget-test
+      // timing assumptions intact; revisit in PR B when status
+      // derivation is in place.
+      await Future.delayed(const Duration(milliseconds: 200));
+      return ScanResult(
+        matchedDevices: List.unmodifiable(devices),
+        failedServices: List.unmodifiable(failures),
+        terminationReason: ScanTerminationReason.completed,
+        duration: DateTime.now().difference(start),
       );
     } finally {
-      completer.future
-          .timeout(Duration(seconds: 30))
-          .then((_) {}, onError: (e) {
-        _log.warning("scan timed out or failed: $e");
-      }).whenComplete(() async {
-        await Future.delayed(Duration(milliseconds: 200), () {
-          if (!_scanningStream.isClosed) _scanningStream.add(false);
-          _log.info("current devices: $devices");
-        });
-      });
+      if (!_scanningStream.isClosed) _scanningStream.add(false);
     }
   }
 

--- a/lib/src/models/device/device_scanner.dart
+++ b/lib/src/models/device/device_scanner.dart
@@ -1,5 +1,8 @@
 import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scan_result.dart';
+
+export 'package:reaprime/src/models/device/scan_result.dart';
 
 /// Abstraction of what [ConnectionManager] needs from [DeviceController].
 ///
@@ -9,7 +12,17 @@ abstract class DeviceScanner {
   Stream<List<Device>> get deviceStream;
   Stream<bool> get scanningStream;
   List<Device> get devices;
-  Future<void> scanForDevices();
+
+  /// Runs one scan cycle across every discovery service and completes
+  /// with the aggregated [ScanResult] when all services have finished
+  /// (success or failure). Concurrent callers share the in-flight
+  /// Future rather than triggering a second scan.
+  ///
+  /// Per-service failures are reported via [ScanResult.failedServices];
+  /// the Future rejects only on catastrophic, scan-wide errors (the
+  /// scan could not even be attempted).
+  Future<ScanResult> scanForDevices();
+
   void stopScan();
 
   /// Aggregated Bluetooth adapter state across any BLE-capable discovery

--- a/lib/src/models/device/scan_result.dart
+++ b/lib/src/models/device/scan_result.dart
@@ -1,0 +1,45 @@
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/scan_report.dart' show ScanTerminationReason;
+
+export 'package:reaprime/src/models/scan_report.dart' show ScanTerminationReason;
+
+/// Result of a single scan cycle across all discovery services.
+///
+/// Completes when every service's scan has finished (success or failure).
+/// Per-service failures are captured in [failedServices] rather than
+/// thrown — one BLE permission denial does not torpedo a user who is
+/// running serial-only, for example. Callers inspect [failedServices]
+/// if they need to surface errors for individual transport classes.
+///
+/// A catastrophic, scan-wide failure (no services could even be
+/// invoked) is still signalled by the Future rejecting, preserving the
+/// existing classify-and-emit path in `ConnectionManager`.
+class ScanResult {
+  final List<Device> matchedDevices;
+  final List<ServiceScanFailure> failedServices;
+  final ScanTerminationReason terminationReason;
+  final Duration duration;
+
+  const ScanResult({
+    required this.matchedDevices,
+    required this.failedServices,
+    required this.terminationReason,
+    required this.duration,
+  });
+}
+
+/// A single discovery-service failure surfaced through [ScanResult].
+/// `serviceName` is the Dart runtime type of the failing
+/// `DeviceDiscoveryService`, suitable for logs and debugging but not
+/// part of any public contract.
+class ServiceScanFailure {
+  final String serviceName;
+  final Object error;
+  final StackTrace stackTrace;
+
+  const ServiceScanFailure({
+    required this.serviceName,
+    required this.error,
+    required this.stackTrace,
+  });
+}

--- a/test/controllers/device_controller_test.dart
+++ b/test/controllers/device_controller_test.dart
@@ -1,29 +1,160 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scan_result.dart';
+import 'package:reaprime/src/models/errors.dart';
+import 'package:rxdart/rxdart.dart';
 
-/// Gap F — regression coverage for comms-harden #20 (disconnect detection
-/// keyed on `device.name` instead of `deviceId`).
-///
-/// `DeviceController._previousDeviceNames` and `_disconnectedAt` are keyed
-/// by `device.name`. Two devices sharing an advertised name (e.g. two DE1s
-/// on the same bench) will have their reconnect-tracking cross-attributed.
-/// A device whose firmware changes its advertised name is also never
-/// cleaned up from `_disconnectedAt` (mitigated by the 24 h cleanup, but
-/// the semantics are still wrong).
-///
-/// Phase 6 switches the key from `name` to `deviceId`. When that lands:
-///   1. Remove the `skip:` argument.
-///   2. Build a `DeviceController` over a stubbed `DeviceDiscoveryService`
-///      that emits two devices with the same `name` but different
-///      `deviceId`s. Disconnect one. Assert the other remains tracked as
-///      connected, and that `_disconnectedAt` only records the one that
-///      actually left.
-///
-/// A migration audit is required before the fix lands because persisted
-/// preference keys may depend on `name` — see `comms-harden.md` landmine.
-///
-/// See: doc/plans/comms-harden.md #20,
-///      doc/plans/comms-phase-0-1.md Gap F.
+/// A DeviceDiscoveryService that always throws from `scanForDevices`.
+class _FailingDiscoveryService implements DeviceDiscoveryService {
+  final _controller = BehaviorSubject<List<Device>>.seeded(const []);
+  final Object error;
+
+  _FailingDiscoveryService(this.error);
+
+  @override
+  Stream<List<Device>> get devices => _controller.stream;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> scanForDevices() async {
+    throw error;
+  }
+
+  @override
+  void stopScan() {}
+}
+
+/// A DeviceDiscoveryService that succeeds and reports one device.
+class _QuietDiscoveryService implements DeviceDiscoveryService {
+  final _controller = BehaviorSubject<List<Device>>.seeded(const []);
+  final Device device;
+
+  _QuietDiscoveryService(this.device);
+
+  @override
+  Stream<List<Device>> get devices => _controller.stream;
+
+  @override
+  Future<void> initialize() async {
+    _controller.add([device]);
+  }
+
+  @override
+  Future<void> scanForDevices() async {
+    // Re-emit on scan so the DeviceController populates its aggregated view.
+    _controller.add([device]);
+  }
+
+  @override
+  void stopScan() {}
+}
+
+/// Minimal `Device` stub.
+class _FakeDevice implements Device {
+  @override
+  final String deviceId;
+
+  @override
+  final String name;
+
+  @override
+  final DeviceType type;
+
+  _FakeDevice({required this.deviceId, required this.name, required this.type});
+
+  @override
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.disconnected);
+
+  @override
+  Future<void> onConnect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+}
+
 void main() {
+  group('DeviceController.scanForDevices partial failures (comms-harden #22)',
+      () {
+    test(
+      'one service throwing does not torpedo the scan — '
+      'devices from succeeding services are still returned',
+      () async {
+        final failing =
+            _FailingDiscoveryService(const PermissionDeniedException('denied'));
+        final succeeding = _QuietDiscoveryService(
+          _FakeDevice(
+            deviceId: 'D9:11:0B:E6:9F:86',
+            name: 'DE1',
+            type: DeviceType.machine,
+          ),
+        );
+
+        final controller = DeviceController([failing, succeeding]);
+        await controller.initialize();
+
+        final result = await controller.scanForDevices();
+
+        expect(result.matchedDevices, hasLength(1),
+            reason: 'succeeding service must still yield its device');
+        expect(result.matchedDevices.first.deviceId, 'D9:11:0B:E6:9F:86');
+        expect(result.failedServices, hasLength(1),
+            reason: 'failing service must be surfaced in failedServices');
+        expect(result.failedServices.first.error,
+            isA<PermissionDeniedException>());
+        expect(result.failedServices.first.serviceName,
+            contains('FailingDiscoveryService'));
+        expect(result.terminationReason, ScanTerminationReason.completed);
+      },
+    );
+
+    test(
+      'all services failing yields a ScanResult with empty matched + '
+      'populated failedServices (no top-level throw)',
+      () async {
+        final a = _FailingDiscoveryService(Exception('adapter-off'));
+        final b = _FailingDiscoveryService(const PermissionDeniedException());
+
+        final controller = DeviceController([a, b]);
+        await controller.initialize();
+
+        final result = await controller.scanForDevices();
+
+        expect(result.matchedDevices, isEmpty);
+        expect(result.failedServices, hasLength(2));
+      },
+    );
+
+    test(
+      'concurrent scanForDevices calls share one in-flight scan',
+      () async {
+        final service = _QuietDiscoveryService(
+          _FakeDevice(
+            deviceId: 'id-1',
+            name: 'D1',
+            type: DeviceType.machine,
+          ),
+        );
+        final controller = DeviceController([service]);
+        await controller.initialize();
+
+        final first = controller.scanForDevices();
+        final second = controller.scanForDevices();
+
+        expect(identical(first, second), isTrue,
+            reason: 'second concurrent call must share the in-flight Future');
+        await first;
+      },
+    );
+  });
+
+  // Gap F — regression coverage for comms-harden #20 (disconnect detection
+  // keyed on device.name instead of deviceId). Kept as a skipped
+  // placeholder; activate when the Phase 6 key-migration lands. See
+  // doc/plans/comms-harden.md #20.
   group('disconnect tracking keys (comms-harden #20)', () {
     test(
       'two devices with same name but different IDs do not collide',
@@ -31,7 +162,7 @@ void main() {
         fail('pending Phase 6 fix for #20');
       },
       skip:
-          'pending fix for comms-harden #20 — see doc/plans/comms-phase-0-1.md',
+          'pending fix for comms-harden #20 — see doc/plans/comms-harden.md',
     );
   });
 }

--- a/test/helpers/mock_device_scanner.dart
+++ b/test/helpers/mock_device_scanner.dart
@@ -72,12 +72,13 @@ class MockDeviceScanner implements DeviceScanner {
   }
 
   @override
-  Future<void> scanForDevices() async {
+  Future<ScanResult> scanForDevices() async {
     if (failNextScanWith != null) {
       final e = failNextScanWith;
       failNextScanWith = null;
       throw e!;
     }
+    final start = DateTime.now();
     _scanningSubject.add(true);
     // Re-emit current devices to simulate scan rediscovery.
     // This ensures listeners that skip(1) the BehaviorSubject replay
@@ -89,6 +90,12 @@ class MockDeviceScanner implements DeviceScanner {
       await Future.delayed(Duration.zero);
       _scanningSubject.add(false);
     }
+    return ScanResult(
+      matchedDevices: List.unmodifiable(_devices),
+      failedServices: const [],
+      terminationReason: ScanTerminationReason.completed,
+      duration: DateTime.now().difference(start),
+    );
   }
 
   @override


### PR DESCRIPTION
## What

- `DeviceScanner.scanForDevices()` now returns `Future<ScanResult>` that resolves when every service's scan has finished.
- `ScanResult` carries `matchedDevices`, `failedServices` (per-service errors), `terminationReason`, `duration`.
- `DeviceController._runScan` captures per-service throws into `failedServices` instead of swallowing them at `warning` level and dropping the whole scan's error visibility.
- Concurrent `scanForDevices()` calls share a single in-flight Future via `_inFlightScan`.
- `ConnectionManager._connectImpl` simplified: 15-line race comment + `scanningStream.firstWhere((s) => !s)` completion-signal gone — `await deviceScanner.scanForDevices()` is authoritative.
- `MockDeviceScanner` updated to the new return type. Existing `failNextScanWith` hook still works (catastrophic-throw path preserved).

The 200 ms settle delay on `scanning=false` is preserved inside `_runScan` to keep widget-test timing assumptions intact. Marked with a TODO to revisit when PR B reworks status derivation.

## Why

Roadmap items 22 and 21. Before this change, one discovery service throwing would silently log at `warning` and callers relied on `scanningStream.firstWhere((s) => !s)` for the done signal — leading to the fragile `Future.any` race plus the 15-line comment admitting it. A user with BLE permission denied but a USB DE1 attached still got no devices.

Post-change: scan completion has a single authoritative signal (the returned Future), per-service errors are surfaced for later classification, and the serial-only user's USB DE1 survives a BLE-side failure.

## Test plan

- `flutter test`: 955 pass (3 new), 1 skip (Gap F placeholder preserved for Phase 6 roadmap item 20).
- `flutter analyze`: clean on changed files.
- Real-hardware smoke on tablet recommended before integration merge: scan → connect should behave identically (no observable timing regression).