### PR TITLE
fix(home): surface machine picker dialog when scan returns ambiguity

### DIFF
--- a/lib/src/home_feature/tiles/settings_tile.dart
+++ b/lib/src/home_feature/tiles/settings_tile.dart
@@ -284,8 +284,49 @@ class _SettingsTileState extends State<SettingsTile> {
 
   Future<void> _handleScan(BuildContext context) async {
     setState(() => _isScanning = true);
-    await widget.connectionManager.connect();
-    if (mounted) setState(() => _isScanning = false);
+    try {
+      await widget.connectionManager.connect();
+    } catch (_) {
+      // Connection errors surface via the ConnectionManager status stream
+      // (banner / status tile). Nothing to do here.
+    } finally {
+      if (mounted) setState(() => _isScanning = false);
+    }
+    if (!context.mounted) return;
+    final status = widget.connectionManager.currentStatus;
+    if (status.pendingAmbiguity == AmbiguityReason.machinePicker) {
+      _showMachinePicker(context, status.foundMachines);
+    }
+  }
+
+  void _showMachinePicker(
+    BuildContext context,
+    List<De1Interface> machines,
+  ) {
+    showShadDialog(
+      context: context,
+      builder: (context) => ShadDialog(
+        title: const Text('Select Machine'),
+        child: Material(
+          color: Colors.transparent,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: machines
+                .map(
+                  (machine) => ListTile(
+                    title: Text(machine.name),
+                    subtitle: Text(machine.deviceId),
+                    onTap: () {
+                      Navigator.of(context).pop();
+                      widget.connectionManager.connectMachine(machine);
+                    },
+                  ),
+                )
+                .toList(),
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/test/helpers/fake_connection_manager.dart
+++ b/test/helpers/fake_connection_manager.dart
@@ -30,7 +30,10 @@ class FakeConnectionManager extends ConnectionManager {
   bool _scaleOnlyLastCall = false;
   bool get scaleOnlyLastCall => _scaleOnlyLastCall;
 
-  FakeConnectionManager._({
+  /// Protected constructor — exposed so subclasses in other test files
+  /// can build their own collaborator wiring. Most tests should use
+  /// the default [FakeConnectionManager.new] factory below.
+  FakeConnectionManager.forSubclass({
     required super.deviceScanner,
     required super.de1Controller,
     required super.scaleController,
@@ -42,7 +45,7 @@ class FakeConnectionManager extends ConnectionManager {
     final de1 = MockDe1Controller(controller: DeviceController([]));
     final scale = MockScaleController();
     final settings = SettingsController(MockSettingsService());
-    return FakeConnectionManager._(
+    return FakeConnectionManager.forSubclass(
       deviceScanner: scanner,
       de1Controller: de1,
       scaleController: scale,

--- a/test/helpers/test_de1.dart
+++ b/test/helpers/test_de1.dart
@@ -13,6 +13,15 @@ import 'package:rxdart/rxdart.dart';
 /// [requestState] only records the call — it does NOT emit a new state.
 /// Use [emitSnapshot] or [emitStateAndSubstate] to drive the stream explicitly.
 class TestDe1 implements De1Interface {
+  /// Override for [deviceId]/[name]. Tests that need to distinguish two
+  /// TestDe1 instances (e.g. picker tests) pass these; everything else
+  /// gets the legacy defaults.
+  final String _deviceId;
+  final String _name;
+
+  TestDe1({String deviceId = 'test-de1', String name = 'TestDe1'})
+      : _deviceId = deviceId,
+        _name = name;
   final BehaviorSubject<MachineSnapshot> snapshotSubject =
       BehaviorSubject.seeded(
     MachineSnapshot(
@@ -97,9 +106,9 @@ class TestDe1 implements De1Interface {
   }
 
   @override
-  String get deviceId => 'test-de1';
+  String get deviceId => _deviceId;
   @override
-  String get name => 'TestDe1';
+  String get name => _name;
   @override
   DeviceType get type => DeviceType.machine;
   @override

--- a/test/home_feature/settings_tile_scan_picker_test.dart
+++ b/test/home_feature/settings_tile_scan_picker_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/home_feature/tiles/settings_tile.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+import '../helpers/fake_connection_manager.dart';
+import '../helpers/mock_de1_controller.dart';
+import '../helpers/mock_device_scanner.dart';
+import '../helpers/mock_scale_controller.dart';
+import '../helpers/mock_settings_service.dart';
+import '../helpers/test_de1.dart';
+
+/// FakeConnectionManager variant that mimics the post-scan state the
+/// real ConnectionManager would publish when the scan ends with
+/// MachinePickerAction: `pendingAmbiguity = machinePicker`, machines
+/// populated on `foundMachines`.
+class _AmbiguousMachineFakeCM extends FakeConnectionManager {
+  final List<De1Interface> machines;
+  int connectMachineCalls = 0;
+  De1Interface? lastConnectMachineArg;
+
+  _AmbiguousMachineFakeCM._({
+    required this.machines,
+    required super.deviceScanner,
+    required super.de1Controller,
+    required super.scaleController,
+    required super.settingsController,
+  }) : super.forSubclass();
+
+  factory _AmbiguousMachineFakeCM(List<De1Interface> machines) {
+    final scanner = MockDeviceScanner();
+    final de1 = MockDe1Controller(controller: DeviceController(const []));
+    final scale = MockScaleController();
+    final settings = SettingsController(MockSettingsService());
+    return _AmbiguousMachineFakeCM._(
+      machines: machines,
+      deviceScanner: scanner,
+      de1Controller: de1,
+      scaleController: scale,
+      settingsController: settings,
+    );
+  }
+
+  @override
+  Future<void> connect({bool scaleOnly = false}) async {
+    await super.connect(scaleOnly: scaleOnly);
+    emitStatus(
+      currentStatus.copyWith(
+        phase: ConnectionPhase.idle,
+        foundMachines: machines,
+        pendingAmbiguity: () => AmbiguityReason.machinePicker,
+      ),
+    );
+  }
+
+  @override
+  Future<void> connectMachine(De1Interface machine) async {
+    connectMachineCalls++;
+    lastConnectMachineArg = machine;
+  }
+}
+
+Widget _wrap(Widget child) =>
+    ShadApp(home: Scaffold(body: Center(child: child)));
+
+void main() {
+  testWidgets(
+    'tapping Scan when preferred machine is missing shows a picker '
+    'dialog (comms-harden dashboard #2)',
+    (tester) async {
+      final m1 = TestDe1(deviceId: 'DE1-AA', name: 'DE1-Left');
+      final m2 = TestDe1(deviceId: 'DE1-BB', name: 'DE1-Right');
+      final cm = _AmbiguousMachineFakeCM([m1, m2]);
+      final de1Controller = MockDe1Controller(
+        controller: DeviceController(const []),
+      );
+
+      await tester.pumpWidget(_wrap(SettingsTile(
+        controller: de1Controller,
+        connectionManager: cm,
+      )));
+      await tester.pump();
+
+      expect(find.text('Scan'), findsOneWidget);
+      await tester.tap(find.text('Scan'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Select Machine'), findsOneWidget,
+          reason: 'picker dialog must appear when connect() returns '
+              'with pendingAmbiguity.machinePicker');
+      expect(find.text('DE1-AA'), findsOneWidget);
+      expect(find.text('DE1-BB'), findsOneWidget);
+
+      await tester.tap(find.text('DE1-AA'));
+      await tester.pump();
+
+      expect(cm.connectMachineCalls, 1);
+      expect(cm.lastConnectMachineArg, m1);
+    },
+  );
+
+  testWidgets(
+    'tapping Scan without ambiguity (machine found & connected) shows '
+    'no picker dialog',
+    (tester) async {
+      final cm = FakeConnectionManager(); // default: connect() no-ops
+      final de1Controller = MockDe1Controller(
+        controller: DeviceController(const []),
+      );
+
+      await tester.pumpWidget(_wrap(SettingsTile(
+        controller: de1Controller,
+        connectionManager: cm,
+      )));
+      await tester.pump();
+
+      await tester.tap(find.text('Scan'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Select Machine'), findsNothing);
+    },
+  );
+}


### PR DESCRIPTION
## What
`SettingsTile._handleScan` now checks `ConnectionManager.currentStatus.pendingAmbiguity == machinePicker` after `connect()` resolves and shows a picker dialog listing `foundMachines`. Mirrors the existing scale picker in `StatusTile`.

## Why
When the preferred machine isn't found but others are available, the policy layer correctly sets the ambiguity hint + `foundMachines` — the dashboard Scan button just never consumed it, so pressing Scan looked like a no-op. Scales had this UX wired up; machines didn't.

## Test plan
- Widget tests (`test/home_feature/settings_tile_scan_picker_test.dart`) cover both paths — picker shows on ambiguity, no picker when connect is clean.
- `flutter test` — 996 pass (+2).
- `flutter analyze` — clean.
- Manual repro verified locally: `sb-dev start --dart-define simulate=1 --preferred-machine-id NONEXISTENT`, navigate to dashboard, press Scan → picker now appears.

## Supporting changes
- `FakeConnectionManager._` → `.forSubclass` so test-local fakes can inject custom collaborators.
- `TestDe1` gains optional `deviceId` / `name` ctor params so picker tests can distinguish instances.