### PR TITLE
refactor(comms): extract DisconnectSupervisor and EarlyConnectWatcher

### DIFF
--- a/lib/src/controllers/connection/disconnect_supervisor.dart
+++ b/lib/src/controllers/connection/disconnect_supervisor.dart
@@ -1,0 +1,168 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/connection/disconnect_expectations.dart';
+import 'package:reaprime/src/controllers/connection/status_publisher.dart';
+import 'package:reaprime/src/controllers/connection_error.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart'
+    show ConnectionPhase;
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart' as device;
+
+/// Watches the machine and scale connection streams for the
+/// lifetime of a [ConnectionManager]. Tracks the latest observed state
+/// of each device and emits an error (through [StatusPublisher]) when
+/// a disconnect arrives that wasn't already announced by the app
+/// (via [DisconnectExpectations]).
+///
+/// Also publishes `phase: idle` on machine disconnect so the UI can
+/// react even if the caller didn't issue an explicit `connect()`.
+///
+/// Extracted from ConnectionManager as part of comms-harden Phase 4
+/// (roadmap items 15 and 19).
+class DisconnectSupervisor {
+  static final _log = Logger('DisconnectSupervisor');
+
+  final Stream<De1Interface?> _machineStream;
+  final Stream<device.ConnectionState> _scaleStream;
+  final StatusPublisher _statusPublisher;
+  final DisconnectExpectations _expectations;
+  final bool Function() _isConnectingMachine;
+  final bool Function() _isConnectingScale;
+  final String? Function() _scaleLastConnectedId;
+  final String? Function() _preferredScaleId;
+
+  De1Interface? _latestDe1;
+  device.ConnectionState _latestScaleState =
+      device.ConnectionState.discovered;
+  String? _lastKnownMachineId;
+
+  StreamSubscription<De1Interface?>? _machineSub;
+  StreamSubscription<device.ConnectionState>? _scaleSub;
+
+  DisconnectSupervisor({
+    required Stream<De1Interface?> machineStream,
+    required Stream<device.ConnectionState> scaleStream,
+    required StatusPublisher statusPublisher,
+    required DisconnectExpectations expectations,
+    required bool Function() isConnectingMachine,
+    required bool Function() isConnectingScale,
+    required String? Function() scaleLastConnectedId,
+    required String? Function() preferredScaleId,
+  })  : _machineStream = machineStream,
+        _scaleStream = scaleStream,
+        _statusPublisher = statusPublisher,
+        _expectations = expectations,
+        _isConnectingMachine = isConnectingMachine,
+        _isConnectingScale = isConnectingScale,
+        _scaleLastConnectedId = scaleLastConnectedId,
+        _preferredScaleId = preferredScaleId {
+    _start();
+  }
+
+  /// `true` if the machine stream has last emitted a non-null
+  /// `De1Interface`. Replaces the old `_machineConnected` flag —
+  /// this is a live view of the stream, not parallel state.
+  bool get isMachineConnected => _latestDe1 != null;
+
+  /// `true` if the scale stream has last emitted `connected`.
+  bool get isScaleConnected =>
+      _latestScaleState == device.ConnectionState.connected;
+
+  /// Pre-null the tracked de1 view so the next null emission from
+  /// [machineStream] doesn't trigger the disconnect path. Used by
+  /// [ConnectionManager.disconnectMachine] which publishes
+  /// `phase: idle` itself and doesn't want a redundant emission from
+  /// the supervisor.
+  void markMachineOffline() {
+    _latestDe1 = null;
+  }
+
+  void _start() {
+    _machineSub = _machineStream.listen((de1) {
+      final hadMachine = _latestDe1 != null;
+      _latestDe1 = de1;
+      if (de1 != null) {
+        _lastKnownMachineId = de1.deviceId;
+        return;
+      }
+      if (hadMachine && !_isConnectingMachine()) {
+        _log.fine('Machine disconnected');
+        _statusPublisher.publish(
+          _statusPublisher.current.copyWith(phase: ConnectionPhase.idle),
+        );
+        final id = _lastKnownMachineId;
+        if (id != null) {
+          _handleMachineDisconnect(id);
+        }
+      }
+    });
+
+    _scaleSub = _scaleStream.listen((state) {
+      final wasConnected =
+          _latestScaleState == device.ConnectionState.connected;
+      _latestScaleState = state;
+      _log.fine('scale connection update: ${state.name}');
+      if (wasConnected &&
+          state == device.ConnectionState.disconnected &&
+          !_isConnectingScale()) {
+        final id = _scaleLastConnectedId() ?? _preferredScaleId();
+        if (id != null) {
+          _handleScaleDisconnect(id);
+        }
+      }
+    });
+  }
+
+  void _handleMachineDisconnect(String deviceId) {
+    if (_expectations.consume(deviceId)) {
+      _log.fine('Machine $deviceId: expected disconnect, suppressing error');
+      return;
+    }
+    _statusPublisher.emitError(ConnectionError(
+      kind: ConnectionErrorKind.machineDisconnected,
+      severity: ConnectionErrorSeverity.error,
+      timestamp: DateTime.now().toUtc(),
+      deviceId: deviceId,
+      message: 'Machine disconnected unexpectedly.',
+      suggestion:
+          'Check the machine is powered on and in range, then reconnect.',
+    ));
+  }
+
+  void _handleScaleDisconnect(String deviceId) {
+    if (_expectations.consume(deviceId)) {
+      _log.fine('Scale $deviceId: expected disconnect, suppressing error');
+      return;
+    }
+    _statusPublisher.emitError(ConnectionError(
+      kind: ConnectionErrorKind.scaleDisconnected,
+      severity: ConnectionErrorSeverity.error,
+      timestamp: DateTime.now().toUtc(),
+      deviceId: deviceId,
+      message: 'Scale disconnected unexpectedly.',
+      suggestion:
+          'The scale may have powered off or moved out of range. '
+          'Wake the scale and reconnect.',
+    ));
+  }
+
+  /// Drive the same error-emission path the stream listener would
+  /// take when it sees an unexpected disconnect for [deviceId].
+  /// Used by ConnectionManager's `@visibleForTesting` wrappers so
+  /// tests can simulate disconnect events without touching the
+  /// underlying streams.
+  void notifyMachineDisconnected(String deviceId) =>
+      _handleMachineDisconnect(deviceId);
+
+  void notifyScaleDisconnected(String deviceId) =>
+      _handleScaleDisconnect(deviceId);
+
+  /// Cancel both stream subscriptions. Safe to call more than once.
+  void dispose() {
+    _machineSub?.cancel();
+    _scaleSub?.cancel();
+    _machineSub = null;
+    _scaleSub = null;
+  }
+}

