### PR TITLE
fix(skin): delay WebView compat test on Teclast/problematic manufacturers

### DIFF
--- a/lib/src/services/webview_compatibility_checker.dart
+++ b/lib/src/services/webview_compatibility_checker.dart
@@ -82,6 +82,29 @@ class WebViewCompatibilityChecker {
       return _cachedResult!;
     }
 
+    // Step 1b: let the BLE / platform-channel burst that typically
+    // runs right before SkinView mounts (profile auto-upload + MMR
+    // reads during onConnect) drain before the headless WebView
+    // spins up. Teclast tablets in particular can't keep the
+    // WebView's platform-channel traffic alive under BLE load and
+    // time out the 10-second rendering test.
+    //
+    // Exploratory fix — see doc/plans/comms-harden.md WebView
+    // investigation notes. If it holds, fold into a named constant.
+    try {
+      final androidInfo = await DeviceInfoPlugin().androidInfo;
+      final manufacturer = androidInfo.manufacturer.toLowerCase();
+      if (_isProblematicManufacturer(manufacturer)) {
+        _log.info(
+          'Problematic manufacturer ($manufacturer) — delaying '
+          'WebView test by 500ms to let BLE traffic settle.',
+        );
+        await Future.delayed(const Duration(milliseconds: 500));
+      }
+    } catch (e, st) {
+      _log.warning('Pre-WebView-test delay probe failed, continuing', e, st);
+    }
+
     // Step 2: Runtime WebView test
     final runtimeCheckResult = await _testWebViewRendering();
     _cachedResult = runtimeCheckResult;

--- a/lib/src/services/webview_compatibility_checker.dart
+++ b/lib/src/services/webview_compatibility_checker.dart
@@ -51,6 +51,12 @@ class WebViewCompatibilityChecker {
   static final _log = Logger('WebViewCompatibilityChecker');
   static CompatibilityResult? _cachedResult;
 
+  /// Settle delay inserted before the headless WebView test on devices
+  /// whose platform-channel throughput can't cope with BLE traffic
+  /// running concurrently. Validated on the Teclast M50Mini.
+  static const _problematicManufacturerSettleDelay =
+      Duration(milliseconds: 500);
+
   /// Checks WebView compatibility using device info and runtime test
   ///
   /// Returns cached result if available, otherwise performs full check.
@@ -87,19 +93,19 @@ class WebViewCompatibilityChecker {
     // reads during onConnect) drain before the headless WebView
     // spins up. Teclast tablets in particular can't keep the
     // WebView's platform-channel traffic alive under BLE load and
-    // time out the 10-second rendering test.
-    //
-    // Exploratory fix — see doc/plans/comms-harden.md WebView
-    // investigation notes. If it holds, fold into a named constant.
+    // time out the 10-second rendering test without this settle
+    // window.
     try {
       final androidInfo = await DeviceInfoPlugin().androidInfo;
       final manufacturer = androidInfo.manufacturer.toLowerCase();
       if (_isProblematicManufacturer(manufacturer)) {
         _log.info(
           'Problematic manufacturer ($manufacturer) — delaying '
-          'WebView test by 500ms to let BLE traffic settle.',
+          'WebView test by '
+          '${_problematicManufacturerSettleDelay.inMilliseconds}ms '
+          'to let BLE traffic settle.',
         );
-        await Future.delayed(const Duration(milliseconds: 500));
+        await Future.delayed(_problematicManufacturerSettleDelay);
       }
     } catch (e, st) {
       _log.warning('Pre-WebView-test delay probe failed, continuing', e, st);


### PR DESCRIPTION
## What

After the static device-info check passes but before the headless WebView test runs, sleep 500 ms on problematic Android manufacturers (teclast / allwinner / rockchip — the same list that already gates the runtime test). Lets the BLE / platform-channel burst that fires during `onConnect` (profile auto-upload + MMR reads during `_initializeData`) drain before `HeadlessInAppWebView.run()` kicks off.

## Why

Surfaced during Phase 2 smoke tests on the M50Mini tablet: the WebView compat check was timing out at the 10 s ceiling in roughly half of all boots, both on pre-hardening `main` and on the comms-phase-2 integration branch. Root cause turned out to be the classic Teclast pattern — WebView's platform channel can't keep up with concurrent BLE traffic on the main thread. The compat check either passes in ~250 ms or times out at exactly 10 s; no middle ground.

Validated across multiple tablet boots overnight on the exploratory branch (including debug mode where BLE is slower). Compat check passes reliably with the 500 ms settle window in place.

The settle delay is bracketed by a try/catch around the `device_info_plus` probe so a plugin-level failure falls back to the old behavior.

## Test plan

- `flutter analyze`: clean on changed file (pre-existing `prefer_initializing_formals` info in an unrelated class is unchanged).
- `flutter test`: full suite green.
- Real-hardware validation on M50Mini: already done during the exploratory-branch iteration.