### PR TITLE
feat(api): add GET /api/v1/profiles/defaults + fix Profiles doc drift

### DIFF
--- a/.agents/skills/streamline-bridge/scenarios/profiles-defaults.md
+++ b/.agents/skills/streamline-bridge/scenarios/profiles-defaults.md
@@ -1,0 +1,45 @@
+# Scenario: discover and restore default profiles
+
+Verifies `GET /api/v1/profiles/defaults` lists the bundled default profiles and that `POST /api/v1/profiles/restore/{filename}` accepts a filename returned by `/defaults`.
+
+## Preconditions
+
+```bash
+scripts/sb-dev.sh start --connect-machine MockDe1 --connect-scale MockScale
+```
+
+## Steps
+
+List defaults:
+
+```bash
+curl -sf http://localhost:8080/api/v1/profiles/defaults | jq .
+```
+
+Expected: non-empty array. Each element has keys `filename`, `title`, `author`, `notes`, `beverageType` (all strings).
+
+One-shot shape assertion:
+
+```bash
+curl -sf http://localhost:8080/api/v1/profiles/defaults \
+  | jq -e 'length > 0 and (.[0]
+           | has("filename") and has("title") and has("author")
+             and has("notes") and has("beverageType"))'
+```
+
+Exit 0 → list non-empty and shape correct.
+
+Round-trip — restore the first default by filename:
+
+```bash
+filename=$(curl -sf http://localhost:8080/api/v1/profiles/defaults | jq -r '.[0].filename')
+curl -sf -X POST "http://localhost:8080/api/v1/profiles/restore/${filename}" | jq -e 'has("id") and has("isDefault") and .isDefault == true'
+```
+
+Exit 0 → restore returned a `ProfileRecord` with `isDefault: true`.
+
+## Postconditions
+
+```bash
+scripts/sb-dev.sh stop
+```

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -2236,6 +2236,30 @@ paths:
         "500":
           description: Internal Server Error
 
+  /api/v1/profiles/defaults:
+    get:
+      summary: List bundled default profiles
+      description: |
+        Returns the entries from the bundled defaults manifest
+        (`assets/defaultProfiles/manifest.json`) with their human-readable
+        metadata. Use the `filename` from each entry as the `{filename}` path
+        parameter for `POST /api/v1/profiles/restore/{filename}`.
+
+        Returns an empty array when the manifest is missing or unreadable;
+        per-file parse failures are skipped and logged server-side.
+      tags: [Profiles]
+      responses:
+        "200":
+          description: Array of bundled default profile descriptors
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DefaultProfileDescriptor'
+        "500":
+          description: Internal Server Error
+
   /api/v1/webui/skins:
     get:
       summary: List all installed WebUI skins
@@ -4199,6 +4223,34 @@ components:
       type: string
       enum: [visible, hidden, deleted]
       description: Visibility state of a profile. 'visible' = shown in UI, 'hidden' = hidden from UI but not deleted, 'deleted' = soft-deleted (user profiles only)
+
+    DefaultProfileDescriptor:
+      type: object
+      required:
+        - filename
+        - title
+        - author
+        - notes
+        - beverageType
+      properties:
+        filename:
+          type: string
+          description: Manifest filename. Use as `{filename}` for `POST /api/v1/profiles/restore/{filename}`.
+          example: "Default1.json"
+        title:
+          type: string
+          description: Human-readable profile title.
+          example: "Default 1"
+        author:
+          type: string
+          example: "Decent"
+        notes:
+          type: string
+          description: Free-form description; may be empty.
+        beverageType:
+          type: string
+          description: Beverage type enum value (e.g. `espresso`, `filter`).
+          example: "espresso"
 
     WebUISkin:
       type: object

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -59,16 +59,17 @@ For skin development, see [`doc/Skins.md`](Skins.md). For plugin development, se
 | Method | Path | Description | Handler |
 |--------|------|-------------|---------|
 | GET | `/api/v1/profiles` | List all profiles | `profile_handler.dart` |
