### PR TITLE
fix(serial): guard iOS against libserialport dlopen failure

### DIFF
--- a/lib/src/services/serial/serial_service.dart
+++ b/lib/src/services/serial/serial_service.dart
@@ -1,14 +1,45 @@
-// export 'serial_service_desktop.dart'
-//     if (Platform.isAndroid) 'serial_service_android.dart';
 import 'dart:io';
 
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/services/serial/serial_service_android.dart';
 import 'package:reaprime/src/services/serial/serial_service_desktop.dart';
+import 'package:rxdart/subjects.dart';
 
+/// Returns the correct serial discovery service for the current platform.
+///
+/// iOS has no viable USB-serial path: the only FFI-backed driver we ship
+/// (`libserialport`) can't `dlopen` under iOS's hardened runtime, and the
+/// failure fires at launch inside `SerialServiceDesktop.initialize()` /
+/// `_performScan()` when they call `SerialPort.availablePorts`. That
+/// surfaces as three Crashlytics FATALs (`9d5fc4e9`, `0f9ece6d`,
+/// `39f895bc`) with SIGNAL_EARLY — 81% of events fire in the first
+/// second of a session. Returning a no-op service on iOS avoids the
+/// dlopen entirely.
 DeviceDiscoveryService createSerialService() {
+  if (Platform.isIOS) {
+    return NoOpSerialService();
+  }
   if (Platform.isAndroid) {
     return SerialServiceAndroid();
   }
   return SerialServiceDesktop();
+}
+
+/// Stand-in for platforms where USB serial isn't supported. Emits an
+/// empty device list once and treats all scan calls as no-ops so the
+/// `DeviceController` service loop remains uniform across platforms.
+class NoOpSerialService implements DeviceDiscoveryService {
+  final _devices = BehaviorSubject<List<Device>>.seeded(const <Device>[]);
+
+  @override
+  Stream<List<Device>> get devices => _devices.stream;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> scanForDevices() async {}
+
+  @override
+  void stopScan() {}
 }

--- a/test/services/serial_service_test.dart
+++ b/test/services/serial_service_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/serial/serial_service.dart';
+
+/// Regression coverage for the iOS `libserialport.dylib` dlopen crashes
+/// (Crashlytics issues `9d5fc4e9…`, `0f9ece6d…`, `39f895bc…`).
+///
+/// iOS can't load libserialport under the hardened runtime. The symptom
+/// was three FATAL crashes with SIGNAL_EARLY (81% in the first second
+/// of a session) because `SerialServiceDesktop.initialize()` called
+/// `SerialPort.availablePorts` at app launch on every platform except
+/// Android.
+///
+/// The fix routes iOS through `NoOpSerialService`. We can't flip
+/// `Platform.isIOS` from a Dart VM test, so these tests pin the no-op
+/// contract directly — a future change that makes it throw or stall
+/// would still crash iOS at launch.
+
+void main() {
+  group('NoOpSerialService contract', () {
+    test('initialize() completes without throwing', () async {
+      final service = NoOpSerialService();
+      await expectLater(service.initialize(), completes);
+    });
+
+    test('scanForDevices() completes without throwing', () async {
+      final service = NoOpSerialService();
+      await expectLater(service.scanForDevices(), completes);
+    });
+
+    test('stopScan() is a no-op', () {
+      final service = NoOpSerialService();
+      expect(service.stopScan, returnsNormally);
+    });
+
+    test(
+      'devices stream emits an empty list synchronously on subscribe',
+      () async {
+        final service = NoOpSerialService();
+        final first = await service.devices.first.timeout(
+          const Duration(seconds: 2),
+        );
+        expect(
+          first,
+          isEmpty,
+          reason: 'DeviceController seeds its per-service device map from '
+              'the first emission — a silent stream stalls the controller',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## What

Route iOS through a new `NoOpSerialService` instead of `SerialServiceDesktop`. Android and desktop paths unchanged.

## Why

iOS can't load `libserialport.dylib` under the hardened runtime. `SerialServiceDesktop.initialize()` / `_performScan()` call `SerialPort.availablePorts`, which triggers a FFI dlopen failure at app launch. Three Crashlytics issues (`9d5fc4e9…`, `0f9ece6d…`, `39f895bc…`) — 99 events across v0.5.6–0.6.0, SIGNAL_EARLY with 81% firing in the first second of a session. Every iOS user hits this at startup.

## Test plan

- New: `test/services/serial_service_test.dart` pins the no-op contract (Platform.isIOS can't be flipped from a Dart VM test).
- Full `flutter test` — 1030 pass.
- `flutter analyze` — no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)