### PR TITLE
change libserialport dep to handle reader throws

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -879,12 +879,12 @@ packages:
     source: hosted
     version: "3.0.2"
   libserialport:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       path: "."
-      ref: HEAD
-      resolved-ref: eab8ee5f860b547c098be732e979d14527d9e0cf
-      url: "https://github.com/AurelienBallier/libserialport.dart"
+      ref: "fix/reader-isolate-uhandled-throw"
+      resolved-ref: "4df4db2334446fdb6fcb8f632f70841889b1353d"
+      url: "https://github.com/tadelv/libserialport.dart"
     source: git
     version: "0.3.0+1"
   lints:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -98,6 +98,10 @@ dependency_overrides:
   # Ubuntu/Debian, so the real flutter_inappwebview_linux plugin cannot build.
   flutter_inappwebview_linux:
     path: packages/flutter_inappwebview_linux_noop
+  libserialport:
+    git:
+      url: https://github.com/tadelv/libserialport.dart
+      ref: fix/reader-isolate-uhandled-throw
 
 dev_dependencies:
   flutter_test:
@@ -127,8 +131,3 @@ flutter:
     - assets/defaultProfiles/
     - assets/bundled_skins/
     - skin_sources.json
-
-
-
-
-


### PR DESCRIPTION
Override libserialport dependency to point to our fork with corrected handling of throwing reads.

ref PR: AurelienBallier/libserialport.dart#2