### PR TITLE
fix(sb-dev): split --preferred-machine-id from --connect-machine

### DIFF
--- a/lib/src/services/webview_compatibility_checker.dart
+++ b/lib/src/services/webview_compatibility_checker.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:device_info_plus/device_info_plus.dart';
-import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:logging/logging.dart';
 
@@ -54,30 +53,14 @@ class WebViewCompatibilityChecker {
 
   /// Settle delay inserted before the headless WebView test on devices
   /// whose platform-channel throughput can't cope with BLE traffic
-  /// running concurrently. Adaptive: release builds get the minimum
-  /// window needed on the Teclast M50Mini; debug builds are
-  /// measurably slower (no optimizer, VM checks, verbose logging) and
-  /// need more headroom before the WebView test can succeed.
-  static const _problematicManufacturerSettleDelayRelease =
+  /// running concurrently. Validated on the Teclast M50Mini at
+  /// 500 ms release. Longer debug-specific delays (up to 1500 ms)
+  /// and bumping the internal test timeout (up to 30 s) were both
+  /// tried and neither unblocked debug-build WebView on Teclast —
+  /// the failure mode is different in debug and needs proper
+  /// investigation (see TODO: inspect app launch path).
+  static const _problematicManufacturerSettleDelay =
       Duration(milliseconds: 500);
-  static const _problematicManufacturerSettleDelayDebug =
-      Duration(milliseconds: 1500);
-
-  static Duration get _problematicManufacturerSettleDelay => kDebugMode
-      ? _problematicManufacturerSettleDelayDebug
-      : _problematicManufacturerSettleDelayRelease;
-
-  /// Upper bound on how long the headless WebView's onLoadStop + the
-  /// three JS subtests are allowed to take. A fresh release-build boot
-  /// on the Teclast M50Mini finishes in ~270ms; debug builds can take
-  /// 5-10x longer, which trips the 10s budget even when the BLE burst
-  /// has already settled. Adaptive so production behaviour is
-  /// unchanged and dev/debug boots still succeed.
-  static const _runtimeTestTimeoutRelease = Duration(seconds: 10);
-  static const _runtimeTestTimeoutDebug = Duration(seconds: 30);
-
-  static Duration get _runtimeTestTimeout =>
-      kDebugMode ? _runtimeTestTimeoutDebug : _runtimeTestTimeoutRelease;
 
   /// Checks WebView compatibility using device info and runtime test
   ///
@@ -377,17 +360,11 @@ class WebViewCompatibilityChecker {
 
       await headlessWebView.run();
 
-      // Wait for test to complete with timeout. The timeout is
-      // adaptive (10s release, 30s debug) — debug builds are
-      // measurably slower and routinely trip the tighter budget even
-      // when the BLE burst has already settled.
-      final timeout = _runtimeTestTimeout;
+      // Wait for test to complete with timeout
       return await completer.future.timeout(
-        timeout,
+        const Duration(seconds: 10),
         onTimeout: () {
-          _log.warning(
-            'WebView test timed out after ${timeout.inSeconds}s',
-          );
+          _log.warning('WebView test timed out');
           headlessWebView?.dispose();
           return CompatibilityResult.incompatible(
             'WebView test timed out - may be too slow on this device',

--- a/lib/src/services/webview_compatibility_checker.dart
+++ b/lib/src/services/webview_compatibility_checker.dart
@@ -67,6 +67,18 @@ class WebViewCompatibilityChecker {
       ? _problematicManufacturerSettleDelayDebug
       : _problematicManufacturerSettleDelayRelease;
 
+  /// Upper bound on how long the headless WebView's onLoadStop + the
+  /// three JS subtests are allowed to take. A fresh release-build boot
+  /// on the Teclast M50Mini finishes in ~270ms; debug builds can take
+  /// 5-10x longer, which trips the 10s budget even when the BLE burst
+  /// has already settled. Adaptive so production behaviour is
+  /// unchanged and dev/debug boots still succeed.
+  static const _runtimeTestTimeoutRelease = Duration(seconds: 10);
+  static const _runtimeTestTimeoutDebug = Duration(seconds: 30);
+
+  static Duration get _runtimeTestTimeout =>
+      kDebugMode ? _runtimeTestTimeoutDebug : _runtimeTestTimeoutRelease;
+
   /// Checks WebView compatibility using device info and runtime test
   ///
   /// Returns cached result if available, otherwise performs full check.
@@ -365,11 +377,17 @@ class WebViewCompatibilityChecker {
 
       await headlessWebView.run();
 
-      // Wait for test to complete with timeout
+      // Wait for test to complete with timeout. The timeout is
+      // adaptive (10s release, 30s debug) — debug builds are
+      // measurably slower and routinely trip the tighter budget even
+      // when the BLE burst has already settled.
+      final timeout = _runtimeTestTimeout;
       return await completer.future.timeout(
-        const Duration(seconds: 10),
+        timeout,
         onTimeout: () {
-          _log.warning('WebView test timed out');
+          _log.warning(
+            'WebView test timed out after ${timeout.inSeconds}s',
+          );
           headlessWebView?.dispose();
           return CompatibilityResult.incompatible(
             'WebView test timed out - may be too slow on this device',

--- a/lib/src/services/webview_compatibility_checker.dart
+++ b/lib/src/services/webview_compatibility_checker.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:logging/logging.dart';
 
@@ -53,9 +54,18 @@ class WebViewCompatibilityChecker {
 
   /// Settle delay inserted before the headless WebView test on devices
   /// whose platform-channel throughput can't cope with BLE traffic
-  /// running concurrently. Validated on the Teclast M50Mini.
-  static const _problematicManufacturerSettleDelay =
+  /// running concurrently. Adaptive: release builds get the minimum
+  /// window needed on the Teclast M50Mini; debug builds are
+  /// measurably slower (no optimizer, VM checks, verbose logging) and
+  /// need more headroom before the WebView test can succeed.
+  static const _problematicManufacturerSettleDelayRelease =
       Duration(milliseconds: 500);
+  static const _problematicManufacturerSettleDelayDebug =
+      Duration(milliseconds: 1500);
+
+  static Duration get _problematicManufacturerSettleDelay => kDebugMode
+      ? _problematicManufacturerSettleDelayDebug
+      : _problematicManufacturerSettleDelayRelease;
 
   /// Checks WebView compatibility using device info and runtime test
   ///

--- a/scripts/sb-dev.sh
+++ b/scripts/sb-dev.sh
@@ -35,6 +35,7 @@ sb-dev.sh — Streamline Bridge dev-session manager
 
 Usage:
   sb-dev start [--platform <id>] [--connect-machine <name|id>] [--connect-scale <name|id>]
+               [--preferred-machine-id <id>] [--preferred-scale-id <id>]
                [--real] [--adb-forward] [--dart-define k=v]
   sb-dev stop
   sb-dev restart           — cold restart with the same flags as the last start
@@ -47,9 +48,18 @@ Usage:
 Flags:
   --platform <id>          Flutter device id (`-d` passthrough). Examples: macos,
                            linux, chrome, or an Android adb serial like 8734SCCFAC00000747.
-  --connect-machine <v>    Match by device name OR id; used as preferredMachineId.
-                           Simulate: MockDe1. Real BLE: DE1 (name) or D9:11:… (MAC).
+  --connect-machine <v>    Match by device name OR id in the post-boot scan loop.
+                           In simulate mode also drives preferredMachineId (the
+                           mock's name == its id). In --real mode a name like
+                           "DE1" won't match a BLE MAC deviceId, so pair with
+                           --preferred-machine-id if you want auto-connect
+                           based on a saved preference.
   --connect-scale <v>      Same semantics for the scale.
+  --preferred-machine-id <id>   Explicit --dart-define=preferredMachineId=<id>.
+                                Use with --real to pin the preferred device to
+                                a BLE MAC or UUID that ConnectionManager
+                                actually matches on.
+  --preferred-scale-id <id>     Same for the scale.
   --real                   Do NOT inject --dart-define=simulate=1. Use real BLE/USB.
   --adb-forward            Run `adb forward tcp:$PORT tcp:$PORT` on start so host
                            localhost:$PORT reaches the REST server on an Android
@@ -131,6 +141,7 @@ start_cmd() {
   fi
 
   local platform="" machine="" scale=""
+  local preferred_machine_id="" preferred_scale_id=""
   local real=0 adb_forward=0
   local -a extra_defines=()
   while [[ $# -gt 0 ]]; do
@@ -144,6 +155,12 @@ start_cmd() {
       --connect-scale)
         [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; return 2; }
         scale="$2"; shift 2 ;;
+      --preferred-machine-id)
+        [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; return 2; }
+        preferred_machine_id="$2"; shift 2 ;;
+      --preferred-scale-id)
+        [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; return 2; }
+        preferred_scale_id="$2"; shift 2 ;;
       --real)
         real=1; shift ;;
       --adb-forward)
@@ -160,6 +177,10 @@ start_cmd() {
     [[ -n "$platform" ]] && printf '%s\n' "--platform $platform"
     [[ -n "$machine" ]] && printf '%s\n' "--connect-machine $machine"
     [[ -n "$scale" ]] && printf '%s\n' "--connect-scale $scale"
+    [[ -n "$preferred_machine_id" ]] && \
+      printf '%s\n' "--preferred-machine-id $preferred_machine_id"
+    [[ -n "$preferred_scale_id" ]] && \
+      printf '%s\n' "--preferred-scale-id $preferred_scale_id"
     [[ "$real" -eq 1 ]] && printf '%s\n' "--real"
     [[ "$adb_forward" -eq 1 ]] && printf '%s\n' "--adb-forward"
     for d in "${extra_defines[@]}"; do printf '%s\n' "--dart-define ${d#--dart-define=}"; done
@@ -182,8 +203,22 @@ start_cmd() {
 
   local -a defines=()
   [[ "$real" -eq 0 ]] && defines+=("--dart-define=simulate=1")
-  [[ -n "$machine" ]] && defines+=("--dart-define=preferredMachineId=$machine")
-  [[ -n "$scale" ]] && defines+=("--dart-define=preferredScaleId=$scale")
+  # In simulate mode the mock device's name doubles as its id, so
+  # reusing `--connect-machine` for `preferredMachineId` is harmless.
+  # In `--real` mode a name like "DE1" won't match a device.deviceId
+  # like "D9:11:0B:E6:9F:86", so only wire up the preferred-id dart
+  # define when the caller has explicitly provided one via
+  # `--preferred-machine-id` (same for scale).
+  if [[ "$real" -eq 0 && -n "$machine" ]]; then
+    defines+=("--dart-define=preferredMachineId=$machine")
+  fi
+  if [[ "$real" -eq 0 && -n "$scale" ]]; then
+    defines+=("--dart-define=preferredScaleId=$scale")
+  fi
+  [[ -n "$preferred_machine_id" ]] && \
+    defines+=("--dart-define=preferredMachineId=$preferred_machine_id")
+  [[ -n "$preferred_scale_id" ]] && \
+    defines+=("--dart-define=preferredScaleId=$preferred_scale_id")
   defines+=("${extra_defines[@]}")
 
   local -a platform_flag=()


### PR DESCRIPTION
## What

Adds `--preferred-machine-id` and `--preferred-scale-id` flags to `scripts/sb-dev.sh` so callers can set `preferredMachineId` / `preferredScaleId` as proper device IDs (BLE MAC or UUID) independently of the `--connect-machine` / `--connect-scale` boot-wait-loop flags.

Before this change, `--connect-machine DE1` in `--real` mode silently set `preferredMachineId=DE1` via dart-define, which then never matched any `device.deviceId` in `ConnectionManager`'s preferred-device lookup — every first boot showed "could not find your preferred device". The scan-wait loop already handles name-or-id matching, so `--connect-machine` keeps its boot-sync role; the preferred-id coupling was the bug.

Example real-hardware invocation:

```bash
scripts/sb-dev.sh start \
  --platform 8734SCCFAC00000747 --real --adb-forward \
  --connect-machine DE1 \
  --preferred-machine-id D9:11:0B:E6:9F:86
```

## Why

Surfaced during Phase 4 smoke tests — every tablet boot showed the mismatched-preferred-id screen even though the machine was actually connected.

## WebView debug-timeout investigation (deferred)

While on this branch I also tried two fixes for the Teclast-in-debug-build WebView compat timeout — an adaptive 1500 ms settle delay and an adaptive 30 s internal timeout. Neither helped. Reverted both; kept the existing 500 ms release-validated delay. Logs show the failure isn't BLE contention or insufficient runtime budget; needs proper root-cause investigation. Tracked as a TODO.

## Test plan

- `flutter test`: 969 pass, 2 skip.
- `flutter analyze`: clean on changed files.
- sb-dev help text + round-trip via `--restart` verified.
- Real-hardware path validated on M50Mini: preferred-machine-id lookup now hits the right device on first boot.