### PR TITLE
refactor(comms): extract DisconnectExpectations, StatusPublisher, ScanReportBuilder

### DIFF
--- a/lib/src/controllers/connection/disconnect_expectations.dart
+++ b/lib/src/controllers/connection/disconnect_expectations.dart
@@ -1,0 +1,58 @@
+import 'dart:async';
+
+/// Tracks deviceIds the app is about to deliberately disconnect.
+///
+/// When a disconnect is about to be app-initiated (e.g., explicit
+/// `disconnectMachine` call, scale-power-down from machine sleep),
+/// callers [mark] the device's id first so the matching
+/// `disconnected` event fires without emitting an error on
+/// `ConnectionManager.status`.
+///
+/// A bounded TTL timer clears the mark if the expected disconnect
+/// event never arrives — otherwise a stale mark would silently
+/// suppress an unrelated real disconnect later.
+///
+/// Extracted from ConnectionManager as part of comms-harden Phase 4
+/// (roadmap item 15 — god-class split).
+class DisconnectExpectations {
+  /// How long a `mark` stays valid if no matching disconnect event
+  /// arrives. Matches the previous inline TTL in ConnectionManager.
+  static const ttl = Duration(seconds: 10);
+
+  final Set<String> _expecting = <String>{};
+  final Map<String, Timer> _timers = <String, Timer>{};
+
+  /// Mark [deviceId] as expecting a disconnect. The next matching
+  /// `disconnected` event will be consumed silently by [consume].
+  ///
+  /// Idempotent: marking the same id twice resets the TTL without
+  /// doubling up entries.
+  void mark(String deviceId) {
+    _expecting.add(deviceId);
+    _timers[deviceId]?.cancel();
+    _timers[deviceId] = Timer(ttl, () {
+      _expecting.remove(deviceId);
+      _timers.remove(deviceId);
+    });
+  }
+
+  /// Consume an expectation for [deviceId]. Returns true if [deviceId]
+  /// was marked (and was cleared as a side effect), false otherwise.
+  bool consume(String deviceId) {
+    final wasExpecting = _expecting.remove(deviceId);
+    if (wasExpecting) {
+      _timers.remove(deviceId)?.cancel();
+    }
+    return wasExpecting;
+  }
+
+  /// Cancel every pending TTL timer and clear all expectations.
+  /// Safe to call more than once.
+  void dispose() {
+    for (final t in _timers.values) {
+      t.cancel();
+    }
+    _timers.clear();
+    _expecting.clear();
+  }
+}

