### PR TITLE
refactor(comms): extract ScanOrchestrator and PolicyResolver

### DIFF
--- a/lib/src/controllers/connection/policy_resolver.dart
+++ b/lib/src/controllers/connection/policy_resolver.dart
@@ -1,0 +1,105 @@
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+
+/// Action `ConnectionManager` should take for the machine phase of a
+/// connect cycle, once the scan has completed.
+///
+/// Sealed so callers must handle every variant — there's no silent
+/// default when a new case is added.
+sealed class MachinePolicyAction {
+  const MachinePolicyAction();
+}
+
+/// Auto-connect this specific machine.
+final class ConnectMachineAction extends MachinePolicyAction {
+  final De1Interface machine;
+  const ConnectMachineAction(this.machine);
+}
+
+/// Present a picker so the user can choose which machine to connect.
+final class MachinePickerAction extends MachinePolicyAction {
+  const MachinePickerAction();
+}
+
+/// Nothing to do — either no machines were found or the preferred
+/// machine wasn't discovered during the scan.
+final class NoMachineAction extends MachinePolicyAction {
+  /// Whether any machines were matched at all. Callers use this to
+  /// decide between `phase: idle` with and without the
+  /// `pendingAmbiguity: machinePicker` hint (preferred-set-but-
+  /// not-found still surfaces the picker when there are other
+  /// machines available).
+  final bool hasOtherMachines;
+  const NoMachineAction({required this.hasOtherMachines});
+}
+
+/// Decide what to do with the machine phase given the scan snapshot.
+///
+/// Rules:
+///   - If `preferredMachineId` is set, early-connect would have
+///     handled the happy path — reaching post-scan means the
+///     preferred device wasn't discovered. Show a picker if any
+///     other machines appeared, otherwise idle.
+///   - If no preferred is set: auto-connect iff exactly one machine
+///     was found; otherwise picker (>1) or idle (0).
+MachinePolicyAction resolveMachinePolicy({
+  required List<De1Interface> machines,
+  required String? preferredMachineId,
+}) {
+  if (preferredMachineId != null) {
+    if (machines.isNotEmpty) return const MachinePickerAction();
+    return const NoMachineAction(hasOtherMachines: false);
+  }
+  if (machines.isEmpty) {
+    return const NoMachineAction(hasOtherMachines: false);
+  }
+  if (machines.length == 1) return ConnectMachineAction(machines.first);
+  return const MachinePickerAction();
+}
+
+/// Action `ConnectionManager` should take for the scale phase.
+sealed class ScalePolicyAction {
+  const ScalePolicyAction();
+}
+
+/// Auto-connect this specific scale.
+final class ConnectScaleAction extends ScalePolicyAction {
+  final Scale scale;
+  const ConnectScaleAction(this.scale);
+}
+
+/// Present a picker so the user can choose which scale to connect.
+final class ScalePickerAction extends ScalePolicyAction {
+  const ScalePickerAction();
+}
+
+/// Nothing to do — no scales were found, or the preferred scale
+/// wasn't discovered and no alternatives are available.
+final class NoScaleAction extends ScalePolicyAction {
+  const NoScaleAction();
+}
+
+/// Decide what to do with the scale phase given the scan snapshot.
+///
+/// Rules:
+///   - If `preferredScaleId` is set and that exact id is in `scales`:
+///     connect it. If preferred is set but not found, show a picker
+///     when other scales exist; otherwise no action.
+///   - If no preferred: auto-connect iff exactly one scale; picker
+///     for >1; no action for 0.
+ScalePolicyAction resolveScalePolicy({
+  required List<Scale> scales,
+  required String? preferredScaleId,
+}) {
+  if (preferredScaleId != null) {
+    final match = scales
+        .where((s) => s.deviceId == preferredScaleId)
+        .firstOrNull;
+    if (match != null) return ConnectScaleAction(match);
+    if (scales.isNotEmpty) return const ScalePickerAction();
+    return const NoScaleAction();
+  }
+  if (scales.length == 1) return ConnectScaleAction(scales.first);
+  if (scales.length > 1) return const ScalePickerAction();
+  return const NoScaleAction();
+}

