### PR TITLE
fix(#106): coerce WorkflowContext string fields from non-string JSON values

### DIFF
--- a/lib/src/models/data/utils.dart
+++ b/lib/src/models/data/utils.dart
@@ -17,3 +17,14 @@ int parseInt(dynamic value) {
   if (value is double) return value.toInt();
   return int.parse(value);
 }
+
+/// Coerce a JSON value to `String?`, tolerating numeric and boolean
+/// inputs (JSON does not require IDs to be strings). Returns null for
+/// nulls and for structured values (Map / List) — silently stringifying
+/// those would poison the field with noise like `"{a: 1}"`.
+String? parseOptionalString(dynamic value) {
+  if (value == null) return null;
+  if (value is String) return value;
+  if (value is num || value is bool) return value.toString();
+  return null;
+}

--- a/lib/src/models/data/workflow_context.dart
+++ b/lib/src/models/data/workflow_context.dart
@@ -54,18 +54,22 @@ class WorkflowContext {
   /// Legacy field migration (doseData/grinderData/coffeeData) is handled
   /// upstream in Workflow.fromJson, not here.
   factory WorkflowContext.fromJson(Map<String, dynamic> json) {
+    // String-typed fields are coerced via parseOptionalString so a
+    // client sending a numeric id (valid JSON) doesn't crash the
+    // handler. See issue #106 for the deepMerge re-parse flow that
+    // previously required a server restart to recover.
     return WorkflowContext(
       targetDoseWeight: parseOptionalDouble(json['targetDoseWeight']),
       targetYield: parseOptionalDouble(json['targetYield']),
-      grinderId: json['grinderId'] as String?,
-      grinderModel: json['grinderModel'] as String?,
-      grinderSetting: json['grinderSetting'] as String?,
-      beanBatchId: json['beanBatchId'] as String?,
-      coffeeName: json['coffeeName'] as String?,
-      coffeeRoaster: json['coffeeRoaster'] as String?,
-      finalBeverageType: json['finalBeverageType'] as String?,
-      baristaName: json['baristaName'] as String?,
-      drinkerName: json['drinkerName'] as String?,
+      grinderId: parseOptionalString(json['grinderId']),
+      grinderModel: parseOptionalString(json['grinderModel']),
+      grinderSetting: parseOptionalString(json['grinderSetting']),
+      beanBatchId: parseOptionalString(json['beanBatchId']),
+      coffeeName: parseOptionalString(json['coffeeName']),
+      coffeeRoaster: parseOptionalString(json['coffeeRoaster']),
+      finalBeverageType: parseOptionalString(json['finalBeverageType']),
+      baristaName: parseOptionalString(json['baristaName']),
+      drinkerName: parseOptionalString(json['drinkerName']),
       extras: json['extras'] as Map<String, dynamic>?,
     );
   }

--- a/test/models/workflow_context_test.dart
+++ b/test/models/workflow_context_test.dart
@@ -80,6 +80,81 @@ void main() {
       expect(updated.targetYield, 40.0);
       expect(updated.coffeeName, 'Ethiopian');
     });
+
+    group('fromJson non-string coercion (#106)', () {
+      test('int values for ID/text fields are stringified, not crashed', () {
+        final restored = WorkflowContext.fromJson({
+          'grinderId': 123,
+          'grinderSetting': 5,
+          'beanBatchId': 456,
+          'coffeeName': 789,
+        });
+        expect(restored.grinderId, '123');
+        expect(restored.grinderSetting, '5');
+        expect(restored.beanBatchId, '456');
+        expect(restored.coffeeName, '789');
+      });
+
+      test('double values are stringified', () {
+        final restored =
+            WorkflowContext.fromJson({'grinderSetting': 5.5});
+        expect(restored.grinderSetting, '5.5');
+      });
+
+      test('bool values are stringified', () {
+        final restored =
+            WorkflowContext.fromJson({'drinkerName': true});
+        expect(restored.drinkerName, 'true');
+      });
+
+      test('null values stay null', () {
+        final restored = WorkflowContext.fromJson({
+          'grinderId': null,
+          'coffeeName': null,
+        });
+        expect(restored.grinderId, isNull);
+        expect(restored.coffeeName, isNull);
+      });
+
+      test(
+        'Map / List values are refused (null-coerced), not silently stringified',
+        () {
+          final restored = WorkflowContext.fromJson({
+            'coffeeName': {'nested': 'map'},
+            'baristaName': [1, 2, 3],
+          });
+          expect(restored.coffeeName, isNull);
+          expect(restored.baristaName, isNull);
+        },
+      );
+
+      test(
+        'toJson → merge-with-int → fromJson roundtrip does not crash '
+        '(regression for workflow_handler deepMerge path)',
+        () {
+          final ctx = WorkflowContext(
+            grinderId: 'grinder-1',
+            grinderSetting: '5',
+            beanBatchId: 'batch-1',
+          );
+          // Simulate a client sending numeric grinderSetting; the
+          // handler's deepMerge produces a mixed-type map, which then
+          // needs to round-trip through fromJson on the next PUT.
+          final merged = {
+            ...ctx.toJson(),
+            'grinderSetting': 7, // int, not string
+          };
+          final reparsed = WorkflowContext.fromJson(merged);
+          expect(reparsed.grinderSetting, '7');
+
+          // Next PUT cycle: serialize + reparse again — must still work.
+          final second = WorkflowContext.fromJson(reparsed.toJson());
+          expect(second.grinderSetting, '7');
+          expect(second.grinderId, 'grinder-1');
+          expect(second.beanBatchId, 'batch-1');
+        },
+      );
+    });
   });
 
   group('Workflow.fromJson - migration-on-read', () {


### PR DESCRIPTION
Closes #106.

## What
- New `parseOptionalString` helper in `lib/src/models/data/utils.dart` — returns String unchanged, `.toString()`s num/bool, null-coerces anything else (Map/List refused rather than silently stringified).
- `WorkflowContext.fromJson` uses it for the nine String? fields that previously hard-cast and crashed on int inputs.

## Why
Clients sending numeric `grinderSetting` / `grinderId` / `beanBatchId` (valid JSON) triggered a 500 on `PUT /api/v1/workflow`. Worse, the handler's `toJson → deepMerge → fromJson` flow meant one poisoned PUT would crash every subsequent PUT — even ones only touching `profile` — until server restart.

## Test plan
- `flutter test` — 994 pass (+6 new cases: int/double/bool/null/Map-List coercion + deepMerge-poisoning regression).
- `flutter analyze` — clean.
- Simulate-mode smoke (`sb-dev.sh start --platform macos --dart-define simulate=1`): PUT with `{"context":{"grinderSetting":5,"grinderId":123,"beanBatchId":456}}` → HTTP 200, context returns stringified. Follow-up PUT `{"name":"Updated"}` → HTTP 200, context still intact.