--- a/lib/src/controllers/connection/early_connect_watcher.dart
+++ b/lib/src/controllers/connection/early_connect_watcher.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/connection/scan_report_builder.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+
+/// Watches the scanner's `deviceStream` during a scan and triggers
+/// connect() on preferred devices as soon as they appear — without
+/// waiting for the full scan to complete.
+///
+/// One instance per `_connectImpl` call. Owns its own
+/// `StreamSubscription` + the `(started, pending)` pair per device
+/// type; [awaitPending] blocks until both in-flight early connects
+/// (if any) finish. [stop] cancels the subscription.
+///
+/// Extracted from ConnectionManager as part of comms-harden Phase 4
+/// (roadmap items 15 and 19).
+class EarlyConnectWatcher {
+  static final _log = Logger('EarlyConnectWatcher');
+
+  final Stream<List<Device>> _deviceStream;
+  final String? _preferredMachineId;
+  final String? _preferredScaleId;
+  final ScanReportBuilder _scanReport;
+  final bool Function() _isMachineConnected;
+  final bool Function() _isScaleConnected;
+  final Future<void> Function(De1Interface, ScanReportBuilder)
+      _connectMachineTracked;
+  final Future<void> Function(Scale, ScanReportBuilder) _connectScaleTracked;
+  final void Function() _onEarlyAttemptComplete;
+
+  var _machineStarted = false;
+  Future<void>? _machinePending;
+  var _scaleStarted = false;
+  Future<void>? _scalePending;
+  StreamSubscription<List<Device>>? _sub;
+
+  EarlyConnectWatcher({
+    required Stream<List<Device>> deviceStream,
+    required String? preferredMachineId,
+    required String? preferredScaleId,
+    required ScanReportBuilder scanReport,
+    required bool Function() isMachineConnected,
+    required bool Function() isScaleConnected,
+    required Future<void> Function(De1Interface, ScanReportBuilder)
+        connectMachineTracked,
+    required Future<void> Function(Scale, ScanReportBuilder) connectScaleTracked,
+    required void Function() onEarlyAttemptComplete,
+  })  : _deviceStream = deviceStream,
+        _preferredMachineId = preferredMachineId,
+        _preferredScaleId = preferredScaleId,
+        _scanReport = scanReport,
+        _isMachineConnected = isMachineConnected,
+        _isScaleConnected = isScaleConnected,
+        _connectMachineTracked = connectMachineTracked,
+        _connectScaleTracked = connectScaleTracked,
+        _onEarlyAttemptComplete = onEarlyAttemptComplete;
+
+  /// Subscribe to the device stream and begin reacting to preferred
+  /// devices appearing. `skip(1)` drops the BehaviorSubject replay
+  /// of stale (disconnected) devices — we only react to fresh
+  /// discoveries from the active scan.
+  void start() {
+    _sub = _deviceStream.skip(1).listen(_onDevicesUpdate);
+  }
+
+  void _onDevicesUpdate(List<Device> devices) {
+    if (_preferredMachineId != null &&
+        !_isMachineConnected() &&
+        !_machineStarted) {
+      final match = devices
+          .whereType<De1Interface>()
+          .where((m) => m.deviceId == _preferredMachineId)
+          .firstOrNull;
+      if (match != null) {
+        _log.fine('Preferred machine found during scan, connecting early');
+        _machineStarted = true;
+        // Seed the tracker now so the connection attempt + result
+        // land on the right entry; the post-scan seed path is
+        // idempotent and leaves this entry intact.
+        _scanReport.seed(match);
+        _machinePending = _connectMachineTracked(match, _scanReport)
+            .then((_) => _onEarlyAttemptComplete());
+      }
+    }
+
+    if (_preferredScaleId != null &&
+        !_isScaleConnected() &&
+        !_scaleStarted) {
+      final match = devices
+          .whereType<Scale>()
+          .where((s) => s.deviceId == _preferredScaleId)
+          .firstOrNull;
+      if (match != null) {
+        _log.fine('Preferred scale found during scan, connecting early');
+        _scaleStarted = true;
+        _scanReport.seed(match);
+        _scalePending = _connectScaleTracked(match, _scanReport)
+            .then((_) => _onEarlyAttemptComplete());
+      }
+    }
+  }
+
+  /// Cancel the device-stream subscription. Safe to call more than
+  /// once; safe to call before [start].
+  void stop() {
+    _sub?.cancel();
+    _sub = null;
+  }
+
+  /// Await any in-flight early connects. Errors from the tracked
+  /// callbacks are caught and logged at `fine` — the tracker already
+  /// recorded the outcome on the ScanReport.
+  Future<void> awaitPending() async {
+    if (_machinePending != null) {
+      try {
+        await _machinePending;
+      } catch (e, st) {
+        _log.fine('Early machine connect slipped past tracker', e, st);
+      }
+    }
+    if (_scalePending != null) {
+      try {
+        await _scalePending;
+      } catch (e, st) {
+        _log.fine('Early scale connect slipped past tracker', e, st);
+      }
+    }
+  }
+}

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -5,6 +5,8 @@ import 'package:flutter_blue_plus/flutter_blue_plus.dart'
     show FlutterBluePlusException;
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/connection/disconnect_expectations.dart';
+import 'package:reaprime/src/controllers/connection/disconnect_supervisor.dart';
+import 'package:reaprime/src/controllers/connection/early_connect_watcher.dart';
 import 'package:reaprime/src/controllers/connection/scan_report_builder.dart';
 import 'package:reaprime/src/controllers/connection/status_publisher.dart';
 import 'package:reaprime/src/controllers/connection_error.dart';