--- a/lib/src/controllers/connection/scan_report_builder.dart
+++ b/lib/src/controllers/connection/scan_report_builder.dart
@@ -1,0 +1,137 @@
+import 'package:reaprime/src/models/adapter_state.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/scan_report.dart';
+
+/// Mutable tracker used during a scan to accumulate connection-attempt
+/// results before building the immutable [MatchedDevice].
+///
+/// Public within the `lib/src/controllers/connection/` module so tests
+/// can construct one directly; not part of the public
+/// `ConnectionManager` API.
+class MatchedDeviceTracker {
+  final String deviceName;
+  final String deviceId;
+  final DeviceType deviceType;
+  bool connectionAttempted = false;
+  ConnectionResult? connectionResult;
+
+  MatchedDeviceTracker({
+    required this.deviceName,
+    required this.deviceId,
+    required this.deviceType,
+  });
+
+  MatchedDevice toMatchedDevice() => MatchedDevice(
+        deviceName: deviceName,
+        deviceId: deviceId,
+        deviceType: deviceType,
+        connectionAttempted: connectionAttempted,
+        connectionResult: connectionResult,
+      );
+}
+
+/// Accumulates per-device connection-attempt results over the lifetime
+/// of one scan and builds the final [ScanReport] from them.
+///
+/// Idempotent `seed` so the early-connect path and the post-scan
+/// snapshot can share one builder without clobbering each other.
+///
+/// Extracted from ConnectionManager as part of comms-harden Phase 4
+/// (roadmap item 15 — god-class split).
+class ScanReportBuilder {
+  final DateTime scanStartTime;
+  final Map<String, MatchedDeviceTracker> _trackers = {};
+
+  ScanReportBuilder({required this.scanStartTime});
+
+  /// Ensure a tracker exists for [d]. Does not clobber an existing
+  /// entry — `putIfAbsent` semantics so recorded attempt results
+  /// survive a second seed call.
+  void seed(Device d) {
+    _trackers.putIfAbsent(
+      d.deviceId,
+      () => MatchedDeviceTracker(
+        deviceName: d.name,
+        deviceId: d.deviceId,
+        deviceType: d.type,
+      ),
+    );
+  }
+
+  /// Mark that a connection attempt was started for [deviceId]. No-op
+  /// if no tracker exists for that id (shouldn't happen in practice
+  /// since connect paths seed before attempting).
+  void markAttempted(String deviceId) {
+    _trackers[deviceId]?.connectionAttempted = true;
+  }
+
+  /// Record the outcome of a connect attempt for [deviceId]. No-op if
+  /// no tracker exists.
+  void recordResult(String deviceId, ConnectionResult result) {
+    _trackers[deviceId]?.connectionResult = result;
+  }
+
+  /// Build the immutable [ScanReport]. Does not clear the builder —
+  /// safe to call again, but typically called once per scan cycle.
+  ScanReport build({
+    required String? preferredMachineId,
+    required String? preferredScaleId,
+    required ScanTerminationReason terminationReason,
+  }) {
+    final matchedDevices =
+        _trackers.values.map((t) => t.toMatchedDevice()).toList();
+    return ScanReport(
+      totalBleDevicesSeen: matchedDevices.length,
+      matchedDevices: matchedDevices,
+      scanDuration: DateTime.now().difference(scanStartTime),
+      adapterStateAtStart: AdapterState.unknown,
+      adapterStateAtEnd: AdapterState.unknown,
+      scanTerminationReason: terminationReason,
+      preferredMachineId: preferredMachineId,
+      preferredScaleId: preferredScaleId,
+    );
+  }
+
+  /// Render a multi-line human-readable summary for logs.
+  static String format(ScanReport report) {
+    final buf = StringBuffer('Scan report: ');
+    buf.write('${report.matchedDevices.length} devices matched, ');
+    buf.write('duration=${report.scanDuration.inMilliseconds}ms, ');
+    buf.write('termination=${report.scanTerminationReason.name}');
+
+    if (report.preferredMachineId != null) {
+      final found = report.matchedDevices
+          .any((d) => d.deviceId == report.preferredMachineId);
+      buf.write(
+        ', preferred machine ${report.preferredMachineId} '
+        '${found ? "found" : "NOT found"}',
+      );
+    }
+    if (report.preferredScaleId != null) {
+      final found = report.matchedDevices
+          .any((d) => d.deviceId == report.preferredScaleId);
+      buf.write(
+        ', preferred scale ${report.preferredScaleId} '
+        '${found ? "found" : "NOT found"}',
+      );
+    }
+
+    for (final d in report.matchedDevices) {
+      buf.write('\n  ${d.deviceName} (${d.deviceId}, ${d.deviceType.name})');
+      if (d.connectionAttempted) {
+        final result = d.connectionResult;
+        if (result == null) {
+          buf.write(' — connection attempted, no result');
+        } else if (result.success) {
+          buf.write(' — connected');
+        } else if (result.error != null) {
+          buf.write(' — connection failed: ${result.error}');
+        } else {
+          buf.write(' — skipped');
+        }
+      }
+    }
+
+    return buf.toString();
+  }
+}

