### PR TITLE
Fix redundant shotSettings writes and WS emits on workflow updates

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,6 +26,7 @@ import 'package:reaprime/src/controllers/profile_controller.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
 import 'package:reaprime/src/controllers/sensor_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/controllers/workflow_device_sync.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
@@ -293,6 +294,14 @@ void main() async {
     persistenceController.saveWorkflow(workflowController.currentWorkflow);
     de1Controller.defaultWorkflow = workflowController.currentWorkflow;
   });
+  // Single writer of DE1 setProfile across REST + UI paths. Must be
+  // constructed after workflowController has its persisted workflow
+  // loaded so its initial snapshot matches what was last pushed.
+  // ignore: unused_local_variable
+  final workflowDeviceSync = WorkflowDeviceSync(
+    workflowController: workflowController,
+    de1Controller: de1Controller,
+  );
   final PluginLoaderService pluginService = PluginLoaderService(
     kvStore: HiveStoreService(defaultNamespace: "plugins")..initialize(),
   );

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -280,5 +280,48 @@ class De1Controller {
 
     _rinseStream.add(settings);
   }
+
+  /// Flow setters live outside the DE1 shot-settings characteristic, so
+  /// changing them used to require a nudge re-emit on `shotSettings` to
+  /// kick `_shotSettingsUpdate` into rebroadcasting the data-controllers
+  /// that UI subscribes to. The nudge leaked redundant WS emits; these
+  /// helpers replace it by writing the MMR value and updating the
+  /// relevant data-controller directly.
+  Future<void> setSteamFlow(double newFlow) async {
+    await connectedDe1().setSteamFlow(newFlow);
+    final current = _steamDataController.valueOrNull;
+    if (current != null) {
+      _steamDataController.add(SteamSettings(
+        targetTemperature: current.targetTemperature,
+        duration: current.duration,
+        flow: newFlow,
+      ));
+    }
+  }
+
+  Future<void> setHotWaterFlow(double newFlow) async {
+    await connectedDe1().setHotWaterFlow(newFlow);
+    final current = _hotWaterDataController.valueOrNull;
+    if (current != null) {
+      _hotWaterDataController.add(HotWaterData(
+        targetTemperature: current.targetTemperature,
+        duration: current.duration,
+        volume: current.volume,
+        flow: newFlow,
+      ));
+    }
+  }
+
+  Future<void> setFlushFlow(double newFlow) async {
+    await connectedDe1().setFlushFlow(newFlow);
+    final current = _rinseStream.valueOrNull;
+    if (current != null) {
+      _rinseStream.add(RinseData(
+        targetTemperature: current.targetTemperature,
+        duration: current.duration,
+        flow: newFlow,
+      ));
+    }
+  }
 }
 

--- a/lib/src/controllers/workflow_device_sync.dart
+++ b/lib/src/controllers/workflow_device_sync.dart
@@ -1,0 +1,62 @@
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/errors.dart';
+
+/// Single writer of `setProfile` for both REST (`PUT /api/v1/workflow`)
+/// and UI (`ProfileTile` picker) paths. Subscribes to
+/// `WorkflowController` changes and pushes the profile to the DE1 on
+/// value diff; equality is handled by `Profile`'s `Equatable`
+/// implementation.
+///
+/// Without this, the profile was uploaded twice on every REST-driven
+/// change: once directly from `WorkflowHandler._applyPendingUpdate`
+/// and again from `ProfileTile._workflowChange` listening to the same
+/// `WorkflowController.notifyListeners()` tick — overlapping BLE
+/// frame writes and a profile-download race on the firmware side.
+///
+/// On DE1 disconnect the push is skipped silently; the existing
+/// `De1Controller._setDe1Defaults` path uploads the current workflow's
+/// profile on reconnect (see `defaultWorkflow` assignment in
+/// `main.dart`).
+class WorkflowDeviceSync {
+  WorkflowDeviceSync({
+    required WorkflowController workflowController,
+    required De1Controller de1Controller,
+  })  : _workflow = workflowController,
+        _de1 = de1Controller {
+    _lastPushedProfile = _workflow.currentWorkflow.profile;
+    _workflow.addListener(_onChange);
+  }
+
+  final WorkflowController _workflow;
+  final De1Controller _de1;
+  final Logger _log = Logger('WorkflowDeviceSync');
+
+  Profile? _lastPushedProfile;
+
+  void _onChange() {
+    final profile = _workflow.currentWorkflow.profile;
+    if (profile == _lastPushedProfile) return;
+    _lastPushedProfile = profile;
+    _push(profile);
+  }
+
+  Future<void> _push(Profile profile) async {
+    try {
+      await _de1.connectedDe1().setProfile(profile);
+    } on DeviceNotConnectedException {
+      _log.fine(
+        'DE1 not connected; skipping profile push — will sync via '
+        'defaultWorkflow on next connect',
+      );
+    } catch (e, st) {
+      _log.warning('setProfile failed', e, st);
+    }
+  }
+
+  void dispose() {
+    _workflow.removeListener(_onChange);
+  }
+}

--- a/lib/src/home_feature/tiles/profile_tile.dart
+++ b/lib/src/home_feature/tiles/profile_tile.dart
@@ -14,7 +14,6 @@ import 'package:reaprime/src/services/storage/bean_storage_service.dart';
 import 'package:reaprime/src/services/storage/grinder_storage_service.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:fl_chart/fl_chart.dart';
-import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/data/workflow_context.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
@@ -63,7 +62,9 @@ class _ProfileState extends State<ProfileTile> {
           "Changing profile to: ${widget.workflowController.currentWorkflow.profile.title}",
         );
         loadedProfile = widget.workflowController.currentWorkflow.profile;
-        widget.de1controller.connectedDe1().setProfile(loadedProfile!);
+        // DE1 upload is owned by WorkflowDeviceSync so REST and UI
+        // paths share one writer. The tile only refreshes its chart
+        // and labels here.
         _log.fine('Loaded profile: ${loadedProfile!.title}');
         _log.fine('Target weight: ${loadedProfile!.targetWeight}');
       }