@@ -12,7 +14,6 @@ import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/adapter_state.dart';
-import 'package:reaprime/src/models/device/device.dart' as device;
 import 'package:reaprime/src/models/device/device_scanner.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/errors.dart';
@@ -91,21 +92,15 @@ class ConnectionManager {
   bool _isConnectingMachine = false;
   bool _isConnectingScale = false;
 
-  // Device-connection state tracked directly from the streams that own
-  // it. `_listenForDisconnects` keeps these in sync; nothing else
-  // mutates them, so they cannot drift from the source of truth.
-  // Replaces the previous `_machineConnected` / `_scaleConnected`
-  // parallel flags (comms-harden #4, #6).
-  De1Interface? _latestDe1;
-  device.ConnectionState _latestScaleState =
-      device.ConnectionState.discovered;
+  // Device-connection state + unexpected-disconnect emission live on
+  // DisconnectSupervisor — it owns the two stream subscribers and
+  // exposes `isMachineConnected` / `isScaleConnected` as live views
+  // of the source streams (no parallel flags).
+  bool get _machineConnected => _disconnectSupervisor.isMachineConnected;
+  bool get _scaleConnected => _disconnectSupervisor.isScaleConnected;
 
-  bool get _machineConnected => _latestDe1 != null;
-  bool get _scaleConnected =>
-      _latestScaleState == device.ConnectionState.connected;
+  late final DisconnectSupervisor _disconnectSupervisor;
 
-  StreamSubscription? _machineDisconnectSub;
-  StreamSubscription? _scaleDisconnectSub;
   StreamSubscription<AdapterState>? _adapterSub;
 
   final DisconnectExpectations _disconnectExpectations =
@@ -122,7 +117,16 @@ class ConnectionManager {
     required this.scaleController,
     required this.settingsController,
   }) {
-    _listenForDisconnects();
+    _disconnectSupervisor = DisconnectSupervisor(
+      machineStream: de1Controller.de1,
+      scaleStream: scaleController.connectionState,
+      statusPublisher: _statusPublisher,
+      expectations: _disconnectExpectations,
+      isConnectingMachine: () => _isConnectingMachine,
+      isConnectingScale: () => _isConnectingScale,
+      scaleLastConnectedId: () => scaleController.lastConnectedDeviceId,
+      preferredScaleId: () => settingsController.preferredScaleId,
+    );
     _listenForAdapter();
   }
 