+| GET | `/api/v1/profiles/defaults` | List bundled default profiles (filename + metadata) | |
 | GET | `/api/v1/profiles/:id` | Get profile by content-hash ID | |
 | POST | `/api/v1/profiles` | Create new profile | |
-| PUT | `/api/v1/profiles/:id` | Update profile | |
-| DELETE | `/api/v1/profiles/:id` | Soft-delete profile | |
-| POST | `/api/v1/profiles/:id/visibility` | Change profile visibility | |
+| PUT | `/api/v1/profiles/:id` | Update profile (in-place; hash change replaces the record) | |
+| DELETE | `/api/v1/profiles/:id` | Soft-delete profile (defaults hidden, user profiles soft-deleted) | |
+| PUT | `/api/v1/profiles/:id/visibility` | Change profile visibility | |
 | GET | `/api/v1/profiles/:id/lineage` | Get profile version history | |
-| DELETE | `/api/v1/profiles/:id/permanent` | Permanently delete | |
+| DELETE | `/api/v1/profiles/:id/purge` | Permanently delete (user profiles only) | |
 | GET | `/api/v1/profiles/export` | Export all profiles as JSON | |
 | POST | `/api/v1/profiles/import` | Import profiles from JSON | |
-| POST | `/api/v1/profiles/:id/restore` | Restore default profile | |
+| POST | `/api/v1/profiles/restore/:filename` | Restore a bundled default by manifest filename | |
 
 ### Workflow
 

--- a/doc/Profiles.md
+++ b/doc/Profiles.md
@@ -322,9 +322,32 @@ Response: JSON array of all `ProfileRecord` objects
 POST /api/v1/profiles/restore/{filename}
 ```
 
-Restores a bundled default profile from assets by filename (e.g., `best_practice.json`).
+Restores a bundled default profile from assets by filename (e.g., `Default1.json`). Use `GET /api/v1/profiles/defaults` (below) to discover valid filenames.
 
 Response: Restored `ProfileRecord` (200) or error (404)
+
+#### List Bundled Defaults
+```http
+GET /api/v1/profiles/defaults
+```
+
+Lists every entry from the bundled defaults manifest with its metadata. Each element:
+
+```json
+{
+  "filename": "Default1.json",
+  "title": "Default 1",
+  "author": "Decent",
+  "notes": "...",
+  "beverageType": "espresso"
+}
+```
+
+Use the `filename` from any entry as the `{filename}` path parameter for `POST /api/v1/profiles/restore/{filename}`.
+
+Returns an empty array if the manifest is missing or unreadable. Per-file parse failures are skipped server-side and logged.
+
+Response: `200` with array of descriptors.
 
 ### Usage Examples
 
@@ -376,6 +399,16 @@ curl http://localhost:8080/api/v1/profiles/export > profiles_backup.json
 curl -X POST http://localhost:8080/api/v1/profiles/import \
   -H "Content-Type: application/json" \
   -d @profiles_backup.json
+```
+
+**Discover and restore a bundled default:**
+```bash
+# 1. Discover available defaults
+curl http://localhost:8080/api/v1/profiles/defaults | jq '.[].title'
+
+# 2. Restore one by filename
+filename=$(curl -s http://localhost:8080/api/v1/profiles/defaults | jq -r '.[0].filename')
+curl -X POST "http://localhost:8080/api/v1/profiles/restore/${filename}"
 ```
 
 ### Testing

--- a/lib/src/controllers/profile_controller.dart
+++ b/lib/src/controllers/profile_controller.dart
@@ -99,6 +99,48 @@ class ProfileController {
     }
   }
 