--- a/lib/src/controllers/connection/status_publisher.dart
+++ b/lib/src/controllers/connection/status_publisher.dart
@@ -1,0 +1,102 @@
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/connection_error.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart'
+    show ConnectionPhase, ConnectionStatus;
+import 'package:rxdart/rxdart.dart';
+
+/// Owns the `ConnectionStatus` stream for `ConnectionManager` and
+/// enforces the error-gating rules that keep sticky errors alive
+/// across phase transitions while stripping re-published transient
+/// errors at clearing-phase boundaries.
+///
+/// All outbound status updates funnel through [publish] so the rules
+/// live in exactly one place. [emitError] is a convenience that keeps
+/// the current phase and sets `error` on it — same gatekeeper path.
+///
+/// Extracted from ConnectionManager as part of comms-harden Phase 4
+/// (roadmap item 15 — god-class split).
+class StatusPublisher {
+  static final _log = Logger('StatusPublisher');
+
+  /// Phases that start a new operation or reach a stable good state.
+  /// Moving into one of these clears a *re-published* transient error
+  /// (but not a new one the caller explicitly passed, and not a
+  /// sticky error — adapter-off, permission-denied, scan-failed —
+  /// which survive until the environment recovers).
+  static const _clearingPhases = {
+    ConnectionPhase.scanning,
+    ConnectionPhase.connectingMachine,
+    ConnectionPhase.connectingScale,
+    ConnectionPhase.ready,
+  };
+
+  final BehaviorSubject<ConnectionStatus> _subject =
+      BehaviorSubject.seeded(const ConnectionStatus());
+
+  Stream<ConnectionStatus> get stream => _subject.stream;
+  ConnectionStatus get current => _subject.value;
+
+  /// Publish [next] onto the status stream, applying the sticky /
+  /// transient / identity rules to the `error` field.
+  void publish(ConnectionStatus next) {
+    final prev = _subject.value;
+    ConnectionError? effectiveError = next.error;
+    final movingIntoClearingPhase =
+        prev.phase != next.phase && _clearingPhases.contains(next.phase);
+
+    if (effectiveError == null &&
+        prev.error != null &&
+        ConnectionErrorKind.sticky.contains(prev.error!.kind)) {
+      // Caller published null but a sticky error was active — keep it.
+      // Sticky errors only clear via explicit environmental-recovery
+      // handlers.
+      effectiveError = prev.error;
+    } else if (effectiveError != null &&
+        movingIntoClearingPhase &&
+        !ConnectionErrorKind.sticky.contains(effectiveError.kind)) {
+      // A new status that carries a transient error into a clearing
+      // phase means the caller is re-publishing an old error — strip
+      // it.
+      effectiveError = null;
+    } else if (prev.error != null &&
+        // copyWith preserves the error reference when the caller does
+        // not pass `error:`, so `identical` is the right identity
+        // check here.
+        identical(next.error, prev.error) &&
+        movingIntoClearingPhase &&
+        !ConnectionErrorKind.sticky.contains(prev.error!.kind)) {
+      effectiveError = null;
+    }
+
+    _subject.add(next.copyWith(error: () => effectiveError));
+  }
+
+  /// Emit [err] on the status stream without changing the current
+  /// phase. Logs at severe/warning depending on severity, then routes
+  /// through [publish] so the same gatekeeper applies.
+  void emitError(ConnectionError err) {
+    final msg = 'emit error: kind=${err.kind} message=${err.message} '
+        'deviceId=${err.deviceId}';
+    if (err.severity == ConnectionErrorSeverity.error) {
+      _log.severe(msg);
+    } else {
+      _log.warning(msg);
+    }
+    publish(current.copyWith(error: () => err));
+  }
+
+  /// Explicitly clear the current error. Used by environmental-recovery
+  /// handlers (adapter-on, scan-started, etc) to drop a sticky error
+  /// that [publish]'s rules would preserve.
+  void clearError() {
+    if (current.error == null) return;
+    _subject.add(current.copyWith(error: () => null));
+  }
+
+  /// Close the underlying subject. Safe to call more than once.
+  void dispose() {
+    if (!_subject.isClosed) {
+      _subject.close();
+    }
+  }
+}

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -4,6 +4,9 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_blue_plus/flutter_blue_plus.dart'
     show FlutterBluePlusException;
 import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/connection/disconnect_expectations.dart';
+import 'package:reaprime/src/controllers/connection/scan_report_builder.dart';
+import 'package:reaprime/src/controllers/connection/status_publisher.dart';
 import 'package:reaprime/src/controllers/connection_error.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
