### PR TITLE
feat(api): ETag / If-None-Match on beans, grinders, profiles, shots

### DIFF
--- a/.agents/skills/streamline-bridge/scenarios/etag-conditional-gets.md
+++ b/.agents/skills/streamline-bridge/scenarios/etag-conditional-gets.md
@@ -1,0 +1,67 @@
+# Scenario: ETag / If-None-Match on list endpoints
+
+Verifies the conditional-GET behaviour for the five cacheable list reads.
+
+## Preconditions
+
+```bash
+scripts/sb-dev.sh start --platform macos --connect-machine MockDe1 --connect-scale MockScale
+```
+
+## Steps
+
+Pick any covered endpoint and walk:
+
+```bash
+ENDPOINT=/api/v1/beans   # or /api/v1/grinders, /api/v1/profiles, /api/v1/shots, /api/v1/beans/{beanId}/batches
+
+# 1. First request: 200 + ETag header
+curl -is "http://localhost:8080${ENDPOINT}" | sed -n '1,/^\r$/p'
+
+# 2. Capture the ETag and re-request conditionally — expect 304
+etag=$(curl -sf -D - "http://localhost:8080${ENDPOINT}" -o /dev/null \
+  | awk '/^[Ee][Tt][Aa][Gg]:/ {print $2}' | tr -d '\r')
+curl -is -H "If-None-Match: ${etag}" "http://localhost:8080${ENDPOINT}" | sed -n '1,/^\r$/p'
+# -> HTTP/1.1 304 Not Modified, ETag matches, no body
+```
+
+One-shot success assertion (run for each endpoint):
+
+```bash
+for ep in /api/v1/beans /api/v1/grinders /api/v1/profiles /api/v1/shots; do
+  etag=$(curl -sf -D - "http://localhost:8080${ep}" -o /dev/null \
+    | awk '/^[Ee][Tt][Aa][Gg]:/ {print $2}' | tr -d '\r')
+  status=$(curl -sf -o /dev/null -w '%{http_code}' \
+    -H "If-None-Match: ${etag}" "http://localhost:8080${ep}")
+  test "$status" = "304" || { echo "FAIL ${ep}: got $status"; exit 1; }
+done
+echo OK
+```
+
+Mutation invalidation — a write should change the ETag:
+
+```bash
+old_etag=$(curl -sf -D - http://localhost:8080/api/v1/beans -o /dev/null \
+  | awk '/^[Ee][Tt][Aa][Gg]:/ {print $2}' | tr -d '\r')
+curl -sf -X POST http://localhost:8080/api/v1/beans \
+  -H 'Content-Type: application/json' \
+  -d '{"roaster":"Sey","name":"Gichathaini"}' >/dev/null
+new_etag=$(curl -sf -D - http://localhost:8080/api/v1/beans -o /dev/null \
+  | awk '/^[Ee][Tt][Aa][Gg]:/ {print $2}' | tr -d '\r')
+test "$old_etag" != "$new_etag" || { echo FAIL; exit 1; }
+echo MUTATION_OK
+```
+
+Wildcard `If-None-Match: *` short-circuits to 304:
+
+```bash
+status=$(curl -sf -o /dev/null -w '%{http_code}' \
+  -H 'If-None-Match: *' http://localhost:8080/api/v1/beans)
+test "$status" = "304" && echo WILDCARD_OK
+```
+
+## Postconditions
+
+```bash
+scripts/sb-dev.sh stop
+```

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -684,10 +684,21 @@ paths:
       responses:
         "200":
           description: Paginated list of shots (without measurements)
+          headers:
+            ETag:
+              schema:
+                type: string
+              description: |
+                Strong entity tag derived from the response body. Echo back as
+                `If-None-Match` on subsequent requests for conditional GET.
+                Tag is keyed on the full response (filters + pagination), so
+                the same query produces the same tag until shots change.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/PaginatedShots"
+        "304":
+          description: Not Modified — client's `If-None-Match` matched the current ETag.
   /api/v1/shots/ids:
     get:
       summary: Get a list of identifiers of all the shots
@@ -886,12 +897,21 @@ paths:
       responses:
         "200":
           description: Array of beans
+          headers:
+            ETag:
+              schema:
+                type: string
+              description: |
+                Strong entity tag derived from the response body. Echo back as
+                `If-None-Match` on subsequent requests for conditional GET.
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: "#/components/schemas/Bean"
+        "304":
+          description: Not Modified — client's `If-None-Match` matched the current ETag.
         "500":
           description: Internal Server Error
     post:
@@ -1127,12 +1147,21 @@ paths:
       responses:
         "200":
           description: Array of batches
