### PR TITLE
feat(comms): Phase 5 lifecycle hygiene — debounce, transport dispose, scale dispose, connect timeout

### DIFF
--- a/doc/plans/comms-phase-5.md
+++ b/doc/plans/comms-phase-5.md
@@ -1,0 +1,148 @@
+# Comms Hardening — Phase 5 Implementation Plan
+
+Execution plan for Phase 5 of `doc/plans/comms-harden.md`: transport + lifecycle hygiene. Resolves Cluster C's remaining items and the reconnect-path items from Cluster E.
+
+Four roadmap items in scope: **5, 12, 13, 31**.
+
+## Pre-work findings
+
+### Item 5 — shot-settings debounce races disconnect
+
+`lib/src/controllers/de1_controller.dart:142–149`:
+
+```dart
+Future<void> _shotSettingsUpdate(De1ShotSettings data) async {
+  _shotSettingsDebounce?.cancel();
+  _shotSettingsDebounce = Timer(const Duration(milliseconds: 100), () async {
+    _log.info('Processing shot settings update (debounced)');
+    await _processShotSettingsUpdate(data);
+  });
+}
+```
+
+`_onDisconnect` cancels `_shotSettingsDebounce` at line 116 — good. But if the 100 ms timer has **already fired** and the closure body is mid-flight in `_processShotSettingsUpdate`, cancelling the timer does nothing. The closure keeps awaiting `connectedDe1().getSteamFlow()` etc., each of which now throws `DeviceNotConnectedException` (Phase 1, item 25) because `_de1` was nulled in `_onDisconnect`. The exception leaks out of the timer callback as an unhandled async error.
+
+**Fix:** generation token. Increment `_connectionGeneration` in `_onDisconnect`; the debounce closure captures the generation at scheduling time and bails out early if it no longer matches. Also wrap the `_processShotSettingsUpdate` body in a try/catch that swallows `DeviceNotConnectedException` specifically (now a typed exception, so the catch is precise). Activates Gap E test from Phase 0.
+
+### Item 12 — transport `_nativeConnectionSub` never cancelled in disconnect()
+
+Three files:
+- `lib/src/services/ble/blue_plus_transport.dart:59–66`
+- `lib/src/services/ble/android_blue_plus_transport.dart:147+`
+- `lib/src/services/ble/linux_blue_plus_transport.dart:164+`
+
+Each cancels `_nativeConnectionSub` at the **start** of `connect()` (good — re-using the transport for a reconnect cycles the subscription) but none cancels it in `disconnect()`. Late `disconnected` events from the FlutterBluePlus stream fire after our own `disconnect()` call and hit a `BehaviorSubject.add` on a controller we've already processed, accumulating subscriptions over repeated connect/disconnect cycles.
+
+**Fix:** add `_nativeConnectionSub?.cancel();` at the start of `disconnect()` in all three files. Null out afterwards so a subsequent `connect()` sees a clean state. Three-line change × 3 files.
+
+### Item 13 — ScaleController.dispose is empty
+
+`lib/src/controllers/scale_controller.dart:27`:
+
+```dart
+void dispose() {}
+```
+
+`_connectionController` (`BehaviorSubject<ConnectionState>`) and `_weightSnapshotController` (`StreamController<WeightSnapshot>.broadcast()`) are never closed. Subscribers never see `onDone`. Minor today (ScaleController is app-wide, disposed only on app shutdown), but resource-leak pattern worth fixing now — part of the Cluster E lifecycle hygiene.
+
+**Fix:** close both subjects in `dispose()`. Guard with `isClosed` so repeated disposes are safe. Also cancel `_scaleSnapshot` / `_scaleConnection` subscriptions if they're live.
+
+### Item 31 — end-to-end connect timeout
+
+`ConnectionManager.connect`, `connectMachine`, `connectScale` have no top-level timeout. Phase 1's item 2 fix bounded the MMR-read hang at 2 s, but other transport-level operations (`de1Controller.connectToDe1(machine)` which internally awaits `_bleConnect()` + service discovery + MMR info reads; `scaleController.connectToScale(scale)` with its own `onConnect()`) can in principle hang on a misbehaving device.
+
+The MMR timeout we have today is the acute protection; the end-to-end timeout is the belt-and-braces that prevents any *other* hang from wedging `_isConnecting`.
+
+**Fix:** wrap `de1Controller.connectToDe1(machine)` in `.timeout(const Duration(seconds: 30))` inside `connectMachine`; same for scale. On timeout, emit `machineConnectFailed` / `scaleConnectFailed` with a distinct suggestion ("Device took too long to respond. Try again, and if the problem persists power-cycle the device."). The timeout fires as a `TimeoutException` which is already caught by the existing `catch (e)` — needs a small classification tweak in `_buildConnectError` to identify it cleanly.
+
+**Timeout value choice.** Real-hardware connect currently observed at 3–10 s on tablet (4.0 s typical, up to 9.9 s with GATT 133 retries). 30 s is ~3× the worst-case observed and leaves headroom for slow BLE adapters. Value lives in a named constant.
+
+---
+
+## Goals
+
+After Phase 5:
+
+- Shot-settings debounce no longer leaks exceptions on disconnect (item 5).
+- Transport subscriptions lifecycle-clean across reconnect cycles (item 12).
+- `ScaleController` disposes its subjects (item 13).
+- `connectMachine` / `connectScale` fail loudly after 30 s instead of hanging (item 31).
+- Gap E placeholder test from Phase 0 activates as a live regression check.
+
+## Non-goals
+
+- Transport-level `_nativeConnectionSub` *re-subscription* on disconnect — cancelling is enough; we don't need to proactively detect the "device vanished while app-initiated-disconnecting" case.
+- Connect timeout for `ConnectionManager.connect()` as a whole (the 15 s scan + variable connect path makes a single-number budget messy; the per-device timeouts on `connectMachine`/`connectScale` cover the real hang risk).
+- Any change to `DisconnectExpectations` TTL (separate concern, already has a 10 s TTL that works).
+
+---
+
+## Landmines
+
+1. **Gap E test existed as a placeholder** (`test/controllers/de1_controller_test.dart`). Activating it needs a real `_processShotSettingsUpdate` call path or a tightly mocked `TestDe1` that can fake `shotSettings` stream. May require extending `TestDe1` with a controllable shot-settings stream.
+2. **Transport-level disconnect() doesn't always get called.** Three scenarios:
+   - App-initiated disconnect (`UnifiedDe1.disconnect()` → transport.disconnect). Covered.
+   - Device-initiated disconnect (BLE drop). The native stream emits `disconnected`; our subscription sees it and propagates. We're NOT in `disconnect()` here. But the subscription still exists and still works.
+   - App shutdown. `dispose()` chain. Needs to cover transport subscription cleanup too.
+   So cancelling in `disconnect()` fixes the reconnect-cycle leak but not the BLE-drop case. That's fine — on BLE drop, the subscription IS still the live channel reporting the drop. It'd get cancelled next time `connect()` runs.
+3. **TimeoutException is already an `Exception`.** `_buildConnectError` runs via `catch (e)` in `connectMachine`/`connectScale` without inspecting type; if we want a distinct suggestion string for timeout, we need a typed check. Alternative: use a single message for all connect failures — simpler, less helpful.
+4. **ScaleController.dispose() caller.** Who calls it today? Probably `main.dart` shutdown path, possibly widget tests. Need to grep before assuming.
+5. **Scale-connection-state listener subscription** (`_scaleConnection` at line 13). Already set up; already cancelled in `_onDisconnect` at line 54. So a proper dispose needs to cancel subscriptions first, then close subjects.
+
+---
+
+## Delivery strategy
+
+One PR — the four items are narrow and touch different files, but together form a coherent "lifecycle hygiene" theme.
+
+**Branch:** `feature/comms-phase-5-lifecycle-hygiene` off `integration/comms-harden-rest`. **Est. size:** ~150 LoC + ~80 LoC test, across 5 files (`de1_controller.dart`, three `*_transport.dart`, `scale_controller.dart`, and the test file).
+
+### Per-item scope
+
+1. **Item 5 — debounce generation token.**
+   - Add `int _connectionGeneration = 0;` to `De1Controller`.
+   - Increment it in `_onDisconnect()`.
+   - `_shotSettingsUpdate` captures `_connectionGeneration` when scheduling the timer; the timer body bails if the value has changed.
+   - `_processShotSettingsUpdate` wrapped in `try { ... } on DeviceNotConnectedException catch (_) { /* expected during teardown */ }` as defence-in-depth.
+   - Activate `test/controllers/de1_controller_test.dart` placeholder with a real test that (a) uses `fake_async` to advance the debounce, (b) nulls `_de1` mid-closure, and (c) asserts no unhandled error leaks from the timer.
+
+2. **Item 12 — transport disconnect cancels sub.** For each of the three transport files:
+   - Add `_nativeConnectionSub?.cancel(); _nativeConnectionSub = null;` at the start of `disconnect()`.
+   - Tests are hard to write without a BLE mock. Rely on code review + tablet smoke (the transport leak only matters on reconnect cycles, already covered by our disconnect+reconnect smoke pass).
+
+3. **Item 13 — ScaleController.dispose proper.**
+   - Cancel `_scaleSnapshot?.cancel()` / `_scaleConnection?.cancel()`.
+   - Close both controllers with `isClosed` guard.
+   - Grep callers, confirm no use-after-dispose risk.
+
+4. **Item 31 — end-to-end connect timeout.**
+   - Add `static const _connectTimeout = Duration(seconds: 30);` on `ConnectionManager`.
+   - Wrap the `await de1Controller.connectToDe1(...)` call in `connectMachine` with `.timeout(_connectTimeout)`.
+   - Same for `scaleController.connectToScale(...)` in `connectScale`.
+   - Extend `_buildConnectError` to check `if (exception is TimeoutException)` and surface a distinct suggestion.
+   - Add a targeted test that uses a fake controller hanging forever on `connectToDe1` and asserts `machineConnectFailed` with timeout-flavoured details after 30 s (run via `fake_async`).
+
+### Tests
+
+- Activate Gap E (`test/controllers/de1_controller_test.dart`): debounce-race regression.
+- New test for item 31 timeout: `connect_timeout_test` style, possibly as a group inside `connection_manager_test.dart`.
+- Existing 80-test ConnectionManager suite + 11 PolicyResolver tests + collaborator unit tests stay green.
+
+---
+
+## Success criteria
+
+- `flutter test`: full suite green (980 → 982-ish after 2 new + Gap E activation). Gap E placeholder count drops from 2 to 1.
+- `flutter analyze`: clean on all changed files.
+- Real-hardware smoke on tablet: multiple disconnect+reconnect cycles to exercise item 12 (expect no "late disconnected event fires on closed subject" SEVERE in logs). Normal connect timing unaffected by item 31 (30 s budget is well above observed real-hardware 3–10 s).
+
+---
+
+## Open questions
+
+1. **Does `main.dart` dispose `ScaleController`?** If not, item 13's fix is theoretical only. Worth confirming, still worth doing.
+2. **Timeout value for item 31.** 30 s proposed — anyone's instinct different? GATT 133 retries can push to ~12 s; 30 s gives headroom without feeling sluggish.
+3. **Should item 12 also close the transport's `BehaviorSubject` in some teardown?** It's owned by the transport, not per-connect. Today nothing disposes the transport itself — device instances are cached by discovery services. Out of scope for Phase 5; revisit as part of a transport-dispose audit later.
+4. **Gap E test strategy.** Real path (debounce timer + disconnect mid-flight) or synthetic (call `_processShotSettingsUpdate` directly with `_de1` nulled)? The real path exercises the generation-token logic; the synthetic is cheaper. Lean real.
+
+Answer (or confirm) these and I kick off the single sub-PR.

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -92,6 +92,14 @@ class ConnectionManager {
   bool _isConnectingMachine = false;
   bool _isConnectingScale = false;
 
+  /// End-to-end timeout for a single `connectMachine` / `connectScale`
+  /// call. Phase 1 bounded the MMR-read hang at 2s; this is the
+  /// belt-and-braces that keeps any other transport-level hang from
+  /// wedging `_isConnecting` (comms-harden #31). Real-hardware
+  /// connect currently observes 3–10s on tablet; 30s leaves ~3x
+  /// headroom for slow adapters without feeling sluggish.
+  static const _connectTimeout = Duration(seconds: 30);
+
   // Device-connection state + unexpected-disconnect emission live on
   // DisconnectSupervisor — it owns the two stream subscribers and
   // exposes `isMachineConnected` / `isScaleConnected` as live views
@@ -452,7 +460,9 @@ class ConnectionManager {
     );
 
     try {
-      await de1Controller.connectToDe1(machine);
+      await de1Controller
+          .connectToDe1(machine)
+          .timeout(_connectTimeout);
       await settingsController.setPreferredMachineId(machine.deviceId);
       // `_latestDe1` is populated by the de1Controller.de1 stream
       // listener; by the time connectToDe1 returns, that microtask has
@@ -463,13 +473,18 @@ class ConnectionManager {
       // phase), so the _publishStatus/_emit ordering isn't load-bearing —
       // kept consistent with connectScale for readability.
       _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.idle));
+      final timedOut = e is TimeoutException;
       _emit(_buildConnectError(
         kind: ConnectionErrorKind.machineConnectFailed,
         deviceId: machine.deviceId,
         deviceName: machine.name,
-        message: 'Machine ${machine.name} failed to connect.',
-        suggestion:
-            'Make sure the DE1 is powered on and in range, then retry.',
+        message: timedOut
+            ? 'Machine ${machine.name} did not respond within '
+                '${_connectTimeout.inSeconds}s.'
+            : 'Machine ${machine.name} failed to connect.',
+        suggestion: timedOut
+            ? 'Try again. If the problem persists, power-cycle the machine.'
+            : 'Make sure the DE1 is powered on and in range, then retry.',
         exception: e,
       ));
       rethrow;
@@ -495,7 +510,9 @@ class ConnectionManager {
     );
 
     try {
-      await scaleController.connectToScale(scale);
+      await scaleController
+          .connectToScale(scale)
+          .timeout(_connectTimeout);
       await settingsController.setPreferredScaleId(scale.deviceId);
       // `_latestScaleState` is populated by the scaleController
       // listener; `_scaleConnected` reads from it.
@@ -516,13 +533,19 @@ class ConnectionManager {
       // run the error through the gatekeeper's strip rule. Publishing the
       // phase first (no error present) then calling `_emit` (bypasses the
       // gatekeeper) is the only order that keeps the error visible.
+      final timedOut = e is TimeoutException;
       _emit(_buildConnectError(
         kind: ConnectionErrorKind.scaleConnectFailed,
         deviceId: scale.deviceId,
         deviceName: scale.name,
-        message: 'Scale ${scale.name} failed to connect.',
-        suggestion: 'Wake the scale and try again. If the problem persists, '
-            'toggle Bluetooth off and on.',
+        message: timedOut
+            ? 'Scale ${scale.name} did not respond within '
+                '${_connectTimeout.inSeconds}s.'
+            : 'Scale ${scale.name} failed to connect.',
+        suggestion: timedOut
+            ? 'Try again. If the problem persists, power-cycle the scale.'
+            : 'Wake the scale and try again. If the problem persists, '
+                'toggle Bluetooth off and on.',
         exception: e,
       ));
     } finally {

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -61,6 +61,14 @@ class De1Controller {
   bool _dataInitialized = false;
   Timer? _shotSettingsDebounce;
 
+  /// Bumped every time `_onDisconnect()` runs. Captured by the
+  /// `_shotSettingsUpdate` debounce-timer closure at scheduling
+  /// time so a timer that fires after a disconnect can see "the
+  /// connection I was scheduled for is gone" and bail out before
+  /// calling `connectedDe1()` (which would throw
+  /// `DeviceNotConnectedException`). Covers comms-harden #5.
+  int _connectionGeneration = 0;
+
   De1Controller({required DeviceController controller})
       : _deviceController = controller {
     _log.info("checking ${_deviceController.devices}");
@@ -110,6 +118,7 @@ class De1Controller {
 
   void _onDisconnect() {
     _log.info("resetting de1");
+    _connectionGeneration++;
     _de1 = null;
     _de1Controller.add(_de1);
     _dataInitialized = false;
@@ -140,11 +149,29 @@ class De1Controller {
   }
 
   Future<void> _shotSettingsUpdate(De1ShotSettings data) async {
-    // Debounce rapid successive calls (e.g., from setSteamFlow + setHotWaterFlow + updateShotSettings)
+    // Debounce rapid successive calls (e.g., from setSteamFlow +
+    // setHotWaterFlow + updateShotSettings). Capture the current
+    // generation so a disconnect + cancel race where the timer has
+    // already fired but the closure hasn't started awaiting yet still
+    // bails out cleanly (comms-harden #5).
     _shotSettingsDebounce?.cancel();
+    final generation = _connectionGeneration;
     _shotSettingsDebounce = Timer(const Duration(milliseconds: 100), () async {
+      if (generation != _connectionGeneration || _de1 == null) {
+        _log.fine(
+          'Shot settings debounce fired after disconnect '
+          '(gen=$generation, current=$_connectionGeneration) — skipping',
+        );
+        return;
+      }
       _log.info('Processing shot settings update (debounced)');
-      await _processShotSettingsUpdate(data);
+      try {
+        await _processShotSettingsUpdate(data);
+      } on DeviceNotConnectedException catch (e) {
+        // Defence in depth: device may have disconnected between the
+        // generation check above and any of the awaits in the body.
+        _log.fine('Shot settings update aborted by disconnect: $e');
+      }
     });
   }
 

--- a/lib/src/controllers/scale_controller.dart
+++ b/lib/src/controllers/scale_controller.dart
@@ -24,7 +24,21 @@ class ScaleController {
 
   ScaleController();
 
-  void dispose() {}
+  /// End-of-life cleanup. Cancels active stream subscriptions and
+  /// closes the exposed subjects so downstream listeners see
+  /// `onDone` (comms-harden #13). Safe to call more than once.
+  void dispose() {
+    _scaleSnapshot?.cancel();
+    _scaleSnapshot = null;
+    _scaleConnection?.cancel();
+    _scaleConnection = null;
+    if (!_connectionController.isClosed) {
+      _connectionController.close();
+    }
+    if (!_weightSnapshotController.isClosed) {
+      _weightSnapshotController.close();
+    }
+  }
 
   Future<void> connectToScale(Scale scale) async {
     _onDisconnect();

--- a/lib/src/services/ble/android_blue_plus_transport.dart
+++ b/lib/src/services/ble/android_blue_plus_transport.dart
@@ -150,11 +150,27 @@ class AndroidBluePlusTransport implements BLETransport {
       null,
       StackTrace.current,
     );
+    // Keep `_nativeConnectionSub` alive here — it forwards the
+    // eventual `disconnected` state from the platform stream to
+    // `_connectionStateSubject`. The subscription is cycled at
+    // connect() start so it doesn't accumulate across reconnect
+    // cycles (comms-harden #12 — closed by dispose() only).
     try {
       await _device.disconnect(queue: false, timeout: 5);
     } catch (e) {
       _log.warning("Error during disconnect: $e");
       _connectionStateSubject.add(device.ConnectionState.disconnected);
+    }
+  }
+
+  /// End-of-life cleanup — close the connection-state subject + any
+  /// lingering native subscription. Re-use after dispose is not
+  /// supported.
+  void dispose() {
+    _nativeConnectionSub?.cancel();
+    _nativeConnectionSub = null;
+    if (!_connectionStateSubject.isClosed) {
+      _connectionStateSubject.close();
     }
   }
 

--- a/lib/src/services/ble/blue_plus_transport.dart
+++ b/lib/src/services/ble/blue_plus_transport.dart
@@ -57,11 +57,30 @@ class BluePlusTransport implements BLETransport {
 
   @override
   Future<void> disconnect() async {
+    // Keep `_nativeConnectionSub` alive here — it's the channel that
+    // forwards the eventual `disconnected` state from the platform
+    // stream to `_connectionStateSubject`, which higher-level code
+    // relies on to clear `_de1` on next reconnect. The subscription
+    // is cycled (cancel+reassign) at the start of each `connect()`
+    // so it doesn't accumulate across reconnect cycles
+    // (comms-harden #12 — closed by the new `dispose()` only).
     try {
       await _device.disconnect(queue: false, timeout: 5);
     } catch (e) {
       _log.warning("Error during disconnect: $e");
       _connectionStateSubject.add(device.ConnectionState.disconnected);
+    }
+  }
+
+  /// End-of-life cleanup — close the connection-state subject so
+  /// downstream listeners see `onDone`. Also cancels any lingering
+  /// native subscription. Safe to call more than once; re-using this
+  /// transport after dispose is not supported.
+  void dispose() {
+    _nativeConnectionSub?.cancel();
+    _nativeConnectionSub = null;
+    if (!_connectionStateSubject.isClosed) {
+      _connectionStateSubject.close();
     }
   }
 

--- a/lib/src/services/ble/linux_blue_plus_transport.dart
+++ b/lib/src/services/ble/linux_blue_plus_transport.dart
@@ -162,11 +162,26 @@ class LinuxBluePlusTransport implements BLETransport {
 
   @override
   Future<void> disconnect() async {
+    // Keep `_nativeConnectionSub` alive here — it forwards the
+    // eventual `disconnected` state from the platform stream to
+    // `_connectionStateSubject`. Cycled at connect() start; closed
+    // only by dispose() (comms-harden #12).
     try {
       await _device.disconnect(queue: false, timeout: 5);
     } catch (e) {
       _log.warning("Error during disconnect: $e");
       _connectionStateSubject.add(device.ConnectionState.disconnected);
+    }
+  }
+
+  /// End-of-life cleanup — close the connection-state subject + any
+  /// lingering native subscription. Re-use after dispose is not
+  /// supported.
+  void dispose() {
+    _nativeConnectionSub?.cancel();
+    _nativeConnectionSub = null;
+    if (!_connectionStateSubject.isClosed) {
+      _connectionStateSubject.close();
     }
   }
 

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -718,6 +718,49 @@ void main() {
         expect(settingsController.preferredMachineId, isNull);
       });
 
+      test(
+          'connect timeout: machine that never responds fails after 30s '
+          '(comms-harden #31)',
+          () {
+        fakeAsync((async) {
+          final completer = Completer<void>();
+          final slowDe1Controller = _SlowMockDe1Controller(
+              controller: DeviceController([dummyDiscoveryService]));
+          slowDe1Controller.connectCompleter = completer;
+
+          final manager = ConnectionManager(
+            deviceScanner: mockScanner,
+            de1Controller: slowDe1Controller,
+            scaleController: mockScaleController,
+            settingsController: settingsController,
+          );
+
+          final fakeDe1 = _FakeDe1(deviceId: 'timeout-de1');
+          Object? caughtError;
+          manager
+              .connectMachine(fakeDe1)
+              .catchError((e) => caughtError = e);
+
+          // Advance past the 30s connect budget; the TimeoutException
+          // in connectMachine should cause rethrow + machineConnectFailed.
+          async.elapse(const Duration(seconds: 35));
+          async.flushMicrotasks();
+
+          expect(caughtError, isA<TimeoutException>(),
+              reason: 'connectMachine must rethrow TimeoutException');
+          final status = manager.currentStatus;
+          expect(status.phase, ConnectionPhase.idle);
+          expect(status.error?.kind, ConnectionErrorKind.machineConnectFailed);
+          expect(
+            status.error?.message,
+            contains('did not respond within 30s'),
+            reason: 'timeout-specific error message should surface',
+          );
+
+          manager.dispose();
+        });
+      });
+
       test('rejects concurrent connection attempts', () async {
         final completer = Completer<void>();
         final slowDe1Controller =

--- a/test/controllers/de1_controller_test.dart
+++ b/test/controllers/de1_controller_test.dart
@@ -1,38 +1,82 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'dart:async';
 
-/// Gap E — regression coverage for comms-harden #5 (shot-settings debounce
-/// races disconnect).
-///
-/// `De1Controller._shotSettingsUpdate` schedules a 100 ms debounce timer
-/// that calls `_processShotSettingsUpdate`. Once the timer fires, its async
-/// body awaits a chain of `connectedDe1().getSteamFlow()` / `getFlushFlow()`
-/// / etc. If the DE1 disconnects mid-chain, `_de1` is nulled by
-/// `_onDisconnect()` and subsequent `connectedDe1()` calls throw the raw
-/// string `"De1 not connected yet"` — unhandled, leaking as an async error
-/// from the timer.
-///
-/// Phase 1 PR 3 replaces the raw string with `DeviceNotConnectedException`.
-/// Phase 5 (#5 proper) adds generation-token guards so the running debounce
-/// body bails out cleanly on disconnect.
-///
-/// When the fix lands:
-///   1. Remove the `skip:` arguments.
-///   2. Implement the test body using `runZonedGuarded` (or a test binding
-///      error hook) to catch async errors from the timer body.
-///   3. Fire `_shotSettingsUpdate`, immediately disconnect, advance time
-///      past the 100 ms debounce, and assert no unhandled exception was
-///      emitted.
-///
-/// See: doc/plans/comms-harden.md #5,
-///      doc/plans/comms-phase-0-1.md Gap E.
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+
+import '../helpers/mock_device_discovery_service.dart';
+import '../helpers/test_de1.dart';
+
+De1ShotSettings _emptyShotSettings() => De1ShotSettings(
+      steamSetting: 0,
+      targetSteamTemp: 0,
+      targetSteamDuration: 0,
+      targetHotWaterTemp: 0,
+      targetHotWaterVolume: 0,
+      targetHotWaterDuration: 0,
+      targetShotVolume: 0,
+      groupTemp: 0,
+    );
+
 void main() {
   group('shot-settings debounce race (comms-harden #5)', () {
     test(
       'disconnect during debounce does not leak an unhandled async error',
       () async {
-        fail('pending Phase 5 fix for #5');
+        final uncaughtErrors = <Object>[];
+
+        await runZonedGuarded(
+          () async {
+            final deviceController =
+                DeviceController([MockDeviceDiscoveryService()]);
+            await deviceController.initialize();
+            final de1Controller = De1Controller(controller: deviceController);
+            final testDe1 = TestDe1();
+
+            // Kick off connect: TestDe1.onConnect is a no-op, so
+            // connectToDe1 completes quickly. ready is Stream.value(true)
+            // so _initializeData fires on the next microtask.
+            await de1Controller.connectToDe1(testDe1);
+
+            // Unblock _initializeData's `shotSettings.first` await +
+            // trigger the first _shotSettingsUpdate, which schedules the
+            // 100ms debounce timer.
+            testDe1.emitShotSettings(_emptyShotSettings());
+            // Let the microtask chain reach the scheduled Timer.
+            await Future<void>.delayed(Duration.zero);
+
+            // Force a disconnect while the debounce timer is still
+            // pending. _onDisconnect bumps _connectionGeneration,
+            // nulls _de1, cancels _shotSettingsDebounce, and cancels
+            // the shotSettings subscription.
+            testDe1.setConnectionState(ConnectionState.disconnected);
+            await Future<void>.delayed(Duration.zero);
+
+            // Wait past the 100ms debounce window. With the generation
+            // fix, the timer body should find a stale generation (or
+            // null _de1) and bail without touching connectedDe1().
+            await Future<void>.delayed(
+                const Duration(milliseconds: 200));
+
+            testDe1.dispose();
+          },
+          (error, stack) {
+            uncaughtErrors.add(error);
+          },
+        );
+
+        expect(
+          uncaughtErrors,
+          isEmpty,
+          reason:
+              'debounce timer closure must bail on disconnect, not leak '
+              'DeviceNotConnectedException into the zone',
+        );
       },
-      skip: 'pending fix for comms-harden #5 — see doc/plans/comms-phase-0-1.md',
+      timeout: const Timeout(Duration(seconds: 5)),
     );
   });
 }

--- a/test/helpers/test_de1.dart
+++ b/test/helpers/test_de1.dart
@@ -37,6 +37,17 @@ class TestDe1 implements De1Interface {
   final BehaviorSubject<ConnectionState> _connectionState =
       BehaviorSubject.seeded(ConnectionState.connected);
 
+  /// Drives the [shotSettings] stream — tests call [emitShotSettings]
+  /// to push a value, which is how [De1Controller._initializeData]
+  /// and its debounce-timer subscription are exercised.
+  final BehaviorSubject<De1ShotSettings> _shotSettingsSubject =
+      BehaviorSubject<De1ShotSettings>();
+
+  /// Emit a [De1ShotSettings] on the [shotSettings] stream.
+  void emitShotSettings(De1ShotSettings settings) {
+    _shotSettingsSubject.add(settings);
+  }
+
   /// Records every [MachineState] passed to [requestState].
   final List<MachineState> requestedStates = [];
 
@@ -63,6 +74,7 @@ class TestDe1 implements De1Interface {
   void dispose() {
     snapshotSubject.close();
     _connectionState.close();
+    _shotSettingsSubject.close();
   }
 
   // ---- Machine / Device ----
@@ -102,7 +114,7 @@ class TestDe1 implements De1Interface {
   @override
   Stream<bool> get ready => Stream.value(true);
   @override
-  Stream<De1ShotSettings> get shotSettings => const Stream.empty();
+  Stream<De1ShotSettings> get shotSettings => _shotSettingsSubject.stream;
   @override
   Future<void> updateShotSettings(De1ShotSettings newSettings) async {}
   @override


### PR DESCRIPTION
## What

Four Cluster C / Cluster E items land together. Includes the Phase 5 plan commit (the prior plan PR can be closed in favour of this one, or merged separately — either works).

- **Item 5** (debounce races disconnect). `De1Controller` tracks a `_connectionGeneration` bumped on every `_onDisconnect()`. The shot-settings debounce-timer closure captures the generation at scheduling time and bails out if the value has changed by the time the timer fires. Body also catches `DeviceNotConnectedException` as defence-in-depth against the narrower interleaving race. Gap E placeholder from Phase 0 is now a live regression test using `runZonedGuarded` + `TestDe1` driving the `shotSettings` stream.
- **Item 12** (transport subscription lifecycle). Three transports get a new `dispose()` that cancels `_nativeConnectionSub` and closes `_connectionStateSubject`. The subscription stays alive across `disconnect()` — it's the channel forwarding the eventual platform-level `disconnected` state into our subject, which higher-level code relies on to clear `_de1` before the next connect. An earlier attempt to cancel the sub inside `disconnect()` broke that propagation and caused reconnect to short-circuit; reverted before landing.
- **Item 13** (ScaleController.dispose proper). Empty placeholder replaced with subscription cancellations + subject closes with `isClosed` guards. Prophylactic today (`main.dart` doesn't dispose the controller) — wiring tracked elsewhere.
- **Item 31** (connect timeout). `_connectTimeout = 30s` constant on `ConnectionManager`. `connectMachine` / `connectScale` wrap their respective `connectToX` calls with `.timeout(_connectTimeout)`. `TimeoutException` gets a distinct suggestion ("did not respond within 30s"). New `connection_manager_test` covers the machine-timeout path via `_SlowMockDe1Controller` + `fakeAsync`.

`TestDe1` extended with a controllable `shotSettings` `BehaviorSubject` so the Gap E test can drive the real `De1Controller.connectToDe1` sequence.

## Why

Cluster C / Cluster E remainder — the last of the pre-Phase-6 hygiene pass. Each item is narrow and orthogonal; together they form a coherent lifecycle-hygiene cut.

## Test plan

- `flutter test`: **982 pass** (+2 vs last phase: Gap E activation + timeout test), **1 skip** (down from 2 — only Gap F / roadmap item 20 pending Phase 6).
- `flutter analyze`: clean on all changed files.
- Real-hardware smoke on M50Mini + DE1Pro: cold connect, disconnect, reconnect 6.0 s. Zero `Bad state` / `MmrTimeoutException` / `DeviceNotConnectedException` / SEVERE errors. Disconnect state correctly propagates from transport through UnifiedDe1 through De1Controller — next `connect()` doesn't short-circuit on a stale `_de1`.