--- a/lib/src/controllers/connection/scan_orchestrator.dart
+++ b/lib/src/controllers/connection/scan_orchestrator.dart
@@ -1,0 +1,207 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/connection/early_connect_watcher.dart';
+import 'package:reaprime/src/controllers/connection/scan_report_builder.dart';
+import 'package:reaprime/src/controllers/connection/status_publisher.dart';
+import 'package:reaprime/src/controllers/connection_error.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart'
+    show ConnectionPhase;
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device_scanner.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/errors.dart';
+
+/// Outcome of [ScanOrchestrator.runScan].
+///
+/// `null` from the orchestrator means a catastrophic scan failure
+/// (bluetoothPermissionDenied / scanFailed) — the orchestrator has
+/// already emitted the sticky error and phase=idle on the status
+/// stream; the coordinator should bail.
+class ScanRunResult {
+  /// Machines matched during the scan.
+  final List<De1Interface> machines;
+
+  /// Scales matched during the scan.
+  final List<Scale> scales;
+
+  /// The per-scan builder. The coordinator feeds connection-attempt
+  /// results back into this before calling [emit].
+  final ScanReportBuilder reportBuilder;
+
+  const ScanRunResult({
+    required this.machines,
+    required this.scales,
+    required this.reportBuilder,
+  });
+}
+
+/// Runs one scan cycle and wires the EarlyConnectWatcher, the
+/// `DeviceScanner.scanForDevices()` call, sticky-error clearing, and
+/// the post-scan ScanReportBuilder seeding. The coordinator stays
+/// responsible for applying the policy + emitting the final
+/// ScanReport so status-emission ownership remains clear.
+///
+/// Extracted from ConnectionManager as part of comms-harden Phase 4
+/// (roadmap items 15, 16).
+class ScanOrchestrator {
+  static final _log = Logger('ScanOrchestrator');
+
+  final DeviceScanner _scanner;
+  final StatusPublisher _statusPublisher;
+  final Future<void> Function(De1Interface, ScanReportBuilder)
+      _connectMachineTracked;
+  final Future<void> Function(Scale, ScanReportBuilder) _connectScaleTracked;
+  final bool Function() _isMachineConnected;
+  final bool Function() _isScaleConnected;
+
+  ScanOrchestrator({
+    required DeviceScanner scanner,
+    required StatusPublisher statusPublisher,
+    required Future<void> Function(De1Interface, ScanReportBuilder)
+        connectMachineTracked,
+    required Future<void> Function(Scale, ScanReportBuilder)
+        connectScaleTracked,
+    required bool Function() isMachineConnected,
+    required bool Function() isScaleConnected,
+  })  : _scanner = scanner,
+        _statusPublisher = statusPublisher,
+        _connectMachineTracked = connectMachineTracked,
+        _connectScaleTracked = connectScaleTracked,
+        _isMachineConnected = isMachineConnected,
+        _isScaleConnected = isScaleConnected;
+
+  /// Publish `phase: scanning`, set up the early-connect watcher,
+  /// run the scan, wait for early connects, and return a snapshot
+  /// for the coordinator's policy stage.
+  ///
+  /// Returns `null` if the scan failed catastrophically — in that
+  /// case this method has already emitted the classified error +
+  /// `phase: idle` and the coordinator should bail without running
+  /// the policy stage.
+  Future<ScanRunResult?> runScan({
+    required String? preferredMachineId,
+    required String? preferredScaleId,
+    required bool earlyStopEnabled,
+    required void Function() onEarlyAttemptComplete,
+    required DateTime scanStartTime,
+  }) async {
+    final reportBuilder = ScanReportBuilder(scanStartTime: scanStartTime);
+
+    _statusPublisher.publish(
+      _statusPublisher.current.copyWith(
+        phase: ConnectionPhase.scanning,
+        pendingAmbiguity: () => null,
+      ),
+    );
+
+    // EarlyConnectWatcher owns the deviceStream subscription + the
+    // `(started, pending)` pair per device type + error handling on
+    // the pending futures.
+    final earlyConnect = EarlyConnectWatcher(
+      deviceStream: _scanner.deviceStream,
+      preferredMachineId: preferredMachineId,
+      preferredScaleId: preferredScaleId,
+      scanReport: reportBuilder,
+      isMachineConnected: _isMachineConnected,
+      isScaleConnected: _isScaleConnected,
+      connectMachineTracked: _connectMachineTracked,
+      connectScaleTracked: _connectScaleTracked,
+      onEarlyAttemptComplete: onEarlyAttemptComplete,
+    );
+    earlyConnect.start();
+
+    // Run full unfiltered scan. The scanner awaits every service's
+    // scan and returns a ScanResult carrying per-service failures;
+    // only a catastrophic, scan-wide error throws out of the Future.
+    final ScanResult scanResult;
+    try {
+      scanResult = await _scanner.scanForDevices();
+    } catch (e) {
+      earlyConnect.stop();
+      _emitScanStartError(e);
+      return null;
+    }
+    earlyConnect.stop();
+
+    // Sticky-error environmental recovery: reaching a completed scan
+    // means permission and scan subsystems are working again. Clear
+    // any sticky scan-related error that was hanging on — the
+    // StatusPublisher gatekeeper would preserve it otherwise.
+    _clearStickyScanError();
+
+    // Wait for any in-flight early connects to finish before the
+    // coordinator runs its policy stage.
+    await earlyConnect.awaitPending();
+
+    // Seed tracker entries for every device in the final snapshot.
+    // Early-connect paths pre-seeded their targets; seed is
+    // idempotent so those entries stay intact.
+    final allDevices = scanResult.matchedDevices;
+    for (final d in allDevices) {
+      reportBuilder.seed(d);
+    }
+
+    final machines = allDevices.whereType<De1Interface>().toList();
+    final scales = allDevices.whereType<Scale>().toList();
+
+    _log.fine(
+      'Scan complete: ${machines.length} machines, ${scales.length} scales',
+    );
+
+    return ScanRunResult(
+      machines: machines,
+      scales: scales,
+      reportBuilder: reportBuilder,
+    );
+  }
+
+  /// Classify an exception thrown by `scanForDevices()` into a
+  /// ConnectionErrorKind, publish `phase: idle`, and emit the
+  /// classified error. Preserves the pre-refactor "DO NOT REORDER"
+  /// invariant (publish phase first so the gatekeeper strips any
+  /// stale transient, then emit the new sticky error).
+  void _emitScanStartError(Object e) {
+    final kind = _classifyScanError(e);
+    _statusPublisher.publish(
+      _statusPublisher.current.copyWith(phase: ConnectionPhase.idle),
+    );
+    _statusPublisher.emitError(ConnectionError(
+      kind: kind,
+      severity: ConnectionErrorSeverity.error,
+      timestamp: DateTime.now().toUtc(),
+      message: kind == ConnectionErrorKind.bluetoothPermissionDenied
+          ? 'Bluetooth permission was denied.'
+          : 'Failed to start Bluetooth scan.',
+      suggestion: kind == ConnectionErrorKind.bluetoothPermissionDenied
+          ? 'Grant Bluetooth permission in system settings and retry.'
+          : 'Check that Bluetooth is enabled and retry.',
+      details: {'exception': e.toString()},
+    ));
+  }
+
+  void _clearStickyScanError() {
+    final prevErr = _statusPublisher.current.error;
+    if (prevErr != null &&
+        (prevErr.kind == ConnectionErrorKind.scanFailed ||
+            prevErr.kind == ConnectionErrorKind.bluetoothPermissionDenied)) {
+      _statusPublisher.clearError();
+    }
+  }
+
+  /// Map a scan-start exception to a [ConnectionErrorKind]. Checks
+  /// the exception type first (for the known [PermissionDeniedException]
+  /// type); falls back to a lowercase substring match on the message
+  /// so platforms that surface permission failures as generic
+  /// exceptions still route to the right kind.
+  static String _classifyScanError(Object e) {
+    if (e is PermissionDeniedException) {
+      return ConnectionErrorKind.bluetoothPermissionDenied;
+    }
+    final msg = e.toString().toLowerCase();
+    if (msg.contains('permission')) {
+      return ConnectionErrorKind.bluetoothPermissionDenied;
+    }
+    return ConnectionErrorKind.scanFailed;
+  }
+}

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -6,7 +6,8 @@ import 'package:flutter_blue_plus/flutter_blue_plus.dart'
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/connection/disconnect_expectations.dart';
 import 'package:reaprime/src/controllers/connection/disconnect_supervisor.dart';