@@ -139,49 +143,6 @@ class ConnectionManager {
       } else if (state == AdapterState.poweredOn &&
           currentStatus.error?.kind == ConnectionErrorKind.adapterOff) {
         _clearError();
-      }
-    });
-  }
-
-  void _listenForDisconnects() {
-    // Watch de1Controller.de1 stream — null means machine disconnected.
-    // Ignore null emissions while actively connecting (connectToDe1 calls
-    // _onDisconnect() at the start, which emits null transiently).
-    String? lastKnownMachineId;
-    _machineDisconnectSub = de1Controller.de1.listen((de1) {
-      final hadMachine = _latestDe1 != null;
-      _latestDe1 = de1;
-      if (de1 != null) {
-        lastKnownMachineId = de1.deviceId;
-        return;
-      }
-      if (hadMachine && !_isConnectingMachine) {
-        _log.fine('Machine disconnected');
-        _publishStatus(
-          currentStatus.copyWith(phase: ConnectionPhase.idle),
-        );
-        final id = lastKnownMachineId;
-        if (id != null) {
-          _handleMachineDisconnect(id);
-        }
-      }
-    });
-
-    // Watch scaleController.connectionState — emit scaleDisconnected on a
-    // connected → disconnected transition (unless marked expected).
-    _scaleDisconnectSub = scaleController.connectionState.listen((state) {
-      final wasConnected =
-          _latestScaleState == device.ConnectionState.connected;
-      _latestScaleState = state;
-      _log.fine("scale connection update: ${state.name}");
-      if (wasConnected &&
-          state == device.ConnectionState.disconnected &&
-          !_isConnectingScale) {
-        final id = scaleController.lastConnectedDeviceId ??
-            settingsController.preferredScaleId;
-        if (id != null) {
-          _handleScaleDisconnect(id);
-        }
       }
     });
   }
@@ -289,52 +250,13 @@ class ConnectionManager {
     _disconnectExpectations.mark(deviceId);
   }
 
-  bool _consumeExpectingDisconnect(String deviceId) =>
-      _disconnectExpectations.consume(deviceId);
-
-  void _handleScaleDisconnect(String deviceId) {
-    if (_consumeExpectingDisconnect(deviceId)) {
-      _log.fine('Scale $deviceId: expected disconnect, suppressing error');
-      return;
-    }
-    _emit(ConnectionError(
-      kind: ConnectionErrorKind.scaleDisconnected,
-      severity: ConnectionErrorSeverity.error,
-      timestamp: DateTime.now().toUtc(),
-      deviceId: deviceId,
-      message: 'Scale disconnected unexpectedly.',
-      suggestion:
-          'The scale may have powered off or moved out of range. '
-          'Wake the scale and reconnect.',
-    ));
-  }
-
-  void _handleMachineDisconnect(String deviceId) {
-    if (_consumeExpectingDisconnect(deviceId)) {
-      _log.fine('Machine $deviceId: expected disconnect, suppressing error');
-      return;
-    }
-    _emit(ConnectionError(
-      kind: ConnectionErrorKind.machineDisconnected,
-      severity: ConnectionErrorSeverity.error,
-      timestamp: DateTime.now().toUtc(),
-      deviceId: deviceId,
-      message: 'Machine disconnected unexpectedly.',
-      suggestion:
-          'Check the machine is powered on and in range, then '
-          'reconnect.',
-    ));
-  }
+  @visibleForTesting
+  void debugNotifyScaleDisconnected(String deviceId) =>
+      _disconnectSupervisor.notifyScaleDisconnected(deviceId);
 
   @visibleForTesting