+          headers:
+            ETag:
+              schema:
+                type: string
+              description: |
+                Strong entity tag derived from the response body. Echo back as
+                `If-None-Match` on subsequent requests for conditional GET.
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: "#/components/schemas/BeanBatch"
+        "304":
+          description: Not Modified — client's `If-None-Match` matched the current ETag.
         "500":
           description: Internal Server Error
     post:
@@ -1372,12 +1401,21 @@ paths:
       responses:
         "200":
           description: Array of grinders
+          headers:
+            ETag:
+              schema:
+                type: string
+              description: |
+                Strong entity tag derived from the response body. Echo back as
+                `If-None-Match` on subsequent requests for conditional GET.
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: "#/components/schemas/Grinder"
+        "304":
+          description: Not Modified — client's `If-None-Match` matched the current ETag.
         "500":
           description: Internal Server Error
     post:
@@ -1903,12 +1941,21 @@ paths:
       responses:
         "200":
           description: Array of profile records
+          headers:
+            ETag:
+              schema:
+                type: string
+              description: |
+                Strong entity tag derived from the response body. Echo back as
+                `If-None-Match` on subsequent requests for conditional GET.
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/ProfileRecord'
+        "304":
+          description: Not Modified — client's `If-None-Match` matched the current ETag.
         "400":
           description: Bad Request (invalid visibility value)
         "500":

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -6,6 +6,32 @@ For skin development, see [`doc/Skins.md`](Skins.md). For plugin development, se
 
 ---
 
+## Conditional GETs (ETag / If-None-Match)
+
+The following list endpoints set a strong `ETag` on every `200 OK` response and honour `If-None-Match` with `304 Not Modified` (empty body) when the client's tag matches:
+
+- `GET /api/v1/beans`
+- `GET /api/v1/beans/{beanId}/batches`
+- `GET /api/v1/grinders`
+- `GET /api/v1/profiles`
+- `GET /api/v1/shots` (per query-param combination — filters and pagination are part of the tag)
+
+Usage:
+
+```bash
+# First request — note the ETag
+curl -is http://localhost:8080/api/v1/beans
+
+# Re-request with If-None-Match — 304 if nothing changed
+curl -is -H 'If-None-Match: "abc123…"' http://localhost:8080/api/v1/beans
+```
+
+Tags are SHA-256 derived from the encoded response body. Single-resource GETs and mutation routes do **not** emit ETags.
+
+For browser clients on a different origin, `ETag` is exposed via `Access-Control-Expose-Headers`.
+
+---
+
 ## REST API
 
 ### Machine

