### PR TITLE
feat(comms): queue scaleOnly reconnect during in-flight connect

### DIFF
--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -109,6 +109,11 @@ class ConnectionManager {
   final Set<String> _expectingDisconnectFor = {};
   final Map<String, Timer> _expectingDisconnectTimers = {};
 
+  /// Completer shared by all `connect(scaleOnly: true)` callers that
+  /// arrive while another connect is already running. Drained in the
+  /// outer connect()'s finally block (comms-harden #9).
+  Completer<void>? _queuedScaleOnly;
+
   ConnectionManager({
     required this.deviceScanner,
     required this.de1Controller,
@@ -399,10 +404,46 @@ class ConnectionManager {
   /// Early-stop: if both preferred machine and preferred scale are set,
   /// the scan stops early once both are connected. If only one (or neither)
   /// preference is set, the full scan runs to discover all available devices.
+  ///
+  /// Concurrency: a `scaleOnly` call that arrives while another `connect`
+  /// is already running is queued and replayed after the in-flight call
+  /// completes. Multiple queued `scaleOnly` calls coalesce into one
+  /// replay and share the same returned Future. Non-`scaleOnly` calls
+  /// during an in-flight connect are still dropped silently
+  /// (comms-harden #9).
   Future<void> connect({bool scaleOnly = false}) async {
-    if (_isConnecting) return;
-    _isConnecting = true;
+    if (_isConnecting) {
+      if (scaleOnly) {
+        final completer = _queuedScaleOnly ??= Completer<void>();
+        return completer.future;
+      }
+      return;
+    }
 
+    // Run the current call, then drain any scale-only requests that
+    // queued up while it was running. The drain runs in a `finally`
+    // so stranded callers get woken up even if the initial call
+    // throws.
+    try {
+      await _executeConnect(scaleOnly);
+    } finally {
+      while (_queuedScaleOnly != null) {
+        final drain = _queuedScaleOnly!;
+        _queuedScaleOnly = null;
+        try {
+          await _executeConnect(true);
+          drain.complete();
+        } catch (e, st) {
+          drain.completeError(e, st);
+        }
+      }
+    }
+  }
+
+  /// One connect iteration — sets `_isConnecting` for the duration so
+  /// the concurrency guard in [connect] sees the in-flight state.
+  Future<void> _executeConnect(bool scaleOnly) async {
+    _isConnecting = true;
     try {
       await _connectImpl(scaleOnly: scaleOnly);
     } finally {

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -568,20 +568,64 @@ void main() {
         expect(mockScanner.stopScanCallCount, 0);
       });
 
-      test('guards against concurrent connect calls', () async {
-        // Start a scaleOnly connect
+      test(
+          'concurrent scaleOnly during another connect is queued and '
+          'drained after the in-flight call (comms-harden #9)', () async {
+        // Start a scaleOnly connect that will block on the scan
+        // completer for deterministic timing.
         mockScanner.scanCompleter = Completer<void>();
         final future1 = connectionManager.connect(scaleOnly: true);
 
-        // Second call should be skipped
+        // Second and third scaleOnly calls arrive while the first is
+        // mid-scan. They must return Futures that complete after the
+        // drain runs the scale-only scan.
         final future2 = connectionManager.connect(scaleOnly: true);
+        final future3 = connectionManager.connect(scaleOnly: true);
+
+        // No scan should have started for future2/future3 yet —
+        // queued requests share the in-flight scan.
+        await Future.delayed(Duration.zero);
+        expect(future2, isA<Future<void>>());
+        expect(future3, isA<Future<void>>());
+        // future2 and future3 must share the same pending completer,
+        // so they resolve at the same moment.
+        var future2Done = false;
+        var future3Done = false;
+        future2.then((_) => future2Done = true);
+        future3.then((_) => future3Done = true);
+        await Future.delayed(Duration.zero);
+        expect(future2Done, isFalse);
+        expect(future3Done, isFalse);
+
+        // Let the first scan finish. The drain runs a second scale-only
+        // scan that resolves future2/future3.
+        mockScanner.completeScan();
+        await future1;
+        // Second scan (the drain) runs its own scanForDevices call.
+        // MockDeviceScanner.scanForDevices with no completer resolves
+        // synchronously after a microtask, so await everything.
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+
+        await future2;
+        await future3;
+        expect(future2Done, isTrue);
+        expect(future3Done, isTrue);
+      });
+
+      test(
+          'non-scaleOnly concurrent connect is still dropped (no queue)',
+          () async {
+        mockScanner.scanCompleter = Completer<void>();
+        final future1 = connectionManager.connect();
+
+        // A full-connect call during another full-connect returns
+        // immediately (silent drop), exactly as before.
+        final future2 = connectionManager.connect();
         await future2;
 
         mockScanner.completeScan();
         await future1;
-
-        // Only one scan should have been triggered
-        // (scanForDevices is called once, not twice)
       });
     });
 


### PR DESCRIPTION
## What

Replaces the silent-drop semantics for `connect(scaleOnly: true)` calls that arrive during an in-flight connect with a shared-completer queue drained in a `finally` block after the in-flight call finishes.

- Multiple queued scaleOnly callers share one completer (coalesce).
- Drain runs even if the initial call throws (no stranded awaiters).
- Non-scaleOnly concurrent calls still dropped — intentional and tested.

## Why

Roadmap item 9 from `doc/plans/comms-harden.md`. `De1StateManager._triggerScaleScan()` fires `connect(scaleOnly: true)` on machine wake to reconnect the preferred scale. Before this change, if another connect was running (e.g. a refresh scan from the UI), the scale-reconnect was silently dropped — the scale stayed off until something else triggered it.

Picked Option A (Queue) per the plan discussion: matches the intent ("eventually connect the scale") without concurrent-BLE risk or caller-side retry logic.

## Test plan

- `flutter test`: 956 pass (1 new concurrency test + 1 renamed drop test), 2 skip.
- `flutter analyze`: clean.
- No real-hardware smoke — scaleOnly concurrency is hard to trigger naturally; unit-test coverage is authoritative here.