--- a/lib/src/models/data/profile.dart
+++ b/lib/src/models/data/profile.dart
@@ -64,7 +64,7 @@ class Profile extends Equatable {
     return {
       'version': version,
       'title': title,
-      'notes': notes.replaceAll('\n', '\\n'),
+      'notes': notes,
       'author': author,
       'beverage_type': beverageType.name,
       'steps': steps.map((step) => step.toJson()).toList(),

--- a/lib/src/models/data/workflow.dart
+++ b/lib/src/models/data/workflow.dart
@@ -46,7 +46,8 @@ class Workflow {
         coffeeName: ctx.coffeeName ?? coffee?['name'] as String?,
         coffeeRoaster: ctx.coffeeRoaster ?? coffee?['roaster'] as String?,
       );
-    } else if (ctx == null && (dose != null || grinder != null || coffee != null)) {
+    } else if (ctx == null &&
+        (dose != null || grinder != null || coffee != null)) {
       ctx = WorkflowContext(
         targetDoseWeight:
             dose != null ? parseOptionalDouble(dose['doseIn']) : null,
@@ -64,15 +65,18 @@ class Workflow {
       description: json['description'],
       profile: Profile.fromJson(json['profile']),
       context: ctx,
-      steamSettings: json['steamSettings'] != null
-          ? SteamSettings.fromJson(json['steamSettings'])
-          : SteamSettings.defaults(),
-      hotWaterData: json['hotWaterData'] != null
-          ? HotWaterData.fromJson(json['hotWaterData'])
-          : HotWaterData.defaults(),
-      rinseData: json['rinseData'] != null
-          ? RinseData.fromJson(json['rinseData'])
-          : RinseData.defaults(),
+      steamSettings:
+          json['steamSettings'] != null
+              ? SteamSettings.fromJson(json['steamSettings'])
+              : SteamSettings.defaults(),
+      hotWaterData:
+          json['hotWaterData'] != null
+              ? HotWaterData.fromJson(json['hotWaterData'])
+              : HotWaterData.defaults(),
+      rinseData:
+          json['rinseData'] != null
+              ? RinseData.fromJson(json['rinseData'])
+              : RinseData.defaults(),
     );
   }
 
@@ -153,6 +157,21 @@ class SteamSettings {
   factory SteamSettings.defaults() {
     return SteamSettings(targetTemperature: 150, duration: 50, flow: 0.8);
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! SteamSettings) {
+      return false;
+    }
+
+    return other.targetTemperature == targetTemperature &&
+        other.flow == flow &&
+        other.duration == duration;
+  }
+
+  @override
+  int get hashCode =>
+      targetTemperature.hashCode ^ flow.hashCode ^ duration.hashCode;
 }
 
 class HotWaterData {
@@ -208,6 +227,23 @@ class HotWaterData {
       flow: 10,
     );
   }
+
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! HotWaterData) {
+      return false;
+    }
+
+    return other.targetTemperature == targetTemperature &&
+        other.flow == flow &&
+        other.duration == duration &&
+        other.volume == volume;
+  }
+
+  @override
+  int get hashCode =>
+      targetTemperature.hashCode ^ flow.hashCode ^ duration.hashCode ^ volume.hashCode;
 }
 
 class RinseData {
@@ -231,8 +267,8 @@ class RinseData {
 
   factory RinseData.fromJson(Map<String, dynamic> json) {
     return RinseData(
-      targetTemperature: parseInt( json['targetTemperature']),
-      duration: parseInt( json['duration']),
+      targetTemperature: parseInt(json['targetTemperature']),
+      duration: parseInt(json['duration']),
       flow: parseDouble(json['flow']),
     );
   }
@@ -240,4 +276,20 @@ class RinseData {
   factory RinseData.defaults() {
     return RinseData(targetTemperature: 90, duration: 10, flow: 6.0);
   }
+
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! RinseData) {
+      return false;
+    }
+
+    return other.targetTemperature == targetTemperature &&
+        other.flow == flow &&
+        other.duration == duration;
+  }
+
+  @override
+  int get hashCode =>
+      targetTemperature.hashCode ^ flow.hashCode ^ duration.hashCode;
 }

--- a/lib/src/models/data/workflow_context.dart
+++ b/lib/src/models/data/workflow_context.dart
@@ -156,4 +156,47 @@ class WorkflowContext {
       'dose: $targetDoseWeight→$targetYield, '
       'grinder: $grinderModel/$grinderSetting, '
       'coffee: $coffeeName by $coffeeRoaster)';
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! WorkflowContext) return false;
+    return other.targetDoseWeight == targetDoseWeight &&
+        other.targetYield == targetYield &&
+        other.grinderId == grinderId &&
+        other.grinderModel == grinderModel &&
+        other.grinderSetting == grinderSetting &&
+        other.beanBatchId == beanBatchId &&
+        other.coffeeName == coffeeName &&
+        other.coffeeRoaster == coffeeRoaster &&
+        other.finalBeverageType == finalBeverageType &&
+        other.baristaName == baristaName &&
+        other.drinkerName == drinkerName &&
+        _mapEquals(other.extras, extras);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        targetDoseWeight,
+        targetYield,
+        grinderId,
+        grinderModel,
+        grinderSetting,
+        beanBatchId,
+        coffeeName,
+        coffeeRoaster,
+        finalBeverageType,
+        baristaName,
+        drinkerName,
+        extras == null ? null : Object.hashAll(extras!.entries.map((e) => Object.hash(e.key, e.value))),
+      );
+}
+
+bool _mapEquals(Map<String, dynamic>? a, Map<String, dynamic>? b) {
+  if (identical(a, b)) return true;
+  if (a == null || b == null) return false;
+  if (a.length != b.length) return false;
+  for (final key in a.keys) {
+    if (!b.containsKey(key) || a[key] != b[key]) return false;
+  }
+  return true;
 }

