### PR TITLE
fix(telemetry): filter benign WebUIStorage noise from Crashlytics

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -66,6 +66,7 @@ import 'package:reaprime/src/services/telemetry/telemetry_service.dart';
 import 'package:reaprime/src/services/telemetry/log_buffer.dart';
 import 'package:reaprime/src/services/telemetry/anonymization.dart';
 import 'package:reaprime/src/services/telemetry/error_report_throttle.dart';
+import 'package:reaprime/src/services/telemetry/telemetry_forwarder_filter.dart';
 import 'package:reaprime/src/services/webview_log_service.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 
@@ -192,6 +193,8 @@ void main() async {
         '${record.level.name}: ${record.loggerName}: ${record.message}',
       );
       logBuffer.append(scrubbed);
+
+      if (!shouldForwardToTelemetry(record)) return;
 
       // Trigger telemetry error report if rate limit allows
       if (errorReportThrottle.shouldReport(scrubbed)) {

--- a/lib/src/services/telemetry/telemetry_forwarder_filter.dart
+++ b/lib/src/services/telemetry/telemetry_forwarder_filter.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+
+const _webUiStorageLoggerName = 'WebUIStorage';
+const _skinAlreadyExistsPrefix = 'Skin already exists';
+const _benignNetworkErrorPrefixes = [
+  'Exception: Failed to fetch GitHub release:',
+  'Exception: Failed to download:',
+];
+
+/// Returns `false` for log records that match a known telemetry-noise pattern
+/// — caller should skip forwarding these to Crashlytics.
+///
+/// Caller is expected to gate on `record.level >= Level.WARNING` first;
+/// records below WARNING never reach Crashlytics today, so this predicate
+/// only describes WARNING+ records.
+bool shouldForwardToTelemetry(LogRecord record) {
+  if (record.loggerName == _webUiStorageLoggerName) {
+    if (record.message.startsWith(_skinAlreadyExistsPrefix)) return false;
+    if (_isTransientNetworkError(record.error)) return false;
+  }
+  return true;
+}
+
+bool _isTransientNetworkError(Object? error) {
+  if (error == null) return false;
+  if (error is SocketException) return true;
+  if (error is TimeoutException) return true;
+  if (error is HttpException) return true;
+  // package:http throws ClientException; matched by name to avoid an import
+  // dependency from the telemetry layer.
+  if (error.runtimeType.toString() == 'ClientException') return true;
+  final asString = error.toString();
+  for (final prefix in _benignNetworkErrorPrefixes) {
+    if (asString.startsWith(prefix)) return true;
+  }
+  return false;
+}

--- a/test/services/telemetry/telemetry_forwarder_filter_test.dart
+++ b/test/services/telemetry/telemetry_forwarder_filter_test.dart
@@ -1,0 +1,126 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/services/telemetry/telemetry_forwarder_filter.dart';
+
+LogRecord _record(
+  Level level,
+  String loggerName,
+  String message, [
+  Object? error,
+  StackTrace? stackTrace,
+]) {
+  return LogRecord(level, message, loggerName, error, stackTrace);
+}
+
+void main() {
+  group('shouldForwardToTelemetry', () {
+    group('drops noise from WebUIStorage', () {
+      test('"Skin already exists: ..." WARNING is dropped', () {
+        final record = _record(
+          Level.WARNING,
+          'WebUIStorage',
+          'Skin already exists: streamline_project-main, overwriting…',
+        );
+        expect(shouldForwardToTelemetry(record), isFalse);
+      });
+
+      test('SocketException at SEVERE is dropped', () {
+        final record = _record(
+          Level.SEVERE,
+          'WebUIStorage',
+          'Failed to install WebUI from URL: https://example.com/skin.zip',
+          const SocketException('Failed host lookup: example.com'),
+        );
+        expect(shouldForwardToTelemetry(record), isFalse);
+      });
+
+      test('TimeoutException at SEVERE is dropped', () {
+        final record = _record(
+          Level.SEVERE,
+          'WebUIStorage',
+          'Failed to install WebUI from URL: https://example.com/skin.zip',
+          TimeoutException('http get'),
+        );
+        expect(shouldForwardToTelemetry(record), isFalse);
+      });
+
+      test('HttpException at SEVERE is dropped', () {
+        final record = _record(
+          Level.SEVERE,
+          'WebUIStorage',
+          'Failed to install WebUI from URL: https://example.com/skin.zip',
+          const HttpException('connection closed'),
+        );
+        expect(shouldForwardToTelemetry(record), isFalse);
+      });
+
+      test('Exception("Failed to fetch GitHub release: 403") is dropped', () {
+        final record = _record(
+          Level.SEVERE,
+          'WebUIStorage',
+          'GitHub release install failed',
+          Exception('Failed to fetch GitHub release: 403'),
+        );
+        expect(shouldForwardToTelemetry(record), isFalse);
+      });
+
+      test('Exception("Failed to download: 404") is dropped', () {
+        final record = _record(
+          Level.SEVERE,
+          'WebUIStorage',
+          'Skin install failed',
+          Exception('Failed to download: 404'),
+        );
+        expect(shouldForwardToTelemetry(record), isFalse);
+      });
+    });
+
+    group('keeps real WebUIStorage problems', () {
+      test('StateError at SEVERE is kept (real bug)', () {
+        final record = _record(
+          Level.SEVERE,
+          'WebUIStorage',
+          'Skin install failed',
+          StateError('zip corrupt'),
+        );
+        expect(shouldForwardToTelemetry(record), isTrue);
+      });
+
+      test('Unrelated WARNING message is kept', () {
+        final record = _record(
+          Level.WARNING,
+          'WebUIStorage',
+          'Manifest parse failed: missing required field',
+        );
+        expect(shouldForwardToTelemetry(record), isTrue);
+      });
+    });
+
+    group('does not affect other loggers', () {
+      test('SocketException from BleTransport is kept', () {
+        final record = _record(
+          Level.SEVERE,
+          'BleTransport',
+          'connection failed',
+          const SocketException('Connection refused'),
+        );
+        expect(shouldForwardToTelemetry(record), isTrue);
+      });
+
+      test(
+        '"Skin already exists" emitted by a different logger is kept',
+        () {
+          final record = _record(
+            Level.WARNING,
+            'SomeOtherLogger',
+            'Skin already exists: foo',
+          );
+          expect(shouldForwardToTelemetry(record), isTrue);
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What
Add `shouldForwardToTelemetry(LogRecord)` predicate consulted by the `Logger.root` listener in `main.dart` before forwarding to Crashlytics. Drops two `WebUIStorage` patterns: messages starting with `"Skin already exists"`, and SEVEREs whose `error` is a transient network error (`SocketException`, `TimeoutException`, `HttpException`, `ClientException` by runtime-type name, or generic `Exception('Failed to fetch GitHub release: …')` / `Exception('Failed to download: …')`).

## Why
Top Crashlytics issue on both platforms is `WebUIStorage: Skin already exists: streamline_project-main, overwriting…` (iOS `bb1c4163`, 266 events / 12 users) — a benign overwrite notice that's drowning out real crashes. Second cluster (`2b524ea8` / `124d147c` / `59640464`, ~21 events) is transient network failures from WebUI install paths — user offline ≠ app crash. Filtering at the forwarder is a P1 meta-fix that makes every future triage pass cheaper.

`LogBuffer` (local file log) continues to receive everything WARNING+ — only telemetry forwarding is short-circuited. Predicate fails open: unknown errors and other loggers reach Crashlytics unchanged.