### PR TITLE
feat(serial): port identity + reader lifecycle + overflow sample logging

### DIFF
--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -201,6 +201,24 @@ class UnifiedDe1Transport {
   static final _messagePattern =
       RegExp(r'(\[[A-Z]\][0-9A-Fa-f\s]*?)(?=\[|\n)');
 
+  // Render the first `max` characters of a buffer for a log line. Replaces
+  // non-printable and whitespace chars with their escape form so the sample
+  // stays on a single line and reveals whether the content is e.g. sensor
+  // basket text, binary noise, or something else.
+  static String _sampleForLog(String s, int max) {
+    final head = s.length <= max ? s : '${s.substring(0, max)}…';
+    final escaped = head
+        .replaceAll('\\', r'\\')
+        .replaceAll('\n', r'\n')
+        .replaceAll('\r', r'\r')
+        .replaceAll('\t', r'\t')
+        .replaceAllMapped(
+          RegExp(r'[^\x20-\x7e]'),
+          (m) => '\\x${m[0]!.codeUnitAt(0).toRadixString(16).padLeft(2, '0')}',
+        );
+    return '"$escaped"';
+  }
+
   void _processSerialInput(String input) {
     _currentBuffer += input;
 
@@ -226,7 +244,8 @@ class UnifiedDe1Transport {
       // Guard against unbounded buffer growth from corrupted serial streams
       if (_currentBuffer.length > 4096) {
         _log.warning(
-            'Serial buffer overflow (${_currentBuffer.length} bytes), discarding');
+            'Serial buffer overflow (${_currentBuffer.length} bytes), discarding. '
+            'Head sample: ${_sampleForLog(_currentBuffer, 200)}');
         _currentBuffer = '';
       }
       return;

--- a/lib/src/services/serial/serial_service_desktop.dart
+++ b/lib/src/services/serial/serial_service_desktop.dart
@@ -330,8 +330,21 @@ class _DesktopSerialPort implements SerialTransport {
 
   @override
   Future<void> connect() async {
+    // Log name↔id mapping on every connect attempt so later log lines tagged
+    // either by path (`SerialPort:/dev/tty…`) or stable id
+    // (`UnifiedDe1Transport-usb-…`) can be correlated.
+    final instanceTag = "instance=${identityHashCode(this).toRadixString(16)}";
+    String? description;
+    String? manufacturer;
+    try { description = _port.description; } catch (_) {}
+    try { manufacturer = _port.manufacturer; } catch (_) {}
+    _log.info(
+      "connect() name=${_port.name} id=$id $instanceTag "
+      "description=$description manufacturer=$manufacturer isOpen=${_port.isOpen}",
+    );
+
     if (_port.isOpen) {
-      _log.warning("already open");
+      _log.warning("already open (id=$id $instanceTag) — bailing out of connect()");
       return;
     }
     await Future.microtask(() async {
@@ -358,7 +371,10 @@ class _DesktopSerialPort implements SerialTransport {
       _log.finest("current config: ${_port.config.baudRate}");
 
       _log.fine("port opened");
-      _portSubscription = SerialPortReader(_port).stream.listen(
+      final reader = SerialPortReader(_port);
+      final readerTag = "reader=${identityHashCode(reader).toRadixString(16)}";
+      _log.info("subscribing reader (id=$id $instanceTag $readerTag)");
+      _portSubscription = reader.stream.listen(
         (data) {
           _rawStreamController.add(data);
           try {
@@ -370,16 +386,26 @@ class _DesktopSerialPort implements SerialTransport {
           }
         },
         onError: (error) {
-          _log.severe("port error:", error);
+          _log.severe(
+            "port error (id=$id $instanceTag $readerTag): $error",
+          );
           _readController.addError(error);
           disconnect();
         },
         onDone: () {
-          _log.warning("serial stream closed (onDone) — cable may be unplugged");
+          // Also fires when the libserialport reader isolate dies on an
+          // uncaught `throw bytes` from `_SerialPortReaderImpl._waitRead`
+          // (package:libserialport/src/reader.dart:151). When that happens
+          // the Dart VM logs `[ERROR:…] Unhandled exception: <negative int>`
+          // with no port identity — correlate by $readerTag / time proximity.
+          _log.warning(
+            "serial stream closed (onDone) — cable unplug or reader isolate "
+            "death. id=$id $instanceTag $readerTag",
+          );
           disconnect();
         },
       );
-      _log.fine("port subscribed: ${_portSubscription}");
+      _log.fine("port subscribed: ${_portSubscription} ($readerTag)");
     });
     _open.add(ConnectionState.connected);
   }


### PR DESCRIPTION
## Summary
- Log `name ↔ id ↔ instance ↔ reader` correlation on every `_DesktopSerialPort.connect()` attempt (incl. the short-circuit `already open` path).
- Enrich reader `onError` / `onDone` with the same tags; `onDone` now explicitly calls out libserialport isolate death as an observable cause.
- Include a 200-char sanitized head sample of the discarded buffer in the `UnifiedDe1Transport` "Serial buffer overflow" warning.

## Why
Keith's 2026-04-23 cal-station log had two symptoms in close sequence — `[ERROR:flutter/runtime/dart_isolate.cc] Unhandled exception: -1` from `_SerialPortReaderImpl._waitRead` (package:libserialport) and `UnifiedDe1Transport-usb-1a86-55d3-... - Serial buffer overflow (4107 bytes), discarding` 29 s later — with no way to tell which port's reader died and no hint at what was piling up in the DE1 parse buffer. These hooks answer both questions in future sessions. Purely observability; no behavior change.