-  void debugNotifyScaleDisconnected(String deviceId) {
-    _handleScaleDisconnect(deviceId);
-  }
-
-  @visibleForTesting
-  void debugNotifyMachineDisconnected(String deviceId) {
-    _handleMachineDisconnect(deviceId);
-  }
+  void debugNotifyMachineDisconnected(String deviceId) =>
+      _disconnectSupervisor.notifyMachineDisconnected(deviceId);
 
   /// Scan for devices and connect based on preference policy.
   ///
@@ -424,66 +346,22 @@ class ConnectionManager {
 
     // Watch device stream during scan — connect preferred devices immediately
     // as they appear, rather than waiting for the full scan to complete.
-    // Skip(1) avoids the BehaviorSubject replay of stale (disconnected) devices;
-    // we only want to react to fresh discoveries from the active scan.
     //
-    // Each early-connect is tracked as an explicit (started, pending)
-    // pair rather than a nullable Future-as-flag (comms-harden #7, #18).
-    // `started` stops the listener from firing a second attempt;
-    // `pending` is the awaitable for post-scan synchronisation.
-    var earlyMachineStarted = false;
-    Future<void>? earlyMachinePending;
-    var earlyScaleStarted = false;
-    Future<void>? earlyScalePending;
-    // The listener only handles early-connect triggering. Per-device
-    // tracker entries are seeded once from the authoritative
-    // ScanResult after the scan completes (comms-harden #17).
-    final sub = deviceScanner.deviceStream.skip(1).listen((devices) {
-      if (preferredMachineId != null &&
-          !_machineConnected &&
-          !earlyMachineStarted) {
-        final match =
-            devices
-                .whereType<De1Interface>()
-                .where((m) => m.deviceId == preferredMachineId)
-                .firstOrNull;
-        if (match != null) {
-          _log.fine('Preferred machine found during scan, connecting early');
-          earlyMachineStarted = true;
-          // Seed the tracker now so the connection attempt + result
-          // land on the right entry; the post-scan seed below is
-          // idempotent and leaves this seed intact.
-          scanReport.seed(match);
-          earlyMachinePending = _connectMachineTracked(
-            match,
-            scanReport,
-          ).then((_) {
-            _checkEarlyStop(earlyStopEnabled);
-          });
-        }
-      }
-
-      if (preferredScaleId != null &&
-          !_scaleConnected &&
-          !earlyScaleStarted) {
-        final match =
-            devices
-                .whereType<Scale>()
-                .where((m) => m.deviceId == preferredScaleId)
-                .firstOrNull;
-        if (match != null) {
-          _log.fine('Preferred scale found during scan, connecting early');
-          earlyScaleStarted = true;
-          scanReport.seed(match);
-          earlyScalePending = _connectScaleTracked(
-            match,
-            scanReport,
-          ).then((_) {
-            _checkEarlyStop(earlyStopEnabled);
-          });
-        }
-      }
-    });
+    // EarlyConnectWatcher owns the deviceStream subscription + the
+    // `(started, pending)` pair per device type + error handling on
+    // the pending futures (comms-harden #7, #18, #19).
+    final earlyConnect = EarlyConnectWatcher(
+      deviceStream: deviceScanner.deviceStream,
+      preferredMachineId: preferredMachineId,
+      preferredScaleId: preferredScaleId,
+      scanReport: scanReport,
+      isMachineConnected: () => _machineConnected,
+      isScaleConnected: () => _scaleConnected,
+      connectMachineTracked: _connectMachineTracked,
+      connectScaleTracked: _connectScaleTracked,
+      onEarlyAttemptComplete: () => _checkEarlyStop(earlyStopEnabled),
+    );
+    earlyConnect.start();
 
     // Run full unfiltered scan. The scanner awaits every service's scan
     // and returns a ScanResult carrying per-service failures; only a
@@ -494,7 +372,7 @@ class ConnectionManager {
     try {
       scanResult = await deviceScanner.scanForDevices();
     } catch (e) {
-      sub.cancel();
+      earlyConnect.stop();
       final kind = _classifyScanError(e);
       // DO NOT REORDER — same rationale as connectScale: publish idle
       // first, then _emit the error (which bypasses the phase-change
@@ -514,7 +392,7 @@ class ConnectionManager {
       ));
       return;
     }
-    sub.cancel();
+    earlyConnect.stop();
 
     // Sticky-error environmental recovery: reaching a completed scan
     // means permission and scan subsystems are working again. Clear
@@ -531,25 +409,9 @@ class ConnectionManager {
       _clearError();
     }
 
-    // Wait for early connections to finish if started
-    if (earlyMachinePending != null) {
-      try {
-        await earlyMachinePending;
-      } catch (e, st) {
-        // connectMachine already emitted machineConnectFailed and
-        // _connectMachineTracked recorded the outcome on the tracker.
-        // If an error still slipped out, log for diagnostics.
-        _log.fine('Early machine connect slipped past tracker', e, st);
-      }
-    }
-
-    if (earlyScalePending != null) {
-      try {
-        await earlyScalePending;
-      } catch (e, st) {
-        _log.fine('Early scale connect slipped past tracker', e, st);
-      }
-    }
+    // Wait for any in-flight early connects to finish before the
+    // post-scan policy runs.
+    await earlyConnect.awaitPending();
 
     // Collect found devices from the authoritative ScanResult rather
     // than re-reading `deviceScanner.devices`. This is the single
@@ -864,11 +726,11 @@ class ConnectionManager {
   }
 
   Future<void> disconnectMachine() async {
-    // Pre-null the tracked-latest view so the de1 stream listener's
+    // Pre-null the supervisor's tracked de1 view so its stream listener's
     // `hadMachine` check sees "no machine was connected" by the time
-    // it fires on the upcoming null emission — otherwise the listener
+    // it fires on the upcoming null emission — otherwise the supervisor
     // would emit a redundant phase=idle on top of the one below.
-    _latestDe1 = null;
+    _disconnectSupervisor.markMachineOffline();
     _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.idle));
     final de1 = await de1Controller.de1.first;
     if (de1 != null) {
@@ -891,8 +753,7 @@ class ConnectionManager {
   }
 
   void dispose() {
-    _machineDisconnectSub?.cancel();
-    _scaleDisconnectSub?.cancel();
+    _disconnectSupervisor.dispose();
     _adapterSub?.cancel();
     _disconnectExpectations.dispose();
     _statusPublisher.dispose();


### PR DESCRIPTION
## What

Two subscription-owning collaborators extracted into `lib/src/controllers/connection/`:

- **`DisconnectSupervisor`** — owns `de1Controller.de1` + `scaleController.connectionState` listeners, the `_latestDe1` + `_latestScaleState` tracked view, and the unexpected-disconnect error emission (through `StatusPublisher`) plus the `phase: idle` publish on machine disconnect. Exposes `isMachineConnected` / `isScaleConnected` as live views, `markMachineOffline()` for the explicit-disconnect pre-null pattern, and `notifyXDisconnected` methods that `ConnectionManager`'s `@visibleForTesting` wrappers delegate to.

- **`EarlyConnectWatcher`** — owns the `deviceStream.skip(1).listen(...)` subscription previously inline in `_connectImpl` + the `(started, pending)` pair per device type. `start()` / `stop()` / `awaitPending()`. Error handling for pending futures is centralised and consistent with pre-extraction behaviour.

`ConnectionManager`: 902 → 763 lines. Cumulative Phase 4 reduction so far: 280 lines.

## Why

Phase 4 PR 4b. Resolves roadmap item 19 (nested subscriptions) and picks up the subscription-lifecycle half of item 7. Zero observable behaviour change.

## Test plan

- `flutter test`: 969 pass, 2 skip (same as PR 4a baseline).
- `flutter analyze`: clean on all changed + new files.
- Real-hardware smoke on M50Mini: connect 3.8 s, disconnect + reconnect 2.7 s. No `Bad state: Stream has already been listened to`, no `MmrTimeoutException`, no stray unexpected-disconnect emissions.