@@ -68,13 +71,12 @@ class ConnectionManager {
 
   final _log = Logger('ConnectionManager');
 
-  final BehaviorSubject<ConnectionStatus> _statusSubject =
-      BehaviorSubject.seeded(const ConnectionStatus());
+  final StatusPublisher _statusPublisher = StatusPublisher();
 
   final BehaviorSubject<ScanReport> _scanReportSubject = BehaviorSubject();
 
-  Stream<ConnectionStatus> get status => _statusSubject.stream;
-  ConnectionStatus get currentStatus => _statusSubject.value;
+  Stream<ConnectionStatus> get status => _statusPublisher.stream;
+  ConnectionStatus get currentStatus => _statusPublisher.current;
 
   /// The most recent scan report, or null if no scan has completed yet.
   ScanReport? get lastScanReport => _scanReportSubject.valueOrNull;
@@ -106,8 +108,8 @@ class ConnectionManager {
   StreamSubscription? _scaleDisconnectSub;
   StreamSubscription<AdapterState>? _adapterSub;
 
-  final Set<String> _expectingDisconnectFor = {};
-  final Map<String, Timer> _expectingDisconnectTimers = {};
+  final DisconnectExpectations _disconnectExpectations =
+      DisconnectExpectations();
 
   /// Completer shared by all `connect(scaleOnly: true)` callers that
   /// arrive while another connect is already running. Drained in the
@@ -185,18 +187,10 @@ class ConnectionManager {
   }
 
   /// Emit a [ConnectionError] onto the status stream without changing
-  /// the current phase. Thin wrapper over [_publishStatus] so every
-  /// outbound update goes through the same gatekeeper (comms-harden #8).
-  void _emit(ConnectionError err) {
-    final msg = 'emit error: kind=${err.kind} message=${err.message} '
-        'deviceId=${err.deviceId}';
-    if (err.severity == ConnectionErrorSeverity.error) {
-      _log.severe(msg);
-    } else {
-      _log.warning(msg);
-    }
-    _publishStatus(currentStatus.copyWith(error: () => err));
-  }
+  /// the current phase. Thin proxy over [StatusPublisher.emitError] so
+  /// every outbound update goes through the same gatekeeper
+  /// (comms-harden #8).
+  void _emit(ConnectionError err) => _statusPublisher.emitError(err);
 
   /// Build a [ConnectionError] for a failed connect attempt. Pulls out
   /// `fbp_code` / `fbp_description` when the caught exception is a
@@ -250,51 +244,14 @@ class ConnectionManager {
     return ConnectionErrorKind.scanFailed;
   }
 
-  /// Clears the current error. Called by environmental recovery handlers
-  /// (adapter on, permission granted).
-  void _clearError() {
-    if (currentStatus.error == null) return;
-    _statusSubject.add(currentStatus.copyWith(error: () => null));
-  }
+  /// Clears the current error. Proxy over [StatusPublisher.clearError]
+  /// — called by environmental recovery handlers (adapter on,
+  /// permission granted).
+  void _clearError() => _statusPublisher.clearError();
 
-  void _publishStatus(ConnectionStatus next) {
-    final prev = _statusSubject.value;
-    // Auto-clear transient errors on phase transitions that start a new
-    // operation or reach a stable good state.
-    const clearingPhases = {
-      ConnectionPhase.scanning,
-      ConnectionPhase.connectingMachine,
-      ConnectionPhase.connectingScale,
-      ConnectionPhase.ready,
-    };
-
-    ConnectionError? effectiveError = next.error;
-    final movingIntoClearingPhase =
-        prev.phase != next.phase && clearingPhases.contains(next.phase);
-
-    if (effectiveError == null &&
-        prev.error != null &&
-        ConnectionErrorKind.sticky.contains(prev.error!.kind)) {
-      // Caller published null but a sticky error was active — keep it.
-      // Sticky errors only clear via explicit environmental-recovery handlers.
-      effectiveError = prev.error;
-    } else if (effectiveError != null &&
-        movingIntoClearingPhase &&
-        !ConnectionErrorKind.sticky.contains(effectiveError.kind)) {
-      // A new status that carries a transient error into a clearing phase
-      // means the caller is re-publishing an old error — strip it.
-      effectiveError = null;
-    } else if (prev.error != null &&
-        // copyWith preserves the error reference when the caller does not
-        // pass `error:`, so `identical` is the right identity check here.
-        identical(next.error, prev.error) &&
-        movingIntoClearingPhase &&
-        !ConnectionErrorKind.sticky.contains(prev.error!.kind)) {
-      effectiveError = null;
-    }
-
-    _statusSubject.add(next.copyWith(error: () => effectiveError));
-  }
+  /// Publish a new [ConnectionStatus] with sticky/transient error
+  /// gating. Proxy over [StatusPublisher.publish].
+  void _publishStatus(ConnectionStatus next) => _statusPublisher.publish(next);
 
   @visibleForTesting
   void debugEmitError({
@@ -321,7 +278,7 @@ class ConnectionManager {
 
   @visibleForTesting
   void debugSetPhase(ConnectionPhase phase) {
-    _statusSubject.add(currentStatus.copyWith(phase: phase));
+    _statusPublisher.publish(currentStatus.copyWith(phase: phase));
   }
 
   /// Call immediately before an app-initiated disconnect. The next
@@ -329,22 +286,11 @@ class ConnectionManager {
   /// will not emit an error. A 10-second TTL safety timer clears the
   /// expectation if the disconnect event never arrives.
   void markExpectingDisconnect(String deviceId) {
-    _expectingDisconnectFor.add(deviceId);
-    _expectingDisconnectTimers[deviceId]?.cancel();
-    _expectingDisconnectTimers[deviceId] =
-        Timer(const Duration(seconds: 10), () {
-      _expectingDisconnectFor.remove(deviceId);
-      _expectingDisconnectTimers.remove(deviceId);
-    });
+    _disconnectExpectations.mark(deviceId);
   }
 
-  bool _consumeExpectingDisconnect(String deviceId) {
-    final wasExpecting = _expectingDisconnectFor.remove(deviceId);
-    if (wasExpecting) {
-      _expectingDisconnectTimers.remove(deviceId)?.cancel();
-    }
-    return wasExpecting;
-  }
+  bool _consumeExpectingDisconnect(String deviceId) =>
+      _disconnectExpectations.consume(deviceId);
 
   void _handleScaleDisconnect(String deviceId) {
     if (_consumeExpectingDisconnect(deviceId)) {
@@ -454,8 +400,9 @@ class ConnectionManager {
   Future<void> _connectImpl({required bool scaleOnly}) async {
     final scanStartTime = DateTime.now();
 
-    // Track matched devices and their connection results
-    final matchedDeviceResults = <String, _MatchedDeviceTracker>{};
+    // Per-scan builder that accumulates attempted/succeeded/failed
+    // results and emits the final ScanReport.
+    final scanReport = ScanReportBuilder(scanStartTime: scanStartTime);
 
     // Emit scanning phase. Do not explicitly clear `error` — the gatekeeper
     // strips transient errors on phase transitions into clearing phases and
@@ -504,12 +451,12 @@ class ConnectionManager {
           _log.fine('Preferred machine found during scan, connecting early');
           earlyMachineStarted = true;
           // Seed the tracker now so the connection attempt + result
-          // land on the right entry; the post-scan populate below uses
-          // putIfAbsent and will leave our seeded tracker intact.
-          _seedTracker(matchedDeviceResults, match);
+          // land on the right entry; the post-scan seed below is
+          // idempotent and leaves this seed intact.
+          scanReport.seed(match);
           earlyMachinePending = _connectMachineTracked(
             match,
-            matchedDeviceResults,
+            scanReport,
           ).then((_) {
             _checkEarlyStop(earlyStopEnabled);
           });
@@ -527,10 +474,10 @@ class ConnectionManager {
         if (match != null) {
           _log.fine('Preferred scale found during scan, connecting early');
           earlyScaleStarted = true;
-          _seedTracker(matchedDeviceResults, match);
+          scanReport.seed(match);
           earlyScalePending = _connectScaleTracked(
             match,
-            matchedDeviceResults,
+            scanReport,
           ).then((_) {
             _checkEarlyStop(earlyStopEnabled);
           });
@@ -613,9 +560,10 @@ class ConnectionManager {
 
     // Seed tracker entries for every device in the final snapshot.
     // Early-connect paths pre-seeded their targets in the stream
-    // listener; putIfAbsent preserves those entries untouched.
+    // listener; ScanReportBuilder.seed is idempotent so those entries
+    // stay intact.
     for (final d in allDevices) {
-      _seedTracker(matchedDeviceResults, d);
+      scanReport.seed(d);
     }
 
     _log.fine(
@@ -628,10 +576,9 @@ class ConnectionManager {
         currentStatus.copyWith(foundScales: scales),
       );
       // Apply scale preference policy only
-      await _connectScalePhase(scales, matchedDeviceResults);
+      await _connectScalePhase(scales, scanReport);
       _emitScanReport(
-        scanStartTime: scanStartTime,
-        matchedDeviceResults: matchedDeviceResults,
+        scanReport: scanReport,
         preferredMachineId: null,
         preferredScaleId: preferredScaleId,
         terminationReason: ScanTerminationReason.completed,
@@ -648,10 +595,9 @@ class ConnectionManager {
     // skip straight to scale phase
     if (_machineConnected) {
       _log.fine('Machine connected, proceeding to scale phase');
-      await _connectScalePhase(scales, matchedDeviceResults);
+      await _connectScalePhase(scales, scanReport);
       _emitScanReport(
-        scanStartTime: scanStartTime,
-        matchedDeviceResults: matchedDeviceResults,
+        scanReport: scanReport,
         preferredMachineId: preferredMachineId,
         preferredScaleId: preferredScaleId,
         terminationReason: ScanTerminationReason.completed,
@@ -678,8 +624,8 @@ class ConnectionManager {
         _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.idle));
       } else if (machines.length == 1) {
         // Exactly one machine — auto-connect
-        await _connectMachineTracked(machines.first, matchedDeviceResults);
-        await _connectScalePhase(scales, matchedDeviceResults);
+        await _connectMachineTracked(machines.first, scanReport);
+        await _connectScalePhase(scales, scanReport);
       } else {
         // Multiple machines — picker
         _publishStatus(
@@ -692,8 +638,7 @@ class ConnectionManager {
     }
 
     _emitScanReport(
-      scanStartTime: scanStartTime,
-      matchedDeviceResults: matchedDeviceResults,
+      scanReport: scanReport,
       preferredMachineId: preferredMachineId,
       preferredScaleId: preferredScaleId,
       terminationReason: ScanTerminationReason.completed,
@@ -708,10 +653,13 @@ class ConnectionManager {
     }
   }
 
-  /// Apply scale preference policy after machine connects.
+  /// Apply scale preference policy after machine connects. If
+  /// [scanReport] is provided, the attempt outcome is recorded on it;
+  /// otherwise a bare `connectScale` is used (the non-scan-driven
+  /// paths don't need tracker bookkeeping).
   Future<void> _connectScalePhase(
     List<Scale> scales, [
-    Map<String, _MatchedDeviceTracker>? matchedDeviceResults,
+    ScanReportBuilder? scanReport,
   ]) async {
     if (_scaleConnected) {
       _log.fine('Scale already connected, skipping scale phase');
@@ -726,8 +674,8 @@ class ConnectionManager {
       final preferred =
           scales.where((s) => s.deviceId == preferredScaleId).toList();
       if (preferred.isNotEmpty) {
-        if (matchedDeviceResults != null) {
-          await _connectScaleTracked(preferred.first, matchedDeviceResults);
+        if (scanReport != null) {
+          await _connectScaleTracked(preferred.first, scanReport);
         } else {
           await connectScale(preferred.first);
         }
@@ -743,8 +691,8 @@ class ConnectionManager {
     } else {
       // No preferred scale set
       if (scales.length == 1) {
-        if (matchedDeviceResults != null) {
-          await _connectScaleTracked(scales.first, matchedDeviceResults);
+        if (scanReport != null) {
+          await _connectScaleTracked(scales.first, scanReport);
         } else {
           await connectScale(scales.first);
         }
@@ -856,125 +804,63 @@ class ConnectionManager {
     }
   }
 
-  /// Connect a machine and track the result for the scan report.
+  /// Connect a machine and record the attempt outcome on the scan
+  /// report builder.
   Future<void> _connectMachineTracked(
     De1Interface machine,
-    Map<String, _MatchedDeviceTracker> trackers,
+    ScanReportBuilder scanReport,
   ) async {
-    final tracker = trackers[machine.deviceId];
-    if (tracker != null) {
-      tracker.connectionAttempted = true;
-    }
+    scanReport.markAttempted(machine.deviceId);
     try {
       await connectMachine(machine);
-      tracker?.connectionResult = const ConnectionResult.succeeded();
+      scanReport.recordResult(
+        machine.deviceId,
+        const ConnectionResult.succeeded(),
+      );
     } catch (e) {
-      tracker?.connectionResult = ConnectionResult.failed(e.toString());
+      scanReport.recordResult(
+        machine.deviceId,
+        ConnectionResult.failed(e.toString()),
+      );
     }
   }
 
-  /// Connect a scale and track the result for the scan report.
+  /// Connect a scale and record the attempt outcome on the scan
+  /// report builder.
   Future<void> _connectScaleTracked(
     Scale scale,
-    Map<String, _MatchedDeviceTracker> trackers,
+    ScanReportBuilder scanReport,
   ) async {
-    final tracker = trackers[scale.deviceId];
-    if (tracker != null) {
-      tracker.connectionAttempted = true;
-    }
+    scanReport.markAttempted(scale.deviceId);
     try {
       await connectScale(scale);
-      tracker?.connectionResult = const ConnectionResult.succeeded();
+      scanReport.recordResult(
+        scale.deviceId,
+        const ConnectionResult.succeeded(),
+      );
     } catch (e) {
-      tracker?.connectionResult = ConnectionResult.failed(e.toString());
+      scanReport.recordResult(
+        scale.deviceId,
+        ConnectionResult.failed(e.toString()),
+      );
     }
   }
 
-  /// Seed a `_MatchedDeviceTracker` entry for `d` if one isn't already
-  /// present. Idempotent via `putIfAbsent` so early-connect paths and
-  /// the post-scan snapshot can share the same tracker map without
-  /// clobbering connection-attempt results (comms-harden #17).
-  void _seedTracker(
-    Map<String, _MatchedDeviceTracker> trackers,
-    device.Device d,
-  ) {
-    trackers.putIfAbsent(
-      d.deviceId,
-      () => _MatchedDeviceTracker(
-        deviceName: d.name,
-        deviceId: d.deviceId,
-        deviceType: d.type,
-      ),
-    );
-  }
-
-  /// Build and emit a [ScanReport] from the collected scan data.
+  /// Build a [ScanReport] from [scanReport] and publish it on the
+  /// scan-report stream + log the human-readable form.
   void _emitScanReport({
-    required DateTime scanStartTime,
-    required Map<String, _MatchedDeviceTracker> matchedDeviceResults,
+    required ScanReportBuilder scanReport,
     required String? preferredMachineId,
     required String? preferredScaleId,
     required ScanTerminationReason terminationReason,
   }) {
-    final scanDuration = DateTime.now().difference(scanStartTime);
-    final matchedDevices =
-        matchedDeviceResults.values.map((t) => t.toMatchedDevice()).toList();
-
-    final report = ScanReport(
-      totalBleDevicesSeen: matchedDevices.length,
-      matchedDevices: matchedDevices,
-      scanDuration: scanDuration,
-      adapterStateAtStart: AdapterState.unknown,
-      adapterStateAtEnd: AdapterState.unknown,
-      scanTerminationReason: terminationReason,
+    final report = scanReport.build(
       preferredMachineId: preferredMachineId,
       preferredScaleId: preferredScaleId,
+      terminationReason: terminationReason,
     );
-
     _scanReportSubject.add(report);
-    _log.info(_formatScanReport(report));
-  }
-
-  String _formatScanReport(ScanReport report) {
-    final buf = StringBuffer('Scan report: ');
-    buf.write('${report.matchedDevices.length} devices matched, ');
-    buf.write('duration=${report.scanDuration.inMilliseconds}ms, ');
-    buf.write('termination=${report.scanTerminationReason.name}');
-
-    if (report.preferredMachineId != null) {
-      final found = report.matchedDevices
-          .any((d) => d.deviceId == report.preferredMachineId);
-      buf.write(
-        ', preferred machine ${report.preferredMachineId} '
-        '${found ? "found" : "NOT found"}',
-      );
-    }
-    if (report.preferredScaleId != null) {
-      final found = report.matchedDevices
-          .any((d) => d.deviceId == report.preferredScaleId);
-      buf.write(
-        ', preferred scale ${report.preferredScaleId} '
-        '${found ? "found" : "NOT found"}',
-      );
-    }
-
-    for (final d in report.matchedDevices) {
-      buf.write('\n  ${d.deviceName} (${d.deviceId}, ${d.deviceType.name})');
-      if (d.connectionAttempted) {
-        final result = d.connectionResult;
-        if (result == null) {
-          buf.write(' — connection attempted, no result');
-        } else if (result.success) {
-          buf.write(' — connected');
-        } else if (result.error != null) {
-          buf.write(' — connection failed: ${result.error}');
-        } else {
-          buf.write(' — skipped');
-        }
-      }
-    }
-
-    return buf.toString();
+    _log.info(ScanReportBuilder.format(report));
   }
 
   Future<void> disconnectMachine() async {
@@ -1008,36 +894,9 @@ class ConnectionManager {
     _machineDisconnectSub?.cancel();
     _scaleDisconnectSub?.cancel();
     _adapterSub?.cancel();
-    for (final t in _expectingDisconnectTimers.values) {
-      t.cancel();
-    }
-    _expectingDisconnectTimers.clear();
-    _expectingDisconnectFor.clear();
-    _statusSubject.close();
+    _disconnectExpectations.dispose();
+    _statusPublisher.dispose();
     _scanReportSubject.close();
   }
 }
 
-/// Mutable tracker used during a scan to accumulate connection attempt results
-/// before building the immutable [MatchedDevice].
-class _MatchedDeviceTracker {
-  final String deviceName;
-  final String deviceId;
-  final device.DeviceType deviceType;
-  bool connectionAttempted = false;
-  ConnectionResult? connectionResult;
-
-  _MatchedDeviceTracker({
-    required this.deviceName,
-    required this.deviceId,
-    required this.deviceType,
-  });
-
-  MatchedDevice toMatchedDevice() => MatchedDevice(
-        deviceName: deviceName,
-        deviceId: deviceId,
-        deviceType: deviceType,
-        connectionAttempted: connectionAttempted,
-        connectionResult: connectionResult,
-      );
-}

--- a/test/controllers/connection/disconnect_expectations_test.dart
+++ b/test/controllers/connection/disconnect_expectations_test.dart
@@ -1,0 +1,62 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection/disconnect_expectations.dart';
+
+void main() {
+  group('DisconnectExpectations', () {
+    test('consume returns false when nothing was marked', () {
+      final e = DisconnectExpectations();
+      expect(e.consume('id-1'), isFalse);
+    });
+
+    test('mark then consume returns true; second consume returns false', () {
+      final e = DisconnectExpectations();
+      e.mark('id-1');
+      expect(e.consume('id-1'), isTrue);
+      expect(e.consume('id-1'), isFalse);
+    });
+
+    test('marks for different ids are independent', () {
+      final e = DisconnectExpectations();
+      e.mark('a');
+      e.mark('b');
+      expect(e.consume('a'), isTrue);
+      expect(e.consume('b'), isTrue);
+    });
+
+    test('TTL clears an un-consumed expectation', () {
+      fakeAsync((async) {
+        final e = DisconnectExpectations();
+        e.mark('id-1');
+        async.elapse(DisconnectExpectations.ttl + const Duration(seconds: 1));
+        expect(e.consume('id-1'), isFalse,
+            reason: 'mark should have expired after TTL');
+      });
+    });
+
+    test('re-marking the same id resets the TTL', () {
+      fakeAsync((async) {
+        final e = DisconnectExpectations();
+        e.mark('id-1');
+        // Almost at TTL, then re-mark.
+        async.elapse(DisconnectExpectations.ttl - const Duration(seconds: 1));
+        e.mark('id-1');
+        // Original TTL would have fired by now without the re-mark.
+        async.elapse(const Duration(seconds: 2));
+        expect(e.consume('id-1'), isTrue,
+            reason: 're-marked id should still be live');
+      });
+    });
+
+    test('dispose cancels pending timers and clears state', () {
+      fakeAsync((async) {
+        final e = DisconnectExpectations();
+        e.mark('id-1');
+        e.dispose();
+        async.elapse(DisconnectExpectations.ttl + const Duration(seconds: 1));
+        // After dispose, consume should already return false (state cleared).
+        expect(e.consume('id-1'), isFalse);
+      });
+    });
+  });
+}

--- a/test/controllers/connection/status_publisher_test.dart
+++ b/test/controllers/connection/status_publisher_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection/status_publisher.dart';
+import 'package:reaprime/src/controllers/connection_error.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart';
+
+ConnectionError _err(String kind) => ConnectionError(
+      kind: kind,
+      severity: ConnectionErrorSeverity.error,
+      timestamp: DateTime(2026, 4, 21, 12, 0),
+      message: 'test',
+    );
+
+void main() {
+  group('StatusPublisher', () {
+    late StatusPublisher pub;
+
+    setUp(() {
+      pub = StatusPublisher();
+    });
+
+    tearDown(() {
+      pub.dispose();
+    });
+
+    test('seeds with an idle ConnectionStatus + no error', () {
+      expect(pub.current.phase, ConnectionPhase.idle);
+      expect(pub.current.error, isNull);
+    });
+
+    test('publish advances phase and emits on stream', () async {
+      final phases = <ConnectionPhase>[];
+      final sub = pub.stream.listen((s) => phases.add(s.phase));
+      pub.publish(pub.current.copyWith(phase: ConnectionPhase.scanning));
+      await Future<void>.delayed(Duration.zero);
+      expect(phases, contains(ConnectionPhase.scanning));
+      sub.cancel();
+    });
+
+    test('emitError records an error without changing phase', () {
+      pub.publish(pub.current.copyWith(phase: ConnectionPhase.ready));
+      pub.emitError(_err(ConnectionErrorKind.scaleConnectFailed));
+      expect(pub.current.phase, ConnectionPhase.ready);
+      expect(pub.current.error?.kind, ConnectionErrorKind.scaleConnectFailed);
+    });
+
+    test('sticky errors survive a publish that leaves error null', () {
+      pub.emitError(_err(ConnectionErrorKind.bluetoothPermissionDenied));
+      pub.publish(pub.current.copyWith(phase: ConnectionPhase.idle));
+      expect(pub.current.error?.kind,
+          ConnectionErrorKind.bluetoothPermissionDenied,
+          reason: 'sticky error must be preserved across phase transitions');
+    });
+
+    test('transient errors get stripped when moving into a clearing phase', () {
+      pub.emitError(_err(ConnectionErrorKind.scaleConnectFailed));
+      // Caller re-publishes current status (preserves error via copyWith)
+      // while transitioning into `scanning`, a clearing phase.
+      pub.publish(pub.current.copyWith(phase: ConnectionPhase.scanning));
+      expect(pub.current.error, isNull,
+          reason:
+              're-published transient error should be stripped on clearing-phase transition');
+    });
+
+    test('a NEW transient error is not stripped on clearing-phase transition',
+        () {
+      pub.publish(pub.current.copyWith(phase: ConnectionPhase.idle));
+      pub.publish(pub.current.copyWith(
+        phase: ConnectionPhase.ready,
+        error: () => _err(ConnectionErrorKind.scaleConnectFailed),
+      ));
+      // Under current semantics (matching the pre-refactor behaviour)
+      // a brand-new error passed atomically with a clearing-phase
+      // transition is also stripped. Keep this test pinning that
+      // behaviour; when we move to unified emission in a later phase,
+      // the assertion will flip.
+      expect(pub.current.error, isNull);
+    });
+
+    test('clearError drops sticky errors explicitly', () {
+      pub.emitError(_err(ConnectionErrorKind.adapterOff));
+      expect(pub.current.error, isNotNull);
+      pub.clearError();
+      expect(pub.current.error, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## What

Three single-responsibility collaborators extracted from `ConnectionManager` into a new `lib/src/controllers/connection/` subfolder:

- **`DisconnectExpectations`** (58 lines) — mark/consume/dispose with TTL timers. Owns what was previously a `Set<String>` + `Map<String, Timer>` + a 10 s TTL constant inline on `ConnectionManager`.
- **`StatusPublisher`** (102 lines) — the `_statusSubject` + the sticky/transient error gatekeeper. Every outbound status update now funnels through `publish`, `emitError`, or `clearError`. `ConnectionManager` holds one and its public `status`/`currentStatus` proxy.
- **`ScanReportBuilder`** (137 lines) — the per-scan `MatchedDeviceTracker` map + seed/markAttempted/recordResult/build/format API. Replaces the prior inline `_MatchedDeviceTracker` + `_seedTracker` + `_emitScanReport` + `_formatScanReport`.

`ConnectionManager`: 1043 → 902 lines.

## Why

Phase 4 PR 4a of the connectivity hardening roadmap — leaf extractions from the god-class split. Each collaborator has a single concern, testable in isolation, with a bounded API.

Deliberately small and mechanical. Zero observable behaviour change.

## Test plan

- `flutter test`: 969 pass (13 new focused tests on the extracted collaborators), 2 skip.
- `flutter analyze`: clean on all changed + new files.
- Real-hardware smoke on M50Mini: connect 7.0 s, disconnect + reconnect 2.7 s, no `Bad state` / `MmrTimeoutException` / late-subscription errors. Scan report still correctly identifies preferred machine ID.