--- a/lib/src/models/device/de1_interface.dart
+++ b/lib/src/models/device/de1_interface.dart
@@ -162,6 +162,31 @@ final class De1ShotSettings {
       groupTemp: groupTemp ?? this.groupTemp,
     );
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! De1ShotSettings) return false;
+    return other.steamSetting == steamSetting &&
+        other.targetSteamTemp == targetSteamTemp &&
+        other.targetSteamDuration == targetSteamDuration &&
+        other.targetHotWaterTemp == targetHotWaterTemp &&
+        other.targetHotWaterVolume == targetHotWaterVolume &&
+        other.targetHotWaterDuration == targetHotWaterDuration &&
+        other.targetShotVolume == targetShotVolume &&
+        other.groupTemp == groupTemp;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        steamSetting,
+        targetSteamTemp,
+        targetSteamDuration,
+        targetHotWaterTemp,
+        targetHotWaterVolume,
+        targetHotWaterDuration,
+        targetShotVolume,
+        groupTemp,
+      );
 }
 
 final class De1WaterLevels {

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -286,11 +286,6 @@ class UnifiedDe1 implements De1Interface {
   @override
   Future<void> setHotWaterFlow(double newFlow) async {
     await _writeMMRScaled(MMRItem.hotWaterFlowRate, newFlow);
-    // Workaround for hot water flow not part of shot settings, will trigger
-    // DE1Controller refresh
-    _transport.shotSettingsSubject.add(
-      await _transport.shotSettingsSubject.first,
-    );
   }
 
   Profile? _currentProfile;
@@ -317,11 +312,6 @@ class UnifiedDe1 implements De1Interface {
   @override
   Future<void> setSteamFlow(double newFlow) async {
     await _writeMMRScaled(MMRItem.targetSteamFlow, newFlow);
-    // Workaround for steam flow not part of shot settings, will trigger
-    // DE1Controller refresh
-    _transport.shotSettingsSubject.add(
-      await _transport.shotSettingsSubject.first,
-    );
   }
 
   @override
@@ -376,7 +366,8 @@ class UnifiedDe1 implements De1Interface {
         notifyFrom(Endpoint.shotSettings, d.buffer.asUint8List());
         return d;
       })
-      .map(_parseShotSettings);
+      .map(_parseShotSettings)
+      .distinct();
 
   @override
   DeviceType get type => DeviceType.machine;

--- a/lib/src/models/device/impl/mock_de1/mock_de1.dart
+++ b/lib/src/models/device/impl/mock_de1/mock_de1.dart
@@ -452,7 +452,8 @@ class MockDe1 implements De1Interface {
       );
 
   @override
-  Stream<De1ShotSettings> get shotSettings => _shotSettingsController.stream;
+  Stream<De1ShotSettings> get shotSettings =>
+      _shotSettingsController.stream.distinct();
 
   @override
   Future<void> updateShotSettings(De1ShotSettings newSettings) async {
@@ -490,7 +491,6 @@ class MockDe1 implements De1Interface {
   @override
   Future<void> setSteamFlow(double newFlow) async {
     _steamFlow = newFlow;
-    _shotSettingsController.add(await _shotSettingsController.stream.first);
   }
 
   double _hotWaterFlow = 1.0;
@@ -502,7 +502,6 @@ class MockDe1 implements De1Interface {
   @override
   Future<void> setHotWaterFlow(double newFlow) async {
     _hotWaterFlow = newFlow;
-    _shotSettingsController.add(await _shotSettingsController.stream.first);
   }
 
   double _flushFlow = 1.0;
@@ -514,7 +513,6 @@ class MockDe1 implements De1Interface {
   @override
   Future<void> setFlushFlow(double newFlow) async {
     _flushFlow = newFlow;
-    _shotSettingsController.add(await _shotSettingsController.stream.first);
   }
 
   @override

--- a/lib/src/realtime_steam_feature/realtime_steam_feature.dart
+++ b/lib/src/realtime_steam_feature/realtime_steam_feature.dart
@@ -270,7 +270,7 @@ class _RealtimeSteamFeatureState extends State<RealtimeSteamFeature> {
               trackHeight: 24.0,
               label: _steamFlow.toStringAsFixed(1),
               onChanged: (value) async {
-                await _de1Controller.connectedDe1().setSteamFlow(value);
+                await _de1Controller.setSteamFlow(value);
                 setState(() {
                   _steamFlow = value;
                 });

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -66,16 +66,16 @@ class De1Handler {
           await de1.setFlushTemperature(parseDouble(json['flushTemp']));
         }
         if (json['flushFlow'] != null) {
-          await de1.setFlushFlow(parseDouble(json['flushFlow']));
+          await _controller.setFlushFlow(parseDouble(json['flushFlow']));
         }
         if (json['flushTimeout'] != null) {
           await de1.setFlushTimeout(parseDouble(json['flushTimeout']));
         }
         if (json['hotWaterFlow'] != null) {
-          await de1.setHotWaterFlow(parseDouble(json['hotWaterFlow']));
+          await _controller.setHotWaterFlow(parseDouble(json['hotWaterFlow']));
         }
         if (json['steamFlow'] != null) {
-          await de1.setSteamFlow(parseDouble(json['steamFlow']));
+          await _controller.setSteamFlow(parseDouble(json['steamFlow']));
         }
         if (json['tankTemp'] != null) {
           await de1.setTankTempThreshold(parseInt(json['tankTemp']));

--- a/lib/src/services/webserver/workflow_handler.dart
+++ b/lib/src/services/webserver/workflow_handler.dart
@@ -51,7 +51,7 @@ class WorkflowHandler {
     return completer.future;
   }
 
-  void _applyPendingUpdate() {
+  Future<void> _applyPendingUpdate() async {
     final merge = _pendingMerge;
     final responses = List<Completer<Response>>.from(_pendingResponses);
     _pendingMerge = {};
@@ -63,12 +63,14 @@ class WorkflowHandler {
     final updatedWorkflow = Workflow.fromJson(resultJson);
 
     _controller.setWorkflow(updatedWorkflow);
-    _de1controller.connectedDe1().setProfile(updatedWorkflow.profile);
+    if (oldWorkflow.profile != updatedWorkflow.profile) {
+      await _de1controller.connectedDe1().setProfile(updatedWorkflow.profile);
+    }
     if (oldWorkflow.rinseData != updatedWorkflow.rinseData) {
-      _de1controller.updateFlushSettings(updatedWorkflow.rinseData);
+      await _de1controller.updateFlushSettings(updatedWorkflow.rinseData);
     }
     if (oldWorkflow.steamSettings != updatedWorkflow.steamSettings) {
-      _de1controller.updateSteamSettings(
+      await _de1controller.updateSteamSettings(
         SteamFormSettings(
           steamEnabled: updatedWorkflow.steamSettings.duration > 0,
           targetTemp: updatedWorkflow.steamSettings.targetTemperature,
@@ -78,7 +80,7 @@ class WorkflowHandler {
       );
     }
     if (oldWorkflow.hotWaterData != updatedWorkflow.hotWaterData) {
-      _de1controller.updateHotWaterSettings(
+      await _de1controller.updateHotWaterSettings(
         HotWaterFormSettings(
           targetTemperature: updatedWorkflow.hotWaterData.targetTemperature,
           flow: updatedWorkflow.hotWaterData.flow,

--- a/lib/src/services/webserver/workflow_handler.dart
+++ b/lib/src/services/webserver/workflow_handler.dart
@@ -63,9 +63,10 @@ class WorkflowHandler {
     final updatedWorkflow = Workflow.fromJson(resultJson);
 
     _controller.setWorkflow(updatedWorkflow);
-    if (oldWorkflow.profile != updatedWorkflow.profile) {
-      await _de1controller.connectedDe1().setProfile(updatedWorkflow.profile);
-    }
+    // Profile push is owned by WorkflowDeviceSync — it observes
+    // `setWorkflow` and uploads the profile if it changed. Keeping a
+    // second setProfile call here would race against that listener and
+    // write every BLE frame twice (see the profile-double-upload P0).
     if (oldWorkflow.rinseData != updatedWorkflow.rinseData) {
       await _de1controller.updateFlushSettings(updatedWorkflow.rinseData);
     }

--- a/test/controllers/de1_controller_shotsettings_emits_test.dart
+++ b/test/controllers/de1_controller_shotsettings_emits_test.dart
@@ -14,17 +14,14 @@ import '../helpers/mock_device_discovery_service.dart';
 /// Counts every event that crosses `MockDe1.shotSettings` — the same
 /// stream `/ws/v1/machine/shotSettings` delivers to clients. These
 /// tests pin the emit-count contract per De1Controller write op so we
-/// catch regressions (and drive follow-up reductions) in the number of
-/// WS messages per workflow change.
+/// catch regressions in the number of WS messages per workflow change.
 ///
 /// Context: the original redundant-writes report observed 5 WS emits
 /// per single steam-duration PUT. After adding value equality on the
-/// workflow data classes and awaiting the individual settings writes
-/// in WorkflowHandler, the count drops to 2 per changed field — one
-/// from the `setXFlow` "nudge" re-emit and one from the actual
-/// `updateShotSettings` write. The nudge is a workaround inside
-/// MockDe1/UnifiedDe1 to trigger the De1Controller refresh when flow
-/// values change; it's still a redundant WS emit from the client's POV.
+/// workflow data classes, awaiting individual settings writes in
+/// WorkflowHandler, dropping the `setXFlow` nudge re-emit in
+/// MockDe1/UnifiedDe1, and applying `.distinct()` on the shotSettings
+/// getter, the count is 1 per changed field.
 void main() {
   late MockDe1 mockDe1;
   late DeviceController deviceController;
@@ -54,7 +51,7 @@ void main() {
 
   group('updateSteamSettings — shotSettings emit count', () {
     test(
-      'exactly one emit per steam change (ideal after nudge removal)',
+      'exactly one emit per steam change',
       () async {
         await de1Controller.updateSteamSettings(
           SteamFormSettings(
@@ -69,52 +66,22 @@ void main() {
         expect(
           observedEmits.length,
           equals(1),
-          reason: 'every setXFlow call in MockDe1/UnifiedDe1 currently '
-              're-adds the current shotSettings to the subject as a '
-              'workaround to trigger the De1Controller refresh; this '
-              'leaks a redundant WS emit. Dropping the nudge (or '
-              'replacing it with a dedicated refresh channel) makes '
-              'this hit 1.',
+          reason: 'nudge re-emits are gone and `.distinct()` on the '
+              'getter collapses firmware echoes — only the actual '
+              'updateShotSettings write should reach the WS stream',
         );
-      },
-      skip: 'pending: drop setXFlow nudge re-emit in '
-          'mock_de1.dart/unified_de1.dart — see workflow-updates fix '
-          'doc. Remove skip when that lands.',
-    );
-
-    test(
-      'current behaviour: two emits per steam change (nudge + write)',
-      () async {
-        await de1Controller.updateSteamSettings(
-          SteamFormSettings(
-            steamEnabled: true,
-            targetTemp: 150,
-            targetDuration: 30,
-            targetFlow: 2.5,
-          ),
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-
-        expect(
-          observedEmits.length,
-          equals(2),
-          reason: '1 from MockDe1.setSteamFlow nudge re-emit + 1 from '
-              'MockDe1.updateShotSettings. Regression guard: if this '
-              'climbs back to 3+ we have reintroduced the '
-              'read-modify-write or diff-miss bug.',
-        );
-        expect(observedEmits.last.targetSteamDuration, equals(30));
+        expect(observedEmits.single.targetSteamDuration, equals(30));
       },
     );
 
     test(
-      'multi-field De1Controller sequence: one emit per setXFlow + write',
+      'multi-field De1Controller sequence: one emit per updateShotSettings',
       () async {
         // Mirrors what WorkflowHandler does for a multi-field PUT that
-        // touches steam + hot-water + rinse (which is how the original
-        // 5-emit report reproduced). With value equality the handler
-        // only enters the branches whose values actually changed; we
-        // simulate all three here to pin the per-path count.
+        // touches steam + hot-water + rinse (the original 5-emit
+        // report). With value equality + sequential awaits + nudge
+        // removal + distinct, the expected output is one emit per
+        // path that actually performs an updateShotSettings write.
         await de1Controller.updateFlushSettings(
           RinseData(targetTemperature: 91, duration: 11, flow: 6.5),
         );
@@ -136,20 +103,48 @@ void main() {
         );
         await Future<void>.delayed(const Duration(milliseconds: 50));
 
-        // rinse  : setFlushFlow nudge (1). setFlushTimeout +
-        //          setFlushTemperature are no-ops on MockDe1 so no
-        //          additional emits.
-        // steam  : setSteamFlow nudge (1) + updateShotSettings (1).
-        // hw     : setHotWaterFlow nudge (1) + updateShotSettings (1).
+        // rinse  : no updateShotSettings call (only MMR writes).
+        // steam  : 1 updateShotSettings with new steam fields.
+        // hw     : 1 updateShotSettings with new hw fields.
         expect(
           observedEmits.length,
-          equals(5),
-          reason: 'post-fix: 1 rinse-nudge + 2 steam + 2 hot-water. '
-              'Reducing this requires dropping the setXFlow nudge '
-              're-emits.',
+          equals(2),
+          reason: '1 steam write + 1 hot-water write. Regression guard:'
+              ' nudge leaks or race-induced duplicates would push this '
+              'higher.',
         );
         expect(observedEmits.last.targetSteamDuration, equals(44));
         expect(observedEmits.last.targetHotWaterDuration, equals(55));
+      },
+    );
+
+    test(
+      'flow-only change via De1Controller.setSteamFlow emits no '
+      'shotSettings event but does broadcast steamData',
+      () async {
+        final steamDataEmits = <SteamSettings>[];
+        final steamSub = de1Controller.steamData.listen(steamDataEmits.add);
+        // Let the seed value replay.
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        steamDataEmits.clear();
+
+        await de1Controller.setSteamFlow(3.3);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(
+          observedEmits,
+          isEmpty,
+          reason: 'flow is not part of the shotSettings characteristic, '
+              'so setSteamFlow must not cause a shotSettings emit',
+        );
+        expect(
+          steamDataEmits.map((s) => s.flow).toList(),
+          contains(3.3),
+          reason: 'steamData subscribers must receive the new flow so '
+              'UI (status tile, live slider) refreshes',
+        );
+
+        await steamSub.cancel();
       },
     );
   });

--- a/test/controllers/de1_controller_shotsettings_emits_test.dart
+++ b/test/controllers/de1_controller_shotsettings_emits_test.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/home_feature/forms/hot_water_form.dart';
+import 'package:reaprime/src/home_feature/forms/steam_form.dart';
+import 'package:reaprime/src/models/data/workflow.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+
+import '../helpers/mock_device_discovery_service.dart';
+
+/// Counts every event that crosses `MockDe1.shotSettings` — the same
+/// stream `/ws/v1/machine/shotSettings` delivers to clients. These
+/// tests pin the emit-count contract per De1Controller write op so we
+/// catch regressions (and drive follow-up reductions) in the number of
+/// WS messages per workflow change.
+///
+/// Context: the original redundant-writes report observed 5 WS emits
+/// per single steam-duration PUT. After adding value equality on the
+/// workflow data classes and awaiting the individual settings writes
+/// in WorkflowHandler, the count drops to 2 per changed field — one
+/// from the `setXFlow` "nudge" re-emit and one from the actual
+/// `updateShotSettings` write. The nudge is a workaround inside
+/// MockDe1/UnifiedDe1 to trigger the De1Controller refresh when flow
+/// values change; it's still a redundant WS emit from the client's POV.
+void main() {
+  late MockDe1 mockDe1;
+  late DeviceController deviceController;
+  late De1Controller de1Controller;
+  late List<De1ShotSettings> observedEmits;
+  late StreamSubscription<De1ShotSettings> sub;
+
+  setUp(() async {
+    mockDe1 = MockDe1();
+    deviceController = DeviceController([MockDeviceDiscoveryService()]);
+    await deviceController.initialize();
+    de1Controller = De1Controller(controller: deviceController);
+    await de1Controller.connectToDe1(mockDe1);
+
+    observedEmits = [];
+    sub = mockDe1.shotSettings.listen(observedEmits.add);
+
+    // Let the De1Controller initialization + its internal 100 ms
+    // shot-settings debounce settle before the test body runs.
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    observedEmits.clear();
+  });
+
+  tearDown(() async {
+    await sub.cancel();
+  });
+
+  group('updateSteamSettings — shotSettings emit count', () {
+    test(
+      'exactly one emit per steam change (ideal after nudge removal)',
+      () async {
+        await de1Controller.updateSteamSettings(
+          SteamFormSettings(
+            steamEnabled: true,
+            targetTemp: 150,
+            targetDuration: 30,
+            targetFlow: 2.5,
+          ),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(
+          observedEmits.length,
+          equals(1),
+          reason: 'every setXFlow call in MockDe1/UnifiedDe1 currently '
+              're-adds the current shotSettings to the subject as a '
+              'workaround to trigger the De1Controller refresh; this '
+              'leaks a redundant WS emit. Dropping the nudge (or '
+              'replacing it with a dedicated refresh channel) makes '
+              'this hit 1.',
+        );
+      },
+      skip: 'pending: drop setXFlow nudge re-emit in '
+          'mock_de1.dart/unified_de1.dart — see workflow-updates fix '
+          'doc. Remove skip when that lands.',
+    );
+
+    test(
+      'current behaviour: two emits per steam change (nudge + write)',
+      () async {
+        await de1Controller.updateSteamSettings(
+          SteamFormSettings(
+            steamEnabled: true,
+            targetTemp: 150,
+            targetDuration: 30,
+            targetFlow: 2.5,
+          ),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(
+          observedEmits.length,
+          equals(2),
+          reason: '1 from MockDe1.setSteamFlow nudge re-emit + 1 from '
+              'MockDe1.updateShotSettings. Regression guard: if this '
+              'climbs back to 3+ we have reintroduced the '
+              'read-modify-write or diff-miss bug.',
+        );
+        expect(observedEmits.last.targetSteamDuration, equals(30));
+      },
+    );
+
+    test(
+      'multi-field De1Controller sequence: one emit per setXFlow + write',
+      () async {
+        // Mirrors what WorkflowHandler does for a multi-field PUT that
+        // touches steam + hot-water + rinse (which is how the original
+        // 5-emit report reproduced). With value equality the handler
+        // only enters the branches whose values actually changed; we
+        // simulate all three here to pin the per-path count.
+        await de1Controller.updateFlushSettings(
+          RinseData(targetTemperature: 91, duration: 11, flow: 6.5),
+        );
+        await de1Controller.updateSteamSettings(
+          SteamFormSettings(
+            steamEnabled: true,
+            targetTemp: 150,
+            targetDuration: 44,
+            targetFlow: 2.5,
+          ),
+        );
+        await de1Controller.updateHotWaterSettings(
+          HotWaterFormSettings(
+            targetTemperature: 76,
+            flow: 10.0,
+            volume: 50,
+            duration: 55,
+          ),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        // rinse  : setFlushFlow nudge (1). setFlushTimeout +
+        //          setFlushTemperature are no-ops on MockDe1 so no
+        //          additional emits.
+        // steam  : setSteamFlow nudge (1) + updateShotSettings (1).
+        // hw     : setHotWaterFlow nudge (1) + updateShotSettings (1).
+        expect(
+          observedEmits.length,
+          equals(5),
+          reason: 'post-fix: 1 rinse-nudge + 2 steam + 2 hot-water. '
+              'Reducing this requires dropping the setXFlow nudge '
+              're-emits.',
+        );
+        expect(observedEmits.last.targetSteamDuration, equals(44));
+        expect(observedEmits.last.targetHotWaterDuration, equals(55));
+      },
+    );
+  });
+}

--- a/test/controllers/workflow_device_sync_test.dart
+++ b/test/controllers/workflow_device_sync_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/controllers/workflow_device_sync.dart';
+import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+
+import '../helpers/mock_device_discovery_service.dart';
+import '../helpers/test_de1.dart';
+
+Profile _profile(String title) => Profile(
+      version: '2',
+      title: title,
+      notes: '',
+      author: 'test',
+      beverageType: BeverageType.espresso,
+      steps: const [],
+      targetVolumeCountStart: 0,
+      tankTemperature: 0,
+    );
+
+class _RecordingDe1 extends TestDe1 {
+  final List<Profile> setProfileCalls = [];
+
+  @override
+  Future<void> setProfile(Profile profile) async {
+    setProfileCalls.add(profile);
+  }
+}
+
+void main() {
+  late WorkflowController workflow;
+  late DeviceController deviceController;
+  late De1Controller de1Controller;
+  late _RecordingDe1 de1;
+  late WorkflowDeviceSync sync;
+
+  setUp(() async {
+    workflow = WorkflowController();
+    deviceController = DeviceController([MockDeviceDiscoveryService()]);
+    await deviceController.initialize();
+    de1Controller = De1Controller(controller: deviceController);
+    de1 = _RecordingDe1();
+    await de1Controller.connectToDe1(de1);
+    // Unblock De1Controller._initializeData which awaits shotSettings.first.
+    de1.emitShotSettings(De1ShotSettings(
+      steamSetting: 0,
+      targetSteamTemp: 150,
+      targetSteamDuration: 30,
+      targetHotWaterTemp: 75,
+      targetHotWaterVolume: 50,
+      targetHotWaterDuration: 30,
+      targetShotVolume: 36,
+      groupTemp: 94.0,
+    ));
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+    sync = WorkflowDeviceSync(
+      workflowController: workflow,
+      de1Controller: de1Controller,
+    );
+  });
+
+  tearDown(() {
+    sync.dispose();
+    de1.dispose();
+  });
+
+  test('profile change triggers exactly one setProfile on the DE1', () async {
+    final initial = workflow.currentWorkflow;
+    workflow.setWorkflow(initial.copyWith(profile: _profile('Adaptive v2')));
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(de1.setProfileCalls.length, equals(1));
+    expect(de1.setProfileCalls.single.title, equals('Adaptive v2'));
+  });
+
+  test(
+    'setWorkflow with identical profile does not push again',
+    () async {
+      final initial = workflow.currentWorkflow;
+      final next = initial.copyWith(profile: _profile('Adaptive v2'));
+      workflow.setWorkflow(next);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(de1.setProfileCalls.length, equals(1));
+
+      // Apply a workflow with a semantically-equal profile — should
+      // short-circuit via Profile's Equatable equality.
+      workflow.setWorkflow(next.copyWith(profile: _profile('Adaptive v2')));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(
+        de1.setProfileCalls.length,
+        equals(1),
+        reason: 'equal profile value must not trigger a second BLE upload',
+      );
+    },
+  );
+
+  test(
+    'non-profile workflow changes do not trigger setProfile',
+    () async {
+      final initial = workflow.currentWorkflow;
+      workflow.setWorkflow(initial.copyWith(name: 'renamed'));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(de1.setProfileCalls, isEmpty);
+    },
+  );
+
+  test(
+    'dispose removes the listener — later workflow changes are ignored',
+    () async {
+      final initial = workflow.currentWorkflow;
+      sync.dispose();
+
+      workflow.setWorkflow(initial.copyWith(profile: _profile('After dispose')));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(de1.setProfileCalls, isEmpty);
+    },
+  );
+}

--- a/test/models/workflow_equality_test.dart
+++ b/test/models/workflow_equality_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/workflow.dart';
+
+// These tests pin down the value-equality contract for the workflow
+// settings classes. The workflow HTTP handler uses `!=` to decide
+// whether to re-apply steam/hot-water/flush settings to the DE1; without
+// value equality, every PUT re-applies everything, producing the
+// redundant shot-settings writes reported on mock and real hardware.
+//
+// See also the race / redundant-emit tests in
+// `test/webserver/workflow_handler_test.dart` — they depend on this
+// contract holding.
+
+void main() {
+  group('SteamSettings equality', () {
+    test('equal by value', () {
+      final a = SteamSettings(targetTemperature: 150, duration: 50, flow: 2.1);
+      final b = SteamSettings(targetTemperature: 150, duration: 50, flow: 2.1);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('differ when duration differs', () {
+      final a = SteamSettings(targetTemperature: 150, duration: 50, flow: 2.1);
+      final b = SteamSettings(targetTemperature: 150, duration: 30, flow: 2.1);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('differ when flow differs', () {
+      final a = SteamSettings(targetTemperature: 150, duration: 50, flow: 2.1);
+      final b = SteamSettings(targetTemperature: 150, duration: 50, flow: 1.5);
+      expect(a, isNot(equals(b)));
+    });
+  });
+
+  group('HotWaterData equality', () {
+    test('equal by value', () {
+      final a = HotWaterData(
+          targetTemperature: 75, duration: 30, volume: 50, flow: 10);
+      final b = HotWaterData(
+          targetTemperature: 75, duration: 30, volume: 50, flow: 10);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('differ when any field differs', () {
+      final base = HotWaterData(
+          targetTemperature: 75, duration: 30, volume: 50, flow: 10);
+      expect(base,
+          isNot(equals(base.copyWith(duration: 31))));
+      expect(base,
+          isNot(equals(base.copyWith(targetTemperature: 76))));
+      expect(base, isNot(equals(base.copyWith(volume: 51))));
+      expect(base, isNot(equals(base.copyWith(flow: 9.9))));
+    });
+  });
+
+  group('RinseData equality', () {
+    test('equal by value', () {
+      final a = RinseData(targetTemperature: 90, duration: 10, flow: 6.0);
+      final b = RinseData(targetTemperature: 90, duration: 10, flow: 6.0);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('differ when duration differs', () {
+      final a = RinseData(targetTemperature: 90, duration: 10, flow: 6.0);
+      final b = RinseData(targetTemperature: 90, duration: 11, flow: 6.0);
+      expect(a, isNot(equals(b)));
+    });
+  });
+
+  group('Workflow equality', () {
+    // Workflow carries an id + profile; for workflow_handler's diff
+    // checks the meaningful equivalence is "all the settings block
+    // fields match by value". These tests pin down that contract.
+
+    test('steamSettings equality survives fromJson round-trip', () {
+      final original = SteamSettings(
+          targetTemperature: 150, duration: 50, flow: 2.1);
+      final roundTrip = SteamSettings.fromJson(original.toJson());
+      expect(original, equals(roundTrip));
+    });
+
+    test('hotWaterData equality survives fromJson round-trip', () {
+      final original = HotWaterData(
+          targetTemperature: 75, duration: 30, volume: 50, flow: 10.0);
+      final roundTrip = HotWaterData.fromJson(original.toJson());
+      expect(original, equals(roundTrip));
+    });
+
+    test('rinseData equality survives fromJson round-trip', () {
+      final original =
+          RinseData(targetTemperature: 90, duration: 10, flow: 6.0);
+      final roundTrip = RinseData.fromJson(original.toJson());
+      expect(original, equals(roundTrip));
+    });
+
+    test(
+        'default workflow fields equal to a freshly-constructed workflow with the same settings',
+        () {
+      final controller = WorkflowController();
+      final wf = controller.currentWorkflow;
+      // Re-deserialize via toJson round-trip (what WorkflowHandler does
+      // on every PUT).
+      final roundTrip = Workflow.fromJson(wf.toJson());
+      expect(wf.steamSettings, equals(roundTrip.steamSettings));
+      expect(wf.hotWaterData, equals(roundTrip.hotWaterData));
+      expect(wf.rinseData, equals(roundTrip.rinseData));
+    });
+  });
+}

--- a/test/models/workflow_equality_test.dart
+++ b/test/models/workflow_equality_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
+import 'package:reaprime/src/models/data/workflow_context.dart';
 
 // These tests pin down the value-equality contract for the workflow
 // settings classes. The workflow HTTP handler uses `!=` to decide
@@ -108,6 +110,80 @@ void main() {
       expect(wf.steamSettings, equals(roundTrip.steamSettings));
       expect(wf.hotWaterData, equals(roundTrip.hotWaterData));
       expect(wf.rinseData, equals(roundTrip.rinseData));
+    });
+  });
+
+  group('Profile equality + JSON round-trip', () {
+    // WorkflowHandler gates `setProfile` with
+    // `oldWorkflow.profile != updatedWorkflow.profile`. Every PUT
+    // rebuilds Profile via fromJson, so round-trip equality is what
+    // determines whether the guard short-circuits. If notes contain
+    // newlines and toJson escapes them without a matching unescape in
+    // fromJson, the guard always misses and setProfile fires every
+    // PUT — on real DE1 that means a full BLE profile re-send plus
+    // the 1 s profileDownloadGuard delay.
+
+    test('default profile (no newlines) round-trips equal', () {
+      final p = Defaults.createDefaultProfile();
+      expect(Profile.fromJson(p.toJson()), equals(p));
+    });
+
+    test('profile with newlines in notes round-trips equal', () {
+      final p = Profile(
+        version: '2',
+        title: 't',
+        notes: 'line1\nline2\nline3',
+        author: 'a',
+        beverageType: BeverageType.espresso,
+        steps: const [],
+        targetVolumeCountStart: 0,
+        tankTemperature: 0,
+      );
+      final rt = Profile.fromJson(p.toJson());
+      expect(rt.notes, equals(p.notes),
+          reason: 'toJson must not escape \\n without fromJson unescaping '
+              'it — the WorkflowHandler profile guard relies on '
+              'round-trip equality');
+      expect(rt, equals(p));
+    });
+  });
+
+  group('WorkflowContext equality', () {
+    test('equal by value', () {
+      const a = WorkflowContext(
+        targetDoseWeight: 18.0,
+        targetYield: 36.0,
+        grinderId: 'g1',
+        coffeeName: 'Illy',
+      );
+      const b = WorkflowContext(
+        targetDoseWeight: 18.0,
+        targetYield: 36.0,
+        grinderId: 'g1',
+        coffeeName: 'Illy',
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('differ when any field differs', () {
+      const base = WorkflowContext(targetDoseWeight: 18.0, targetYield: 36.0);
+      expect(base, isNot(equals(base.copyWith(targetDoseWeight: 18.5))));
+      expect(base, isNot(equals(base.copyWith(grinderId: 'g2'))));
+    });
+
+    test('round-trip via toJson/fromJson', () {
+      const original = WorkflowContext(
+        targetDoseWeight: 18.0,
+        targetYield: 36.0,
+        grinderId: '123',
+        grinderSetting: '5',
+        beanBatchId: '456',
+        coffeeName: 'Illy',
+        coffeeRoaster: 'Mixed',
+      );
+      final rt = WorkflowContext.fromJson(original.toJson());
+      expect(rt, equals(original));
     });
   });
 }

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -1,0 +1,419 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/de1_rawmessage.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/services/webserver/workflow_handler.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+import '../helpers/mock_device_discovery_service.dart';
+
+/// Observes every call the WorkflowHandler + De1Controller make on the
+/// DE1 surface. Used to pin the contract down to the device boundary.
+///
+/// Unlike `helpers/test_de1.dart`, this spy keeps a [BehaviorSubject]
+/// for `shotSettings` (mirroring both `MockDe1` and `UnifiedDe1`), so
+/// read-modify-write races on the controller surface reproduce here
+/// exactly like they do on the running app.
+class SpyDe1 implements De1Interface {
+  SpyDe1({De1ShotSettings? seed}) {
+    _shotSettings = BehaviorSubject.seeded(
+      seed ??
+          De1ShotSettings(
+            steamSetting: 0,
+            targetSteamTemp: 150,
+            targetSteamDuration: 50,
+            targetHotWaterTemp: 75,
+            targetHotWaterVolume: 50,
+            targetHotWaterDuration: 30,
+            targetShotVolume: 36,
+            groupTemp: 94.0,
+          ),
+    );
+  }
+
+  late final BehaviorSubject<De1ShotSettings> _shotSettings;
+
+  final List<De1ShotSettings> updateShotSettingsCalls = [];
+  final List<Profile> setProfileCalls = [];
+  final List<double> setSteamFlowCalls = [];
+  final List<double> setHotWaterFlowCalls = [];
+  final List<double> setFlushFlowCalls = [];
+  final List<double> setFlushTimeoutCalls = [];
+  final List<double> setFlushTemperatureCalls = [];
+
+  /// Every emit that crosses the `shotSettings` stream, in order. This
+  /// is the stream `/ws/v1/machine/shotSettings` subscribes to.
+  final List<De1ShotSettings> emittedShotSettings = [];
+
+  @override
+  Stream<De1ShotSettings> get shotSettings =>
+      _shotSettings.stream.map((e) {
+        emittedShotSettings.add(e);
+        return e;
+      });
+
+  @override
+  Future<void> updateShotSettings(De1ShotSettings newSettings) async {
+    updateShotSettingsCalls.add(newSettings);
+    _shotSettings.add(newSettings);
+  }
+
+  @override
+  Future<void> setProfile(Profile profile) async {
+    setProfileCalls.add(profile);
+  }
+
+  @override
+  Future<void> setSteamFlow(double newFlow) async {
+    setSteamFlowCalls.add(newFlow);
+  }
+
+  @override
+  Future<void> setHotWaterFlow(double newFlow) async {
+    setHotWaterFlowCalls.add(newFlow);
+  }
+
+  @override
+  Future<void> setFlushFlow(double newFlow) async {
+    setFlushFlowCalls.add(newFlow);
+  }
+
+  @override
+  Future<void> setFlushTimeout(double newTimeout) async {
+    setFlushTimeoutCalls.add(newTimeout);
+  }
+
+  @override
+  Future<void> setFlushTemperature(double newTemp) async {
+    setFlushTemperatureCalls.add(newTemp);
+  }
+
+  // ---- Uninteresting plumbing ----
+
+  final BehaviorSubject<ConnectionState> _connectionState =
+      BehaviorSubject.seeded(ConnectionState.connected);
+  final BehaviorSubject<MachineSnapshot> _snapshot = BehaviorSubject.seeded(
+    MachineSnapshot(
+      timestamp: DateTime(2026, 1, 1),
+      state: const MachineStateSnapshot(
+        state: MachineState.idle,
+        substate: MachineSubstate.idle,
+      ),
+      flow: 0,
+      pressure: 0,
+      targetFlow: 0,
+      targetPressure: 0,
+      mixTemperature: 0,
+      groupTemperature: 0,
+      targetMixTemperature: 0,
+      targetGroupTemperature: 0,
+      profileFrame: 0,
+      steamTemperature: 0,
+    ),
+  );
+
+  void dispose() {
+    _shotSettings.close();
+    _connectionState.close();
+    _snapshot.close();
+  }
+
+  @override
+  String get deviceId => 'spy-de1';
+  @override
+  String get name => 'SpyDe1';
+  @override
+  DeviceType get type => DeviceType.machine;
+  @override
+  MachineInfo get machineInfo => MachineInfo(
+        version: '1',
+        model: '1',
+        serialNumber: '1',
+        groupHeadControllerPresent: false,
+        extra: {},
+      );
+  @override
+  Future<void> onConnect() async {}
+  @override
+  Future<void> disconnect() async {}
+  @override
+  Stream<ConnectionState> get connectionState => _connectionState.stream;
+  @override
+  Stream<MachineSnapshot> get currentSnapshot => _snapshot.stream;
+  @override
+  Future<void> requestState(MachineState newState) async {}
+  @override
+  Stream<bool> get ready => Stream.value(true);
+  @override
+  Stream<De1WaterLevels> get waterLevels => const Stream.empty();
+  @override
+  Future<void> setRefillLevel(int newRefillLevel) async {}
+  @override
+  Future<void> setFanThreshhold(int temp) async {}
+  @override
+  Future<int> getFanThreshhold() async => 55;
+  @override
+  Future<int> getTankTempThreshold() async => 0;
+  @override
+  Future<void> setTankTempThreshold(int temp) async {}
+  @override
+  Future<double> getSteamFlow() async =>
+      setSteamFlowCalls.isEmpty ? 2.1 : setSteamFlowCalls.last;
+  @override
+  Future<double> getHotWaterFlow() async =>
+      setHotWaterFlowCalls.isEmpty ? 10.0 : setHotWaterFlowCalls.last;
+  @override
+  Future<double> getFlushFlow() async =>
+      setFlushFlowCalls.isEmpty ? 6.0 : setFlushFlowCalls.last;
+  @override
+  Future<double> getFlushTimeout() async =>
+      setFlushTimeoutCalls.isEmpty ? 10.0 : setFlushTimeoutCalls.last;
+  @override
+  Future<double> getFlushTemperature() async =>
+      setFlushTemperatureCalls.isEmpty ? 90.0 : setFlushTemperatureCalls.last;
+  @override
+  Future<double> getFlowEstimation() async => 1.0;
+  @override
+  Future<void> setFlowEstimation(double multiplier) async {}
+  @override
+  Future<bool> getUsbChargerMode() async => false;
+  @override
+  Future<void> setUsbChargerMode(bool t) async {}
+  @override
+  Future<void> setSteamPurgeMode(int mode) async {}
+  @override
+  Future<int> getSteamPurgeMode() async => 0;
+  @override
+  Future<void> enableUserPresenceFeature() async {}
+  @override
+  Future<void> sendUserPresent() async {}
+  @override
+  Stream<De1RawMessage> get rawOutStream => const Stream.empty();
+  @override
+  void sendRawMessage(De1RawMessage message) {}
+  @override
+  Future<double> getHeaterPhase1Flow() async => 0;
+  @override
+  Future<void> setHeaterPhase1Flow(double val) async {}
+  @override
+  Future<double> getHeaterPhase2Flow() async => 0;
+  @override
+  Future<void> setHeaterPhase2Flow(double val) async {}
+  @override
+  Future<double> getHeaterPhase2Timeout() async => 0;
+  @override
+  Future<void> setHeaterPhase2Timeout(double val) async {}
+  @override
+  Future<double> getHeaterIdleTemp() async => 0;
+  @override
+  Future<void> setHeaterIdleTemp(double val) async {}
+  @override
+  Future<void> updateFirmware(Uint8List fwImage,
+      {required void Function(double progress) onProgress}) async {}
+  @override
+  Future<void> cancelFirmwareUpload() async {}
+}
+
+Future<void> _settleHandler() async {
+  // Workflow handler debounce is 400 ms (private constant). Wait
+  // comfortably past that so _applyPendingUpdate fires and the
+  // downstream controller writes run to completion.
+  await Future<void>.delayed(const Duration(milliseconds: 600));
+}
+
+void main() {
+  late SpyDe1 spy;
+  late DeviceController deviceController;
+  late De1Controller de1Controller;
+  late WorkflowController workflowController;
+  late Handler handler;
+
+  setUp(() async {
+    spy = SpyDe1();
+    deviceController = DeviceController([MockDeviceDiscoveryService()]);
+    await deviceController.initialize();
+    de1Controller = De1Controller(controller: deviceController);
+    await de1Controller.connectToDe1(spy);
+    workflowController = WorkflowController();
+
+    final workflowHandler = WorkflowHandler(
+      controller: workflowController,
+      de1controller: de1Controller,
+    );
+    final app = Router().plus;
+    workflowHandler.addRoutes(app);
+    handler = app.call;
+  });
+
+  tearDown(() {
+    spy.dispose();
+  });
+
+  Future<Response> put(Map<String, dynamic> body) async {
+    return await handler(
+      Request(
+        'PUT',
+        Uri.parse('http://localhost/api/v1/workflow'),
+        body: jsonEncode(body),
+        headers: {'content-type': 'application/json'},
+      ),
+    );
+  }
+
+  group('PUT /api/v1/workflow — redundant writes', () {
+    test(
+      'steam-only PUT does not trigger hot-water or flush writes',
+      () async {
+        // Clear any emits from initial seed + DE1 controller init.
+        await _settleHandler();
+        spy.updateShotSettingsCalls.clear();
+        spy.setSteamFlowCalls.clear();
+        spy.setHotWaterFlowCalls.clear();
+        spy.setFlushFlowCalls.clear();
+        spy.setFlushTimeoutCalls.clear();
+        spy.setFlushTemperatureCalls.clear();
+        spy.setProfileCalls.clear();
+        spy.emittedShotSettings.clear();
+
+        unawaited(put({
+          'steamSettings': {'duration': 30},
+        }));
+        await _settleHandler();
+
+        expect(
+          spy.setHotWaterFlowCalls,
+          isEmpty,
+          reason: 'hot-water settings did not change; setHotWaterFlow '
+              'must not be invoked',
+        );
+        expect(
+          spy.setFlushFlowCalls,
+          isEmpty,
+          reason: 'rinse settings did not change; setFlushFlow must not '
+              'be invoked',
+        );
+        expect(
+          spy.setFlushTimeoutCalls,
+          isEmpty,
+          reason: 'rinse settings did not change; setFlushTimeout must '
+              'not be invoked',
+        );
+        expect(
+          spy.setFlushTemperatureCalls,
+          isEmpty,
+          reason: 'rinse settings did not change; setFlushTemperature '
+              'must not be invoked',
+        );
+        expect(
+          spy.updateShotSettingsCalls.length,
+          equals(1),
+          reason: 'exactly one shot-settings write should be issued per '
+              'steam-only change',
+        );
+        expect(
+          spy.updateShotSettingsCalls.single.targetSteamDuration,
+          equals(30),
+        );
+      },
+    );
+
+    test(
+      'no-op PUT (same values) issues no DE1 writes',
+      () async {
+        await _settleHandler();
+        final snapshot = workflowController.currentWorkflow;
+        spy.updateShotSettingsCalls.clear();
+        spy.setSteamFlowCalls.clear();
+        spy.setHotWaterFlowCalls.clear();
+        spy.setFlushFlowCalls.clear();
+        spy.setFlushTimeoutCalls.clear();
+        spy.setFlushTemperatureCalls.clear();
+        spy.setProfileCalls.clear();
+
+        unawaited(put({
+          'steamSettings': snapshot.steamSettings.toJson(),
+          'hotWaterData': snapshot.hotWaterData.toJson(),
+          'rinseData': snapshot.rinseData.toJson(),
+        }));
+        await _settleHandler();
+
+        expect(spy.updateShotSettingsCalls, isEmpty);
+        expect(spy.setSteamFlowCalls, isEmpty);
+        expect(spy.setHotWaterFlowCalls, isEmpty);
+        expect(spy.setFlushFlowCalls, isEmpty);
+        expect(spy.setProfileCalls, isEmpty,
+            reason: 'identical profile must not be re-sent');
+      },
+    );
+  });
+
+  group('PUT /api/v1/workflow — read-modify-write race', () {
+    test(
+      'multi-field PUT: final shot-settings write reflects BOTH changes',
+      () async {
+        await _settleHandler();
+        spy.updateShotSettingsCalls.clear();
+        spy.emittedShotSettings.clear();
+
+        unawaited(put({
+          'steamSettings': {'duration': 44},
+          'hotWaterData': {'duration': 55},
+        }));
+        await _settleHandler();
+
+        expect(
+          spy.updateShotSettingsCalls,
+          isNotEmpty,
+          reason: 'steam + hot-water change must produce at least one '
+              'shot-settings write',
+        );
+        final last = spy.updateShotSettingsCalls.last;
+        expect(
+          last.targetSteamDuration,
+          equals(44),
+          reason: 'last updateShotSettings must carry the new steam '
+              'duration (lost-write race if stale)',
+        );
+        expect(
+          last.targetHotWaterDuration,
+          equals(55),
+          reason: 'last updateShotSettings must carry the new hot-water '
+              'duration',
+        );
+      },
+    );
+
+    test(
+      'WebSocket-observable stream: final emit reflects BOTH changes',
+      () async {
+        await _settleHandler();
+        spy.emittedShotSettings.clear();
+
+        unawaited(put({
+          'steamSettings': {'duration': 44},
+          'hotWaterData': {'duration': 55},
+        }));
+        await _settleHandler();
+
+        expect(
+          spy.emittedShotSettings,
+          isNotEmpty,
+          reason: 'handler must produce at least one shotSettings emit',
+        );
+        final last = spy.emittedShotSettings.last;
+        expect(last.targetSteamDuration, equals(44));
+        expect(last.targetHotWaterDuration, equals(55));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## What

- Fix read-modify-write race in `WorkflowHandler` that caused the last `shotSettings` WS emit on multi-field PUTs to carry stale values (steam overwritten by a snapshot taken before the hot-water write landed, etc).
- Add value equality to `SteamSettings`, `HotWaterData`, `RinseData`, `WorkflowContext`, `De1ShotSettings` so diff checks and `.distinct()` work correctly.
- Fix `Profile.toJson` escaping `\n` in notes with no matching unescape in `fromJson` — caused `setProfile` to fire every workflow PUT (full BLE profile re-send + 1 s `profileDownloadGuard`) for profiles with multi-line notes.
- Drop the `setSteamFlow` / `setHotWaterFlow` / `setFlushFlow` nudge re-emit on the shotSettings subject; apply `.distinct()` on the `shotSettings` getter; route the two bypass callers (live steam slider + `POST /api/v1/machine/settings`) through new `De1Controller.setSteamFlow` / `setHotWaterFlow` / `setFlushFlow` helpers that broadcast directly to the `steamData` / `hotWaterData` / `rinseData` streams `status_tile` subscribes to.

## Why

P0 reported in TODO: redundant writes and notifications over the `/ws/v1/machine/shotSettings` WebSocket on both real and mock machines. A single steam-duration PUT emitted 5 WS messages with the last one carrying a stale value on mock; multi-field PUTs produced stale final values on both transports.

## Emit-count impact (empirical, on `/ws/v1/machine/shotSettings`)

| Case | Before | After |
|---|---|---|
| no-op PUT (identical values) | 1+ writes | 1 (seed only) |
| steam-only field change | 5, last stale on mock | 2 (seed + 1 write) |
| multi-field (steam + hot water) | 5, last stale | 3 (seed + 2 writes) |
| full triple (rinse matches current) | 5 | 3 (rinse equality-skip) |

## Test plan

- `flutter test` (1019 tests, all green).
- New tests:
  - `test/models/workflow_equality_test.dart` — value equality + `fromJson` round-trip for all workflow settings classes, `Profile` (incl. notes with newlines), `WorkflowContext`.
  - `test/webserver/workflow_handler_test.dart` — spy-driven PUT flow: steam-only PUT doesn't touch hot-water/flush writers; multi-field PUT's final `updateShotSettings` carries both new values.
  - `test/controllers/de1_controller_shotsettings_emits_test.dart` — 1 emit per changed field on the WS-observable stream; `setSteamFlow` emits no shotSettings but does broadcast `steamData`.
- Smoke via `scripts/sb-dev.sh` + `python3 /tmp/sb_ws_listen.py` on **mock (macOS)** and **real DE1 (macOS BLE)**. Cases: baseline seed, steam-only change, no-op repeat, multi-field, full triple. Numbers above captured empirically.