+  /// List bundled default profiles from the manifest
+  ///
+  /// Returns one entry per profile file referenced by `assets/defaultProfiles/manifest.json`,
+  /// each carrying `filename`, `title`, `author`, `notes`, `beverageType`. Clients use
+  /// `filename` to call `POST /api/v1/profiles/restore/{filename}`.
+  ///
+  /// Returns an empty list when the manifest is missing or unreadable.
+  /// Per-file parse failures are logged and skipped.
+  Future<List<Map<String, dynamic>>> listDefaults() async {
+    try {
+      final manifestData = await rootBundle.loadString(
+        'assets/defaultProfiles/manifest.json',
+      );
+      final manifest = jsonDecode(manifestData) as Map<String, dynamic>;
+      final profileFiles = manifest['profiles'] as List<dynamic>;
+
+      final defaults = <Map<String, dynamic>>[];
+      for (final filename in profileFiles) {
+        try {
+          final profileData = await rootBundle.loadString(
+            'assets/defaultProfiles/$filename',
+          );
+          final profileJson = jsonDecode(profileData) as Map<String, dynamic>;
+          final profile = Profile.fromJson(profileJson);
+          defaults.add({
+            'filename': filename,
+            'title': profile.title,
+            'author': profile.author,
+            'notes': profile.notes,
+            'beverageType': profile.beverageType.name,
+          });
+        } catch (e) {
+          _log.warning('Failed to parse default profile: $filename', e);
+        }
+      }
+      return defaults;
+    } catch (e) {
+      _log.warning('Failed to load default profiles manifest', e);
+      return [];
+    }
+  }
+
   /// Update the profile count stream
   Future<void> _updateProfileCount() async {
     final count = await _storage.count(visibility: Visibility.visible);

--- a/lib/src/services/webserver/profile_handler.dart
+++ b/lib/src/services/webserver/profile_handler.dart
@@ -11,6 +11,10 @@ class ProfileHandler {
     // Get all profiles
     app.get('/api/v1/profiles', _handleGetAll);
 
+    // List bundled default profiles — must be registered before the /<id> route
+    // so 'defaults' isn't matched as an id.
+    app.get('/api/v1/profiles/defaults', _handleListDefaults);
+
     // Get single profile by ID
     app.get('/api/v1/profiles/<id>', _handleGetById);
 
@@ -80,6 +84,17 @@ class ProfileHandler {
       return jsonOk(profiles.map((p) => p.toJson()).toList());
     } catch (e, st) {
       log.severe('Error in _handleGetAll', e, st);
+      return jsonError({'error': 'Internal server error', 'message': '$e'});
+    }
+  }
+
+  /// GET /api/v1/profiles/defaults
+  Future<Response> _handleListDefaults(Request request) async {
+    try {
+      final defaults = await _controller.listDefaults();
+      return jsonOk(defaults);
+    } catch (e, st) {
+      log.severe('Error in _handleListDefaults', e, st);
       return jsonError({'error': 'Internal server error', 'message': '$e'});
     }
   }

--- a/test/services/webserver/profile_handler_defaults_test.dart
+++ b/test/services/webserver/profile_handler_defaults_test.dart
@@ -1,0 +1,131 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/profile_controller.dart';
+import 'package:reaprime/src/models/data/profile_record.dart';
+import 'package:reaprime/src/services/storage/profile_storage_service.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:shelf/shelf.dart';
+import 'package:shelf_router/shelf_router.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+class _StubStorage implements ProfileStorageService {
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<void> store(ProfileRecord record) async {}
+  @override
+  Future<ProfileRecord?> get(String id) async => null;
+  @override
+  Future<List<ProfileRecord>> getAll({Visibility? visibility}) async => const [];
+  @override
+  Future<void> update(ProfileRecord record) async {}
+  @override
+  Future<void> delete(String id) async {}
+  @override
+  Future<bool> exists(String id) async => false;
+  @override
+  Future<List<String>> getAllIds() async => const [];
+  @override
+  Future<List<ProfileRecord>> getByParentId(String parentId) async => const [];
+  @override
+  Future<void> storeAll(List<ProfileRecord> records) async {}
+  @override
+  Future<void> clear() async {}
+  @override
+  Future<int> count({Visibility? visibility}) async => 0;
+}
+
+class _ListDefaultsStub extends ProfileController {
+  _ListDefaultsStub({required this.fixture})
+    : super(storage: _StubStorage());
+
+  final List<Map<String, dynamic>> fixture;
+
+  @override
+  Future<List<Map<String, dynamic>>> listDefaults() async => fixture;
+}
+
+void main() {
+  late Handler handler;
+
+  Future<Response> sendGet(String path) async {
+    return await handler(Request('GET', Uri.parse('http://localhost$path')));
+  }
+
+  void wireHandler(List<Map<String, dynamic>> fixture) {
+    final controller = _ListDefaultsStub(fixture: fixture);
+    final profileHandler = ProfileHandler(controller: controller);
+    final app = Router().plus;
+    profileHandler.addRoutes(app);
+    handler = app.call;
+  }
+
+  group('GET /api/v1/profiles/defaults', () {
+    test('returns array of default profiles with full metadata', () async {
+      wireHandler([
+        {
+          'filename': 'Default1.json',
+          'title': 'Default 1',
+          'author': 'Decent',
+          'notes': 'Bundled default',
+          'beverageType': 'espresso',
+        },
+        {
+          'filename': 'Filter_20.json',
+          'title': 'Filter 20',
+          'author': 'Decent',
+          'notes': '',
+          'beverageType': 'filter',
+        },
+      ]);
+
+      final response = await sendGet('/api/v1/profiles/defaults');
+
+      expect(response.statusCode, 200);
+      expect(response.headers['content-type'], contains('application/json'));
+
+      final body = jsonDecode(await response.readAsString()) as List;
+      expect(body.length, 2);
+      expect(body[0], {
+        'filename': 'Default1.json',
+        'title': 'Default 1',
+        'author': 'Decent',
+        'notes': 'Bundled default',
+        'beverageType': 'espresso',
+      });
+      expect(body[1]['filename'], 'Filter_20.json');
+    });
+
+    test('returns empty array when no defaults are bundled', () async {
+      wireHandler([]);
+
+      final response = await sendGet('/api/v1/profiles/defaults');
+
+      expect(response.statusCode, 200);
+      final body = jsonDecode(await response.readAsString()) as List;
+      expect(body, isEmpty);
+    });
+
+    test('does not collide with /{id} route', () async {
+      // Regression: the /defaults literal must match before the /{id} catch-all,
+      // otherwise a GET on /defaults would land in _handleGetById with id='defaults'
+      // and 404 instead of returning the manifest list.
+      wireHandler([
+        {
+          'filename': 'Only.json',
+          'title': 'Only',
+          'author': '',
+          'notes': '',
+          'beverageType': 'espresso',
+        },
+      ]);
+
+      final response = await sendGet('/api/v1/profiles/defaults');
+
+      expect(response.statusCode, 200);
+      final body = jsonDecode(await response.readAsString()) as List;
+      expect(body.first['filename'], 'Only.json');
+    });
+  });
+}


### PR DESCRIPTION
## What
- New `GET /api/v1/profiles/defaults` returning `[{filename, title, author, notes, beverageType}, ...]` from the bundled manifest. Spec entry + new `DefaultProfileDescriptor` schema added to `assets/api/rest_v1.yml`.
- Fix three pre-existing handler-vs-doc mismatches in `doc/Api.md`'s Profiles table (`POST /:id/visibility` → PUT, `DELETE /:id/permanent` → `DELETE /:id/purge`, `POST /:id/restore` → `POST restore/:filename`).
- New end-to-end recipe under `.agents/skills/streamline-bridge/scenarios/profiles-defaults.md`.

## Why
`POST /api/v1/profiles/restore/{filename}` requires a manifest filename, but no API exposed valid filenames — the manifest was loaded only at boot inside a private controller method. Real discoverability gap, not just spec rot. New endpoint closes it; clients now `GET /defaults` → pick filename → `POST /restore/{filename}` without round-tripping through storage.