-import 'package:reaprime/src/controllers/connection/early_connect_watcher.dart';
+import 'package:reaprime/src/controllers/connection/policy_resolver.dart';
+import 'package:reaprime/src/controllers/connection/scan_orchestrator.dart';
 import 'package:reaprime/src/controllers/connection/scan_report_builder.dart';
 import 'package:reaprime/src/controllers/connection/status_publisher.dart';
 import 'package:reaprime/src/controllers/connection_error.dart';
@@ -16,7 +17,6 @@ import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/models/device/device_scanner.dart';
 import 'package:reaprime/src/models/device/scale.dart';
-import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/models/scan_report.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:rxdart/rxdart.dart';
@@ -100,6 +100,7 @@ class ConnectionManager {
   bool get _scaleConnected => _disconnectSupervisor.isScaleConnected;
 
   late final DisconnectSupervisor _disconnectSupervisor;
+  late final ScanOrchestrator _scanOrchestrator;
 
   StreamSubscription<AdapterState>? _adapterSub;
 
@@ -126,6 +127,14 @@ class ConnectionManager {
       isConnectingScale: () => _isConnectingScale,
       scaleLastConnectedId: () => scaleController.lastConnectedDeviceId,
       preferredScaleId: () => settingsController.preferredScaleId,
+    );
+    _scanOrchestrator = ScanOrchestrator(
+      scanner: deviceScanner,
+      statusPublisher: _statusPublisher,
+      connectMachineTracked: _connectMachineTracked,
+      connectScaleTracked: _connectScaleTracked,
+      isMachineConnected: () => _machineConnected,
+      isScaleConnected: () => _scaleConnected,
     );
     _listenForAdapter();
   }
