### PR TITLE
fix(comms): key disconnect detection by deviceId (Phase 6A)

### DIFF
--- a/doc/plans/comms-phase-6.md
+++ b/doc/plans/comms-phase-6.md
@@ -1,0 +1,111 @@
+# Comms Harden — Phase 6 (polish)
+
+**Branch:** `feature/comms-phase-6-polish` off `integration/comms-harden-rest`.
+**Scope:** the six remaining E-cluster items in the comms-harden roadmap (20, 24, 27, 28, 29, 30). All pure hygiene — no runtime-semantics changes expected beyond item 20.
+**Completion:** two sub-PRs into `integration/comms-harden-rest`, then `integration/comms-harden-rest` → `main` as the capstone PR for the whole hardening effort.
+
+## Items
+
+| # | What | Shape |
+|---|------|-------|
+| 20 | Disconnect detection keyed by `deviceId`, not `device.name` | runtime-visible (telemetry key + reconnect detection) |
+| 24 | Magic durations → named constants | mechanical |
+| 27 | Populate `ScanReport.adapterStateAtStart/End` | thin plumb |
+| 28 | Cache `DeviceController.devices` getter | perf micro-fix |
+| 29 | Multicast adapter state across *all* BLE services (or document single-adapter assumption) | either fix or doc |
+| 30 | Document `ConnectionPhase` state machine | doc |
+
+## Delivery
+
+### PR 6A — item 20 (disconnect detection by deviceId)
+
+**Why separate:** touches runtime behaviour — disconnect tracking, telemetry custom-key names. Easier to land and verify independently than in a bundle of polish.
+
+**Files:**
+- `lib/src/controllers/device_controller.dart`
+  - `_previousDeviceNames: Set<String>` → `_previousDeviceIds: Set<String>` (keyed by `Device.id`).
+  - `_disconnectedAt: Map<String, DateTime>` → keyed by `Device.id`.
+  - Diff computation (lines 208–250) swaps to ids.
+  - Telemetry custom key: `reconnection_duration_$deviceName` → `reconnection_duration_$deviceId`.
+  - Log strings keep `device.name` *in the message body* (human readable) but track by id.
+  - `_updateDeviceCustomKeys`: `device_${device.name}_type` — keep as name (user-facing diagnostic string, not used for correlation). Document why.
+
+**Migration audit — required before touching code:**
+1. Grep every `device.name` / `_previousDeviceNames` / `_disconnectedAt` reference.
+2. Split into (a) *correlation* keys (must move to id) vs (b) *display* strings (stay name, documented).
+3. Check any external surface — WebSocket events, REST, telemetry dashboards — that embeds `reconnection_duration_<name>` custom keys. If anything downstream watches for that pattern, call it out before flipping.
+4. Check test fixtures for identical-name devices; add one if none exists.
+
+**Tests:**
+- New unit test in `test/controllers/device_controller_test.dart` (create if missing): two devices with the *same advertised name* but different ids — one disconnects, the other shouldn't be flagged. Also: device reconnects with a *different* name (firmware-update scenario) — tracking still resolves by id.
+- Existing tests that assert on `_disconnectedAt` keys / telemetry key strings must be updated.
+
+**Risk:** low. One user-visible change — telemetry custom-key string shape. Production dashboards consume custom keys only if somebody set them up; we did not.
+
+---
+
+### PR 6B — items 24, 27, 28, 29, 30 (bundle)
+
+All under `lib/src/controllers/` + `lib/src/services/ble/` + `doc/`. Mechanical polish.
+
+**Item 24 — magic numbers → constants.**
+- New file `lib/src/controllers/connection/connection_timings.dart` with:
+  ```dart
+  class ConnectionTimings {
+    static const scanDuration = Duration(seconds: 15);
+    static const earlyConnectTimeout = Duration(seconds: 30);
+    static const preScanDeviceCheckTimeout = Duration(seconds: 2);
+    static const postScanSettleDelay = Duration(milliseconds: 200);
+    static const shotSettingsDebounce = Duration(milliseconds: 100);
+    static const profileDownloadGuard = Duration(milliseconds: 500);
+  }
+  ```
+- Replace inline literals at the 7 sites in the roadmap. Keep per-transport constants (`_postConnectDelay`, `_discoveryRetryDelay`, etc.) where they are — those are transport-implementation internals, not controller-level timings.
+- `DisconnectExpectations.ttl` (already a constant) stays where it is.
+
+**Item 27 — adapter state in ScanReport.**
+- `ScanReportBuilder.build({...})` gains `required AdapterState adapterStateAtStart` and `required AdapterState adapterStateAtEnd` parameters.
+- `ScanOrchestrator.run()` captures the start state immediately before scanning, passes to builder at build time. End state: read again at build. Source: `_deviceScanner.adapterStateStream` via a new `currentAdapterState` getter on `DeviceScanner` (`BehaviorSubject.value`).
+- Test: extend `scan_report_builder_test.dart` (if exists) or add one asserting both fields populated from injected state.
+
+**Item 28 — cache `DeviceController.devices`.**
+- Add `List<Device>? _flatDevicesCache;` invalidated to `null` in `_serviceUpdate` (the sole mutation point).
+- Getter returns cached list (wrapped `List.unmodifiable`) or rebuilds on miss.
+- Keep `fold` logic unchanged.
+
+**Item 29 — adapter-state multicast.**
+- Current: `initialize()` only subscribes to `adapterStateStream` of each `BleDiscoveryService` and forwards each event. Correct in principle; check if events *actually* compose (e.g. service A says `on`, service B says `unknown` — current code passes both through). If not already a problem in practice:
+  - Document single-adapter assumption in doc-comment on `_adapterStateStream`, note that multi-adapter merging is TODO.
+  - Or: merge with a reducer (`on` if any on, else `off` if any off, else `unknown`) — preferred if trivial.
+- Decision at implementation time based on whether a sensible merge exists; if not, document and move on.
+
+**Item 30 — ConnectionPhase state machine doc.**
+- Add an ASCII diagram to `doc/DeviceManagement.md` or a dedicated `doc/connection-phases.md`:
+  ```
+  idle → scanning → connectingMachine → connectingScale → ready
+                                     ↘ ready (no scale)
+         (any phase) → error → idle
+  ```
+- List the transition-owner per edge (`ConnectionManager._connectImpl`, `connectMachine`, etc.) so a future reader can find where transitions happen.
+- Inline docstring on `ConnectionPhase` enum pointing at the doc.
+- No code change. Illegal-transition enforcement deferred — scope creep.
+
+## Verification
+
+**Analyze + unit + integration:**
+- `flutter analyze` clean.
+- `flutter test` — all green, no skips beyond existing.
+
+**End-to-end smoke (M50Mini + real DE1Pro):**
+- Cold connect, disconnect, reconnect cycle per `.agents/skills/streamline-bridge/verification.md`.
+- Check `flutter logs` for the new `reconnection_duration_<deviceId>` key format after a reconnect (item 20 verification).
+- No regressions in connect/disconnect timing.
+
+Because the effort is mostly constant-rename + doc, smoke test only once at the end of 6B (or at 6A if the audit surfaces behavior risk).
+
+## Post-merge
+
+Once both sub-PRs land in `integration/comms-harden-rest`:
+1. Move all `doc/plans/comms-phase-*.md` + `comms-harden.md` + `comms-code-review.md` → `doc/plans/archive/comms-harden/` (per CLAUDE.md).
+2. Audit `doc/Api.md`, `doc/DeviceManagement.md` for drift vs the Phase 2–5 changes.
+3. Open `integration/comms-harden-rest` → `main` PR. Body: short recap of items resolved, pointer to the archived plan folder.