--- a/lib/src/services/webserver/beans_handler.dart
+++ b/lib/src/services/webserver/beans_handler.dart
@@ -35,7 +35,7 @@ class BeansHandler {
           req.url.queryParameters['includeArchived'] == 'true';
       final beans =
           await _storage.getAllBeans(includeArchived: includeArchived);
-      return jsonOk(beans.map((b) => b.toJson()).toList());
+      return jsonOkConditional(req, beans.map((b) => b.toJson()).toList());
     } catch (e, st) {
       _log.severe('Error getting beans', e, st);
       return jsonError({'error': e.toString()});
@@ -139,7 +139,7 @@ class BeansHandler {
           req.url.queryParameters['includeArchived'] == 'true';
       final batches = await _storage.getBatchesForBean(beanId,
           includeArchived: includeArchived);
-      return jsonOk(batches.map((b) => b.toJson()).toList());
+      return jsonOkConditional(req, batches.map((b) => b.toJson()).toList());
     } catch (e, st) {
       _log.severe('Error getting batches for bean $beanId', e, st);
       return jsonError({'error': e.toString()});

--- a/lib/src/services/webserver/grinders_handler.dart
+++ b/lib/src/services/webserver/grinders_handler.dart
@@ -26,7 +26,7 @@ class GrindersHandler {
           req.url.queryParameters['includeArchived'] == 'true';
       final grinders =
           await _storage.getAllGrinders(includeArchived: includeArchived);
-      return jsonOk(grinders.map((g) => g.toJson()).toList());
+      return jsonOkConditional(req, grinders.map((g) => g.toJson()).toList());
     } catch (e, st) {
       _log.severe('Error getting grinders', e, st);
       return jsonError({'error': e.toString()});

--- a/lib/src/services/webserver/json_response.dart
+++ b/lib/src/services/webserver/json_response.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:crypto/crypto.dart';
 import 'package:shelf/shelf.dart';
 
 const _jsonHeaders = {'Content-Type': 'application/json'};
@@ -7,6 +8,29 @@ Response jsonOk(Object? data) => Response.ok(
       jsonEncode(data),
       headers: _jsonHeaders,
     );
+
+/// Like [jsonOk], but adds a strong `ETag` derived from the encoded body and
+/// honours `If-None-Match` from the request — returns `304 Not Modified` with
+/// the same `ETag` and empty body when the client's tag matches.
+///
+/// ETag format: `"<first 16 hex chars of sha256(body)>"` (RFC 7232 strong tag).
+/// `If-None-Match: *` matches any current representation per RFC 7232 §3.2.
+Response jsonOkConditional(Request request, Object? data) {
+  final body = jsonEncode(data);
+  final digest = sha256.convert(utf8.encode(body)).toString().substring(0, 16);
+  final etag = '"$digest"';
+
+  final ifNoneMatch = request.headers['if-none-match']?.trim();
+  if (ifNoneMatch != null &&
+      (ifNoneMatch == '*' || ifNoneMatch == etag)) {
+    return Response.notModified(headers: {'ETag': etag});
+  }
+
+  return Response.ok(
+    body,
+    headers: {..._jsonHeaders, 'ETag': etag},
+  );
+}
 
 Response jsonCreated(Object? data) => Response(
       201,

--- a/lib/src/services/webserver/profile_handler.dart
+++ b/lib/src/services/webserver/profile_handler.dart
@@ -81,7 +81,10 @@ class ProfileHandler {
         );
       }
 
-      return jsonOk(profiles.map((p) => p.toJson()).toList());
+      return jsonOkConditional(
+        request,
+        profiles.map((p) => p.toJson()).toList(),
+      );
     } catch (e, st) {
       log.severe('Error in _handleGetAll', e, st);
       return jsonError({'error': 'Internal server error', 'message': '$e'});

--- a/lib/src/services/webserver/shots_handler.dart
+++ b/lib/src/services/webserver/shots_handler.dart
@@ -102,7 +102,7 @@ class ShotsHandler {
       // Strip measurements from list response for performance
       final items = shots.map((s) => s.toJsonWithoutMeasurements()).toList();
 
-      return jsonOk({
+      return jsonOkConditional(req, {
         'items': items,
         'total': total,
         'limit': limit,

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -313,7 +313,12 @@ Handler _init(
           },
         ),
       )
-      .addMiddleware(corsHeaders())
+      .addMiddleware(corsHeaders(headers: {
+        // Browsers gate cross-origin reads of non-safelisted response headers
+        // behind Access-Control-Expose-Headers. ETag isn't safelisted, so
+        // skin/web clients couldn't read it without this.
+        'Access-Control-Expose-Headers': 'ETag',
+      }))
       .addHandler(app.call);
 
   return handler;

--- a/test/services/webserver/json_response_test.dart
+++ b/test/services/webserver/json_response_test.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/webserver/json_response.dart';
+import 'package:shelf/shelf.dart';
+
+Request _get({Map<String, String> headers = const {}}) {
+  return Request(
+    'GET',
+    Uri.parse('http://localhost/test'),
+    headers: headers,
+  );
+}
+
+void main() {
+  group('jsonOkConditional', () {
+    test(
+      'returns 200 with strong quoted ETag when If-None-Match is absent',
+      () async {
+        final response = jsonOkConditional(_get(), {'a': 1, 'b': 'x'});
+
+        expect(response.statusCode, 200);
+        expect(response.headers['content-type'], contains('application/json'));
+        final etag = response.headers['etag'];
+        expect(etag, isNotNull);
+        expect(etag, startsWith('"'));
+        expect(etag, endsWith('"'));
+        // 16 hex chars + 2 quote chars
+        expect(etag!.length, 18);
+        expect(
+          jsonDecode(await response.readAsString()),
+          {'a': 1, 'b': 'x'},
+        );
+      },
+    );
+
+    test('returns the same ETag for identical bodies', () {
+      final r1 = jsonOkConditional(_get(), [1, 2, 3]);
+      final r2 = jsonOkConditional(_get(), [1, 2, 3]);
+      expect(r1.headers['etag'], equals(r2.headers['etag']));
+    });
+
+    test('returns different ETags for different bodies', () {
+      final r1 = jsonOkConditional(_get(), [1, 2, 3]);
+      final r2 = jsonOkConditional(_get(), [1, 2, 4]);
+      expect(r1.headers['etag'], isNot(equals(r2.headers['etag'])));
+    });
+
+    test('returns 304 when If-None-Match matches the computed ETag', () async {
+      final fresh = jsonOkConditional(_get(), {'k': 'v'});
+      final etag = fresh.headers['etag']!;
+
+      final conditional = jsonOkConditional(
+        _get(headers: {'If-None-Match': etag}),
+        {'k': 'v'},
+      );
+
+      expect(conditional.statusCode, 304);
+      expect(conditional.headers['etag'], etag);
+      expect(await conditional.readAsString(), isEmpty);
+    });
+
+    test('returns 200 + new ETag when If-None-Match does not match', () async {
+      final r = jsonOkConditional(
+        _get(headers: {'If-None-Match': '"deadbeef00000000"'}),
+        {'k': 'v'},
+      );
+
+      expect(r.statusCode, 200);
+      expect(r.headers['etag'], isNot('"deadbeef00000000"'));
+      expect(jsonDecode(await r.readAsString()), {'k': 'v'});
+    });
+
+    test('treats If-None-Match: * as a wildcard match → 304', () async {
+      // Per RFC 7232 §3.2: "*" matches any current representation.
+      final r = jsonOkConditional(
+        _get(headers: {'If-None-Match': '*'}),
+        {'whatever': true},
+      );
+
+      expect(r.statusCode, 304);
+      expect(r.headers['etag'], isNotNull);
+      expect(await r.readAsString(), isEmpty);
+    });
+  });
+}

--- a/test/webserver/beans_handler_test.dart
+++ b/test/webserver/beans_handler_test.dart
@@ -235,6 +235,30 @@ void main() {
       expect(getRes.statusCode, 404);
     });
 
+    test('GET /api/v1/beans sets ETag and honours If-None-Match', () async {
+      // Empty list: still has ETag
+      final empty = await sendGet('/api/v1/beans');
+      expect(empty.statusCode, 200);
+      expect(empty.headers['etag'], isNotNull);
+
+      // After a mutation, ETag changes
+      await sendPost('/api/v1/beans', {'roaster': 'Sey', 'name': 'X'});
+      final populated = await sendGet('/api/v1/beans');
+      final etag = populated.headers['etag'];
+      expect(etag, isNotNull);
+      expect(etag, isNot(empty.headers['etag']));
+
+      // Re-request with the same ETag → 304, no body
+      final cached = await handler(Request(
+        'GET',
+        Uri.parse('http://localhost/api/v1/beans'),
+        headers: {'If-None-Match': etag!},
+      ));
+      expect(cached.statusCode, 304);
+      expect(cached.headers['etag'], etag);
+      expect(await cached.readAsString(), isEmpty);
+    });
+
     test('GET /api/v1/beans filters out archived by default', () async {
       final createRes = await sendPost('/api/v1/beans', {
         'roaster': 'Sey',

--- a/test/webserver/grinders_handler_test.dart
+++ b/test/webserver/grinders_handler_test.dart
@@ -179,6 +179,30 @@ void main() {
       expect(getRes.statusCode, 404);
     });
 
+    test('GET /api/v1/grinders sets ETag and honours If-None-Match', () async {
+      final empty = await sendGet('/api/v1/grinders');
+      expect(empty.statusCode, 200);
+      expect(empty.headers['etag'], isNotNull);
+
+      await sendPost('/api/v1/grinders', {
+        'manufacturer': 'Niche',
+        'model': 'Zero',
+      });
+      final populated = await sendGet('/api/v1/grinders');
+      final etag = populated.headers['etag'];
+      expect(etag, isNotNull);
+      expect(etag, isNot(empty.headers['etag']));
+
+      final cached = await handler(Request(
+        'GET',
+        Uri.parse('http://localhost/api/v1/grinders'),
+        headers: {'If-None-Match': etag!},
+      ));
+      expect(cached.statusCode, 304);
+      expect(cached.headers['etag'], etag);
+      expect(await cached.readAsString(), isEmpty);
+    });
+
     test('GET /api/v1/grinders filters out archived by default', () async {
       final createRes =
           await sendPost('/api/v1/grinders', {'model': 'Niche Zero'});


### PR DESCRIPTION
Closes #203.

## What
- New `jsonOkConditional(Request, Object?)` helper in `lib/src/services/webserver/json_response.dart` — computes a strong SHA-256-derived ETag over the encoded body, returns `304 Not Modified` (empty body, ETag intact) when the client's `If-None-Match` matches (incl. `*`).
- Swapped `jsonOk` → `jsonOkConditional` at five call sites: `GET /api/v1/{beans, beans/{beanId}/batches, grinders, profiles, shots}`. Single-resource GETs and mutation routes unchanged.
- `corsHeaders()` updated with `Access-Control-Expose-Headers: ETag` so cross-origin JS can read the header.
- Spec entries (`ETag` header + `304` response) on all five paths in `assets/api/rest_v1.yml`. New "Conditional GETs" section in `doc/Api.md`. End-to-end recipe under `.agents/skills/streamline-bridge/scenarios/etag-conditional-gets.md`.

## Why
Skin clients (Passione, others) currently re-fetch full payloads on every visibility-resume poll because the catalog GETs have no change-detection mechanism. With this in place, `useBeans` / `useGrinders` and equivalents can poll cheaply and stay reactive only when content actually changed — issue #203's stated goal. Phase 2 of Passione's cross-device refresh design will start consuming these once shipped.

Live smoke confirmed: 304 round-trip on all four primary endpoints, mutation flips the tag, `If-None-Match: *` short-circuits to 304, `Access-Control-Expose-Headers: ETag` reaches cross-origin responses.