### PR TITLE
chore(comms): Phase 6B polish — constants, adapter state, cache, docs

### DIFF
--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -198,11 +198,8 @@ The ConnectionManager is the centralized orchestrator for all device connection 
 
 ### Connection Status
 
-ConnectionManager exposes a `ConnectionStatus` stream with the following phases:
-
-```
-idle → scanning → connectingMachine → connectingScale → ready
-```
+ConnectionManager exposes a `ConnectionStatus` stream driven by the
+`ConnectionPhase` enum.
 
 - **`idle`:** No connection activity
 - **`scanning`:** BLE/USB scan in progress
@@ -214,6 +211,46 @@ The status also tracks:
 - `foundMachines` / `foundScales` — devices discovered during the last scan
 - `pendingAmbiguity` — `machinePicker` or `scalePicker` when the UI needs to show a device selection dialog
 - `error` — error message from the last connection attempt
+
+#### Phase transitions
+
+All phase writes route through `StatusPublisher.publish`. If a
+transition isn't listed below, it's not supposed to happen.
+
+```
+                       ┌──────────────────────────────┐
+                       │                              │
+                       ▼                              │
+   ┌─────┐         ┌──────────┐    ┌───────────────┐  │    ┌───────────────┐    ┌───────┐
+   │idle │──scan──▶│ scanning │───▶│connectingMach.│──┴───▶│connectingScale│───▶│ ready │
+   └─────┘         └──────────┘    └───────────────┘       └───────────────┘    └───────┘
+      ▲                │                    │                       │                │
+      │                │ error              │ error/no-match        │ error/no-scale │
+      │                ▼                    ▼                       ▼                │
+      │          (idle + error)       (idle + error / ready)   (ready / idle+err)    │
+      │                                                                              │
+      └──────────────────────────── disconnect ──────────────────────────────────────┘
+```
+
+Transition owners (where the `publish(phase: …)` call lives):
+
+| Edge                                    | Owner                                                   |
+|-----------------------------------------|---------------------------------------------------------|
+| `idle → scanning`                       | `ScanOrchestrator.runScan`                              |
+| `scanning → idle` (scan failure)        | `ScanOrchestrator._emitScanStartError`                  |
+| `scanning → connectingMachine`          | `ConnectionManager.connectMachine` (policy stage)       |
+| `connectingMachine → connectingScale`   | `ConnectionManager.connectScale` (post-machine policy)  |
+| `connectingMachine → ready` (no scale)  | `ConnectionManager._finalizePhase`                      |
+| `connectingScale → ready`               | `ConnectionManager._finalizePhase`                      |
+| `connectingScale → idle` (scale error)  | `StatusPublisher.emitError` → gatekeeper folds to idle  |
+| any `→ idle` on disconnect              | `DisconnectSupervisor._onMachineGone / _onScaleGone`    |
+
+`scaleOnly` reconnects (`scanAndConnectScale`) skip the
+`connectingMachine` edge and go `idle → scanning → connectingScale → ready`.
+
+Non-phase status fields (`error`, `foundMachines`, `pendingAmbiguity`)
+are allowed to change on any edge; only the `phase` field follows the
+table above.
 
 ### Connection Policy
 

--- a/lib/src/controllers/connection/connection_timings.dart
+++ b/lib/src/controllers/connection/connection_timings.dart
@@ -1,0 +1,30 @@
+/// Centralised durations used by the connection / comms layer.
+///
+/// Per-implementation internals (transport post-connect delays, BlueZ
+/// cache-refresh scan, per-platform MTU settle times, etc.) stay with
+/// their owners — those are tuned for one platform and don't benefit
+/// from cross-file visibility. What lives here is the handful of
+/// timings the review surfaced as "magic numbers that a future reader
+/// would want to find in one place" (comms-harden #24).
+class ConnectionTimings {
+  /// Per-device `connectionState.first` timeout during the
+  /// pre-scan staleness check in `DeviceController`.
+  static const preScanDeviceCheckTimeout = Duration(seconds: 2);
+
+  /// Settle delay after all services report scan-complete, before
+  /// flipping `scanningStream` to `false`. Gives downstream UI a
+  /// stable "scanning" window rather than a zero-duration flicker.
+  static const postScanSettleDelay = Duration(milliseconds: 200);
+
+  /// Debounce window for `De1Controller` shot-settings pushes. Coalesces
+  /// the flurry of calls that come from consecutive UI adjustments
+  /// (`setSteamFlow`, `setHotWaterFlow`, `updateShotSettings`) into one
+  /// MMR round-trip.
+  static const shotSettingsDebounce = Duration(milliseconds: 100);
+
+  /// Post-profile-upload wait before allowing the next state change.
+  /// Works around a firmware `ProfileDownloadInProgress` race where a
+  /// state=espresso request that hits the loop before the flash write
+  /// returns aborts the shot to HeaterDown.
+  static const profileDownloadGuard = Duration(milliseconds: 500);
+}