--- a/doc/plans/comms-phase-6.md
+++ b/doc/plans/comms-phase-6.md
@@ -27,8 +27,8 @@
   - `_disconnectedAt: Map<String, DateTime>` → keyed by `Device.id`.
   - Diff computation (lines 208–250) swaps to ids.
   - Telemetry custom key: `reconnection_duration_$deviceName` → `reconnection_duration_$deviceId`.
+  - Telemetry custom key: `device_${device.name}_type` → `device_${device.id}_type` (move to id too — any two same-name devices would clobber each other in the custom-key map).
   - Log strings keep `device.name` *in the message body* (human readable) but track by id.
-  - `_updateDeviceCustomKeys`: `device_${device.name}_type` — keep as name (user-facing diagnostic string, not used for correlation). Document why.
 
 **Migration audit — required before touching code:**
 1. Grep every `device.name` / `_previousDeviceNames` / `_disconnectedAt` reference.

--- a/lib/src/controllers/device_controller.dart
+++ b/lib/src/controllers/device_controller.dart
@@ -37,11 +37,18 @@ class DeviceController implements DeviceScanner {
   // Telemetry service for reporting device state changes
   TelemetryService? _telemetryService;
 
-  // Track when devices were last seen disconnecting
+  // Track when devices were last seen disconnecting, keyed by deviceId.
+  // Keying by id (not name) avoids cross-attribution when two devices
+  // advertise the same name, and survives firmware-update name changes
+  // (comms-harden #20).
   final Map<String, DateTime> _disconnectedAt = {};
 
-  // Track previously seen device names for disconnection detection
-  final Set<String> _previousDeviceNames = {};
+  // Track previously seen device ids for disconnection detection.
+  final Set<String> _previousDeviceIds = {};
+
+  // Map of deviceId → display name for the most recent observation.
+  // Used only to render human-readable log messages; correlation is by id.
+  final Map<String, String> _deviceNamesById = {};
 
   /// Set the telemetry service for tracking device state changes
   ///
@@ -147,8 +154,11 @@ class DeviceController implements DeviceScanner {
       // Sync the disconnect-detection baseline with the cleaned list so
       // that service emissions arriving during the scan don't see false
       // diffs.
-      _previousDeviceNames.clear();
-      _previousDeviceNames.addAll(devices.map((d) => d.name));
+      _previousDeviceIds.clear();
+      _previousDeviceIds.addAll(devices.map((d) => d.deviceId));
+      _deviceNamesById
+        ..clear()
+        ..addEntries(devices.map((d) => MapEntry(d.deviceId, d.name)));
       _deviceStream.add(devices);
 
       // Run every service's scan in parallel and capture per-service
@@ -204,50 +214,58 @@ class DeviceController implements DeviceScanner {
     _log.fine("$service update: $devices");
     _devices[service] = devices;
 
-    // Get current device names
-    final currentDeviceNames = this.devices.map((d) => d.name).toSet();
+    // Snapshot current device ids + id→name map. Correlation keys are
+    // always deviceId; name is kept only for human-readable log output
+    // (comms-harden #20).
+    final currentDevices = this.devices;
+    final currentDeviceIds = currentDevices.map((d) => d.deviceId).toSet();
+    for (final d in currentDevices) {
+      _deviceNamesById[d.deviceId] = d.name;
+    }
 
     // Skip disconnect/reconnect detection during active scans — the device
     // list is in flux and intermediate states are transient noise. The scan
     // will produce the authoritative list when it completes.
     if (!isScanning) {
       // Detect disconnections: devices that were in previous update but not in current
-      final disconnectedDevices =
-          _previousDeviceNames.difference(currentDeviceNames);
-      for (var deviceName in disconnectedDevices) {
-        _disconnectedAt[deviceName] = DateTime.now();
-        _log.info("Device $deviceName disconnected");
+      final disconnectedIds =
+          _previousDeviceIds.difference(currentDeviceIds);
+      for (var deviceId in disconnectedIds) {
+        _disconnectedAt[deviceId] = DateTime.now();
+        final name = _deviceNamesById[deviceId] ?? deviceId;
+        _log.info("Device $name ($deviceId) disconnected");
       }
 
       // Detect reconnections: devices in current update that have disconnection timestamps
-      for (var deviceName in currentDeviceNames) {
-        if (_disconnectedAt.containsKey(deviceName)) {
-          final disconnectedTime = _disconnectedAt[deviceName]!;
+      for (var deviceId in currentDeviceIds) {
+        if (_disconnectedAt.containsKey(deviceId)) {
+          final disconnectedTime = _disconnectedAt[deviceId]!;
           final duration = DateTime.now().difference(disconnectedTime);
+          final name = _deviceNamesById[deviceId] ?? deviceId;
           _log.info(
-              "Device $deviceName reconnected after ${duration.inSeconds}s");
+              "Device $name ($deviceId) reconnected after ${duration.inSeconds}s");
 
           // Set telemetry custom key with reconnection duration
           _telemetryService?.setCustomKey(
-            'reconnection_duration_$deviceName',
+            'reconnection_duration_$deviceId',
             duration.inSeconds,
           );
 
           // Remove from disconnected tracking
-          _disconnectedAt.remove(deviceName);
+          _disconnectedAt.remove(deviceId);
         }
       }
 
       // Clean up stale disconnection entries (older than 24 hours)
       final now = DateTime.now();
-      _disconnectedAt.removeWhere((deviceName, timestamp) {
+      _disconnectedAt.removeWhere((_, timestamp) {
         return now.difference(timestamp).inHours > 24;
       });
     }
 
-    // Update previous device names for next comparison
-    _previousDeviceNames.clear();
-    _previousDeviceNames.addAll(currentDeviceNames);
+    // Update previous device ids for next comparison
+    _previousDeviceIds.clear();
+    _previousDeviceIds.addAll(currentDeviceIds);
 
     _deviceStream.add(this.devices);
     _updateDeviceCustomKeys();
@@ -265,9 +283,10 @@ class DeviceController implements DeviceScanner {
     int sensorCount = 0;
 
     for (var device in devices) {
-      // Set individual device type key
+      // Set individual device type key, keyed by deviceId so same-named
+      // devices don't clobber each other (comms-harden #20).
       _telemetryService!.setCustomKey(
-        'device_${device.name}_type',
+        'device_${device.deviceId}_type',
         device.type.name,
       );
 

--- a/test/controllers/device_controller_test.dart
+++ b/test/controllers/device_controller_test.dart
@@ -3,6 +3,7 @@ import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/scan_result.dart';
 import 'package:reaprime/src/models/errors.dart';
+import 'package:reaprime/src/services/telemetry/telemetry_service.dart';
 import 'package:rxdart/rxdart.dart';
 
 /// A DeviceDiscoveryService that always throws from `scanForDevices`.
@@ -50,6 +51,50 @@ class _QuietDiscoveryService implements DeviceDiscoveryService {
 
   @override
   void stopScan() {}
+}
+
+/// Manual discovery service — tests push emissions by calling `emit`.
+class _ManualDiscoveryService implements DeviceDiscoveryService {
+  final _controller = BehaviorSubject<List<Device>>.seeded(const []);
+
+  @override
+  Stream<List<Device>> get devices => _controller.stream;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> scanForDevices() async {}
+
+  @override
+  void stopScan() {}
+
+  void emit(List<Device> devices) => _controller.add(devices);
+}
+
+class _RecordingTelemetry implements TelemetryService {
+  final Map<String, Object> customKeys = {};
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> recordError(Object error, StackTrace? stackTrace,
+      {bool fatal = false}) async {}
+
+  @override
+  Future<void> log(String message) async {}
+
+  @override
+  Future<void> setCustomKey(String key, Object value) async {
+    customKeys[key] = value;
+  }
+
+  @override
+  Future<void> setConsentEnabled(bool enabled) async {}
+
+  @override
+  String getLogBuffer() => '';
 }
 
 /// Minimal `Device` stub.
@@ -151,18 +196,108 @@ void main() {
     );
   });
 
-  // Gap F — regression coverage for comms-harden #20 (disconnect detection
-  // keyed on device.name instead of deviceId). Kept as a skipped
-  // placeholder; activate when the Phase 6 key-migration lands. See
-  // doc/plans/comms-harden.md #20.
   group('disconnect tracking keys (comms-harden #20)', () {
     test(
-      'two devices with same name but different IDs do not collide',
+      'two devices with same name but different IDs do not collide on disconnect',
       () async {
-        fail('pending Phase 6 fix for #20');
+        final service = _ManualDiscoveryService();
+        final telemetry = _RecordingTelemetry();
+        final controller = DeviceController([service])
+          ..telemetryService = telemetry;
+        await controller.initialize();
+
+        final a = _FakeDevice(
+          deviceId: 'AA:11:11:11:11:11',
+          name: 'DE1',
+          type: DeviceType.machine,
+        );
+        final b = _FakeDevice(
+          deviceId: 'BB:22:22:22:22:22',
+          name: 'DE1',
+          type: DeviceType.machine,
+        );
+
+        // Baseline: both present.
+        service.emit([a, b]);
+        await Future<void>.delayed(Duration.zero);
+
+        // Drop b only.
+        service.emit([a]);
+        await Future<void>.delayed(Duration.zero);
+
+        // Bring b back. Only b's reconnection_duration_* should land,
+        // not a's (would happen with name-based keying since both named
+        // 'DE1').
+        service.emit([a, b]);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(telemetry.customKeys,
+            contains('reconnection_duration_${b.deviceId}'));
+        expect(telemetry.customKeys,
+            isNot(contains('reconnection_duration_${a.deviceId}')));
       },
-      skip:
-          'pending fix for comms-harden #20 — see doc/plans/comms-harden.md',
+    );
+
+    test(
+      'device returning with a different advertised name is still matched by id',
+      () async {
+        final service = _ManualDiscoveryService();
+        final telemetry = _RecordingTelemetry();
+        final controller = DeviceController([service])
+          ..telemetryService = telemetry;
+        await controller.initialize();
+
+        final before = _FakeDevice(
+          deviceId: 'CC:33:33:33:33:33',
+          name: 'DE1',
+          type: DeviceType.machine,
+        );
+        final afterFirmware = _FakeDevice(
+          deviceId: 'CC:33:33:33:33:33',
+          name: 'DE1Pro', // firmware update renamed advertised name
+          type: DeviceType.machine,
+        );
+
+        service.emit([before]);
+        await Future<void>.delayed(Duration.zero);
+        service.emit(const []);
+        await Future<void>.delayed(Duration.zero);
+        service.emit([afterFirmware]);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(telemetry.customKeys,
+            contains('reconnection_duration_${before.deviceId}'));
+      },
+    );
+
+    test(
+      'telemetry device_<id>_type key uses deviceId, not name',
+      () async {
+        final service = _ManualDiscoveryService();
+        final telemetry = _RecordingTelemetry();
+        final controller = DeviceController([service])
+          ..telemetryService = telemetry;
+        await controller.initialize();
+
+        final a = _FakeDevice(
+          deviceId: 'AA:11:11:11:11:11',
+          name: 'DE1',
+          type: DeviceType.machine,
+        );
+        final b = _FakeDevice(
+          deviceId: 'BB:22:22:22:22:22',
+          name: 'DE1',
+          type: DeviceType.scale,
+        );
+
+        service.emit([a, b]);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(telemetry.customKeys, contains('device_${a.deviceId}_type'));
+        expect(telemetry.customKeys, contains('device_${b.deviceId}_type'));
+        expect(telemetry.customKeys['device_${a.deviceId}_type'], 'machine');
+        expect(telemetry.customKeys['device_${b.deviceId}_type'], 'scale');
+      },
     );
   });
 }


### PR DESCRIPTION
## What
- Disconnect-detection keys in `DeviceController` moved from `device.name` → `device.deviceId`.
- Telemetry custom keys (`reconnection_duration_*`, `device_*_type`) now use id.
- Adds Phase 6 plan doc (`doc/plans/comms-phase-6.md`).

## Why
Two devices advertising the same name (two DE1s on a bench) cross-attributed disconnects. A device whose advertised name changed (firmware update) was never cleaned from `_disconnectedAt`. Resolves comms-harden roadmap item 20.

## Test plan
- Unit: three new tests in `device_controller_test.dart` (same-name collision, name-change-on-reconnect, telemetry key shape). Activates prior Gap F placeholder.
- `flutter test` — 985 pass (+3), 0 failures.
- `flutter analyze` — clean (pre-existing infos only).
- Real-hardware smoke deferred to end of 6B per plan — this PR is internal-bookkeeping only, no change to BLE behaviour.