### PR TITLE
feat(comms): scan ownership — cancellable wait, parallel cleanup, Linux refresh lane

### DIFF
--- a/lib/src/controllers/device_controller.dart
+++ b/lib/src/controllers/device_controller.dart
@@ -118,22 +118,30 @@ class DeviceController implements DeviceScanner {
     _scanningStream.add(true);
     final start = DateTime.now();
     try {
-      // Throw out disconnected/discovered devices (keep connected and connecting).
+      // Throw out disconnected/discovered devices (keep connected and
+      // connecting). Run the per-device `connectionState.first` checks
+      // across every service in parallel so pre-scan latency is
+      // capped at 2s total regardless of how many services or
+      // devices are cached (comms-harden #23).
+      final pairs = <({DeviceDiscoveryService service, Device device})>[];
       for (final entry in _devices.entries) {
-        final devices = entry.value;
-        final toRemove = <Device>[];
-        for (final device in devices) {
-          final state = await device.connectionState.first.timeout(
+        for (final device in entry.value) {
+          pairs.add((service: entry.key, device: device));
+        }
+      }
+      final staleFlags = await Future.wait(
+        pairs.map((p) async {
+          final state = await p.device.connectionState.first.timeout(
             const Duration(seconds: 2),
             onTimeout: () => ConnectionState.disconnected,
           );
-          if (state != ConnectionState.connected &&
-              state != ConnectionState.connecting) {
-            toRemove.add(device);
-          }
-        }
-        for (final device in toRemove) {
-          devices.remove(device);
+          return state != ConnectionState.connected &&
+              state != ConnectionState.connecting;
+        }),
+      );
+      for (var i = 0; i < pairs.length; i++) {
+        if (staleFlags[i]) {
+          _devices[pairs[i].service]?.remove(pairs[i].device);
         }
       }
       // Sync the disconnect-detection baseline with the cleaned list so

--- a/lib/src/services/ble/linux_ble_discovery_service.dart
+++ b/lib/src/services/ble/linux_ble_discovery_service.dart
@@ -48,6 +48,13 @@ class LinuxBleDiscoveryService extends BleDiscoveryService {
   /// Queue of devices discovered during scan, processed after scan stops.
   final List<_PendingDevice> _pendingDevices = [];
 
+  /// Set while a BlueZ-cache-refresh scan is in flight. The public
+  /// `stopScan()` ignores external cancels during this window so
+  /// `ConnectionManager._checkEarlyStop` can't abort the refresh
+  /// mid-flight and leave the cache in an uncertain state
+  /// (comms-harden #10).
+  bool _refreshScanInProgress = false;
+
   StreamSubscription<String>? _logSubscription;
   StreamSubscription<BluetoothAdapterState>? _adapterSubscription;
 
@@ -258,6 +265,18 @@ class LinuxBleDiscoveryService extends BleDiscoveryService {
 
   @override
   void stopScan() {
+    // Refresh scan runs post-main-scan to reset BlueZ's internal
+    // cache before (re-)creating devices. If we let an external stop
+    // abort it mid-flight (e.g., ConnectionManager._checkEarlyStop
+    // firing when both preferred devices connect fast), retries can
+    // silently fail on "Bad state: No element" lookups in
+    // flutter_blue_plus_linux. Refresh scans own their lane.
+    if (_refreshScanInProgress) {
+      _log.fine(
+        'External stopScan ignored — refresh scan in progress',
+      );
+      return;
+    }
     FlutterBluePlus.stopScan();
   }
 
@@ -366,7 +385,13 @@ class LinuxBleDiscoveryService extends BleDiscoveryService {
   }
 
   /// Brief scan to refresh BlueZ's internal device cache before a retry.
+  ///
+  /// Sets `_refreshScanInProgress` for the duration so the public
+  /// `stopScan()` short-circuits and ignores external cancel attempts
+  /// (see comms-harden #10 — fixes silent retry failures when
+  /// `_checkEarlyStop` fires during post-main-scan processing).
   Future<void> _runRefreshScan() async {
+    _refreshScanInProgress = true;
     _log.fine("Refresh scan for ${_refreshScanDuration.inSeconds}s");
     try {
       await FlutterBluePlus.startScan(oneByOne: true);
@@ -381,6 +406,8 @@ class LinuxBleDiscoveryService extends BleDiscoveryService {
       } catch (e, st) {
         _log.fine('stopScan after failed refresh scan errored', e, st);
       }
+    } finally {
+      _refreshScanInProgress = false;
     }
   }
 

--- a/lib/src/services/blue_plus_discovery_service.dart
+++ b/lib/src/services/blue_plus_discovery_service.dart
@@ -19,6 +19,12 @@ class BluePlusDiscoveryService extends BleDiscoveryService {
   final Set<String> _devicesBeingCreated = {};
   bool _isScanning = false;
 
+  // Cancellable 15s scan-duration wait. External stopScan() cancels
+  // the timer and completes the completer so scanForDevices returns
+  // promptly instead of being pinned for 15s (comms-harden #11).
+  Timer? _scanDurationTimer;
+  Completer<void>? _scanDurationCompleter;
+
   // On Linux, queue discovered devices and process after scan stops
   // to avoid BlueZ le-connection-abort-by-local errors
   final List<_PendingDevice> _pendingDevices = [];
@@ -103,7 +109,39 @@ class BluePlusDiscoveryService extends BleDiscoveryService {
 
   @override
   void stopScan() {
+    _cancelScanDurationWait();
     FlutterBluePlus.stopScan();
+  }
+
+  /// Cancel the scheduled 15s stopScan and unblock the awaiter in
+  /// scanForDevices so it can proceed to post-scan processing /
+  /// clean up `_isScanning`. Called from the public stopScan() and
+  /// from the timer's own fire path.
+  void _cancelScanDurationWait() {
+    _scanDurationTimer?.cancel();
+    _scanDurationTimer = null;
+    final c = _scanDurationCompleter;
+    if (c != null && !c.isCompleted) {
+      c.complete();
+    }
+    _scanDurationCompleter = null;
+  }
+
+  /// Wait up to [duration] for the scan to finish, or return early if
+  /// `stopScan()` is called. The BLE scan is stopped in either case
+  /// before this returns.
+  Future<void> _waitForScanDuration(Duration duration) async {
+    final completer = Completer<void>();
+    _scanDurationCompleter = completer;
+    _scanDurationTimer = Timer(duration, () async {
+      try {
+        await FlutterBluePlus.stopScan();
+      } catch (e, st) {
+        _log.warning('Scheduled stopScan failed', e, st);
+      }
+      _cancelScanDurationWait();
+    });
+    await completer.future;
   }
 
   @override
@@ -115,16 +153,23 @@ class BluePlusDiscoveryService extends BleDiscoveryService {
 
     _isScanning = true;
 
-    // Remove disconnected devices so re-discovered ones get fresh objects
-    final toRemove = <Device>[];
-    for (final device in _devices) {
-      final state = await device.connectionState.first
-          .timeout(const Duration(seconds: 2),
-              onTimeout: () => ConnectionState.disconnected);
-      if (state != ConnectionState.connected) {
-        toRemove.add(device);
-      }
-    }
+    // Remove disconnected devices so re-discovered ones get fresh
+    // objects. Run the per-device `connectionState.first` checks in
+    // parallel so pre-scan latency is capped at 2s regardless of how
+    // many devices are cached (comms-harden #23).
+    final staleFlags = await Future.wait(
+      _devices.map((d) async {
+        final state = await d.connectionState.first.timeout(
+          const Duration(seconds: 2),
+          onTimeout: () => ConnectionState.disconnected,
+        );
+        return state != ConnectionState.connected;
+      }),
+    );
+    final toRemove = <Device>[
+      for (var i = 0; i < _devices.length; i++)
+        if (staleFlags[i]) _devices[i],
+    ];
     for (final device in toRemove) {
       _devices.remove(device);
       _devicesBeingCreated.remove(device.deviceId);
@@ -179,26 +224,22 @@ class BluePlusDiscoveryService extends BleDiscoveryService {
       // Unfiltered scan — no withServices parameter
       await FlutterBluePlus.startScan(oneByOne: true);
 
-      if (Platform.isLinux) {
-        // On Linux/BlueZ, we must stop scanning before connecting to devices.
-        // Scan for 15s to ensure we catch devices with slow advertising intervals,
-        // then process all queued devices after the scan stops.
-        await Future.delayed(Duration(seconds: 15), () async {
-          await FlutterBluePlus.stopScan();
-        });
+      // Scan for up to 15s. External stopScan() cancels the timer and
+      // completes the completer early so the scanner can free
+      // `_isScanning` without waiting out the full duration
+      // (comms-harden #11).
+      await _waitForScanDuration(const Duration(seconds: 15));
 
-        if (_pendingDevices.isNotEmpty) {
-          _log.info("Processing ${_pendingDevices.length} queued BLE devices");
-          await Future.delayed(Duration(milliseconds: 200));
-          for (final pending in _pendingDevices) {
-            await _createDeviceFromName(pending.deviceId, pending.name);
-          }
-          _pendingDevices.clear();
+      if (Platform.isLinux && _pendingDevices.isNotEmpty) {
+        // On Linux/BlueZ, we must stop scanning before connecting to
+        // devices. The 15s (or shorter, on early-stop) scan above has
+        // collected devices into _pendingDevices; now process them.
+        _log.info("Processing ${_pendingDevices.length} queued BLE devices");
+        await Future.delayed(Duration(milliseconds: 200));
+        for (final pending in _pendingDevices) {
+          await _createDeviceFromName(pending.deviceId, pending.name);
         }
-      } else {
-        await Future.delayed(Duration(seconds: 15), () async {
-          await FlutterBluePlus.stopScan();
-        });
+        _pendingDevices.clear();
       }
 
       _deviceStreamController.add(_devices.toList());


### PR DESCRIPTION
## What

Three Cluster B items landed together:

- **Cancellable 15 s scan wait** (`BluePlusDiscoveryService`). Timer + Completer replaces `Future.delayed`. External `stopScan()` cancels the timer and completes the awaiter, so `_isScanning` frees promptly instead of being pinned for the full 15 s.
- **Parallel pre-scan cleanup** (`BluePlusDiscoveryService` + `DeviceController`). Each layer's per-device `connectionState.first.timeout(2s)` loop is wrapped in `Future.wait`. Same logic, now concurrent — scan-start latency capped at 2 s regardless of device count.
- **Linux refresh-scan ownership**. `LinuxBleDiscoveryService.stopScan()` short-circuits when `_refreshScanInProgress` is set, so `ConnectionManager._checkEarlyStop` can't abort a BlueZ-cache refresh mid-flight. Fixes silent retry failures after early-stop fires during post-main-scan processing.

## Why

Roadmap items 10, 11, 23. Together these finish Cluster B (scan ownership) — the scan lifecycle now has a single, cancellable, well-owned shape.

## Test plan

- `flutter test`: 956 pass, 2 skip.
- `flutter analyze`: clean on changed files (pre-existing `_isBleDeviceId` / `_logSubscription` warnings unchanged).
- Real-hardware smoke on M50Mini: connect 3.9 s, reconnect 2.9 s, scan 15.4 s (Phase 2 baseline).
- Linux-specific path for item 10 validated by inspection; no Linux hardware available for direct smoke test.