--- a/lib/src/controllers/connection/scan_orchestrator.dart
+++ b/lib/src/controllers/connection/scan_orchestrator.dart
@@ -86,7 +86,8 @@ class ScanOrchestrator {
     required void Function() onEarlyAttemptComplete,
     required DateTime scanStartTime,
   }) async {
-    final reportBuilder = ScanReportBuilder(scanStartTime: scanStartTime);
+    final reportBuilder = ScanReportBuilder(scanStartTime: scanStartTime)
+      ..recordAdapterStateAtStart(_scanner.currentAdapterState);
 
     _statusPublisher.publish(
       _statusPublisher.current.copyWith(

--- a/lib/src/controllers/connection/scan_report_builder.dart
+++ b/lib/src/controllers/connection/scan_report_builder.dart
@@ -42,7 +42,19 @@ class ScanReportBuilder {
   final DateTime scanStartTime;
   final Map<String, MatchedDeviceTracker> _trackers = {};
 
+  /// Adapter state captured at scan start. Set by the orchestrator
+  /// via [recordAdapterStateAtStart]; used by [build] so callers
+  /// don't have to thread it through a separate arg.
+  AdapterState _adapterStateAtStart = AdapterState.unknown;
+
   ScanReportBuilder({required this.scanStartTime});
+
+  /// Record the adapter state sampled at scan start. The end state is
+  /// supplied to [build] so the builder captures a true start/end pair
+  /// around the whole scan+connect window (comms-harden #27).
+  void recordAdapterStateAtStart(AdapterState state) {
+    _adapterStateAtStart = state;
+  }
 
   /// Ensure a tracker exists for [d]. Does not clobber an existing
   /// entry — `putIfAbsent` semantics so recorded attempt results
@@ -77,6 +89,7 @@ class ScanReportBuilder {
     required String? preferredMachineId,
     required String? preferredScaleId,
     required ScanTerminationReason terminationReason,
+    required AdapterState adapterStateAtEnd,
   }) {
     final matchedDevices =
         _trackers.values.map((t) => t.toMatchedDevice()).toList();
@@ -84,8 +97,8 @@ class ScanReportBuilder {
       totalBleDevicesSeen: matchedDevices.length,
       matchedDevices: matchedDevices,
       scanDuration: DateTime.now().difference(scanStartTime),
-      adapterStateAtStart: AdapterState.unknown,
-      adapterStateAtEnd: AdapterState.unknown,
+      adapterStateAtStart: _adapterStateAtStart,
+      adapterStateAtEnd: adapterStateAtEnd,
       scanTerminationReason: terminationReason,
       preferredMachineId: preferredMachineId,
       preferredScaleId: preferredScaleId,

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -21,6 +21,11 @@ import 'package:reaprime/src/models/scan_report.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:rxdart/rxdart.dart';
 
+/// High-level phase of the [ConnectionManager] state machine.
+///
+/// Transitions are documented in `doc/DeviceManagement.md` →
+/// "Phase transitions" (comms-harden #30). All writes route through
+/// `StatusPublisher.publish`.
 enum ConnectionPhase {
   idle,
   scanning,
@@ -607,6 +612,7 @@ class ConnectionManager {
       preferredMachineId: preferredMachineId,
       preferredScaleId: preferredScaleId,
       terminationReason: terminationReason,
+      adapterStateAtEnd: deviceScanner.currentAdapterState,
     );
     _scanReportSubject.add(report);
     _log.info(ScanReportBuilder.format(report));

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/connection/connection_timings.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/home_feature/forms/hot_water_form.dart';
 import 'package:reaprime/src/home_feature/forms/steam_form.dart';
@@ -156,7 +157,7 @@ class De1Controller {
     // bails out cleanly (comms-harden #5).
     _shotSettingsDebounce?.cancel();
     final generation = _connectionGeneration;
-    _shotSettingsDebounce = Timer(const Duration(milliseconds: 100), () async {
+    _shotSettingsDebounce = Timer(ConnectionTimings.shotSettingsDebounce, () async {
       if (generation != _connectionGeneration || _de1 == null) {
         _log.fine(
           'Shot settings debounce fired after disconnect '

--- a/lib/src/controllers/device_controller.dart
+++ b/lib/src/controllers/device_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/connection/connection_timings.dart';
 import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_scanner.dart';
@@ -23,14 +24,22 @@ class DeviceController implements DeviceScanner {
   Stream<bool> get scanningStream => _scanningStream.stream;
   bool get isScanning => _scanningStream.value;
 
-  /// Aggregated adapter state across BLE discovery services. Replays the
-  /// most recent state to new subscribers.
+  /// Adapter state surfaced to consumers. Currently reflects the most
+  /// recent emission from *any* registered `BleDiscoveryService`, last
+  /// writer wins — we assume a single BLE adapter per host (true on
+  /// every platform this app runs on). If a second BLE stack is ever
+  /// added, this needs to merge per-adapter states rather than
+  /// overwrite, e.g. `on` if any adapter on, else `off` if any off,
+  /// else `unknown` (comms-harden #29).
   final BehaviorSubject<AdapterState> _adapterStateStream =
       BehaviorSubject.seeded(AdapterState.unknown);
 
   @override
   Stream<AdapterState> get adapterStateStream =>
       _adapterStateStream.stream;
+
+  @override
+  AdapterState get currentAdapterState => _adapterStateStream.value;
 
   final List<StreamSubscription> _serviceSubscriptions = [];
 
@@ -66,11 +75,26 @@ class DeviceController implements DeviceScanner {
   @override
   Stream<List<Device>> get deviceStream => _deviceStream.stream;
 
-  List<Device> get devices =>
-      _devices.values.fold(List<Device>.empty(growable: true), (res, el) {
-        res.addAll(el);
-        return res;
-      }).toList();
+  /// Flattened view over `_devices`. Rebuilt lazily when the underlying
+  /// per-service lists mutate (comms-harden #28 — hot-path callers like
+  /// telemetry + scan-cleanup were paying the fold cost per call).
+  List<Device>? _flatDevicesCache;
+
+  List<Device> get devices {
+    final cached = _flatDevicesCache;
+    if (cached != null) return cached;
+    final out = <Device>[];
+    for (final list in _devices.values) {
+      out.addAll(list);
+    }
+    final frozen = List<Device>.unmodifiable(out);
+    _flatDevicesCache = frozen;
+    return frozen;
+  }
+
+  void _invalidateDevicesCache() {
+    _flatDevicesCache = null;
+  }
 
   DeviceController(this._services) {
     _devices = {};
@@ -139,7 +163,7 @@ class DeviceController implements DeviceScanner {
       final staleFlags = await Future.wait(
         pairs.map((p) async {
           final state = await p.device.connectionState.first.timeout(
-            const Duration(seconds: 2),
+            ConnectionTimings.preScanDeviceCheckTimeout,
             onTimeout: () => ConnectionState.disconnected,
           );
           return state != ConnectionState.connected &&
@@ -149,6 +173,7 @@ class DeviceController implements DeviceScanner {
       for (var i = 0; i < pairs.length; i++) {
         if (staleFlags[i]) {
           _devices[pairs[i].service]?.remove(pairs[i].device);
+          _invalidateDevicesCache();
         }
       }
       // Sync the disconnect-detection baseline with the cleaned list so
@@ -191,7 +216,7 @@ class DeviceController implements DeviceScanner {
       // Preserved from the pre-PR-A implementation to keep widget-test
       // timing assumptions intact; revisit in PR B when status
       // derivation is in place.
-      await Future.delayed(const Duration(milliseconds: 200));
+      await Future.delayed(ConnectionTimings.postScanSettleDelay);
       return ScanResult(
         matchedDevices: List.unmodifiable(devices),
         failedServices: List.unmodifiable(failures),
@@ -213,6 +238,7 @@ class DeviceController implements DeviceScanner {
   void _serviceUpdate(DeviceDiscoveryService service, List<Device> devices) {
     _log.fine("$service update: $devices");
     _devices[service] = devices;
+    _invalidateDevicesCache();
 
     // Snapshot current device ids + id→name map. Correlation keys are
     // always deviceId; name is kept only for human-readable log output

--- a/lib/src/models/device/device_scanner.dart
+++ b/lib/src/models/device/device_scanner.dart
@@ -29,4 +29,9 @@ abstract class DeviceScanner {
   /// services. Non-BLE transports (serial, simulated) contribute nothing;
   /// if no BLE service is registered the stream emits [AdapterState.unknown].
   Stream<AdapterState> get adapterStateStream;
+
+  /// Synchronous snapshot of the most recently emitted adapter state.
+  /// Used by the scan orchestrator to populate `ScanReport` without
+  /// awaiting a stream value (comms-harden #27).
+  AdapterState get currentAdapterState;
 }

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/connection/connection_timings.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/device/de1_firmwaremodel.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
@@ -310,7 +311,7 @@ class UnifiedDe1 implements De1Interface {
     // that flash write returns. If a state=espresso request hits the
     // firmware task loop before the flag clears, doEspresso() aborts to
     // HeaterDown and the shot ends after preinfuse. See BC 9788201734.
-    await Future.delayed(const Duration(milliseconds: 500));
+    await Future.delayed(ConnectionTimings.profileDownloadGuard);
   }
 
   @override

--- a/test/controllers/connection/scan_report_builder_test.dart
+++ b/test/controllers/connection/scan_report_builder_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection/scan_report_builder.dart';
+import 'package:reaprime/src/models/adapter_state.dart';
+import 'package:reaprime/src/models/scan_report.dart';
+
+void main() {
+  group('ScanReportBuilder adapter state (comms-harden #27)', () {
+    test('build() uses the recorded start state + supplied end state', () {
+      final builder = ScanReportBuilder(scanStartTime: DateTime.now())
+        ..recordAdapterStateAtStart(AdapterState.poweredOff);
+
+      final report = builder.build(
+        preferredMachineId: null,
+        preferredScaleId: null,
+        terminationReason: ScanTerminationReason.completed,
+        adapterStateAtEnd: AdapterState.poweredOn,
+      );
+
+      expect(report.adapterStateAtStart, AdapterState.poweredOff);
+      expect(report.adapterStateAtEnd, AdapterState.poweredOn);
+    });
+
+    test(
+      'build() defaults adapterStateAtStart to unknown when not recorded',
+      () {
+        final builder = ScanReportBuilder(scanStartTime: DateTime.now());
+
+        final report = builder.build(
+          preferredMachineId: null,
+          preferredScaleId: null,
+          terminationReason: ScanTerminationReason.completed,
+          adapterStateAtEnd: AdapterState.unknown,
+        );
+
+        expect(report.adapterStateAtStart, AdapterState.unknown);
+      },
+    );
+  });
+}

--- a/test/controllers/device_controller_test.dart
+++ b/test/controllers/device_controller_test.dart
@@ -196,6 +196,38 @@ void main() {
     );
   });
 
+  group('devices getter caching (comms-harden #28)', () {
+    test(
+      'repeat getter calls return the same list instance until a mutation',
+      () async {
+        final service = _ManualDiscoveryService();
+        final controller = DeviceController([service]);
+        await controller.initialize();
+
+        service.emit([
+          _FakeDevice(
+            deviceId: 'AA:11:11:11:11:11',
+            name: 'DE1',
+            type: DeviceType.machine,
+          ),
+        ]);
+        await Future<void>.delayed(Duration.zero);
+
+        final first = controller.devices;
+        final second = controller.devices;
+        expect(identical(first, second), isTrue,
+            reason: 'cache should return the same instance on a hot call');
+
+        service.emit(const []);
+        await Future<void>.delayed(Duration.zero);
+
+        final afterMutation = controller.devices;
+        expect(identical(first, afterMutation), isFalse,
+            reason: 'cache must rebuild after a device-list mutation');
+      },
+    );
+  });
+
   group('disconnect tracking keys (comms-harden #20)', () {
     test(
       'two devices with same name but different IDs do not collide on disconnect',

--- a/test/helpers/mock_device_scanner.dart
+++ b/test/helpers/mock_device_scanner.dart
@@ -44,6 +44,9 @@ class MockDeviceScanner implements DeviceScanner {
       _adapterStateSubject.stream;
 
   @override
+  AdapterState get currentAdapterState => _adapterStateSubject.value;
+
+  @override
   List<Device> get devices => List.from(_devices);
 
   /// Push an adapter state onto the stream for tests that drive environmental


### PR DESCRIPTION
## What
- **24** Named constants in `connection_timings.dart` for the scattered comms-layer durations (pre-scan check, post-scan settle, shot-settings debounce, profile-download guard).
- **27** Real adapter state in `ScanReport.adapterStateAtStart/End` — previously hardcoded `unknown`.
- **28** Cache `DeviceController.devices`; invalidate on mutation.
- **29** Document single-adapter assumption on `_adapterStateStream`.
- **30** Phase-transition table + ASCII diagram in `doc/DeviceManagement.md`; `ConnectionPhase` docstring links there.

## Why
Last comms-harden roadmap sweep. All pure hygiene — no runtime-behaviour changes beyond populating previously-placeholder fields.

## Test plan
- Unit: new tests in `scan_report_builder_test.dart` + `device_controller_test.dart` (adapter state, devices-cache identity + invalidation).
- `flutter test` — 988 pass (+3).
- `flutter analyze` — clean (only pre-existing infos).
- Real-hardware smoke on M50Mini + DE1Pro: cold connect, disconnect, reconnect. Zero SEVERE / Bad state / MmrTimeout / uncaught errors. Scan report emits twice, both with `completed` termination.

After merge: open `integration/comms-harden-rest` → `main` capstone PR.