### PR TITLE
fix(de1): stop three Crashlytics-fatal paths from triage pass

### DIFF
--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -172,6 +172,14 @@ class De1Controller {
         // Defence in depth: device may have disconnected between the
         // generation check above and any of the awaits in the body.
         _log.fine('Shot settings update aborted by disconnect: $e');
+      } on MmrTimeoutException catch (e) {
+        // An MMR read inside the readback can time out if the BLE
+        // adapter drops mid-sequence. That's functionally the same as
+        // a disconnect — don't escalate to a fatal crash.
+        _log.warning(
+          'Shot settings update MMR read timed out '
+          '(treating as disconnect): $e',
+        );
       }
     });
   }

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -19,7 +19,11 @@ class UnifiedDe1Transport {
   final TransportType transportType;
   final Logger _log;
 
-  late StreamSubscription<String> _transportSubscription;
+  // Only assigned on the serial transport path (`_serialConnect`).
+  // Nullable so `disconnect()` can be called safely if connect failed
+  // before the subscription was wired, or on BLE transports where the
+  // serial branch never runs.
+  StreamSubscription<String>? _transportSubscription;
 
   Stream<device.ConnectionState> get connectionState => _transport.connectionState;
 
@@ -164,7 +168,8 @@ class UnifiedDe1Transport {
         if (_transport is! SerialTransport) {
           throw "Wrong transport type";
         }
-        _transportSubscription.cancel();
+        await _transportSubscription?.cancel();
+        _transportSubscription = null;
         // Start notifications - regular setup
         await _transport.writeCommand(
           "<-${Endpoint.stateInfo.representation}>",
@@ -309,11 +314,32 @@ class UnifiedDe1Transport {
     return result;
   }
 
+  // Minimum lengths required by `_parseStateAndShotSample` in
+  // `unified_de1.parsing.dart`. Shorter frames (observed in the wild on
+  // Galaxy Tab A9+ 0.5.13) cause a `RangeError` deep in rxdart and land
+  // in Crashlytics as fatal. Drop them here with a warning instead.
+  static const _minShotSampleBytes = 19;
+  static const _minStateBytes = 2;
+
   void _shotSampleNotification(ByteData d) {
+    if (d.lengthInBytes < _minShotSampleBytes) {
+      _log.warning(
+        'Dropping short shotSample frame '
+        '(${d.lengthInBytes} < $_minShotSampleBytes bytes)',
+      );
+      return;
+    }
     _shotSampleSubject.add(d);
   }
 
   void _stateNotification(ByteData d) {
+    if (d.lengthInBytes < _minStateBytes) {
+      _log.warning(
+        'Dropping short state frame '
+        '(${d.lengthInBytes} < $_minStateBytes bytes)',
+      );
+      return;
+    }
     _stateSubject.add(d);
   }
 

--- a/lib/src/sample_feature/sample_item_list_view.dart
+++ b/lib/src/sample_feature/sample_item_list_view.dart
@@ -79,10 +79,17 @@ class SampleItemListView extends StatelessWidget {
                       size: ShadButtonSize.sm,
                       child: const Text('Connect'),
                       onPressed: () async {
-                        if (item is De1Interface) {
-                          await connectionManager.connectMachine(item);
-                        } else if (item is Scale) {
-                          await connectionManager.connectScale(item);
+                        try {
+                          if (item is De1Interface) {
+                            await connectionManager.connectMachine(item);
+                          } else if (item is Scale) {
+                            await connectionManager.connectScale(item);
+                          }
+                        } catch (_) {
+                          // Error already surfaced by ConnectionManager via
+                          // its status stream. Swallow here so the rethrow
+                          // doesn't escape the async onPressed into the
+                          // Flutter error zone (→ Crashlytics fatal).
                         }
                         if (!context.mounted) return;
                         _navigateToDebugView(context, item, inspect: false);

--- a/test/controllers/de1_controller_mmr_timeout_test.dart
+++ b/test/controllers/de1_controller_mmr_timeout_test.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/errors.dart';
+
+import '../helpers/mock_device_discovery_service.dart';
+import '../helpers/test_de1.dart';
+
+/// Regression coverage for Crashlytics issue `a2aee0d1…` — a
+/// `MmrTimeoutException` thrown from the shot-settings readback (e.g.
+/// `getFlushFlow`) used to bubble out of the debounce Timer callback as
+/// an uncaught async error → Flutter error zone → Crashlytics fatal.
+///
+/// Fix: `_processShotSettingsUpdate`'s caller now catches
+/// `MmrTimeoutException` alongside `DeviceNotConnectedException` and
+/// logs it at warning level instead.
+
+class _MmrTimingOutDe1 extends TestDe1 {
+  _MmrTimingOutDe1() : super(deviceId: 'mmr-timeout-de1', name: 'MmrTimeoutDe1');
+
+  @override
+  Future<double> getFlushFlow() async {
+    throw const MmrTimeoutException('flushFlowRate', Duration(seconds: 2));
+  }
+}
+
+De1ShotSettings _emptyShotSettings() => De1ShotSettings(
+      steamSetting: 0,
+      targetSteamTemp: 0,
+      targetSteamDuration: 0,
+      targetHotWaterTemp: 0,
+      targetHotWaterVolume: 0,
+      targetHotWaterDuration: 0,
+      targetShotVolume: 0,
+      groupTemp: 0,
+    );
+
+void main() {
+  test(
+    'MmrTimeoutException from shot-settings readback does not leak as '
+    'an uncaught async error',
+    () async {
+      final uncaughtErrors = <Object>[];
+
+      await runZonedGuarded(
+        () async {
+          final deviceController =
+              DeviceController([MockDeviceDiscoveryService()]);
+          await deviceController.initialize();
+          final de1Controller = De1Controller(controller: deviceController);
+          final testDe1 = _MmrTimingOutDe1();
+
+          await de1Controller.connectToDe1(testDe1);
+          testDe1.emitShotSettings(_emptyShotSettings());
+
+          // Wait past the 100 ms shot-settings debounce so the timer
+          // callback runs and invokes _processShotSettingsUpdate →
+          // getFlushFlow throws MmrTimeoutException.
+          await Future<void>.delayed(const Duration(milliseconds: 200));
+
+          testDe1.dispose();
+        },
+        (error, stack) {
+          uncaughtErrors.add(error);
+        },
+      );
+
+      expect(
+        uncaughtErrors,
+        isEmpty,
+        reason:
+            'MMR timeouts inside the debounce callback must be caught by '
+            'the controller, not escalate to the Flutter error zone',
+      );
+    },
+  );
+}
+

--- a/test/models/device/unified_de1_crashlytics_triage_test.dart
+++ b/test/models/device/unified_de1_crashlytics_triage_test.dart
@@ -1,0 +1,146 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+import 'package:reaprime/src/models/device/transport/serial_port.dart';
+import 'package:reaprime/src/models/errors.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// Regression coverage for two crashes surfaced in the 2026-04-24
+/// Crashlytics triage pass:
+///
+/// 1b. `_parseStateAndShotSample` threw `RangeError (length 0..8: 9)`
+///     when a short (9-byte) shotSample frame was published. Observed on
+///     Galaxy Tab A9+ v0.5.13 (issue `204f6a96…`). Fix: drop short
+///     state/shotSample frames at the transport notification layer.
+///
+/// 1c. `UnifiedDe1Transport.disconnect()` threw `LateInitializationError:
+///     _transportSubscription` when invoked before `_serialConnect()` had
+///     wired the subscription. Observed on Android v0.5.14, FRESH
+///     2026-04-23 (issue `9b3a0fdf…`). Fix: subscription is nullable.
+
+class _ControllableSerialTransport extends SerialTransport {
+  final _connState = BehaviorSubject<ConnectionState>.seeded(
+    ConnectionState.connected,
+  );
+  final _readCtl = StreamController<String>.broadcast();
+
+  @override
+  String get id => 'triage-test-de1';
+
+  @override
+  String get name => 'TriageTestDe1';
+
+  @override
+  Stream<ConnectionState> get connectionState => _connState.stream;
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Stream<String> get readStream => _readCtl.stream;
+
+  @override
+  Stream<Uint8List> get rawStream => const Stream.empty();
+
+  @override
+  Future<void> writeHexCommand(Uint8List command) async {}
+
+  @override
+  Future<void> writeCommand(String command) async {}
+
+  /// Feeds a raw serial chunk into the transport's input parser.
+  void injectSerial(String chunk) {
+    _readCtl.add(chunk);
+  }
+
+  void dispose() {
+    _connState.close();
+    _readCtl.close();
+  }
+}
+
+void main() {
+  group('1b — short BLE frames do not crash _parseStateAndShotSample', () {
+    late _ControllableSerialTransport transport;
+    late UnifiedDe1 de1;
+
+    setUp(() {
+      transport = _ControllableSerialTransport();
+      de1 = UnifiedDe1(transport: transport);
+    });
+
+    tearDown(() {
+      transport.dispose();
+    });
+
+    test(
+      'a 9-byte shotSample does not propagate a RangeError through '
+      'currentSnapshot',
+      () async {
+        final errors = <Object>[];
+        final sub = de1.currentSnapshot.listen((_) {}, onError: errors.add);
+
+        // Kick off onConnect in the background. The stub transport
+        // doesn't answer MMR reads, so this will eventually throw
+        // `MmrTimeoutException` — we catch it below. What matters
+        // here is that `_serialConnect()` wires the readStream
+        // listener early (before the MMR reads), so our injected
+        // frame reaches `_shotSampleNotification`.
+        final onConnectFuture = de1.onConnect().catchError((e) {
+          if (e is MmrTimeoutException) return;
+          throw e;
+        });
+
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        // 9 bytes = 18 hex chars under `[M]` (shotSample endpoint).
+        // Before the fix, this crashed deep in rxdart with
+        // `RangeError (length): Not in inclusive range 0..8: 9`.
+        transport.injectSerial('[M]000102030405060708\n');
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(
+          errors.whereType<RangeError>(),
+          isEmpty,
+          reason: 'short frames must be dropped at the notification '
+              'layer, not propagate through the parser',
+        );
+
+        await sub.cancel();
+        await onConnectFuture;
+      },
+      timeout: const Timeout(Duration(seconds: 10)),
+    );
+  });
+
+  group('1c — UnifiedDe1Transport.disconnect() is safe before connect()', () {
+    late _ControllableSerialTransport transport;
+
+    setUp(() {
+      transport = _ControllableSerialTransport();
+    });
+
+    tearDown(() {
+      transport.dispose();
+    });
+
+    test(
+      'disconnect() without a prior connect() does not throw '
+      'LateInitializationError',
+      () async {
+        final de1 = UnifiedDe1(transport: transport);
+        // Before the fix, the serial branch of `disconnect()` called
+        // `_transportSubscription.cancel()` on an uninitialized late
+        // field, throwing LateInit.
+        await expectLater(de1.disconnect(), completes);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## What

Three targeted fixes from the 2026-04-24 Crashlytics triage pass:

- **`a2aee0d1…`** — `MmrTimeoutException` from shot-settings readback and `onConnect` v13Model now stays non-fatal. `de1_controller._processShotSettingsUpdate` catches it alongside `DeviceNotConnectedException`; `SampleItemListView`'s manual-connect `onPressed` catches the rethrow from `ConnectionManager.connectMachine` so it doesn't escape to Flutter's error zone.
- **`204f6a96…`** — short (9-byte) shotSample frames on Galaxy Tab A9+ used to hit `RangeError` in `_parseStateAndShotSample`. `UnifiedDe1Transport` now drops short state/shotSample frames at the notification layer with a warning.
- **`9b3a0fdf…`** — `UnifiedDe1Transport.disconnect()` threw `LateInitializationError` when invoked before `_serialConnect()` wired the subscription. Field is now nullable; disconnect uses `?.cancel()`.

## Why

All three surface as Crashlytics fatals even though the underlying state is recoverable (BLE adapter off, malformed frame, disconnect before connect). Keeping them as fatals drowns real crashes in the top-issues view.

## Test plan

- New: `test/controllers/de1_controller_mmr_timeout_test.dart`, `test/models/device/unified_de1_crashlytics_triage_test.dart`
- Full `flutter test` — 1026 pass
- `flutter analyze` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)