@@ -187,22 +196,6 @@ class ConnectionManager {
       suggestion: suggestion,
       details: details,
     );
-  }
-
-  /// Map a scan-start exception to a [ConnectionErrorKind]. Checks the
-  /// exception type first (for the known [PermissionDeniedException]
-  /// type); falls back to a lowercase substring match on the message
-  /// so platforms that surface permission failures as generic exceptions
-  /// still route to the right kind.
-  String _classifyScanError(Object e) {
-    if (e is PermissionDeniedException) {
-      return ConnectionErrorKind.bluetoothPermissionDenied;
-    }
-    final msg = e.toString().toLowerCase();
-    if (msg.contains('permission')) {
-      return ConnectionErrorKind.bluetoothPermissionDenied;
-    }
-    return ConnectionErrorKind.scanFailed;
   }
 
   /// Clears the current error. Proxy over [StatusPublisher.clearError]
@@ -320,125 +313,33 @@ class ConnectionManager {
   }
 
   Future<void> _connectImpl({required bool scaleOnly}) async {
-    final scanStartTime = DateTime.now();
-
-    // Per-scan builder that accumulates attempted/succeeded/failed
-    // results and emits the final ScanReport.
-    final scanReport = ScanReportBuilder(scanStartTime: scanStartTime);
-
-    // Emit scanning phase. Do not explicitly clear `error` — the gatekeeper
-    // strips transient errors on phase transitions into clearing phases and
-    // preserves sticky ones (e.g. adapterOff).
-    _publishStatus(
-      currentStatus.copyWith(
-        phase: ConnectionPhase.scanning,
-        pendingAmbiguity: () => null,
-      ),
-    );
-
     final preferredMachineId =
         scaleOnly ? null : settingsController.preferredMachineId;
     final preferredScaleId = settingsController.preferredScaleId;
-
-    // Early-stop is only enabled when both preferences are set (and not scaleOnly).
     final earlyStopEnabled =
         !scaleOnly && preferredMachineId != null && preferredScaleId != null;
 
-    // Watch device stream during scan — connect preferred devices immediately
-    // as they appear, rather than waiting for the full scan to complete.
-    //
-    // EarlyConnectWatcher owns the deviceStream subscription + the
-    // `(started, pending)` pair per device type + error handling on
-    // the pending futures (comms-harden #7, #18, #19).
-    final earlyConnect = EarlyConnectWatcher(
-      deviceStream: deviceScanner.deviceStream,
+    final scanStartTime = DateTime.now();
+    final scanRun = await _scanOrchestrator.runScan(
       preferredMachineId: preferredMachineId,
       preferredScaleId: preferredScaleId,
-      scanReport: scanReport,
-      isMachineConnected: () => _machineConnected,
-      isScaleConnected: () => _scaleConnected,
-      connectMachineTracked: _connectMachineTracked,
-      connectScaleTracked: _connectScaleTracked,
+      earlyStopEnabled: earlyStopEnabled,
       onEarlyAttemptComplete: () => _checkEarlyStop(earlyStopEnabled),
+      scanStartTime: scanStartTime,
     );
-    earlyConnect.start();
-
-    // Run full unfiltered scan. The scanner awaits every service's scan
-    // and returns a ScanResult carrying per-service failures; only a
-    // catastrophic, scan-wide error throws out of the Future. Classify
-    // any such throw into bluetoothPermissionDenied or scanFailed —
-    // both are sticky errors that survive phase transitions.
-    final ScanResult scanResult;
-    try {
-      scanResult = await deviceScanner.scanForDevices();
-    } catch (e) {
-      earlyConnect.stop();
-      final kind = _classifyScanError(e);
-      // DO NOT REORDER — same rationale as connectScale: publish idle
-      // first, then _emit the error (which bypasses the phase-change
-      // error-stripping gatekeeper) so the sticky error is preserved.
-      _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.idle));
-      _emit(ConnectionError(
-        kind: kind,
-        severity: ConnectionErrorSeverity.error,
-        timestamp: DateTime.now().toUtc(),
-        message: kind == ConnectionErrorKind.bluetoothPermissionDenied
-            ? 'Bluetooth permission was denied.'
-            : 'Failed to start Bluetooth scan.',
-        suggestion: kind == ConnectionErrorKind.bluetoothPermissionDenied
-            ? 'Grant Bluetooth permission in system settings and retry.'
-            : 'Check that Bluetooth is enabled and retry.',
-        details: {'exception': e.toString()},
-      ));
+    if (scanRun == null) {
+      // Scan failed catastrophically; orchestrator already emitted
+      // the sticky error + phase=idle.
       return;
     }
-    earlyConnect.stop();
 
-    // Sticky-error environmental recovery: reaching a completed scan
-    // means permission and scan subsystems are working again. Clear
-    // any sticky scan-related error that was hanging on — the
-    // _publishStatus gatekeeper would preserve it otherwise.
-    //
-    // TODO(comms-phase-2 PR B): consult scanResult.failedServices to
-    // surface per-transport failures (e.g. BLE permission denied while
-    // serial succeeded). Deferred to the error-path unification pass.
-    final prevErr = currentStatus.error;
-    if (prevErr != null &&
-        (prevErr.kind == ConnectionErrorKind.scanFailed ||
-            prevErr.kind == ConnectionErrorKind.bluetoothPermissionDenied)) {
-      _clearError();
-    }
-
-    // Wait for any in-flight early connects to finish before the
-    // post-scan policy runs.
-    await earlyConnect.awaitPending();
-
-    // Collect found devices from the authoritative ScanResult rather
-    // than re-reading `deviceScanner.devices`. This is the single
-    // source of truth for "what the scan turned up" (comms-harden #17).
-    final allDevices = scanResult.matchedDevices;
-    final machines = allDevices.whereType<De1Interface>().toList();
-    final scales = allDevices.whereType<Scale>().toList();
-
-    // Seed tracker entries for every device in the final snapshot.
-    // Early-connect paths pre-seeded their targets in the stream
-    // listener; ScanReportBuilder.seed is idempotent so those entries
-    // stay intact.
-    for (final d in allDevices) {
-      scanReport.seed(d);
-    }
-
-    _log.fine(
-      'Scan complete: ${machines.length} machines, ${scales.length} scales',
-    );
+    final machines = scanRun.machines;
+    final scales = scanRun.scales;
+    final scanReport = scanRun.reportBuilder;
 
     if (scaleOnly) {
-      // Update found scales in status
-      _publishStatus(
-        currentStatus.copyWith(foundScales: scales),
-      );
-      // Apply scale preference policy only
-      await _connectScalePhase(scales, scanReport);
+      _publishStatus(currentStatus.copyWith(foundScales: scales));
+      await _applyScalePolicy(scales, preferredScaleId, scanReport);
       _emitScanReport(
         scanReport: scanReport,
         preferredMachineId: null,
@@ -448,16 +349,15 @@ class ConnectionManager {
       return;
     }
 
-    // Store found devices in status for UI pickers
     _publishStatus(
       currentStatus.copyWith(foundMachines: machines, foundScales: scales),
     );
 
-    // If machine is already connected (either from before or early connect),
-    // skip straight to scale phase
+    // If machine is already connected (either from before or
+    // early-connect), skip straight to scale phase.
     if (_machineConnected) {
       _log.fine('Machine connected, proceeding to scale phase');
-      await _connectScalePhase(scales, scanReport);
+      await _applyScalePolicy(scales, preferredScaleId, scanReport);
       _emitScanReport(
         scanReport: scanReport,
         preferredMachineId: preferredMachineId,
@@ -467,36 +367,24 @@ class ConnectionManager {
       return;
     }
 
-    // Apply machine preference policy for remaining cases
-    if (preferredMachineId != null) {
-      // Preferred was set but not found during scan
-      if (machines.isNotEmpty) {
-        _publishStatus(
-          currentStatus.copyWith(
-            phase: ConnectionPhase.idle,
-            pendingAmbiguity: () => AmbiguityReason.machinePicker,
-          ),
-        );
-      } else {
+    // Post-scan machine policy. Early-connect already handled the
+    // "preferred found during scan" happy path; what arrives here
+    // is everything else.
+    final machineAction = resolveMachinePolicy(
+      machines: machines,
+      preferredMachineId: preferredMachineId,
+    );
+    switch (machineAction) {
+      case ConnectMachineAction(machine: final m):
+        await _connectMachineTracked(m, scanReport);
+        await _applyScalePolicy(scales, preferredScaleId, scanReport);
+      case MachinePickerAction():
+        _publishStatus(currentStatus.copyWith(
+          phase: ConnectionPhase.idle,
+          pendingAmbiguity: () => AmbiguityReason.machinePicker,
+        ));
+      case NoMachineAction():
         _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.idle));
-      }
-    } else {
-      // No preferred machine set
-      if (machines.isEmpty) {
-        _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.idle));
-      } else if (machines.length == 1) {
-        // Exactly one machine — auto-connect
-        await _connectMachineTracked(machines.first, scanReport);
-        await _connectScalePhase(scales, scanReport);
-      } else {
-        // Multiple machines — picker
-        _publishStatus(
-          currentStatus.copyWith(
-            phase: ConnectionPhase.idle,
-            pendingAmbiguity: () => AmbiguityReason.machinePicker,
-          ),
-        );
-      }
     }
 
     _emitScanReport(
@@ -515,57 +403,33 @@ class ConnectionManager {
     }
   }
 
-  /// Apply scale preference policy after machine connects. If
-  /// [scanReport] is provided, the attempt outcome is recorded on it;
-  /// otherwise a bare `connectScale` is used (the non-scan-driven
-  /// paths don't need tracker bookkeeping).
-  Future<void> _connectScalePhase(
-    List<Scale> scales, [
-    ScanReportBuilder? scanReport,
-  ]) async {
+  /// Apply the scale-phase policy, tracking attempts on [scanReport].
+  Future<void> _applyScalePolicy(
+    List<Scale> scales,
+    String? preferredScaleId,
+    ScanReportBuilder scanReport,
+  ) async {
     if (_scaleConnected) {
       _log.fine('Scale already connected, skipping scale phase');
       return;
     }
-    _log.fine('Scale phase: ${scales.length} scales found');
-    final preferredScaleId = settingsController.preferredScaleId;
-    _log.fine('Scale phase: preferredScaleId=$preferredScaleId');
-
-    if (preferredScaleId != null) {
-      // Preferred scale is set
-      final preferred =
-          scales.where((s) => s.deviceId == preferredScaleId).toList();
-      if (preferred.isNotEmpty) {
-        if (scanReport != null) {
-          await _connectScaleTracked(preferred.first, scanReport);
-        } else {
-          await connectScale(preferred.first);
-        }
-      } else if (scales.isNotEmpty) {
-        // Preferred not found but others available — picker
-        _log.fine('Scale phase: preferred not found, showing picker');
-        _publishStatus(
-          currentStatus.copyWith(
-            pendingAmbiguity: () => AmbiguityReason.scalePicker,
-          ),
-        );
-      }
-    } else {
-      // No preferred scale set
-      if (scales.length == 1) {
-        if (scanReport != null) {
-          await _connectScaleTracked(scales.first, scanReport);
-        } else {
-          await connectScale(scales.first);
-        }
-      } else if (scales.length > 1) {
-        // Multiple scales — picker
-        _publishStatus(
-          currentStatus.copyWith(
-            pendingAmbiguity: () => AmbiguityReason.scalePicker,
-          ),
-        );
-      }
+    _log.fine(
+      'Scale phase: ${scales.length} scales, preferredScaleId=$preferredScaleId',
+    );
+    final action = resolveScalePolicy(
+      scales: scales,
+      preferredScaleId: preferredScaleId,
+    );
+    switch (action) {
+      case ConnectScaleAction(scale: final s):
+        await _connectScaleTracked(s, scanReport);
+      case ScalePickerAction():
+        _publishStatus(currentStatus.copyWith(
+          pendingAmbiguity: () => AmbiguityReason.scalePicker,
+        ));
+      case NoScaleAction():
+        // Nothing to do — idle scale phase.
+        break;
     }
   }
 

--- a/test/controllers/connection/policy_resolver_test.dart
+++ b/test/controllers/connection/policy_resolver_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection/policy_resolver.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+
+class _FakeDe1 implements De1Interface {
+  @override
+  final String deviceId;
+
+  _FakeDe1(this.deviceId);
+
+  @override
+  DeviceType get type => DeviceType.machine;
+
+  @override
+  dynamic noSuchMethod(Invocation i) => null;
+}
+
+class _FakeScale implements Scale {
+  @override
+  final String deviceId;
+
+  _FakeScale(this.deviceId);
+
+  @override
+  DeviceType get type => DeviceType.scale;
+
+  @override
+  dynamic noSuchMethod(Invocation i) => null;
+}
+
+void main() {
+  group('resolveMachinePolicy', () {
+    test('no preferred + no machines → idle (no others)', () {
+      final result = resolveMachinePolicy(
+        machines: const [],
+        preferredMachineId: null,
+      );
+      expect(result, isA<NoMachineAction>());
+    });
+
+    test('no preferred + exactly one machine → connect', () {
+      final m = _FakeDe1('a');
+      final result = resolveMachinePolicy(
+        machines: [m],
+        preferredMachineId: null,
+      );
+      expect(result, isA<ConnectMachineAction>());
+      expect((result as ConnectMachineAction).machine, same(m));
+    });
+
+    test('no preferred + two machines → picker', () {
+      final result = resolveMachinePolicy(
+        machines: [_FakeDe1('a'), _FakeDe1('b')],
+        preferredMachineId: null,
+      );
+      expect(result, isA<MachinePickerAction>());
+    });
+
+    test('preferred set + no machines → idle', () {
+      final result = resolveMachinePolicy(
+        machines: const [],
+        preferredMachineId: 'pref',
+      );
+      expect(result, isA<NoMachineAction>());
+    });
+
+    test(
+        'preferred set but not discovered + other machines present → picker',
+        () {
+      // Early-connect would have handled the happy "preferred found"
+      // path; reaching here with a non-empty list means the preferred
+      // id wasn't among them.
+      final result = resolveMachinePolicy(
+        machines: [_FakeDe1('other')],
+        preferredMachineId: 'pref',
+      );
+      expect(result, isA<MachinePickerAction>());
+    });
+  });
+
+  group('resolveScalePolicy', () {
+    test('no preferred + zero scales → no action', () {
+      final result = resolveScalePolicy(
+        scales: const [],
+        preferredScaleId: null,
+      );
+      expect(result, isA<NoScaleAction>());
+    });
+
+    test('no preferred + exactly one scale → connect', () {
+      final s = _FakeScale('a');
+      final result = resolveScalePolicy(
+        scales: [s],
+        preferredScaleId: null,
+      );
+      expect(result, isA<ConnectScaleAction>());
+      expect((result as ConnectScaleAction).scale, same(s));
+    });
+
+    test('no preferred + two scales → picker', () {
+      final result = resolveScalePolicy(
+        scales: [_FakeScale('a'), _FakeScale('b')],
+        preferredScaleId: null,
+      );
+      expect(result, isA<ScalePickerAction>());
+    });
+
+    test('preferred scale found in list → connect that one', () {
+      final target = _FakeScale('pref');
+      final result = resolveScalePolicy(
+        scales: [_FakeScale('other'), target, _FakeScale('other2')],
+        preferredScaleId: 'pref',
+      );
+      expect(result, isA<ConnectScaleAction>());
+      expect((result as ConnectScaleAction).scale, same(target));
+    });
+
+    test('preferred set but not in list + others present → picker', () {
+      final result = resolveScalePolicy(
+        scales: [_FakeScale('other')],
+        preferredScaleId: 'pref',
+      );
+      expect(result, isA<ScalePickerAction>());
+    });
+
+    test('preferred set but no scales at all → no action', () {
+      final result = resolveScalePolicy(
+        scales: const [],
+        preferredScaleId: 'pref',
+      );
+      expect(result, isA<NoScaleAction>());
+    });
+  });
+}


### PR DESCRIPTION
## What

Two new collaborators in `lib/src/controllers/connection/`:

- **`PolicyResolver`** (top-level sealed-class functions). `resolveMachinePolicy({machines, preferredMachineId})` → `MachinePolicyAction` (one of `ConnectMachineAction(m)` / `MachinePickerAction` / `NoMachineAction`). `resolveScalePolicy` has the same shape for scales. Pure — no side effects, no dependencies.
- **`ScanOrchestrator`** (105 LoC + 207 LoC). Owns the `EarlyConnectWatcher` lifecycle, the `deviceScanner.scanForDevices()` await + scan-start error emission, post-scan sticky-error clearing, and the final `ScanReportBuilder` seeding. Returns a `ScanRunResult` or `null` on catastrophic scan failure. Also owns `_classifyScanError`.

In `ConnectionManager`:

- `_connectImpl` shrinks from ~190 lines of inline scan + policy to ~60 lines of top-level orchestration.
- `_connectScalePhase` collapses into `_applyScalePolicy` — a switch over the sealed `ScalePolicyAction`. No more if-ladders reading and writing the same status fields.
- `_classifyScanError` and `_connectScalePhase` removed; imports cleaned up (`EarlyConnectWatcher`, `errors.dart` no longer needed here).

`ConnectionManager`: 763 → 627 lines. Cumulative Phase 4 reduction: **1043 → 627** (−416 lines).

## Why

Phase 4 PR 4c — Cluster D keystone. The policy rules are now unit-testable in isolation (11 new tests pin every branch). The scan lifecycle has a single owner. Zero observable behaviour change — the existing 65-test `ConnectionManager` suite stays green verbatim.

## Test plan

- `flutter test`: 980 pass (11 new), 2 skip.
- `flutter analyze`: clean on all changed/new files.
- Real-hardware smoke on M50Mini + DE1Pro: preferred-id auto-connect fires on boot (`Connected to DE1`, scan report shows `preferred machine D9:11:0B:E6:9F:86 found`). Disconnect + reconnect cycle 2.8 s. No `Bad state`, `MmrTimeoutException`, or late-subscription errors.