### PR TITLE
Bengle foundation: capability-mixin shape on UnifiedDe1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ After every meaningful code change:
 Plans go in `doc/plans/`. Don't commit unless asked. After implementation, ask whether to update related docs.
 
 **Before opening a PR, merging locally, or considering work done:**
-1. Move all plans and implementation documents from `doc/plans/` to `doc/plans/archive/<meaningful-subfolder-name>/`. The subfolder name should reflect the feature or fix (e.g., `app-store-readiness`, `scale-auto-connect`).
+1. Move design docs from `doc/plans/` to `doc/plans/archive/<meaningful-subfolder-name>/`. The subfolder name should reflect the feature or fix (e.g., `app-store-readiness`, `scale-auto-connect`). Design docs are worth keeping — they capture the *why*, the rejected alternatives, and constraints that aren't obvious from code, all of which matter when debugging months later. Implementation plans (step-by-step task lists) are not worth archiving — once the work ships, the commit chain is more durable and authoritative; delete them instead.
 2. Check if any documentation needs updating based on the changes made — e.g., `doc/Api.md` if endpoints changed/added, `doc/Skins.md` if skin behavior changed, `doc/Plugins.md` if events changed/added, `doc/Profiles.md` if profile handling changed, `doc/DeviceManagement.md` if device flows changed, etc.
 
 Both steps are required, not optional.

--- a/doc/plans/archive/bengle-foundation/2026-04-29-bengle-foundation-design.md
+++ b/doc/plans/archive/bengle-foundation/2026-04-29-bengle-foundation-design.md
@@ -1,0 +1,281 @@
+# Bengle Foundation — Design
+
+## Problem
+
+Bengle is a DE1-derived espresso machine adding integrated scale, optional milk-temp probe, cup warmer, and a color LED strip. Streamline-Bridge needs to support it (internal beta end of May 2026). Most of the work is SB-side, not firmware.
+
+The current state in `lib/`:
+
+- `Bengle extends UnifiedDe1 implements BengleInterface` (`models/device/impl/bengle/bengle.dart`) — stub that overrides `name` only.
+- `BengleInterface extends De1Interface` — empty.
+- `DecentMachineModel.Bengle` enum value present (`models/device/impl/de1/de1.models.dart:274`).
+- `device_matcher.dart` routes advertised name `Bengle*` to the `Bengle` instance.
+- `UnifiedDe1.onConnect` already detects Bengle hardware via the `v13Model` MMR (`unified_de1.dart:185`) and warns.
+
+Nothing else exists. Cup warmer, integrated scale, LED, milk probe, and the FW-update prelude are all unimplemented. Each of these will need new endpoints / MMR addresses, some new state, and some new public methods on Bengle.
+
+This doc is the **foundation step**. It locks the abstraction so the per-feature work in later steps plugs in without base-class churn.
+
+## Goal
+
+Land an extension shape on `UnifiedDe1` that:
+
+1. Lets Bengle add new capabilities (with their own state, endpoints, and MMRs) without modifying `UnifiedDe1` or the shared `Endpoint` / `MMRItem` enums beyond a one-time interface lift.
+2. Keeps the BLE/serial transport split working for Bengle the same way it works for DE1 today.
+3. Lets Bengle modify inherited DE1 behavior (specifically the FW upload prelude) cleanly via subclass override.
+4. Keeps existing DE1 behavior unchanged — no functional regression.
+
+No feature implementation lands in this step. After this step, `Bengle` is still functionally identical to `UnifiedDe1`.
+
+## Architecture decision
+
+### Shape: `UnifiedDe1` baseline + capability mixins + per-capability registries
+
+```dart
+mixin CupWarmerCapability on UnifiedDe1 { ... }
+mixin IntegratedScaleCapability on UnifiedDe1 { ... }
+mixin LedStripCapability on UnifiedDe1 { ... }
+mixin MilkProbeCapability on UnifiedDe1 { ... }
+
+class Bengle extends UnifiedDe1
+    with CupWarmerCapability,
+         IntegratedScaleCapability,
+         LedStripCapability,
+         MilkProbeCapability
+    implements BengleInterface { ... }
+```
+
+Considered and rejected:
+
+- **Subclass + per-feature helpers inside `Bengle`.** Cheap, but `Bengle` becomes a god class and inheritance is sticky.
+- **Pure composition (`Bengle` holds a `UnifiedDe1`).** Maximum flexibility but ~50 boilerplate forwarders, easy to drift on unimplemented surface.
+
+Chosen because:
+
+- **Future-proof for Bengle 2.0 / GHC replacement / 3rd-party peripherals.** Other devices mix and match capabilities. Aftermarket LED add-on = some other device implementing `LedStripCapability`.
+- **Capability discovery falls out for free.** Skins / handlers query `device is LedStripCapability` at the boundary. The dynamic API surface (which endpoints to mount) follows from this without per-device branching.
+- **Per-capability registries.** Each capability owns its own MMR addresses and `LogicalEndpoint`s in its own file. Shared DE1 endpoints/MMRs stay in their existing enums untouched.
+
+### When to use what
+
+| Bengle addition shape | Mechanism | Example |
+|---|---|---|
+| Single MMR write, no state | Extension on `Bengle` in own file | Cup warmer (likely) |
+| Stateful (stream subs, BehaviorSubjects) | Mixin on `UnifiedDe1` in own file | Integrated scale, LED state, milk probe |
+| Modifies inherited DE1 behavior | `@protected` template-method hook on `UnifiedDe1`, override on `Bengle` (not a mixin) | FW update `0x22` prelude |
+
+### Transport access for capabilities
+
+`UnifiedDe1` runs on top of two very different `DataTransport` shapes:
+
+- `BLETransport` — addressable by `(serviceUUID, characteristicUUID)`; supports per-characteristic subscribe/read/write.
+- `SerialTransport` — line/hex command stream, no addressing; single read stream parsed by the consumer; writes go through `writeCommand("<+X>")` framing.
+
+The codebase already abstracts this divide: `Endpoint` (in `de1.models.dart`) carries **both** wire encodings — `uuid` for BLE and a single-char `representation` for serial. `UnifiedDe1Transport._bleConnect` subscribes via `uuid`; `_serialConnect` subscribes via `<+${representation}>`.
+
+The capability layer must target *logical endpoints*, never wire identifiers — otherwise serial breaks.
+
+`@protected` is annotation-only in Dart but the linter honors it. Mixins declared `on UnifiedDe1` see methods marked `@protected` in `UnifiedDe1`.
+
+MMR helpers live one level above the endpoint primitives. They wrap the existing MMR protocol (address packing, read/response correlation, timeout) implemented in `unified_de1.mmr.dart`, which itself rides the standard `Endpoint.readFromMMR` / `Endpoint.writeToMMR` endpoints. MMR is not a parallel wire path.
+
+### Interfaces that lift the closed enums
+
+`LogicalEndpoint`:
+
+```dart
+abstract class LogicalEndpoint {
+  String? get uuid;            // BLE characteristic UUID, null if BLE-unsupported
+  String? get representation;  // serial single-char id, null if serial-unsupported
+  String get name;
+}
+
+// Existing
+enum Endpoint implements LogicalEndpoint { ... }
+
+// In bengle/integrated_scale_capability.dart:
+enum BengleScaleEndpoint implements LogicalEndpoint {
+  weight('B001', 'W'),
+  control('B002', 'X');
+  ...
+}
+```
+
+`UnifiedDe1Transport` switches on the active wire and reads the appropriate field. `null` on the active wire → throw a clear "endpoint not supported on this transport" error. This makes FW gaps (Bengle features that have BLE wire support but not serial yet, or vice versa) explicit at the code level.
+
+`MmrAddress`:
+
+```dart
+enum MmrValueKind {
+  int32,        // signed 32-bit int
+  int16,        // signed 16-bit int
+  scaledFloat,  // int with read/write scale (current scale-config use)
+  boolean,      // 0/1 int
+  bytes,        // raw bytes, no decoding
+  string,       // null-terminated or length-prefixed string
+}
+
+abstract class MmrAddress {
+  int get address;
+  int get length;
+  String get name;
+  MmrValueKind get kind;
+}
+
+enum MMRItem implements MmrAddress { ... }   // existing — gains a kind per entry
+// Capability mixins ship their own enums implementing MmrAddress.
+```
+
+`MmrValueKind` documents the value shape on the address itself. Helpers validate kind: calling `readMmrInt` on a `scaledFloat` address throws `StateError`. Catches "wrong helper for this address" mistakes at runtime; opens up debug printers / API autogen that group MMRs by type. Migration to a fully generic `MmrAddress<T>` (encode/decode pair on the address) is open if `_MMRConfig` ever merits collapsing into the address itself, but is out of scope for the foundation step.
+
+The existing `_MMRConfig` map in `unified_de1.mmr.dart` (scales + bounds, keyed by `MMRItem`) stays. Capability MMR enums that need scaling can either supply a similar config or use the raw `int` helpers.
+
+### Protected surface on `UnifiedDe1`
+
+```dart
+class UnifiedDe1 implements De1Interface {
+  // Existing private state stays private:
+  // final UnifiedDe1Transport _transport;
+  // final Logger _log = Logger("DE1");
+
+  // Endpoint primitives (transport-aware: dispatches BLE vs. serial inside UnifiedDe1Transport)
+  @protected
+  Future<void> writeEndpoint(LogicalEndpoint endpoint, Uint8List data, {bool withResponse = true});
+
+  @protected
+  Future<ByteData> readEndpoint(LogicalEndpoint endpoint, {Duration? timeout});
+
+  @protected
+  Stream<ByteData> notificationsFor(LogicalEndpoint endpoint);
+
+  // MMR helpers (build on Endpoint.readFromMMR/writeToMMR; protocol from unified_de1.mmr.dart)
+  @protected
+  Future<int> readMmrInt(MmrAddress addr);
+
+  @protected
+  Future<double> readMmrScaled(MmrAddress addr, {required double readScale});
+
+  @protected
+  Future<void> writeMmrInt(MmrAddress addr, int value, {int? min, int? max});
+
+  @protected
+  Future<void> writeMmrScaled(MmrAddress addr, double value, {required double writeScale, int? min, int? max});
+
+  @protected
+  Future<List<int>> readMmrRaw(MmrAddress addr);
+
+  @protected
+  Future<void> writeMmrRaw(MmrAddress addr, List<int> data);
+
+  // Template-method hooks
+  @protected
+  Future<void> beforeFirmwareUpload() async {} // default no-op
+
+  // Logger access for capability mixins
+  @protected
+  Logger get log;
+}
+```
+
+### Lifecycle convention for stateful capabilities
+
+Stateful mixins ship matched `init/disposeXyz()` methods. `Bengle.onConnect` / `onDisconnect` calls each one it carries, in order. No magic, no reflection — explicit.
+
+```dart
+mixin IntegratedScaleCapability on UnifiedDe1 {
+  StreamSubscription<ByteData>? _weightSub;
+  final _weight = BehaviorSubject<WeightSample>();
+
+  @protected
+  Future<void> initIntegratedScale() async {
+    _weightSub = notificationsFor(BengleScaleEndpoint.weight).listen(_handle);
+  }
+
+  @protected
+  Future<void> disposeIntegratedScale() async {
+    await _weightSub?.cancel();
+    await _weight.close();
+  }
+}
+```
+
+Convention: every stateful capability mixin exposes `init<Name>()` + `dispose<Name>()`. `Bengle` orchestrates them.
+
+### FW upload prelude
+
+`unified_de1.firmware.dart:13-14` already gestures at the right pattern:
+
+```dart
+// TODO: move to Machine impl that needs this
+// await requestState(MachineState.fwUpgrade);
+```
+
+Resolve the TODO as a template-method hook:
+
+```dart
+// In unified_de1.dart
+@protected
+Future<void> beforeFirmwareUpload() async {} // default no-op
+
+// In _updateFirmware (firmware extension), after requestState(sleeping):
+await beforeFirmwareUpload();   // replaces the commented-out line
+
+// In bengle.dart
+@override
+Future<void> beforeFirmwareUpload() async {
+  await requestState(MachineState.fwUpgrade); // 0x22 — already in MachineState enum
+}
+```
+
+## Capability boundaries (forward reference)
+
+This step does not implement these. Listed here as evidence the abstraction can carry them — and to set up where each capability's code will land.
+
+- **`CupWarmerCapability`** — likely an extension on `Bengle` (stateless), single MMR write. 1 new `MmrAddress`. No lifecycle.
+- **`IntegratedScaleCapability`** — mixin. Owns weight stream, target weight, SAW state. New `LogicalEndpoint`s for weight notify and control. Lifecycle: `initIntegratedScale` / `disposeIntegratedScale`.
+- **`LedStripCapability`** — mixin (probably). Color/pattern state. New `MmrAddress`(es). Optional cache hydration in `initLedStrip`.
+- **`MilkProbeCapability`** — mixin. Temperature stream + presence detection. New notify endpoint. Lifecycle. (May alternatively be modelled as a separate `Sensor` device — decided in later step.)
+
+Per-capability impl design lives in its own design doc when the time comes (steps 4–7 of the broader Bengle roadmap, tracked in vault note `Professional/Decent/Bengle/ReaPrime Integration.md`).
+
+## Refactor sequence
+
+1. Introduce `LogicalEndpoint` abstract class in `lib/src/models/device/transport/`. `Endpoint implements LogicalEndpoint`. `UnifiedDe1Transport` methods take `LogicalEndpoint` instead of `Endpoint`. Pure rename + interface lift.
+2. Introduce `MmrAddress` abstract class in `lib/src/models/device/impl/de1/`. `MMRItem implements MmrAddress`. `unified_de1.mmr.dart` helpers accept `MmrAddress`. Pure rename + interface lift.
+3. Add `@protected` surface methods on `UnifiedDe1` that wrap the existing extensions. The MMR/firmware/profile/raw `part of` files stay structurally unchanged.
+4. Resolve `unified_de1.firmware.dart:14` TODO — add `beforeFirmwareUpload()` hook on `UnifiedDe1` (default no-op). Call from `_updateFirmware` after `requestState(sleeping)`.
+5. Override `beforeFirmwareUpload()` on `Bengle` to request `MachineState.fwUpgrade` (`0x22`).
+
+After (1)–(5) the abstraction is in place. Capability mixins added in later steps without further base-class churn.
+
+## Files to change
+
+- `lib/src/models/device/transport/logical_endpoint.dart` — new. `LogicalEndpoint` abstract class.
+- `lib/src/models/device/impl/de1/de1.models.dart` — `Endpoint implements LogicalEndpoint`. `MMRItem implements MmrAddress`.
+- `lib/src/models/device/impl/de1/mmr_address.dart` — new. `MmrAddress` abstract class.
+- `lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart` — accept `LogicalEndpoint` instead of `Endpoint` in subscribe/write/read methods. No behavior change.
+- `lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart` — helpers accept `MmrAddress` instead of `MMRItem`. `_MMRConfig` map keyed by `MmrAddress`.
+- `lib/src/models/device/impl/de1/unified_de1/unified_de1.dart` — add `@protected` surface methods (delegating to existing transport / extension internals). Add `beforeFirmwareUpload()` hook. Expose `Logger get log` as `@protected`.
+- `lib/src/models/device/impl/de1/unified_de1/unified_de1.firmware.dart` — call `beforeFirmwareUpload()` after `requestState(sleeping)` in `_updateFirmware`. Remove the obsolete commented-out line.
+- `lib/src/models/device/impl/bengle/bengle.dart` — override `beforeFirmwareUpload()`.
+
+## Testing
+
+Existing behavior must not regress. The lifts are mechanical interface changes; existing tests should pass without modification once the type signatures match.
+
+- **Unit**: existing `unified_de1` and transport tests must pass.
+- **Unit (new)**: `bengle.beforeFirmwareUpload()` requests `MachineState.fwUpgrade` (1 test). Default `UnifiedDe1.beforeFirmwareUpload()` is a no-op (1 test).
+- **Integration**: existing DE1 BLE/serial connect smoke tests must pass.
+- **End-to-end**: `scripts/sb-dev.sh` with `simulate=1` — connect, run a fake shot, verify no regression in machine snapshot stream. (No Bengle hardware needed yet — Bengle is still a `UnifiedDe1` after this step.)
+
+No new end-to-end scenario for the FW prelude — gets exercised when actual Bengle hardware lands.
+
+## Out of scope / deferred
+
+- Roadmap steps 2–7 (simulated Bengle, real subclass + USB discovery, cup warmer impl, scale impl, LED impl, milk probe impl).
+- USB-first vs. BLE-first for v1 Bengle path — decided when starting step 3.
+- `ScaleController` integration (virtual `Scale` vs. third pathway) — decided in step 5.
+- LED API surface (workflow setting vs. dedicated REST) — decided in step 6.
+- LED transport (MMR vs. dedicated characteristic) — confirm with FW before step 6.
+- Milk probe as `Sensor` vs. capability mixin — decided in step 7.
+- API capability discovery wiring — deferred until at least one Bengle feature is end-to-end (after step 4 or 5).

--- a/lib/src/models/device/bengle_interface.dart
+++ b/lib/src/models/device/bengle_interface.dart
@@ -1,5 +1,13 @@
 import 'package:reaprime/src/models/device/de1_interface.dart';
 
-abstract class BengleInterface extends De1Interface {
-
-} 
+/// Marker interface for Bengle-specific machine API. Currently empty —
+/// Bengle inherits the full DE1 surface unchanged.
+///
+/// **Future capability methods land here.** When a Bengle capability
+/// (cup warmer, integrated scale, LED strip, milk probe) needs a public
+/// API method, add it to this interface and implement it on `Bengle`.
+/// Capability-internal state and helpers belong in their own
+/// `Capability` mixins on `UnifiedDe1` (see the protected surface in
+/// `UnifiedDe1` for the contract: `readMmrInt`, `readMmrScaled`,
+/// `writeMmrInt`, `writeMmrScaled`, `notificationsFor`, etc.).
+abstract class BengleInterface extends De1Interface {}

--- a/lib/src/models/device/impl/bengle/bengle.dart
+++ b/lib/src/models/device/impl/bengle/bengle.dart
@@ -1,9 +1,21 @@
+import 'package:flutter/foundation.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+import 'package:reaprime/src/models/device/machine.dart';
 
 class Bengle extends UnifiedDe1 implements BengleInterface {
   Bengle({required super.transport});
 
   @override
   String get name => "Bengle";
+
+  /// Bengle FW requires entering state 0x22 (`MachineState.fwUpgrade`) between
+  /// the `requestState(sleeping)` step and the start of `.dat` upload.
+  /// DE1 doesn't need this — see [UnifiedDe1.beforeFirmwareUpload]
+  /// for the hook contract.
+  @override
+  @protected
+  Future<void> beforeFirmwareUpload() async {
+    await requestState(MachineState.fwUpgrade);
+  }
 }

--- a/lib/src/models/device/impl/de1/de1.models.dart
+++ b/lib/src/models/device/impl/de1/de1.models.dart
@@ -283,8 +283,6 @@ enum MMRItem implements MmrAddress {
     MmrValueKind.int32,
     "GHC Info Bitmask, 0x1 = GHC LED Controller Present, 0x2 = GHC Touch Controller_Present, 0x4 GHC Active, 0x80000000 = Factory Mode",
   ),
-  prefGHCMCI(0x00803820, 4, MmrValueKind.int32, "TODO"),
-  maxShotPres(0x00803824, 4, MmrValueKind.int32, "TODO"),
   targetSteamFlow(
     0x00803828,
     4,

--- a/lib/src/models/device/impl/de1/de1.models.dart
+++ b/lib/src/models/device/impl/de1/de1.models.dart
@@ -32,20 +32,15 @@ enum Endpoint implements LogicalEndpoint {
 
   const Endpoint(this.uuid, this.representation);
 
-  // Explicit override: Dart's CFE (test compiler) does not accept `Enum.name`
-  // as satisfying `String get name;` on an `implements` clause, even though
-  // the analyzer does. Delegate to the synthesized enum name via a thin
-  // top-level helper that takes `Enum`.
+  // CFE doesn't accept the synthesized Enum.name through `implements`; cast satisfies it.
   @override
-  String get name => _enumName(this);
+  String get name => (this as Enum).name;
 
   // Helper method to find an Endpoint by its UUID
   static Endpoint? fromUuid(String uuid) {
     return Endpoint.values.where((e) => e.uuid == uuid).firstOrNull;
   }
 }
-
-String _enumName(Enum e) => e.name;
 
 enum De1StateEnum {
   sleep(0x0), // Everything is off

--- a/lib/src/models/device/impl/de1/de1.models.dart
+++ b/lib/src/models/device/impl/de1/de1.models.dart
@@ -1,10 +1,11 @@
 // ignore_for_file: constant_identifier_names
 
 import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/transport/logical_endpoint.dart';
 
 final String de1ServiceUUID = 'A000';
 
-enum Endpoint {
+enum Endpoint implements LogicalEndpoint {
   versions('A001', 'A'),
   requestedState('A002', 'B'),
   setTime('A003', 'C'),
@@ -24,7 +25,9 @@ enum Endpoint {
   waterLevels('A011', 'Q'),
   calibration('A012', 'R');
 
+  @override
   final String uuid;
+  @override
   final String representation;
 
   const Endpoint(this.uuid, this.representation);

--- a/lib/src/models/device/impl/de1/de1.models.dart
+++ b/lib/src/models/device/impl/de1/de1.models.dart
@@ -244,25 +244,38 @@ enum MMRItem implements MmrAddress {
     MmrValueKind.int32,
     "BLEDebugConfig. (Reading restarts logging into the BLE log)",
   ),
-  fanThreshold(0x00803808, 4, MmrValueKind.int32, "Fan threshold temp"),
+  fanThreshold(
+    0x00803808,
+    4,
+    MmrValueKind.int32,
+    "Fan threshold temp",
+    min: 0,
+    max: 50,
+  ),
   tankTemp(0x0080380C, 4, MmrValueKind.int32, "Tank water temp threshold."),
   heaterUp1Flow(
     0x00803810,
     4,
     MmrValueKind.scaledFloat,
     "HeaterUp Phase 1 Flow Rate",
+    readScale: 0.1,
+    writeScale: 10.0,
   ),
   heaterUp2Flow(
     0x00803814,
     4,
     MmrValueKind.scaledFloat,
     "HeaterUp Phase 2 Flow Rate",
+    readScale: 0.1,
+    writeScale: 10.0,
   ),
   waterHeaterIdleTemp(
     0x00803818,
     4,
     MmrValueKind.scaledFloat,
     "Water Heater Idle Temperature",
+    readScale: 0.1,
+    writeScale: 10.0,
   ),
   ghcInfo(
     0x0080381C,
@@ -277,6 +290,8 @@ enum MMRItem implements MmrAddress {
     4,
     MmrValueKind.scaledFloat,
     "Target steam flow rate",
+    readScale: 0.01,
+    writeScale: 100.0,
   ),
   steamStartSecs(
     0x0080382C,
@@ -296,21 +311,50 @@ enum MMRItem implements MmrAddress {
     4,
     MmrValueKind.scaledFloat,
     "HeaterUp Phase 2 Timeout",
+    readScale: 0.1,
+    writeScale: 10.0,
   ),
   calFlowEst(
     0x0080383C,
     4,
     MmrValueKind.scaledFloat,
     "Flow Estimation Calibration",
+    readScale: 0.001,
+    writeScale: 1000.0,
+    min: 130,
+    max: 2000,
   ),
-  flushFlowRate(0x00803840, 4, MmrValueKind.scaledFloat, "Flush Flow Rate"),
-  flushTemp(0x00803844, 4, MmrValueKind.scaledFloat, "Flush Temp"),
-  flushTimeout(0x00803848, 4, MmrValueKind.scaledFloat, "Flush Timeout"),
+  flushFlowRate(
+    0x00803840,
+    4,
+    MmrValueKind.scaledFloat,
+    "Flush Flow Rate",
+    readScale: 0.1,
+    writeScale: 10.0,
+  ),
+  flushTemp(
+    0x00803844,
+    4,
+    MmrValueKind.scaledFloat,
+    "Flush Temp",
+    readScale: 0.1,
+    writeScale: 10.0,
+  ),
+  flushTimeout(
+    0x00803848,
+    4,
+    MmrValueKind.scaledFloat,
+    "Flush Timeout",
+    readScale: 0.1,
+    writeScale: 10.0,
+  ),
   hotWaterFlowRate(
     0x0080384C,
     4,
     MmrValueKind.scaledFloat,
     "Hot Water Flow Rate",
+    readScale: 0.1,
+    writeScale: 10.0,
   ),
   steamPurgeMode(0x00803850, 4, MmrValueKind.int32, "Steam Purge Mode"),
   allowUSBCharging(0x00803854, 4, MmrValueKind.boolean, "Allow USB charging"),
@@ -326,8 +370,25 @@ enum MMRItem implements MmrAddress {
   @override
   final MmrValueKind kind;
   final String description;
+  @override
+  final double readScale;
+  @override
+  final double writeScale;
+  @override
+  final int? min;
+  @override
+  final int? max;
 
-  const MMRItem(this.address, this.length, this.kind, this.description);
+  const MMRItem(
+    this.address,
+    this.length,
+    this.kind,
+    this.description, {
+    this.readScale = 1.0,
+    this.writeScale = 1.0,
+    this.min,
+    this.max,
+  });
 
   // Dart enums auto-synthesize `name`, but the analyzer doesn't see it as
   // satisfying `MmrAddress.name` through `implements` — the cast forces

--- a/lib/src/models/device/impl/de1/de1.models.dart
+++ b/lib/src/models/device/impl/de1/de1.models.dart
@@ -315,8 +315,9 @@ enum MMRItem implements MmrAddress {
   steamPurgeMode(0x00803850, 4, MmrValueKind.int32, "Steam Purge Mode"),
   allowUSBCharging(0x00803854, 4, MmrValueKind.boolean, "Allow USB charging"),
   appFeatureFlags(0x00803858, 4, MmrValueKind.int32, "App Feature Flags"),
+  // Tri-state (0=absent, 1=present, 2=auto-detect). int32, not boolean.
   refillKitPresent(0x0080385C, 4, MmrValueKind.int32, "Refill Kit Present"),
-  userPresent(0x00803860, 4, MmrValueKind.int32, "Is User Present");
+  userPresent(0x00803860, 4, MmrValueKind.boolean, "Is User Present");
 
   @override
   final int address;
@@ -331,7 +332,8 @@ enum MMRItem implements MmrAddress {
   // Dart enums auto-synthesize `name`, but the analyzer doesn't see it as
   // satisfying `MmrAddress.name` through `implements` — the cast forces
   // dispatch to the synthesized Enum.name. Do not "simplify" by removing the
-  // cast; it will fail to compile (see fix commits 553550d / b7b8ed7).
+  // cast; it will fail to compile (see Endpoint history, fix commits
+  // 553550d / b7b8ed7).
   @override
   String get name => (this as Enum).name;
 }

--- a/lib/src/models/device/impl/de1/de1.models.dart
+++ b/lib/src/models/device/impl/de1/de1.models.dart
@@ -32,7 +32,10 @@ enum Endpoint implements LogicalEndpoint {
 
   const Endpoint(this.uuid, this.representation);
 
-  // CFE doesn't accept the synthesized Enum.name through `implements`; cast satisfies it.
+  // Dart enums auto-synthesize `name`, but the analyzer doesn't see it as
+  // satisfying `LogicalEndpoint.name` through `implements` — the cast forces
+  // dispatch to the synthesized Enum.name. Do not "simplify" by removing the
+  // cast; it will fail to compile (see fix commits 553550d / b7b8ed7).
   @override
   String get name => (this as Enum).name;
 

--- a/lib/src/models/device/impl/de1/de1.models.dart
+++ b/lib/src/models/device/impl/de1/de1.models.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: constant_identifier_names
 
 import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
 import 'package:reaprime/src/models/device/transport/logical_endpoint.dart';
 
 final String de1ServiceUUID = 'A000';
@@ -203,77 +204,136 @@ enum De1SubState {
   }
 }
 
-enum MMRItem {
-  externalFlash(0x00000000, 0xFFFFF, "Flash RW"),
-  hwConfig(0x00800000, 4, "HWConfig"),
-  model(0x00800004, 4, "Model"),
-  cpuBoardModel(0x00800008, 4, "CPU Board Model * 1000. eg: 1100 = 1.1"),
+enum MMRItem implements MmrAddress {
+  externalFlash(0x00000000, 0xFFFFF, MmrValueKind.bytes, "Flash RW"),
+  hwConfig(0x00800000, 4, MmrValueKind.int32, "HWConfig"),
+  model(0x00800004, 4, MmrValueKind.int32, "Model"),
+  cpuBoardModel(
+    0x00800008,
+    4,
+    MmrValueKind.int32,
+    "CPU Board Model * 1000. eg: 1100 = 1.1",
+  ),
   v13Model(
     0x0080000C,
     4,
+    MmrValueKind.int32,
     "v1.3+ Firmware Model (Unset = 0, DE1 = 1, DE1Plus = 2, DE1Pro = 3, DE1XL = 4, DE1Cafe = 5)",
   ),
   cpuFirmwareBuild(
     0x00800010,
     4,
+    MmrValueKind.int32,
     "CPU Board Firmware build number. (Starts at 1000 for 1.3, increments by 1 for every build)",
   ),
   debugLen(
     0x00802800,
     4,
+    MmrValueKind.int32,
     "How many characters in debug buffer are valid. Accessing this pauses BLE debug logging.",
   ),
   debugBuffer(
     0x00802804,
     0x1000,
+    MmrValueKind.bytes,
     "Last 4K of output. Zero terminated if buffer not full yet. Pauses BLE debug logging.",
   ),
   debugConfig(
     0x00803804,
     4,
+    MmrValueKind.int32,
     "BLEDebugConfig. (Reading restarts logging into the BLE log)",
   ),
-  fanThreshold(0x00803808, 4, "Fan threshold temp"),
-  tankTemp(0x0080380C, 4, "Tank water temp threshold."),
-  heaterUp1Flow(0x00803810, 4, "HeaterUp Phase 1 Flow Rate"),
-  heaterUp2Flow(0x00803814, 4, "HeaterUp Phase 2 Flow Rate"),
-  waterHeaterIdleTemp(0x00803818, 4, "Water Heater Idle Temperature"),
+  fanThreshold(0x00803808, 4, MmrValueKind.int32, "Fan threshold temp"),
+  tankTemp(0x0080380C, 4, MmrValueKind.int32, "Tank water temp threshold."),
+  heaterUp1Flow(
+    0x00803810,
+    4,
+    MmrValueKind.scaledFloat,
+    "HeaterUp Phase 1 Flow Rate",
+  ),
+  heaterUp2Flow(
+    0x00803814,
+    4,
+    MmrValueKind.scaledFloat,
+    "HeaterUp Phase 2 Flow Rate",
+  ),
+  waterHeaterIdleTemp(
+    0x00803818,
+    4,
+    MmrValueKind.scaledFloat,
+    "Water Heater Idle Temperature",
+  ),
   ghcInfo(
     0x0080381C,
     4,
+    MmrValueKind.int32,
     "GHC Info Bitmask, 0x1 = GHC LED Controller Present, 0x2 = GHC Touch Controller_Present, 0x4 GHC Active, 0x80000000 = Factory Mode",
   ),
-  prefGHCMCI(0x00803820, 4, "TODO"),
-  maxShotPres(0x00803824, 4, "TODO"),
-  targetSteamFlow(0x00803828, 4, "Target steam flow rate"),
+  prefGHCMCI(0x00803820, 4, MmrValueKind.int32, "TODO"),
+  maxShotPres(0x00803824, 4, MmrValueKind.int32, "TODO"),
+  targetSteamFlow(
+    0x00803828,
+    4,
+    MmrValueKind.scaledFloat,
+    "Target steam flow rate",
+  ),
   steamStartSecs(
     0x0080382C,
     4,
+    MmrValueKind.scaledFloat,
     "Seconds of high steam flow * 100. Valid range 0.0 - 4.0. 0 may result in an overheated heater. Be careful.",
   ),
-  serialN(0x00803830, 4, "Current serial number"),
+  serialN(0x00803830, 4, MmrValueKind.int32, "Current serial number"),
   heaterV(
     0x00803834,
     4,
+    MmrValueKind.int32,
     "Nominal Heater Voltage (0, 120V or 230V). +1000 if it's a set value.",
   ),
-  heaterUp2Timeout(0x00803838, 4, "HeaterUp Phase 2 Timeout"),
-  calFlowEst(0x0080383C, 4, "Flow Estimation Calibration"),
-  flushFlowRate(0x00803840, 4, "Flush Flow Rate"),
-  flushTemp(0x00803844, 4, "Flush Temp"),
-  flushTimeout(0x00803848, 4, "Flush Timeout"),
-  hotWaterFlowRate(0x0080384C, 4, "Hot Water Flow Rate"),
-  steamPurgeMode(0x00803850, 4, "Steam Purge Mode"),
-  allowUSBCharging(0x00803854, 4, "Allow USB charging"),
-  appFeatureFlags(0x00803858, 4, "App Feature Flags"),
-  refillKitPresent(0x0080385C, 4, "Refill Kit Present"),
-  userPresent(0x00803860, 4, "Is User Present");
+  heaterUp2Timeout(
+    0x00803838,
+    4,
+    MmrValueKind.scaledFloat,
+    "HeaterUp Phase 2 Timeout",
+  ),
+  calFlowEst(
+    0x0080383C,
+    4,
+    MmrValueKind.scaledFloat,
+    "Flow Estimation Calibration",
+  ),
+  flushFlowRate(0x00803840, 4, MmrValueKind.scaledFloat, "Flush Flow Rate"),
+  flushTemp(0x00803844, 4, MmrValueKind.scaledFloat, "Flush Temp"),
+  flushTimeout(0x00803848, 4, MmrValueKind.scaledFloat, "Flush Timeout"),
+  hotWaterFlowRate(
+    0x0080384C,
+    4,
+    MmrValueKind.scaledFloat,
+    "Hot Water Flow Rate",
+  ),
+  steamPurgeMode(0x00803850, 4, MmrValueKind.int32, "Steam Purge Mode"),
+  allowUSBCharging(0x00803854, 4, MmrValueKind.boolean, "Allow USB charging"),
+  appFeatureFlags(0x00803858, 4, MmrValueKind.int32, "App Feature Flags"),
+  refillKitPresent(0x0080385C, 4, MmrValueKind.int32, "Refill Kit Present"),
+  userPresent(0x00803860, 4, MmrValueKind.int32, "Is User Present");
 
+  @override
   final int address;
+  @override
   final int length;
+  @override
+  final MmrValueKind kind;
   final String description;
 
-  const MMRItem(this.address, this.length, this.description);
+  const MMRItem(this.address, this.length, this.kind, this.description);
+
+  // Dart enums auto-synthesize `name`, but the analyzer doesn't see it as
+  // satisfying `MmrAddress.name` through `implements` — the cast forces
+  // dispatch to the synthesized Enum.name. Do not "simplify" by removing the
+  // cast; it will fail to compile (see fix commits 553550d / b7b8ed7).
+  @override
+  String get name => (this as Enum).name;
 }
 
 enum DecentMachineModel {

--- a/lib/src/models/device/impl/de1/de1.models.dart
+++ b/lib/src/models/device/impl/de1/de1.models.dart
@@ -32,11 +32,20 @@ enum Endpoint implements LogicalEndpoint {
 
   const Endpoint(this.uuid, this.representation);
 
+  // Explicit override: Dart's CFE (test compiler) does not accept `Enum.name`
+  // as satisfying `String get name;` on an `implements` clause, even though
+  // the analyzer does. Delegate to the synthesized enum name via a thin
+  // top-level helper that takes `Enum`.
+  @override
+  String get name => _enumName(this);
+
   // Helper method to find an Endpoint by its UUID
   static Endpoint? fromUuid(String uuid) {
     return Endpoint.values.where((e) => e.uuid == uuid).firstOrNull;
   }
 }
+
+String _enumName(Enum e) => e.name;
 
 enum De1StateEnum {
   sleep(0x0), // Everything is off

--- a/lib/src/models/device/impl/de1/mmr_address.dart
+++ b/lib/src/models/device/impl/de1/mmr_address.dart
@@ -3,13 +3,30 @@
 /// Capability mixins use this to pick the right read/write helper.
 /// Helpers validate against [kind] and throw on mismatch — catches
 /// "wrong helper for this address" mistakes at runtime.
+///
+/// Kinds are extended as new value shapes appear (e.g. `uint32`,
+/// `bitmask`, `float32` for raw IEEE floats). `scaledFloat` is the only
+/// one with helper-side semantics today; the rest are documentation.
+/// DE1 itself doesn't yet consume `kind` — Task 3 adds the protected
+/// helper surface that validates against it.
 enum MmrValueKind {
-  int32, // signed 32-bit int
-  int16, // signed 16-bit int
-  scaledFloat, // int with read/write scale (current _MMRConfig usage)
-  boolean, // 0/1 int treated as bool
-  bytes, // raw bytes, no decoding
-  string, // null-terminated or length-prefixed string
+  /// signed 32-bit int
+  int32,
+
+  /// signed 16-bit int
+  int16,
+
+  /// int with read/write scale (current _MMRConfig usage)
+  scaledFloat,
+
+  /// 0/1 int treated as bool
+  boolean,
+
+  /// raw bytes, no decoding
+  bytes,
+
+  /// null-terminated or length-prefixed string
+  string,
 }
 
 /// Wire-agnostic identifier for a single MMR slot.

--- a/lib/src/models/device/impl/de1/mmr_address.dart
+++ b/lib/src/models/device/impl/de1/mmr_address.dart
@@ -1,0 +1,24 @@
+/// Documents the value shape stored at a given MMR address.
+///
+/// Capability mixins use this to pick the right read/write helper.
+/// Helpers validate against [kind] and throw on mismatch — catches
+/// "wrong helper for this address" mistakes at runtime.
+enum MmrValueKind {
+  int32, // signed 32-bit int
+  int16, // signed 16-bit int
+  scaledFloat, // int with read/write scale (current _MMRConfig usage)
+  boolean, // 0/1 int treated as bool
+  bytes, // raw bytes, no decoding
+  string, // null-terminated or length-prefixed string
+}
+
+/// Wire-agnostic identifier for a single MMR slot.
+///
+/// DE1's [MMRItem] implements this; capability mixins ship their own
+/// enums (e.g. `BengleCupWarmerMmr`) that also implement it.
+abstract class MmrAddress {
+  int get address;
+  int get length;
+  String get name;
+  MmrValueKind get kind;
+}

--- a/lib/src/models/device/impl/de1/mmr_address.dart
+++ b/lib/src/models/device/impl/de1/mmr_address.dart
@@ -16,7 +16,7 @@ enum MmrValueKind {
   /// signed 16-bit int
   int16,
 
-  /// int with read/write scale (current _MMRConfig usage)
+  /// int with read/write scale (see [MmrAddress.readScale] / [MmrAddress.writeScale])
   scaledFloat,
 
   /// 0/1 int treated as bool
@@ -33,9 +33,29 @@ enum MmrValueKind {
 ///
 /// DE1's [MMRItem] implements this; capability mixins ship their own
 /// enums (e.g. `BengleCupWarmerMmr`) that also implement it.
+///
+/// Scaling/clamp config travels with the address itself: [readScale],
+/// [writeScale], [min], [max] default to "no transform" so addresses
+/// without scaling don't have to declare anything. Addresses that need
+/// non-default values override the relevant getter (or pass via the
+/// constructor on enum implementers like [MMRItem]).
 abstract class MmrAddress {
   int get address;
   int get length;
   String get name;
   MmrValueKind get kind;
+
+  /// Multiplier applied when reading a `scaledFloat`. 1.0 means "the
+  /// raw int is the value as-is." Ignored for non-scaledFloat kinds.
+  double get readScale => 1.0;
+
+  /// Multiplier applied (then truncated to int) when writing a
+  /// `scaledFloat`. 1.0 means "the int is the value as-is."
+  double get writeScale => 1.0;
+
+  /// Optional minimum bound; null means no lower clamp.
+  int? get min => null;
+
+  /// Optional maximum bound; null means no upper clamp.
+  int? get max => null;
 }

--- a/lib/src/models/device/impl/de1/mmr_address.dart
+++ b/lib/src/models/device/impl/de1/mmr_address.dart
@@ -38,7 +38,13 @@ enum MmrValueKind {
 /// [writeScale], [min], [max] default to "no transform" so addresses
 /// without scaling don't have to declare anything. Addresses that need
 /// non-default values override the relevant getter (or pass via the
-/// constructor on enum implementers like [MMRItem]).
+/// constructor on enum implementers like `MMRItem`).
+///
+/// **Note for enum implementers:** Dart's analyzer doesn't see the
+/// synthesized `Enum.name` as satisfying this interface's `String get name`
+/// getter. Add `@override String get name => (this as Enum).name;` to your
+/// enum. See `MMRItem` for an example and fix-commit history
+/// (553550d / b7b8ed7).
 abstract class MmrAddress {
   int get address;
   int get length;

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -450,6 +450,19 @@ class UnifiedDe1 implements De1Interface {
   @protected
   Logger get log => _log;
 
+  /// Override on machine subclasses that need to take an action between
+  /// `requestState(sleeping)` and the start of FW image upload.
+  ///
+  /// Default: no-op. Bengle overrides this to request
+  /// `MachineState.fwUpgrade` (state 0x22) — Bengle FW requires entering
+  /// that state before the `.dat` upload protocol starts. DE1 doesn't.
+  ///
+  /// This resolves the TODO at `unified_de1.firmware.dart:13-14` (commented
+  /// `requestState(MachineState.fwUpgrade)` originally lived in the shared
+  /// upload routine).
+  @protected
+  Future<void> beforeFirmwareUpload() async {} // default no-op
+
   /// Writes [data] to [endpoint]. Fire-and-forget writes
   /// (`withResponse: false`) are not yet wired — passing `false` throws
   /// [UnimplementedError] rather than silently using `writeWithResponse`.

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -450,12 +450,20 @@ class UnifiedDe1 implements De1Interface {
   @protected
   Logger get log => _log;
 
+  /// Writes [data] to [endpoint]. Fire-and-forget writes
+  /// (`withResponse: false`) are not yet wired — passing `false` throws
+  /// [UnimplementedError] rather than silently using `writeWithResponse`.
+  /// When a capability needs without-response writes, add a sibling
+  /// method on [UnifiedDe1Transport] and dispatch here.
   @protected
   Future<void> writeEndpoint(LogicalEndpoint endpoint, Uint8List data,
-      {bool withResponse = true}) {
-    // All DE1 writes go through writeWithResponse today. If a future
-    // capability needs without-response writes, add a sibling method on
-    // the transport rather than branching here.
+      {bool withResponse = true}) async {
+    if (!withResponse) {
+      throw UnimplementedError(
+          'UnifiedDe1.writeEndpoint: withResponse=false not yet wired. '
+          'When a capability needs fire-and-forget writes, add a sibling '
+          'write method on UnifiedDe1Transport and dispatch here.');
+    }
     return _transport.writeWithResponse(endpoint, data);
   }
 
@@ -510,6 +518,13 @@ class UnifiedDe1 implements De1Interface {
     return _unpackMMRInt(raw);
   }
 
+  /// Reads a `scaledFloat` MMR address as `raw * readScale`.
+  ///
+  /// Asymmetric with [writeMmrScaled]: read scaling is purely a
+  /// multiplier — there is no `min`/`max` clamp here. Bounds are a
+  /// write-side concern (the firmware reports whatever it stored;
+  /// callers that need range validation should clamp before writing,
+  /// not after reading).
   @protected
   Future<double> readMmrScaled(MmrAddress addr,
       {required double readScale}) async {
@@ -538,7 +553,10 @@ class UnifiedDe1 implements De1Interface {
       {required double writeScale, int? min, int? max}) async {
     _assertKind(addr, const {MmrValueKind.scaledFloat}, 'writeMmrScaled');
     final scaled = (value * writeScale).toInt();
-    return writeMmrInt(addr, scaled, min: min, max: max);
+    if (addr is MMRItem) return _writeMMRInt(addr, scaled);
+    final clamped =
+        (min != null && max != null) ? scaled.clamp(min, max) : scaled;
+    return _mmrWriteRaw(addr.address, _packMMRInt(clamped));
   }
 
   @protected

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -468,11 +468,22 @@ class UnifiedDe1 implements De1Interface {
     return _transport.read(endpoint, timeout: timeout);
   }
 
+  /// Returns the broadcast notification stream for [endpoint].
+  ///
+  /// Two fall-through paths exist for callers to be aware of:
+  ///
+  /// 1. A known DE1 [Endpoint] that is not a notifying characteristic
+  ///    (e.g. [Endpoint.versions], [Endpoint.requestedState],
+  ///    [Endpoint.headerWrite]) raises [UnimplementedError] — by design,
+  ///    these endpoints are write-only or one-shot reads. Asking for a
+  ///    notification stream is a usage bug, not a missing feature.
+  /// 2. A non-[Endpoint] [LogicalEndpoint] (capability-supplied — e.g.
+  ///    a future `BengleCupWarmerEndpoint`) also raises
+  ///    [UnimplementedError]. Runtime subscription wiring for capability
+  ///    endpoints lands with the first capability that needs it.
   @protected
   Stream<ByteData> notificationsFor(LogicalEndpoint endpoint) {
     // Known DE1 endpoints route to their existing typed Subjects.
-    // Capability-supplied endpoints throw — runtime subscription wiring
-    // lands with the first capability that needs it.
     if (endpoint is Endpoint) {
       switch (endpoint) {
         case Endpoint.shotSample:
@@ -489,7 +500,8 @@ class UnifiedDe1 implements De1Interface {
           return _transport.fwMapRequest;
         default:
           throw UnimplementedError(
-              'UnifiedDe1.notificationsFor: ${endpoint.name} has no Subject wired');
+              'UnifiedDe1.notificationsFor: Endpoint.${endpoint.name} is '
+              'not a notifying characteristic on UnifiedDe1');
       }
     }
     throw UnimplementedError(

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -446,21 +446,16 @@ class UnifiedDe1 implements De1Interface {
   @protected
   Future<void> beforeFirmwareUpload() async {} // default no-op
 
-  /// Writes [data] to [endpoint]. Fire-and-forget writes
-  /// (`withResponse: false`) are not yet wired — passing `false` throws
-  /// [UnimplementedError] rather than silently using `writeWithResponse`.
-  /// When a capability needs without-response writes, add a sibling
-  /// method on [UnifiedDe1Transport] and dispatch here.
+  /// Writes [data] to [endpoint]. When [withResponse] is `true` (default)
+  /// dispatches to [UnifiedDe1Transport.writeWithResponse]; when `false`
+  /// dispatches to [UnifiedDe1Transport.write] for fire-and-forget writes.
   @protected
   Future<void> writeEndpoint(LogicalEndpoint endpoint, Uint8List data,
       {bool withResponse = true}) async {
-    if (!withResponse) {
-      throw UnimplementedError(
-          'UnifiedDe1.writeEndpoint: withResponse=false not yet wired. '
-          'When a capability needs fire-and-forget writes, add a sibling '
-          'write method on UnifiedDe1Transport and dispatch here.');
+    if (withResponse) {
+      return _transport.writeWithResponse(endpoint, data);
     }
-    return _transport.writeWithResponse(endpoint, data);
+    return _transport.write(endpoint, data);
   }
 
   @protected
@@ -470,7 +465,7 @@ class UnifiedDe1 implements De1Interface {
       throw StateError(
           'UnifiedDe1.readEndpoint: endpoint ${endpoint.name} has no BLE read path');
     }
-    return _transport.readEndpoint(endpoint, timeout: timeout);
+    return _transport.read(endpoint, timeout: timeout);
   }
 
   @protected

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -27,23 +27,6 @@ part 'unified_de1.profile.dart';
 part 'unified_de1.firmware.dart';
 part 'unified_de1.raw.dart';
 
-// Add this configuration class
-class _MMRConfig {
-  final MMRItem item;
-  final double readScale;
-  final double writeScale;
-  final int? minValue;
-  final int? maxValue;
-
-  const _MMRConfig({
-    required this.item,
-    this.readScale = 1.0,
-    this.writeScale = 1.0,
-    this.minValue,
-    this.maxValue,
-  });
-}
-
 class UnifiedDe1 implements De1Interface {
   static final BleServiceIdentifier advertisingIdentifier =
       BleServiceIdentifier.short('ffff');
@@ -531,7 +514,7 @@ class UnifiedDe1 implements De1Interface {
     return _unpackMMRInt(raw);
   }
 
-  /// Reads a `scaledFloat` MMR address as `raw * readScale`.
+  /// Reads a `scaledFloat` MMR address as `raw * addr.readScale`.
   ///
   /// Asymmetric with [writeMmrScaled]: read scaling is purely a
   /// multiplier — there is no `min`/`max` clamp here. Bounds are a
@@ -539,36 +522,35 @@ class UnifiedDe1 implements De1Interface {
   /// callers that need range validation should clamp before writing,
   /// not after reading).
   @protected
-  Future<double> readMmrScaled(MmrAddress addr,
-      {required double readScale}) async {
+  Future<double> readMmrScaled(MmrAddress addr) async {
     _assertKind(addr, const {MmrValueKind.scaledFloat}, 'readMmrScaled');
     if (addr is MMRItem) return _readMMRScaled(addr);
     final raw = await _mmrReadRaw(addr.address);
-    return _unpackMMRInt(raw).toDouble() * readScale;
+    return _unpackMMRInt(raw).toDouble() * addr.readScale;
   }
 
   @protected
-  Future<void> writeMmrInt(MmrAddress addr, int value,
-      {int? min, int? max}) async {
+  Future<void> writeMmrInt(MmrAddress addr, int value) async {
     _assertKind(addr, const {
       MmrValueKind.int32,
       MmrValueKind.int16,
       MmrValueKind.boolean,
     }, 'writeMmrInt');
     if (addr is MMRItem) return _writeMMRInt(addr, value);
-    final clamped =
-        (min != null && max != null) ? value.clamp(min, max) : value;
+    final clamped = (addr.min != null && addr.max != null)
+        ? value.clamp(addr.min!, addr.max!)
+        : value;
     return _mmrWriteRaw(addr.address, _packMMRInt(clamped));
   }
 
   @protected
-  Future<void> writeMmrScaled(MmrAddress addr, double value,
-      {required double writeScale, int? min, int? max}) async {
+  Future<void> writeMmrScaled(MmrAddress addr, double value) async {
     _assertKind(addr, const {MmrValueKind.scaledFloat}, 'writeMmrScaled');
-    final scaled = (value * writeScale).toInt();
+    final scaled = (value * addr.writeScale).toInt();
     if (addr is MMRItem) return _writeMMRInt(addr, scaled);
-    final clamped =
-        (min != null && max != null) ? scaled.clamp(min, max) : scaled;
+    final clamped = (addr.min != null && addr.max != null)
+        ? scaled.clamp(addr.min!, addr.max!)
+        : scaled;
     return _mmrWriteRaw(addr.address, _packMMRInt(clamped));
   }
 

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
-import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/connection/connection_timings.dart';
 import 'package:reaprime/src/models/data/profile.dart';
@@ -12,10 +12,12 @@ import 'package:reaprime/src/models/device/de1_rawmessage.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.utils.dart';
+import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/device/ble_service_identifier.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:reaprime/src/models/device/transport/logical_endpoint.dart';
 import 'package:reaprime/src/models/errors.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -437,6 +439,128 @@ class UnifiedDe1 implements De1Interface {
         return d;
       })
       .map(_parseWaterLevels);
+
+  // ---- Protected surface for capability mixins (`on UnifiedDe1`) ----
+  //
+  // Mixins reach the transport and MMR plumbing through these methods
+  // instead of touching `_transport` / `_log` directly. New capabilities
+  // (Bengle cup warmer, integrated scale, etc.) declare `on UnifiedDe1`
+  // and call only the @protected API below.
+
+  @protected
+  Logger get log => _log;
+
+  @protected
+  Future<void> writeEndpoint(LogicalEndpoint endpoint, Uint8List data,
+      {bool withResponse = true}) {
+    // All DE1 writes go through writeWithResponse today. If a future
+    // capability needs without-response writes, add a sibling method on
+    // the transport rather than branching here.
+    return _transport.writeWithResponse(endpoint, data);
+  }
+
+  @protected
+  Future<ByteData> readEndpoint(LogicalEndpoint endpoint,
+      {Duration? timeout}) async {
+    if (endpoint.uuid == null) {
+      throw StateError(
+          'UnifiedDe1.readEndpoint: endpoint ${endpoint.name} has no BLE read path');
+    }
+    return _transport.readEndpoint(endpoint, timeout: timeout);
+  }
+
+  @protected
+  Stream<ByteData> notificationsFor(LogicalEndpoint endpoint) {
+    // Known DE1 endpoints route to their existing typed Subjects.
+    // Capability-supplied endpoints throw — runtime subscription wiring
+    // lands with the first capability that needs it.
+    if (endpoint is Endpoint) {
+      switch (endpoint) {
+        case Endpoint.shotSample:
+          return _transport.shotSample;
+        case Endpoint.stateInfo:
+          return _transport.state;
+        case Endpoint.waterLevels:
+          return _transport.waterLevels;
+        case Endpoint.shotSettings:
+          return _transport.shotSettings;
+        case Endpoint.readFromMMR:
+          return _mmr;
+        case Endpoint.fwMapRequest:
+          return _transport.fwMapRequest;
+        default:
+          throw UnimplementedError(
+              'UnifiedDe1.notificationsFor: ${endpoint.name} has no Subject wired');
+      }
+    }
+    throw UnimplementedError(
+        'UnifiedDe1.notificationsFor: runtime subscription for ${endpoint.name} '
+        'lands with capability impl');
+  }
+
+  @protected
+  Future<int> readMmrInt(MmrAddress addr) async {
+    _assertKind(addr, const {
+      MmrValueKind.int32,
+      MmrValueKind.int16,
+      MmrValueKind.boolean,
+    }, 'readMmrInt');
+    if (addr is MMRItem) return _readMMRInt(addr);
+    final raw = await _mmrReadRaw(addr.address);
+    return _unpackMMRInt(raw);
+  }
+
+  @protected
+  Future<double> readMmrScaled(MmrAddress addr,
+      {required double readScale}) async {
+    _assertKind(addr, const {MmrValueKind.scaledFloat}, 'readMmrScaled');
+    if (addr is MMRItem) return _readMMRScaled(addr);
+    final raw = await _mmrReadRaw(addr.address);
+    return _unpackMMRInt(raw).toDouble() * readScale;
+  }
+
+  @protected
+  Future<void> writeMmrInt(MmrAddress addr, int value,
+      {int? min, int? max}) async {
+    _assertKind(addr, const {
+      MmrValueKind.int32,
+      MmrValueKind.int16,
+      MmrValueKind.boolean,
+    }, 'writeMmrInt');
+    if (addr is MMRItem) return _writeMMRInt(addr, value);
+    final clamped =
+        (min != null && max != null) ? value.clamp(min, max) : value;
+    return _mmrWriteRaw(addr.address, _packMMRInt(clamped));
+  }
+
+  @protected
+  Future<void> writeMmrScaled(MmrAddress addr, double value,
+      {required double writeScale, int? min, int? max}) async {
+    _assertKind(addr, const {MmrValueKind.scaledFloat}, 'writeMmrScaled');
+    final scaled = (value * writeScale).toInt();
+    return writeMmrInt(addr, scaled, min: min, max: max);
+  }
+
+  @protected
+  Future<List<int>> readMmrRaw(MmrAddress addr) async {
+    if (addr is MMRItem) return _mmrRead(addr);
+    return _mmrReadRaw(addr.address);
+  }
+
+  @protected
+  Future<void> writeMmrRaw(MmrAddress addr, List<int> data) async {
+    if (addr is MMRItem) return _mmrWrite(addr, data);
+    return _mmrWriteRaw(addr.address, data);
+  }
+
+  void _assertKind(MmrAddress addr, Set<MmrValueKind> allowed, String helper) {
+    if (!allowed.contains(addr.kind)) {
+      throw StateError(
+        'UnifiedDe1.$helper: called on ${addr.name} (kind=${addr.kind.name}); '
+        'expected one of $allowed',
+      );
+    }
+  }
 
   // Private getter for MMR stream with notifyFrom called once per event
   // Cached to ensure only one stream chain is created

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.firmware.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.firmware.dart
@@ -9,9 +9,7 @@ extension UnifiedDe1Firmware on UnifiedDe1 {
     _log.info("Starting firmware upgrade ...");
 
     await requestState(MachineState.sleeping);
-
-    // TODO: move to Machine impl that needs this
-    // await requestState(MachineState.fwUpgrade);
+    await beforeFirmwareUpload();
 
     // unsub = _subscribe(Endpoint.fwMapRequest, (ByteData data) async {
     final unsub = _transport.fwMapRequest.listen((ByteData data) async {

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart
@@ -76,69 +76,6 @@ extension UnifiedDe1MMR on UnifiedDe1 {
     );
   }
 
-  // Add MMR configuration map
-  static const Map<MMRItem, _MMRConfig> _mmrConfigs = {
-    MMRItem.fanThreshold: _MMRConfig(
-      item: MMRItem.fanThreshold,
-      minValue: 0,
-      maxValue: 50,
-    ),
-    MMRItem.flushFlowRate: _MMRConfig(
-      item: MMRItem.flushFlowRate,
-      readScale: 0.1,
-      writeScale: 10.0,
-    ),
-    MMRItem.flushTemp: _MMRConfig(
-      item: MMRItem.flushTemp,
-      readScale: 0.1,
-      writeScale: 10.0,
-    ),
-    MMRItem.flushTimeout: _MMRConfig(
-      item: MMRItem.flushTimeout,
-      readScale: 0.1,
-      writeScale: 10.0,
-    ),
-    MMRItem.waterHeaterIdleTemp: _MMRConfig(
-      item: MMRItem.waterHeaterIdleTemp,
-      readScale: 0.1,
-      writeScale: 10.0,
-    ),
-    MMRItem.heaterUp1Flow: _MMRConfig(
-      item: MMRItem.heaterUp1Flow,
-      readScale: 0.1,
-      writeScale: 10.0,
-    ),
-    MMRItem.heaterUp2Flow: _MMRConfig(
-      item: MMRItem.heaterUp2Flow,
-      readScale: 0.1,
-      writeScale: 10.0,
-    ),
-    MMRItem.heaterUp2Timeout: _MMRConfig(
-      item: MMRItem.heaterUp2Timeout,
-      readScale: 0.1,
-      writeScale: 10.0,
-    ),
-    MMRItem.hotWaterFlowRate: _MMRConfig(
-      item: MMRItem.hotWaterFlowRate,
-      readScale: 0.1,
-      writeScale: 10.0,
-    ),
-    MMRItem.targetSteamFlow: _MMRConfig(
-      item: MMRItem.targetSteamFlow,
-      readScale: 0.01,
-      writeScale: 100.0,
-    ),
-    MMRItem.tankTemp: _MMRConfig(item: MMRItem.tankTemp),
-    MMRItem.allowUSBCharging: _MMRConfig(item: MMRItem.allowUSBCharging),
-    MMRItem.calFlowEst: _MMRConfig(
-      item: MMRItem.calFlowEst,
-      readScale: 0.001,
-      writeScale: 1000.0,
-      minValue: 130,
-      maxValue: 2000,
-    ),
-  };
-
   int _unpackMMRInt(List<int> buffer) {
     // Defensive guard: `_mmrRead` now throws `MmrTimeoutException` on
     // missing responses and shouldn't reach here with a short buffer,
@@ -172,23 +109,19 @@ extension UnifiedDe1MMR on UnifiedDe1 {
   }
 
   Future<double> _readMMRScaled(MMRItem item) async {
-    final config = _mmrConfigs[item]!;
     final rawValue = await _readMMRInt(item);
-    return rawValue.toDouble() * config.readScale;
+    return rawValue.toDouble() * item.readScale;
   }
 
   Future<void> _writeMMRInt(MMRItem item, int value) async {
-    final config = _mmrConfigs[item];
-    final clampedValue =
-        config?.minValue != null && config?.maxValue != null
-            ? min(config!.maxValue!, max(config.minValue!, value))
-            : value;
+    final clampedValue = (item.min != null && item.max != null)
+        ? value.clamp(item.min!, item.max!)
+        : value;
     await _mmrWrite(item, _packMMRInt(clampedValue));
   }
 
   Future<void> _writeMMRScaled(MMRItem item, double value) async {
-    final config = _mmrConfigs[item]!;
-    final scaledValue = (value * config.writeScale).toInt();
+    final scaledValue = (value * item.writeScale).toInt();
     await _writeMMRInt(item, scaledValue);
   }
 }

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart
@@ -6,10 +6,21 @@ part of 'unified_de1.dart';
 const _mmrReadTimeout = Duration(seconds: 2);
 
 extension UnifiedDe1MMR on UnifiedDe1 {
-  Future<List<int>> _mmrRead(MMRItem item, {int length = 0}) async {
-    _log.info("mmr read: ${item.name}");
+  Future<List<int>> _mmrRead(MMRItem item, {int length = 0}) =>
+      _mmrReadRaw(item.address, length: length, label: item.name);
+
+  Future<void> _mmrWrite(MMRItem item, List<int> bufferData) =>
+      _mmrWriteRaw(item.address, bufferData, label: item.name);
+
+  /// Address-only MMR read for capability mixins whose addresses aren't
+  /// in the [MMRItem] enum. Same wire behavior as [_mmrRead]; uses the
+  /// hex address as the log/timeout label when no enum name is given.
+  Future<List<int>> _mmrReadRaw(int address,
+      {int length = 0, String? label}) async {
+    final logLabel = label ?? '0x${address.toRadixString(16)}';
+    _log.info("mmr read: $logLabel");
     ByteData bytes = ByteData(20);
-    bytes.setInt32(0, item.address, Endian.big);
+    bytes.setInt32(0, address, Endian.big);
     var buffer = bytes.buffer.asUint8List();
     buffer[0] = (length % 0xFF);
 
@@ -25,8 +36,6 @@ extension UnifiedDe1MMR on UnifiedDe1 {
     var result = await _mmr
         .map((d) => d.buffer.asUint8List().toList())
         .firstWhere((element) {
-          // log.info("listen where event  ${element.map(toHexString).toList()}");
-
           if (buffer[1] == element[1] &&
               buffer[2] == element[2] &&
               buffer[3] == element[3]) {
@@ -38,7 +47,7 @@ extension UnifiedDe1MMR on UnifiedDe1 {
         .timeout(
           _mmrReadTimeout,
           onTimeout: () =>
-              throw MmrTimeoutException(item.name, _mmrReadTimeout),
+              throw MmrTimeoutException(logLabel, _mmrReadTimeout),
         );
     _log.info(
       "listen event Result:  ${result.map((e) => e.toRadixString(16)).toList()}",
@@ -46,11 +55,14 @@ extension UnifiedDe1MMR on UnifiedDe1 {
     return result;
   }
 
-  Future<void> _mmrWrite(MMRItem item, List<int> bufferData) {
-    _log.info("mmr write: ${item.name}");
+  /// Address-only MMR write for capability mixins; see [_mmrReadRaw].
+  Future<void> _mmrWriteRaw(int address, List<int> bufferData,
+      {String? label}) {
+    final logLabel = label ?? '0x${address.toRadixString(16)}';
+    _log.info("mmr write: $logLabel");
 
     ByteData bytes = ByteData(20);
-    bytes.setInt32(0, item.address, Endian.big);
+    bytes.setInt32(0, address, Endian.big);
     var buffer = bytes.buffer.asUint8List();
     buffer[0] = (bufferData.length % 0xFF);
     var i = 0;

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -360,14 +360,6 @@ class UnifiedDe1Transport {
     _mmrSubject.add(d);
   }
 
-  /// Thin alias for [read] that accepts an optional BLE-side `timeout`.
-  /// Used by `UnifiedDe1.readEndpoint` (the @protected capability surface).
-  /// Serial transport ignores `timeout` — its read path is a one-shot
-  /// `Subject.first` already.
-  Future<ByteData> readEndpoint(LogicalEndpoint endpoint,
-          {Duration? timeout}) =>
-      read(endpoint, timeout: timeout);
-
   Future<ByteData> read(LogicalEndpoint endpoint, {Duration? timeout}) async {
     if (await _transport.connectionState.first != device.ConnectionState.connected) {
       throw ("de1 not connected");

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -360,7 +360,15 @@ class UnifiedDe1Transport {
     _mmrSubject.add(d);
   }
 
-  Future<ByteData> read(LogicalEndpoint endpoint) async {
+  /// Thin alias for [read] that accepts an optional BLE-side `timeout`.
+  /// Used by `UnifiedDe1.readEndpoint` (the @protected capability surface).
+  /// Serial transport ignores `timeout` — its read path is a one-shot
+  /// `Subject.first` already.
+  Future<ByteData> readEndpoint(LogicalEndpoint endpoint,
+          {Duration? timeout}) =>
+      read(endpoint, timeout: timeout);
+
+  Future<ByteData> read(LogicalEndpoint endpoint, {Duration? timeout}) async {
     if (await _transport.connectionState.first != device.ConnectionState.connected) {
       throw ("de1 not connected");
     }
@@ -372,7 +380,7 @@ class UnifiedDe1Transport {
             throw StateError(
                 'UnifiedDe1Transport.read: endpoint ${endpoint.name} has no BLE wire support');
           }
-          return await _bleRead(endpoint);
+          return await _bleRead(endpoint, timeout: timeout);
         case TransportType.serial:
           // _serialRead has a closed switch on Endpoint values to map to RX subjects;
           // non-Endpoint LogicalEndpoints can't be dispatched here.
@@ -396,7 +404,7 @@ class UnifiedDe1Transport {
       if (_isBleTimeout(e)) {
         if (await _handleBleTimeout(e, st)) {
           _log.info('Retrying read of ${endpoint.name} after reconnect');
-          return read(endpoint);
+          return read(endpoint, timeout: timeout);
         }
       }
       _log.severe("failed to read", e, st);
@@ -404,11 +412,12 @@ class UnifiedDe1Transport {
     }
   }
 
-  Future<ByteData> _bleRead(LogicalEndpoint e) async {
+  Future<ByteData> _bleRead(LogicalEndpoint e, {Duration? timeout}) async {
     if (_transport is! BLETransport) {
       throw "Invalid transport type, expected BLE";
     }
-    var data = await _transport.read(de1ServiceUUID, e.uuid!);
+    var data =
+        await _transport.read(de1ServiceUUID, e.uuid!, timeout: timeout);
     ByteData response = ByteData.sublistView(Uint8List.fromList(data));
     return response;
   }

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -365,23 +365,22 @@ class UnifiedDe1Transport {
       throw ("de1 not connected");
     }
 
-    final endpointName = _endpointName(endpoint);
     try {
       switch (transportType) {
         case TransportType.ble:
           if (endpoint.uuid == null) {
             throw StateError(
-                'Endpoint $endpointName has no BLE wire support');
+                'Endpoint ${endpoint.name} has no BLE wire support');
           }
           return await _bleRead(endpoint);
         case TransportType.serial:
           if (endpoint.representation == null) {
             throw StateError(
-                'Endpoint $endpointName has no serial wire support');
+                'Endpoint ${endpoint.name} has no serial wire support');
           }
           if (endpoint is! Endpoint) {
             throw StateError(
-                'Serial read requires DE1 Endpoint, got $endpointName');
+                'Serial read requires DE1 Endpoint, got ${endpoint.name}');
           }
           return await _serialRead(endpoint);
         default:
@@ -390,7 +389,7 @@ class UnifiedDe1Transport {
     } catch (e, st) {
       if (_isBleTimeout(e)) {
         if (await _handleBleTimeout(e, st)) {
-          _log.info('Retrying read of $endpointName after reconnect');
+          _log.info('Retrying read of ${endpoint.name} after reconnect');
           return read(endpoint);
         }
       }
@@ -458,9 +457,8 @@ class UnifiedDe1Transport {
     if (await _transport.connectionState.first != device.ConnectionState.connected) {
       throw ("de1 not connected");
     }
-    final endpointName = _endpointName(endpoint);
     try {
-      _log.fine('about to write to $endpointName');
+      _log.fine('about to write to ${endpoint.name}');
       _log.fine(
         'payload: ${data.map((el) => el.toRadixString(16).padLeft(2, '0')).join(' ')}',
       );
@@ -469,14 +467,14 @@ class UnifiedDe1Transport {
         case TransportType.ble:
           if (endpoint.uuid == null) {
             throw StateError(
-                'Endpoint $endpointName has no BLE wire support');
+                'Endpoint ${endpoint.name} has no BLE wire support');
           }
           await _bleWrite(endpoint, data, false);
           break;
         case TransportType.serial:
           if (endpoint.representation == null) {
             throw StateError(
-                'Endpoint $endpointName has no serial wire support');
+                'Endpoint ${endpoint.name} has no serial wire support');
           }
           await _serialWrite(endpoint, data);
           break;
@@ -486,7 +484,7 @@ class UnifiedDe1Transport {
     } catch (e, st) {
       if (_isBleTimeout(e)) {
         if (await _handleBleTimeout(e, st)) {
-          _log.info('Retrying write to $endpointName after reconnect');
+          _log.info('Retrying write to ${endpoint.name} after reconnect');
           return write(endpoint, data);
         }
       }
@@ -499,9 +497,8 @@ class UnifiedDe1Transport {
     if (await _transport.connectionState.first != device.ConnectionState.connected) {
       throw ("de1 not connected");
     }
-    final endpointName = _endpointName(endpoint);
     try {
-      _log.fine('about to write to $endpointName');
+      _log.fine('about to write to ${endpoint.name}');
       _log.fine(
         'payload: ${data.map((el) => el.toRadixString(16).padLeft(2, '0')).join(' ')}',
       );
@@ -509,14 +506,14 @@ class UnifiedDe1Transport {
         case TransportType.ble:
           if (endpoint.uuid == null) {
             throw StateError(
-                'Endpoint $endpointName has no BLE wire support');
+                'Endpoint ${endpoint.name} has no BLE wire support');
           }
           await _bleWrite(endpoint, data, true);
           break;
         case TransportType.serial:
           if (endpoint.representation == null) {
             throw StateError(
-                'Endpoint $endpointName has no serial wire support');
+                'Endpoint ${endpoint.name} has no serial wire support');
           }
           await _serialWrite(endpoint, data);
           break;
@@ -526,7 +523,7 @@ class UnifiedDe1Transport {
     } catch (e, st) {
       if (_isBleTimeout(e)) {
         if (await _handleBleTimeout(e, st)) {
-          _log.info('Retrying write to $endpointName after reconnect');
+          _log.info('Retrying write to ${endpoint.name} after reconnect');
           return writeWithResponse(endpoint, data);
         }
       }
@@ -534,9 +531,6 @@ class UnifiedDe1Transport {
       rethrow;
     }
   }
-
-  String _endpointName(LogicalEndpoint e) =>
-      e is Enum ? (e as Enum).name : e.toString();
 
   bool _isBleTimeout(Object error) {
     return transportType == TransportType.ble &&

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -9,6 +9,7 @@ import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/transport/ble_timeout_exception.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:reaprime/src/models/device/transport/logical_endpoint.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -359,16 +360,29 @@ class UnifiedDe1Transport {
     _mmrSubject.add(d);
   }
 
-  Future<ByteData> read(Endpoint endpoint) async {
+  Future<ByteData> read(LogicalEndpoint endpoint) async {
     if (await _transport.connectionState.first != device.ConnectionState.connected) {
       throw ("de1 not connected");
     }
 
+    final endpointName = _endpointName(endpoint);
     try {
       switch (transportType) {
         case TransportType.ble:
+          if (endpoint.uuid == null) {
+            throw StateError(
+                'Endpoint $endpointName has no BLE wire support');
+          }
           return await _bleRead(endpoint);
         case TransportType.serial:
+          if (endpoint.representation == null) {
+            throw StateError(
+                'Endpoint $endpointName has no serial wire support');
+          }
+          if (endpoint is! Endpoint) {
+            throw StateError(
+                'Serial read requires DE1 Endpoint, got $endpointName');
+          }
           return await _serialRead(endpoint);
         default:
           throw ("Unknown transport type: $transportType");
@@ -376,7 +390,7 @@ class UnifiedDe1Transport {
     } catch (e, st) {
       if (_isBleTimeout(e)) {
         if (await _handleBleTimeout(e, st)) {
-          _log.info('Retrying read of ${endpoint.name} after reconnect');
+          _log.info('Retrying read of $endpointName after reconnect');
           return read(endpoint);
         }
       }
@@ -385,11 +399,11 @@ class UnifiedDe1Transport {
     }
   }
 
-  Future<ByteData> _bleRead(Endpoint e) async {
+  Future<ByteData> _bleRead(LogicalEndpoint e) async {
     if (_transport is! BLETransport) {
       throw "Invalid transport type, expected BLE";
     }
-    var data = await _transport.read(de1ServiceUUID, e.uuid);
+    var data = await _transport.read(de1ServiceUUID, e.uuid!);
     ByteData response = ByteData.sublistView(Uint8List.fromList(data));
     return response;
   }
@@ -440,21 +454,30 @@ class UnifiedDe1Transport {
     }
   }
 
-  Future<void> write(Endpoint endpoint, Uint8List data) async {
+  Future<void> write(LogicalEndpoint endpoint, Uint8List data) async {
     if (await _transport.connectionState.first != device.ConnectionState.connected) {
       throw ("de1 not connected");
     }
+    final endpointName = _endpointName(endpoint);
     try {
-      _log.fine('about to write to ${endpoint.name}');
+      _log.fine('about to write to $endpointName');
       _log.fine(
         'payload: ${data.map((el) => el.toRadixString(16).padLeft(2, '0')).join(' ')}',
       );
 
       switch (transportType) {
         case TransportType.ble:
+          if (endpoint.uuid == null) {
+            throw StateError(
+                'Endpoint $endpointName has no BLE wire support');
+          }
           await _bleWrite(endpoint, data, false);
           break;
         case TransportType.serial:
+          if (endpoint.representation == null) {
+            throw StateError(
+                'Endpoint $endpointName has no serial wire support');
+          }
           await _serialWrite(endpoint, data);
           break;
         default:
@@ -463,7 +486,7 @@ class UnifiedDe1Transport {
     } catch (e, st) {
       if (_isBleTimeout(e)) {
         if (await _handleBleTimeout(e, st)) {
-          _log.info('Retrying write to ${endpoint.name} after reconnect');
+          _log.info('Retrying write to $endpointName after reconnect');
           return write(endpoint, data);
         }
       }
@@ -472,20 +495,29 @@ class UnifiedDe1Transport {
     }
   }
 
-  Future<void> writeWithResponse(Endpoint endpoint, Uint8List data) async {
+  Future<void> writeWithResponse(LogicalEndpoint endpoint, Uint8List data) async {
     if (await _transport.connectionState.first != device.ConnectionState.connected) {
       throw ("de1 not connected");
     }
+    final endpointName = _endpointName(endpoint);
     try {
-      _log.fine('about to write to ${endpoint.name}');
+      _log.fine('about to write to $endpointName');
       _log.fine(
         'payload: ${data.map((el) => el.toRadixString(16).padLeft(2, '0')).join(' ')}',
       );
       switch (transportType) {
         case TransportType.ble:
+          if (endpoint.uuid == null) {
+            throw StateError(
+                'Endpoint $endpointName has no BLE wire support');
+          }
           await _bleWrite(endpoint, data, true);
           break;
         case TransportType.serial:
+          if (endpoint.representation == null) {
+            throw StateError(
+                'Endpoint $endpointName has no serial wire support');
+          }
           await _serialWrite(endpoint, data);
           break;
         default:
@@ -494,7 +526,7 @@ class UnifiedDe1Transport {
     } catch (e, st) {
       if (_isBleTimeout(e)) {
         if (await _handleBleTimeout(e, st)) {
-          _log.info('Retrying write to ${endpoint.name} after reconnect');
+          _log.info('Retrying write to $endpointName after reconnect');
           return writeWithResponse(endpoint, data);
         }
       }
@@ -502,6 +534,9 @@ class UnifiedDe1Transport {
       rethrow;
     }
   }
+
+  String _endpointName(LogicalEndpoint e) =>
+      e is Enum ? (e as Enum).name : e.toString();
 
   bool _isBleTimeout(Object error) {
     return transportType == TransportType.ble &&
@@ -533,24 +568,24 @@ class UnifiedDe1Transport {
     }
   }
 
-  Future<void> _serialWrite(Endpoint e, Uint8List data) async {
+  Future<void> _serialWrite(LogicalEndpoint e, Uint8List data) async {
     if (_transport is! SerialTransport) {
       throw "Invalid transport type, expected Serial";
     }
     final payload = data
         .map((e) => e.toRadixString(16).padLeft(2, '0'))
         .join('');
-    await _transport.writeCommand('<${e.representation}>$payload');
+    await _transport.writeCommand('<${e.representation!}>$payload');
   }
 
-  Future<void> _bleWrite(Endpoint e, Uint8List data, bool withResponse) async {
+  Future<void> _bleWrite(LogicalEndpoint e, Uint8List data, bool withResponse) async {
     if (_transport is! BLETransport) {
       throw "Invalid transport type, expected BLE";
     }
 
     await _transport.write(
       de1ServiceUUID,
-      e.uuid,
+      e.uuid!,
       data,
       withResponse: withResponse,
     );

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -370,17 +370,23 @@ class UnifiedDe1Transport {
         case TransportType.ble:
           if (endpoint.uuid == null) {
             throw StateError(
-                'Endpoint ${endpoint.name} has no BLE wire support');
+                'UnifiedDe1Transport.read: endpoint ${endpoint.name} has no BLE wire support');
           }
           return await _bleRead(endpoint);
         case TransportType.serial:
-          if (endpoint.representation == null) {
-            throw StateError(
-                'Endpoint ${endpoint.name} has no serial wire support');
-          }
+          // _serialRead has a closed switch on Endpoint values to map to RX subjects;
+          // non-Endpoint LogicalEndpoints can't be dispatched here.
           if (endpoint is! Endpoint) {
             throw StateError(
-                'Serial read requires DE1 Endpoint, got ${endpoint.name}');
+                'UnifiedDe1Transport.read: endpoint ${endpoint.name} is not a DE1 Endpoint, serial read not supported');
+          }
+          // Defense-in-depth: `Endpoint.representation` is currently
+          // declared non-null, but if a future variant relaxes that we
+          // want a clear error rather than passing null downstream.
+          // ignore: unnecessary_null_comparison
+          if (endpoint.representation == null) {
+            throw StateError(
+                'UnifiedDe1Transport.read: endpoint ${endpoint.name} has no serial wire support');
           }
           return await _serialRead(endpoint);
         default:
@@ -467,14 +473,14 @@ class UnifiedDe1Transport {
         case TransportType.ble:
           if (endpoint.uuid == null) {
             throw StateError(
-                'Endpoint ${endpoint.name} has no BLE wire support');
+                'UnifiedDe1Transport.write: endpoint ${endpoint.name} has no BLE wire support');
           }
           await _bleWrite(endpoint, data, false);
           break;
         case TransportType.serial:
           if (endpoint.representation == null) {
             throw StateError(
-                'Endpoint ${endpoint.name} has no serial wire support');
+                'UnifiedDe1Transport.write: endpoint ${endpoint.name} has no serial wire support');
           }
           await _serialWrite(endpoint, data);
           break;
@@ -506,14 +512,14 @@ class UnifiedDe1Transport {
         case TransportType.ble:
           if (endpoint.uuid == null) {
             throw StateError(
-                'Endpoint ${endpoint.name} has no BLE wire support');
+                'UnifiedDe1Transport.writeWithResponse: endpoint ${endpoint.name} has no BLE wire support');
           }
           await _bleWrite(endpoint, data, true);
           break;
         case TransportType.serial:
           if (endpoint.representation == null) {
             throw StateError(
-                'Endpoint ${endpoint.name} has no serial wire support');
+                'UnifiedDe1Transport.writeWithResponse: endpoint ${endpoint.name} has no serial wire support');
           }
           await _serialWrite(endpoint, data);
           break;

--- a/lib/src/models/device/transport/logical_endpoint.dart
+++ b/lib/src/models/device/transport/logical_endpoint.dart
@@ -6,8 +6,11 @@
 /// `uuid` is the BLE characteristic UUID; null means the endpoint has no
 /// BLE wire support. `representation` is the single-character serial
 /// command id; null means no serial wire support. At least one must be
-/// non-null in any production endpoint.
+/// non-null in any production endpoint. `name` is a human-readable
+/// identifier used in logs and error messages — Dart enums satisfy this
+/// via `Enum.name` automatically.
 abstract class LogicalEndpoint {
   String? get uuid;
   String? get representation;
+  String get name;
 }

--- a/lib/src/models/device/transport/logical_endpoint.dart
+++ b/lib/src/models/device/transport/logical_endpoint.dart
@@ -1,0 +1,13 @@
+/// Wire-agnostic identifier for a DE1-family endpoint.
+///
+/// Capabilities target [LogicalEndpoint], never raw UUIDs or serial chars,
+/// so the BLE/serial dispatch in `UnifiedDe1Transport` keeps working.
+///
+/// `uuid` is the BLE characteristic UUID; null means the endpoint has no
+/// BLE wire support. `representation` is the single-character serial
+/// command id; null means no serial wire support. At least one must be
+/// non-null in any production endpoint.
+abstract class LogicalEndpoint {
+  String? get uuid;
+  String? get representation;
+}

--- a/lib/src/models/device/transport/logical_endpoint.dart
+++ b/lib/src/models/device/transport/logical_endpoint.dart
@@ -7,8 +7,13 @@
 /// BLE wire support. `representation` is the single-character serial
 /// command id; null means no serial wire support. At least one must be
 /// non-null in any production endpoint. `name` is a human-readable
-/// identifier used in logs and error messages — Dart enums satisfy this
-/// via `Enum.name` automatically.
+/// identifier used in logs and error messages.
+///
+/// **Note for enum implementers:** Dart's analyzer doesn't see the
+/// synthesized `Enum.name` as satisfying this interface's `String get name`
+/// getter. Add `@override String get name => (this as Enum).name;` to your
+/// enum. See [Endpoint] for an example and fix-commit history
+/// (553550d / b7b8ed7).
 abstract class LogicalEndpoint {
   String? get uuid;
   String? get representation;

--- a/test/helpers/fake_ble_transport.dart
+++ b/test/helpers/fake_ble_transport.dart
@@ -1,0 +1,228 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:typed_data';
+
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// Recorded write captured by [FakeBleTransport]. Includes the
+/// `withResponse` flag so tests covering `writeWithResponse` vs.
+/// fire-and-forget paths can distinguish them.
+typedef FakeBleWrite = ({
+  String characteristicUUID,
+  Uint8List data,
+  bool withResponse,
+});
+
+/// Consolidated BLE transport stub for tests.
+///
+/// Replaces the per-test stubs that lived in `protected_surface_test.dart`
+/// (`_ProgrammableBleTransport`), `firmware_prelude_hook_test.dart`
+/// (`_CapturingBleTransport`), and `bengle_firmware_prelude_test.dart`
+/// (`_CapturingBleTransport`).
+///
+/// Capabilities provided:
+///
+/// * BLE service discovery returns `[de1ServiceUUID]`.
+/// * Per-UUID subscribe-callback capture.
+/// * Per-UUID `read()` queue ([queueRead]) — falls through to a 20-byte
+///   zero buffer for unstubbed reads.
+/// * Ordered write capture in [writes].
+/// * MMR-response synthesis: calling [queueMmrResponseInt] /
+///   [queueMmrResponseRaw] sets up a pending response that is emitted
+///   on the `readFromMMR` notification stream when a matching MMR
+///   read request hits `Endpoint.readFromMMR.uuid`.
+/// * [lastRequestedState] decodes the most recent write to
+///   `Endpoint.requestedState` back into a [MachineState] for
+///   readable assertions.
+class FakeBleTransport extends BLETransport {
+  final _connState =
+      BehaviorSubject<ConnectionState>.seeded(ConnectionState.connected);
+
+  /// Subscribe callbacks keyed by characteristic UUID.
+  final Map<String, void Function(Uint8List)> subscribers = {};
+
+  /// Address -> integer to emit on the next matching MMR read request.
+  final Map<int, int> _intResponses = {};
+
+  /// Address -> raw 16-byte payload (bytes 4..19 of the 20-byte MMR
+  /// notification frame). Takes precedence over [_intResponses] when
+  /// both are queued for the same address.
+  final Map<int, List<int>> _rawResponses = {};
+
+  /// Per-UUID queued `read()` payloads.
+  final Map<String, Queue<Uint8List>> _readQueue = {};
+
+  /// Ordered writes seen by the transport.
+  final List<FakeBleWrite> writes = [];
+
+  /// Queue an integer to be returned when a read request to [item] hits
+  /// the MMR write characteristic.
+  void queueMmrResponseInt(MmrAddress item, int value) {
+    _intResponses[item.address] = value;
+  }
+
+  /// Queue a raw payload (1..16 bytes) to be returned when a read
+  /// request to [item] hits the MMR write characteristic.
+  void queueMmrResponseRaw(MmrAddress item, List<int> payload) {
+    _rawResponses[item.address] = payload;
+  }
+
+  /// Queue [bytes] for the next `read()` call against [characteristicUUID].
+  /// Subsequent reads pop further entries; once empty the default 20-byte
+  /// zero buffer is returned.
+  void queueRead(String characteristicUUID, Uint8List bytes) {
+    _readQueue.putIfAbsent(characteristicUUID, Queue.new).add(bytes);
+  }
+
+  /// Decoded last `requestedState` write, or null if none seen.
+  MachineState? get lastRequestedState {
+    for (final w in writes.reversed) {
+      if (w.characteristicUUID != Endpoint.requestedState.uuid) continue;
+      if (w.data.isEmpty) continue;
+      final stateEnum = De1StateEnum.fromHexValue(w.data[0]);
+      for (final ms in MachineState.values) {
+        if (De1StateEnum.fromMachineState(ms) == stateEnum) return ms;
+      }
+      return null;
+    }
+    return null;
+  }
+
+  @override
+  String get id => 'fake-ble';
+
+  @override
+  String get name => 'FakeBle';
+
+  @override
+  Stream<ConnectionState> get connectionState => _connState.stream;
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<List<String>> discoverServices() async => [de1ServiceUUID];
+
+  @override
+  Future<Uint8List> read(String serviceUUID, String characteristicUUID,
+      {Duration? timeout}) async {
+    final q = _readQueue[characteristicUUID];
+    if (q != null && q.isNotEmpty) return q.removeFirst();
+    // 20-byte zero buffer matches MMR/state response width; tolerated by
+    // parsers during onConnect.
+    return Uint8List(20);
+  }
+
+  @override
+  Future<void> subscribe(String serviceUUID, String characteristicUUID,
+      void Function(Uint8List) callback) async {
+    subscribers[characteristicUUID] = callback;
+  }
+
+  @override
+  Future<void> setTransportPriority(bool prioritized) async {}
+
+  @override
+  Future<void> write(
+      String serviceUUID, String characteristicUUID, Uint8List data,
+      {bool withResponse = true, Duration? timeout}) async {
+    writes.add((
+      characteristicUUID: characteristicUUID,
+      data: data,
+      withResponse: withResponse,
+    ));
+
+    // The DE1 firmware overloads `Endpoint.readFromMMR` for *requests*:
+    // a write to that characteristic asks for a payload; the firmware
+    // then notifies on the same UUID. Synthesize a matching notification
+    // when the test has queued a response for the requested address.
+    if (characteristicUUID != Endpoint.readFromMMR.uuid) return;
+    if (data.length < 4) return;
+    final addrMid1 = data[1];
+    final addrMid2 = data[2];
+    final addrLow = data[3];
+
+    int? matchedRawAddr;
+    for (final addr in _rawResponses.keys) {
+      final bytes = ByteData(4)..setInt32(0, addr, Endian.big);
+      if (bytes.getUint8(1) == addrMid1 &&
+          bytes.getUint8(2) == addrMid2 &&
+          bytes.getUint8(3) == addrLow) {
+        matchedRawAddr = addr;
+        break;
+      }
+    }
+    if (matchedRawAddr != null) {
+      final payload = _rawResponses.remove(matchedRawAddr)!;
+      final resp = Uint8List(20);
+      resp[0] = data[0];
+      resp[1] = addrMid1;
+      resp[2] = addrMid2;
+      resp[3] = addrLow;
+      for (var i = 0; i < payload.length && i + 4 < 20; i++) {
+        resp[i + 4] = payload[i];
+      }
+      final cb = subscribers[Endpoint.readFromMMR.uuid];
+      if (cb != null) {
+        scheduleMicrotask(() => cb(resp));
+      }
+      return;
+    }
+
+    int? matchedAddr;
+    for (final addr in _intResponses.keys) {
+      final bytes = ByteData(4)..setInt32(0, addr, Endian.big);
+      if (bytes.getUint8(1) == addrMid1 &&
+          bytes.getUint8(2) == addrMid2 &&
+          bytes.getUint8(3) == addrLow) {
+        matchedAddr = addr;
+        break;
+      }
+    }
+    if (matchedAddr == null) return;
+    final value = _intResponses.remove(matchedAddr)!;
+    final resp = Uint8List(20);
+    final view = ByteData.sublistView(resp);
+    view.setUint8(0, data[0]);
+    view.setUint8(1, addrMid1);
+    view.setUint8(2, addrMid2);
+    view.setUint8(3, addrLow);
+    view.setInt32(4, value, Endian.little);
+    final cb = subscribers[Endpoint.readFromMMR.uuid];
+    if (cb != null) {
+      // Emit asynchronously so `_mmrRead`'s firstWhere subscription is
+      // set up before the value lands.
+      scheduleMicrotask(() => cb(resp));
+    }
+  }
+
+  /// Queue the standard set of MMR responses needed for `onConnect()` to
+  /// complete (`v13Model`, `ghcInfo`, `serialN`, `cpuFirmwareBuild`,
+  /// `heaterV`, `refillKitPresent`). Override individual values via
+  /// keyword arguments.
+  void queueOnConnectResponses({
+    int v13Model = 1,
+    int ghcInfo = 0,
+    int serialN = 12345,
+    int cpuFirmwareBuild = 1300,
+    int heaterV = 230,
+    int refillKitPresent = 0,
+  }) {
+    queueMmrResponseInt(MMRItem.v13Model, v13Model);
+    queueMmrResponseInt(MMRItem.ghcInfo, ghcInfo);
+    queueMmrResponseInt(MMRItem.serialN, serialN);
+    queueMmrResponseInt(MMRItem.cpuFirmwareBuild, cpuFirmwareBuild);
+    queueMmrResponseInt(MMRItem.heaterV, heaterV);
+    queueMmrResponseInt(MMRItem.refillKitPresent, refillKitPresent);
+  }
+
+  void dispose() => _connState.close();
+}

--- a/test/unit/models/device/impl/bengle/bengle_firmware_prelude_test.dart
+++ b/test/unit/models/device/impl/bengle/bengle_firmware_prelude_test.dart
@@ -1,0 +1,95 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// Minimal BLE transport stub: captures every characteristic write so the
+/// test can decode the byte written to `Endpoint.requestedState`.
+class _CapturingBleTransport extends BLETransport {
+  final _connState =
+      BehaviorSubject<ConnectionState>.seeded(ConnectionState.connected);
+
+  /// Ordered list of `(uuid, data)` writes seen by the transport.
+  final List<({String characteristicUUID, Uint8List data})> writes = [];
+
+  /// Last `MachineState` requested via a write to `Endpoint.requestedState`,
+  /// decoded by reversing `De1StateEnum.fromMachineState(...)`.
+  MachineState? get lastRequestedState {
+    for (final w in writes.reversed) {
+      if (w.characteristicUUID != Endpoint.requestedState.uuid) continue;
+      if (w.data.isEmpty) continue;
+      final stateEnum = De1StateEnum.fromHexValue(w.data[0]);
+      for (final ms in MachineState.values) {
+        if (De1StateEnum.fromMachineState(ms) == stateEnum) return ms;
+      }
+      return null;
+    }
+    return null;
+  }
+
+  @override
+  String get id => 'capturing-ble';
+
+  @override
+  String get name => 'CapturingBle';
+
+  @override
+  Stream<ConnectionState> get connectionState => _connState.stream;
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<List<String>> discoverServices() async => [de1ServiceUUID];
+
+  @override
+  Future<Uint8List> read(String serviceUUID, String characteristicUUID,
+          {Duration? timeout}) async =>
+      Uint8List(20);
+
+  @override
+  Future<void> subscribe(String serviceUUID, String characteristicUUID,
+      void Function(Uint8List) callback) async {}
+
+  @override
+  Future<void> setTransportPriority(bool prioritized) async {}
+
+  @override
+  Future<void> write(
+      String serviceUUID, String characteristicUUID, Uint8List data,
+      {bool withResponse = true, Duration? timeout}) async {
+    writes.add((characteristicUUID: characteristicUUID, data: data));
+  }
+
+  void dispose() => _connState.close();
+}
+
+void main() {
+  group('Bengle.beforeFirmwareUpload', () {
+    test('requests MachineState.fwUpgrade', () async {
+      final transport = _CapturingBleTransport();
+      addTearDown(transport.dispose);
+      final bengle = Bengle(transport: transport);
+
+      // Tests live in the same package; @protected lint is irrelevant here.
+      // ignore: invalid_use_of_protected_member
+      await bengle.beforeFirmwareUpload();
+
+      expect(transport.lastRequestedState, MachineState.fwUpgrade);
+      // Wire byte must be 0x22.
+      final stateWrites = transport.writes
+          .where((w) => w.characteristicUUID == Endpoint.requestedState.uuid)
+          .toList();
+      expect(stateWrites, hasLength(1));
+      expect(stateWrites.single.data[0], 0x22);
+    });
+  });
+}

--- a/test/unit/models/device/impl/bengle/bengle_firmware_prelude_test.dart
+++ b/test/unit/models/device/impl/bengle/bengle_firmware_prelude_test.dart
@@ -1,81 +1,17 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/machine.dart';
-import 'package:reaprime/src/models/device/transport/ble_transport.dart';
-import 'package:rxdart/rxdart.dart';
 
-/// Minimal BLE transport stub: captures every characteristic write so the
-/// test can decode the byte written to `Endpoint.requestedState`.
-class _CapturingBleTransport extends BLETransport {
-  final _connState =
-      BehaviorSubject<ConnectionState>.seeded(ConnectionState.connected);
-
-  /// Ordered list of `(uuid, data)` writes seen by the transport.
-  final List<({String characteristicUUID, Uint8List data})> writes = [];
-
-  /// Last `MachineState` requested via a write to `Endpoint.requestedState`,
-  /// decoded by reversing `De1StateEnum.fromMachineState(...)`.
-  MachineState? get lastRequestedState {
-    for (final w in writes.reversed) {
-      if (w.characteristicUUID != Endpoint.requestedState.uuid) continue;
-      if (w.data.isEmpty) continue;
-      final stateEnum = De1StateEnum.fromHexValue(w.data[0]);
-      for (final ms in MachineState.values) {
-        if (De1StateEnum.fromMachineState(ms) == stateEnum) return ms;
-      }
-      return null;
-    }
-    return null;
-  }
-
-  @override
-  String get id => 'capturing-ble';
-
-  @override
-  String get name => 'CapturingBle';
-
-  @override
-  Stream<ConnectionState> get connectionState => _connState.stream;
-
-  @override
-  Future<void> connect() async {}
-
-  @override
-  Future<void> disconnect() async {}
-
-  @override
-  Future<List<String>> discoverServices() async => [de1ServiceUUID];
-
-  @override
-  Future<Uint8List> read(String serviceUUID, String characteristicUUID,
-          {Duration? timeout}) async =>
-      Uint8List(20);
-
-  @override
-  Future<void> subscribe(String serviceUUID, String characteristicUUID,
-      void Function(Uint8List) callback) async {}
-
-  @override
-  Future<void> setTransportPriority(bool prioritized) async {}
-
-  @override
-  Future<void> write(
-      String serviceUUID, String characteristicUUID, Uint8List data,
-      {bool withResponse = true, Duration? timeout}) async {
-    writes.add((characteristicUUID: characteristicUUID, data: data));
-  }
-
-  void dispose() => _connState.close();
-}
+import '../../../../../helpers/fake_ble_transport.dart';
 
 void main() {
   group('Bengle.beforeFirmwareUpload', () {
     test('requests MachineState.fwUpgrade', () async {
-      final transport = _CapturingBleTransport();
+      final transport = FakeBleTransport();
       addTearDown(transport.dispose);
       final bengle = Bengle(transport: transport);
 
@@ -90,6 +26,47 @@ void main() {
           .toList();
       expect(stateWrites, hasLength(1));
       expect(stateWrites.single.data[0], 0x22);
+    });
+
+    test(
+        'updateFirmware drives sleeping -> fwUpgrade write sequence on the wire',
+        () async {
+      final transport = FakeBleTransport();
+      addTearDown(transport.dispose);
+      transport.queueOnConnectResponses();
+
+      final bengle = Bengle(transport: transport);
+      await bengle.onConnect();
+
+      final preFwWrites = transport.writes.length;
+
+      // The FW protocol blocks waiting on `fwMapRequest` notifications
+      // (and a 10s erase wait). Drive it just long enough for the
+      // prelude writes to land, then bail via timeout.
+      try {
+        await bengle
+            .updateFirmware(Uint8List(0), onProgress: (_) {})
+            .timeout(const Duration(seconds: 1));
+      } on TimeoutException catch (_) {
+        // Expected: protocol is blocked waiting on FW-path notifications.
+      }
+
+      final fwWrites = transport.writes.sublist(preFwWrites);
+      // First two writes belong to the prelude:
+      //   1. requestState(sleeping) — UnifiedDe1._updateFirmware
+      //   2. requestState(fwUpgrade) — Bengle.beforeFirmwareUpload
+      // Subsequent writes (poll for fwMapRequest, etc.) are FW-protocol
+      // territory and intentionally not asserted on.
+      expect(fwWrites.length, greaterThanOrEqualTo(2),
+          reason: 'expected at least the sleeping + fwUpgrade writes');
+      expect(fwWrites[0].characteristicUUID, Endpoint.requestedState.uuid);
+      expect(fwWrites[0].data[0],
+          De1StateEnum.fromMachineState(MachineState.sleeping).hexValue);
+      expect(fwWrites[1].characteristicUUID, Endpoint.requestedState.uuid);
+      expect(fwWrites[1].data[0], 0x22,
+          reason: 'second prelude write must be fwUpgrade (0x22)');
+      expect(fwWrites[1].data[0],
+          De1StateEnum.fromMachineState(MachineState.fwUpgrade).hexValue);
     });
   });
 }

--- a/test/unit/models/device/impl/de1/mmr_address_test.dart
+++ b/test/unit/models/device/impl/de1/mmr_address_test.dart
@@ -1,0 +1,31 @@
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('MmrAddress', () {
+    test('every MMRItem implements MmrAddress with a kind', () {
+      for (final m in MMRItem.values) {
+        expect(m, isA<MmrAddress>(), reason: m.name);
+        expect(m.address, greaterThanOrEqualTo(0));
+        expect(m.length, greaterThan(0));
+        expect(m.kind, isNotNull, reason: '${m.name} kind');
+      }
+    });
+
+    test('scaled MMRItems have kind == scaledFloat', () {
+      expect(MMRItem.flushFlowRate.kind, MmrValueKind.scaledFloat);
+      expect(MMRItem.targetSteamFlow.kind, MmrValueKind.scaledFloat);
+      expect(MMRItem.calFlowEst.kind, MmrValueKind.scaledFloat);
+    });
+
+    test('unscaled int MMRItems have kind == int32', () {
+      expect(MMRItem.fanThreshold.kind, MmrValueKind.int32);
+      expect(MMRItem.tankTemp.kind, MmrValueKind.int32);
+    });
+
+    test('boolean MMRItems have kind == boolean', () {
+      expect(MMRItem.allowUSBCharging.kind, MmrValueKind.boolean);
+    });
+  });
+}

--- a/test/unit/models/device/impl/de1/mmr_address_test.dart
+++ b/test/unit/models/device/impl/de1/mmr_address_test.dart
@@ -26,6 +26,27 @@ void main() {
 
     test('boolean MMRItems have kind == boolean', () {
       expect(MMRItem.allowUSBCharging.kind, MmrValueKind.boolean);
+      expect(MMRItem.userPresent.kind, MmrValueKind.boolean);
+    });
+
+    test('entries with length > 4 are bytes or string', () {
+      for (final m in MMRItem.values) {
+        if (m.length > 4) {
+          expect([MmrValueKind.bytes, MmrValueKind.string], contains(m.kind),
+              reason: '${m.name} has length ${m.length} but kind ${m.kind.name}');
+        }
+      }
+    });
+
+    test('all kinds covered by at least one MMRItem (DE1 baseline)', () {
+      // string and int16 may legitimately be unused by DE1; the others must appear.
+      final used = MMRItem.values.map((m) => m.kind).toSet();
+      expect(used, containsAll([
+        MmrValueKind.int32,
+        MmrValueKind.scaledFloat,
+        MmrValueKind.boolean,
+        MmrValueKind.bytes,
+      ]));
     });
   });
 }

--- a/test/unit/models/device/impl/de1/unified_de1/firmware_prelude_hook_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/firmware_prelude_hook_test.dart
@@ -1,0 +1,182 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// Minimal BLE transport stub: captures every characteristic write so the
+/// FW upload prelude assertions can inspect the order of `requestedState`
+/// writes vs. the `beforeFirmwareUpload` hook firing.
+class _CapturingBleTransport extends BLETransport {
+  final _connState =
+      BehaviorSubject<ConnectionState>.seeded(ConnectionState.connected);
+  final Map<String, void Function(Uint8List)> _subscribers = {};
+  final Map<int, int> _intResponses = {};
+
+  /// Ordered list of `(uuid, data)` writes seen by the transport.
+  final List<({String characteristicUUID, Uint8List data})> writes = [];
+
+  void queueMmrResponseInt(MmrAddress addr, int value) {
+    _intResponses[addr.address] = value;
+  }
+
+  @override
+  String get id => 'capturing-ble';
+
+  @override
+  String get name => 'CapturingBle';
+
+  @override
+  Stream<ConnectionState> get connectionState => _connState.stream;
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<List<String>> discoverServices() async => [de1ServiceUUID];
+
+  @override
+  Future<Uint8List> read(String serviceUUID, String characteristicUUID,
+          {Duration? timeout}) async =>
+      Uint8List(20);
+
+  @override
+  Future<void> subscribe(String serviceUUID, String characteristicUUID,
+      void Function(Uint8List) callback) async {
+    _subscribers[characteristicUUID] = callback;
+  }
+
+  @override
+  Future<void> setTransportPriority(bool prioritized) async {}
+
+  @override
+  Future<void> write(
+      String serviceUUID, String characteristicUUID, Uint8List data,
+      {bool withResponse = true, Duration? timeout}) async {
+    writes.add((characteristicUUID: characteristicUUID, data: data));
+
+    // Synthesize MMR-read responses so onConnect can complete.
+    if (characteristicUUID != Endpoint.readFromMMR.uuid) return;
+    if (data.length < 4) return;
+    final addrMid1 = data[1];
+    final addrMid2 = data[2];
+    final addrLow = data[3];
+    int? matchedAddr;
+    for (final addr in _intResponses.keys) {
+      final bytes = ByteData(4)..setInt32(0, addr, Endian.big);
+      if (bytes.getUint8(1) == addrMid1 &&
+          bytes.getUint8(2) == addrMid2 &&
+          bytes.getUint8(3) == addrLow) {
+        matchedAddr = addr;
+        break;
+      }
+    }
+    if (matchedAddr == null) return;
+    final value = _intResponses.remove(matchedAddr)!;
+    final resp = Uint8List(20);
+    final view = ByteData.sublistView(resp);
+    view.setUint8(0, data[0]);
+    view.setUint8(1, addrMid1);
+    view.setUint8(2, addrMid2);
+    view.setUint8(3, addrLow);
+    view.setInt32(4, value, Endian.little);
+    final cb = _subscribers[Endpoint.readFromMMR.uuid];
+    if (cb != null) {
+      scheduleMicrotask(() => cb(resp));
+    }
+  }
+
+  void dispose() => _connState.close();
+}
+
+class _FwHookProbe extends UnifiedDe1 {
+  _FwHookProbe({required super.transport});
+
+  bool hookCalled = false;
+
+  /// Number of writes captured at the moment the hook fires. Lets a test
+  /// assert ordering relative to `requestState(sleeping)` without driving
+  /// the full FW protocol.
+  int writeCountAtHook = -1;
+
+  /// Set by tests to read the underlying transport's write log when the
+  /// hook fires.
+  late _CapturingBleTransport probeTransport;
+
+  @override
+  @protected
+  Future<void> beforeFirmwareUpload() async {
+    hookCalled = true;
+    writeCountAtHook = probeTransport.writes.length;
+  }
+}
+
+void main() {
+  group('beforeFirmwareUpload hook', () {
+    test('UnifiedDe1.beforeFirmwareUpload defaults to no-op', () async {
+      final transport = _CapturingBleTransport();
+      addTearDown(transport.dispose);
+      final de1 = UnifiedDe1(transport: transport);
+      // The default implementation must complete without side effects.
+      // Tests live in the same package; @protected lint is irrelevant here.
+      // ignore: invalid_use_of_protected_member
+      await de1.beforeFirmwareUpload();
+      // No writes should have happened from the no-op default.
+      expect(transport.writes, isEmpty);
+    });
+
+    test('subclass override is invoked by the FW upload path', () async {
+      final transport = _CapturingBleTransport();
+      addTearDown(transport.dispose);
+      transport
+        ..queueMmrResponseInt(MMRItem.v13Model, 1)
+        ..queueMmrResponseInt(MMRItem.ghcInfo, 0)
+        ..queueMmrResponseInt(MMRItem.serialN, 12345)
+        ..queueMmrResponseInt(MMRItem.cpuFirmwareBuild, 1300)
+        ..queueMmrResponseInt(MMRItem.heaterV, 230)
+        ..queueMmrResponseInt(MMRItem.refillKitPresent, 0);
+
+      final de1 = _FwHookProbe(transport: transport);
+      de1.probeTransport = transport;
+      await de1.onConnect();
+
+      // Snapshot the write count after onConnect so we can isolate the
+      // FW prelude writes.
+      final preFwWrites = transport.writes.length;
+
+      // _updateFirmware sleeps for 10 seconds waiting on firmware erase
+      // before the upload loop. We don't need to drive it to completion
+      // — we just need the hook to fire (which happens immediately after
+      // requestState(sleeping)).
+      try {
+        await de1
+            .updateFirmware(Uint8List(0), onProgress: (_) {})
+            .timeout(const Duration(seconds: 1));
+      } on TimeoutException catch (_) {
+        // Expected: erase wait blocks for 10s.
+      }
+
+      expect(de1.hookCalled, isTrue,
+          reason: 'beforeFirmwareUpload hook was not invoked '
+              'by the FW upload path');
+
+      // The hook must fire AFTER requestState(sleeping) — i.e., at least
+      // one write to Endpoint.requestedState must have landed on the
+      // wire before hookCalled flipped.
+      expect(de1.writeCountAtHook, greaterThan(preFwWrites),
+          reason: 'hook fired before requestState(sleeping) wrote to wire');
+      final fwPreludeWrites = transport.writes.sublist(preFwWrites);
+      expect(fwPreludeWrites.first.characteristicUUID,
+          Endpoint.requestedState.uuid,
+          reason: 'first FW-path write must be requestState(sleeping)');
+    });
+  });
+}

--- a/test/unit/models/device/impl/de1/unified_de1/firmware_prelude_hook_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/firmware_prelude_hook_test.dart
@@ -2,100 +2,10 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
-import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
-import 'package:reaprime/src/models/device/transport/ble_transport.dart';
-import 'package:rxdart/rxdart.dart';
 
-/// Minimal BLE transport stub: captures every characteristic write so the
-/// FW upload prelude assertions can inspect the order of `requestedState`
-/// writes vs. the `beforeFirmwareUpload` hook firing.
-class _CapturingBleTransport extends BLETransport {
-  final _connState =
-      BehaviorSubject<ConnectionState>.seeded(ConnectionState.connected);
-  final Map<String, void Function(Uint8List)> _subscribers = {};
-  final Map<int, int> _intResponses = {};
-
-  /// Ordered list of `(uuid, data)` writes seen by the transport.
-  final List<({String characteristicUUID, Uint8List data})> writes = [];
-
-  void queueMmrResponseInt(MmrAddress addr, int value) {
-    _intResponses[addr.address] = value;
-  }
-
-  @override
-  String get id => 'capturing-ble';
-
-  @override
-  String get name => 'CapturingBle';
-
-  @override
-  Stream<ConnectionState> get connectionState => _connState.stream;
-
-  @override
-  Future<void> connect() async {}
-
-  @override
-  Future<void> disconnect() async {}
-
-  @override
-  Future<List<String>> discoverServices() async => [de1ServiceUUID];
-
-  @override
-  Future<Uint8List> read(String serviceUUID, String characteristicUUID,
-          {Duration? timeout}) async =>
-      Uint8List(20);
-
-  @override
-  Future<void> subscribe(String serviceUUID, String characteristicUUID,
-      void Function(Uint8List) callback) async {
-    _subscribers[characteristicUUID] = callback;
-  }
-
-  @override
-  Future<void> setTransportPriority(bool prioritized) async {}
-
-  @override
-  Future<void> write(
-      String serviceUUID, String characteristicUUID, Uint8List data,
-      {bool withResponse = true, Duration? timeout}) async {
-    writes.add((characteristicUUID: characteristicUUID, data: data));
-
-    // Synthesize MMR-read responses so onConnect can complete.
-    if (characteristicUUID != Endpoint.readFromMMR.uuid) return;
-    if (data.length < 4) return;
-    final addrMid1 = data[1];
-    final addrMid2 = data[2];
-    final addrLow = data[3];
-    int? matchedAddr;
-    for (final addr in _intResponses.keys) {
-      final bytes = ByteData(4)..setInt32(0, addr, Endian.big);
-      if (bytes.getUint8(1) == addrMid1 &&
-          bytes.getUint8(2) == addrMid2 &&
-          bytes.getUint8(3) == addrLow) {
-        matchedAddr = addr;
-        break;
-      }
-    }
-    if (matchedAddr == null) return;
-    final value = _intResponses.remove(matchedAddr)!;
-    final resp = Uint8List(20);
-    final view = ByteData.sublistView(resp);
-    view.setUint8(0, data[0]);
-    view.setUint8(1, addrMid1);
-    view.setUint8(2, addrMid2);
-    view.setUint8(3, addrLow);
-    view.setInt32(4, value, Endian.little);
-    final cb = _subscribers[Endpoint.readFromMMR.uuid];
-    if (cb != null) {
-      scheduleMicrotask(() => cb(resp));
-    }
-  }
-
-  void dispose() => _connState.close();
-}
+import '../../../../../../helpers/fake_ble_transport.dart';
 
 class _FwHookProbe extends UnifiedDe1 {
   _FwHookProbe({required super.transport});
@@ -109,7 +19,7 @@ class _FwHookProbe extends UnifiedDe1 {
 
   /// Set by tests to read the underlying transport's write log when the
   /// hook fires.
-  late _CapturingBleTransport probeTransport;
+  late FakeBleTransport probeTransport;
 
   @override
   @protected
@@ -122,7 +32,7 @@ class _FwHookProbe extends UnifiedDe1 {
 void main() {
   group('beforeFirmwareUpload hook', () {
     test('UnifiedDe1.beforeFirmwareUpload defaults to no-op', () async {
-      final transport = _CapturingBleTransport();
+      final transport = FakeBleTransport();
       addTearDown(transport.dispose);
       final de1 = UnifiedDe1(transport: transport);
       // The default implementation must complete without side effects.
@@ -134,15 +44,9 @@ void main() {
     });
 
     test('subclass override is invoked by the FW upload path', () async {
-      final transport = _CapturingBleTransport();
+      final transport = FakeBleTransport();
       addTearDown(transport.dispose);
-      transport
-        ..queueMmrResponseInt(MMRItem.v13Model, 1)
-        ..queueMmrResponseInt(MMRItem.ghcInfo, 0)
-        ..queueMmrResponseInt(MMRItem.serialN, 12345)
-        ..queueMmrResponseInt(MMRItem.cpuFirmwareBuild, 1300)
-        ..queueMmrResponseInt(MMRItem.heaterV, 230)
-        ..queueMmrResponseInt(MMRItem.refillKitPresent, 0);
+      transport.queueOnConnectResponses();
 
       final de1 = _FwHookProbe(transport: transport);
       de1.probeTransport = transport;

--- a/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
@@ -168,18 +168,16 @@ mixin _TestCapability on UnifiedDe1 {
   // Intentionally calls `readMmrScaled` on an int32 address (fanThreshold)
   // — exercises the kind-mismatch StateError path.
   Future<double> readFanAsScaledFloat() =>
-      readMmrScaled(MMRItem.fanThreshold, readScale: 0.1);
+      readMmrScaled(MMRItem.fanThreshold);
 
   // Re-exports so tests can drive these from a mixin context (the only
   // legitimate access path for `@protected` members).
   Future<List<int>> capRead(MmrAddress addr) => readMmrRaw(addr);
   Future<void> capWrite(MmrAddress addr, List<int> bytes) =>
       writeMmrRaw(addr, bytes);
-  Future<double> capReadScaled(MmrAddress addr, double scale) =>
-      readMmrScaled(addr, readScale: scale);
-  Future<void> capWriteScaled(MmrAddress addr, double v,
-          {required double scale, int? min, int? max}) =>
-      writeMmrScaled(addr, v, writeScale: scale, min: min, max: max);
+  Future<double> capReadScaled(MmrAddress addr) => readMmrScaled(addr);
+  Future<void> capWriteScaled(MmrAddress addr, double v) =>
+      writeMmrScaled(addr, v);
   Stream<ByteData> capNotifications(LogicalEndpoint ep) =>
       notificationsFor(ep);
   Future<void> capWriteEndpoint(LogicalEndpoint ep, Uint8List data,
@@ -198,11 +196,23 @@ class _CapabilityAddr implements MmrAddress {
   final String name;
   @override
   final MmrValueKind kind;
+  @override
+  final double readScale;
+  @override
+  final double writeScale;
+  @override
+  final int? min;
+  @override
+  final int? max;
   const _CapabilityAddr({
     required this.address,
     required this.length,
     required this.name,
     required this.kind,
+    this.readScale = 1.0,
+    this.writeScale = 1.0,
+    this.min,
+    this.max,
   });
 }
 
@@ -322,10 +332,11 @@ void main() {
         length: 4,
         name: 'cupWarmerTemp',
         kind: MmrValueKind.scaledFloat,
+        readScale: 0.1,
       );
       // raw int32 = 250, little-endian -> [0xFA, 0x00, 0x00, 0x00]
       transport.queueMmrResponseRaw(addr, [0xFA, 0x00, 0x00, 0x00]);
-      final result = await de1.capReadScaled(addr, 0.1);
+      final result = await de1.capReadScaled(addr);
       expect(result, closeTo(25.0, 1e-9));
     });
 
@@ -335,10 +346,13 @@ void main() {
         length: 4,
         name: 'cupWarmerSetTemp',
         kind: MmrValueKind.scaledFloat,
+        writeScale: 10.0,
+        min: 0,
+        max: 500,
       );
       transport.writes.clear();
       // value 99.9 * writeScale 10.0 = 999, clamped to 500.
-      await de1.capWriteScaled(addr, 99.9, scale: 10.0, min: 0, max: 500);
+      await de1.capWriteScaled(addr, 99.9);
       final frame = transport.writes.firstWhere(
         (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
       );

--- a/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
@@ -42,7 +42,8 @@ class _ProgrammableBleTransport extends BLETransport {
   /// Captures each frame written to a non-MMR-read characteristic so
   /// tests can assert on the bytes that hit the wire. Specifically used
   /// for `Endpoint.writeToMMR` capture in the writeMmr* tests.
-  final List<({String characteristicUUID, Uint8List data})> writes = [];
+  final List<({String characteristicUUID, Uint8List data, bool withResponse})>
+      writes = [];
 
   void queueMmrResponseInt(MmrAddress addr, int value) {
     _intResponses[addr.address] = value;
@@ -92,7 +93,11 @@ class _ProgrammableBleTransport extends BLETransport {
       {bool withResponse = true, Duration? timeout}) async {
     // Capture every write so tests can assert on bytes that hit the
     // wire (used for writeMmr* coverage).
-    writes.add((characteristicUUID: characteristicUUID, data: data));
+    writes.add((
+      characteristicUUID: characteristicUUID,
+      data: data,
+      withResponse: withResponse,
+    ));
 
     // Only react to MMR write-read requests on the writeToMMR
     // characteristic (`Endpoint.readFromMMR.uuid` is what `_mmrRead`
@@ -401,17 +406,17 @@ void main() {
       );
     });
 
-    test('writeEndpoint(withResponse: false) throws UnimplementedError',
+    test('writeEndpoint(withResponse: false) routes through transport.write',
         () async {
-      await expectLater(
-        de1.capWriteEndpoint(Endpoint.requestedState, Uint8List(1),
-            withResponse: false),
-        throwsA(isA<UnimplementedError>().having(
-          (e) => e.message,
-          'message',
-          contains('withResponse=false'),
-        )),
+      transport.writes.clear();
+      final payload = Uint8List.fromList([0xAB]);
+      await de1.capWriteEndpoint(Endpoint.requestedState, payload,
+          withResponse: false);
+      final frame = transport.writes.firstWhere(
+        (w) => w.characteristicUUID == Endpoint.requestedState.uuid,
       );
+      expect(frame.data, payload);
+      expect(frame.withResponse, isFalse);
     });
   });
 }

--- a/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
@@ -1,0 +1,172 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// Programmable BLE transport that intercepts writes to the
+/// `writeToMMR` characteristic and synthesizes a matching `readFromMMR`
+/// notification with a queued integer payload. The DE1 firmware
+/// normally echoes the address bytes and appends the value as a
+/// little-endian int32 on the readFromMMR characteristic — this stub
+/// keeps that contract so `_mmrRead` finds its matching response.
+class _ProgrammableBleTransport extends BLETransport {
+  final _connState =
+      BehaviorSubject<ConnectionState>.seeded(ConnectionState.connected);
+  final Map<String, void Function(Uint8List)> _subscribers = {};
+
+  /// Map address (full 32-bit) -> integer to emit on the next matching
+  /// MMR read request.
+  final Map<int, int> _intResponses = {};
+
+  void queueMmrResponseInt(MmrAddress addr, int value) {
+    _intResponses[addr.address] = value;
+  }
+
+  @override
+  String get id => 'programmable-ble';
+
+  @override
+  String get name => 'ProgrammableBle';
+
+  @override
+  Stream<ConnectionState> get connectionState => _connState.stream;
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<List<String>> discoverServices() async => [de1ServiceUUID];
+
+  @override
+  Future<Uint8List> read(String serviceUUID, String characteristicUUID,
+          {Duration? timeout}) async =>
+      Uint8List(20);
+
+  @override
+  Future<void> subscribe(String serviceUUID, String characteristicUUID,
+      void Function(Uint8List) callback) async {
+    _subscribers[characteristicUUID] = callback;
+  }
+
+  @override
+  Future<void> setTransportPriority(bool prioritized) async {}
+
+  @override
+  Future<void> write(
+      String serviceUUID, String characteristicUUID, Uint8List data,
+      {bool withResponse = true, Duration? timeout}) async {
+    // Only react to MMR write-read requests on the writeToMMR
+    // characteristic (`Endpoint.readFromMMR.uuid` is what `_mmrRead`
+    // actually writes to — the firmware overloads the read endpoint
+    // with a write to request a payload, then notifies the same UUID).
+    // Looking at `_mmrRead`, it writes to `Endpoint.readFromMMR`.
+    if (characteristicUUID != Endpoint.readFromMMR.uuid) return;
+    if (data.length < 4) return;
+    final addrMid1 = data[1];
+    final addrMid2 = data[2];
+    final addrLow = data[3];
+    int? matchedAddr;
+    for (final addr in _intResponses.keys) {
+      final bytes = ByteData(4)..setInt32(0, addr, Endian.big);
+      if (bytes.getUint8(1) == addrMid1 &&
+          bytes.getUint8(2) == addrMid2 &&
+          bytes.getUint8(3) == addrLow) {
+        matchedAddr = addr;
+        break;
+      }
+    }
+    if (matchedAddr == null) return;
+    final value = _intResponses.remove(matchedAddr)!;
+    final resp = Uint8List(20);
+    final view = ByteData.sublistView(resp);
+    view.setUint8(0, data[0]);
+    view.setUint8(1, addrMid1);
+    view.setUint8(2, addrMid2);
+    view.setUint8(3, addrLow);
+    view.setInt32(4, value, Endian.little);
+    final cb = _subscribers[Endpoint.readFromMMR.uuid];
+    if (cb != null) {
+      // Emit asynchronously so `_mmrRead`'s firstWhere subscription is
+      // set up before the value lands.
+      scheduleMicrotask(() => cb(resp));
+    }
+  }
+
+  void dispose() => _connState.close();
+}
+
+// Capability-style mixin that exercises the protected surface.
+mixin _TestCapability on UnifiedDe1 {
+  Future<int> readFan() => readMmrInt(MMRItem.fanThreshold);
+  Future<int> readFanViaWrongHelper() => readMmrInt(MMRItem.targetSteamFlow);
+  Future<double> readScaledViaWrongHelper() =>
+      readMmrScaled(MMRItem.fanThreshold, readScale: 0.1);
+}
+
+class _TestDe1 extends UnifiedDe1 with _TestCapability {
+  _TestDe1({required super.transport});
+}
+
+void main() {
+  group('UnifiedDe1 protected surface', () {
+    late _ProgrammableBleTransport transport;
+    late _TestDe1 de1;
+
+    setUp(() async {
+      transport = _ProgrammableBleTransport();
+      de1 = _TestDe1(transport: transport);
+      // Subscribe wiring needs the BLE connect path to run; queue the
+      // MMR reads `onConnect` performs so it can complete.
+      transport
+        ..queueMmrResponseInt(MMRItem.v13Model, 1)
+        ..queueMmrResponseInt(MMRItem.ghcInfo, 0)
+        ..queueMmrResponseInt(MMRItem.serialN, 12345)
+        ..queueMmrResponseInt(MMRItem.cpuFirmwareBuild, 1300)
+        ..queueMmrResponseInt(MMRItem.heaterV, 230)
+        ..queueMmrResponseInt(MMRItem.refillKitPresent, 0);
+      await de1.onConnect();
+    });
+
+    tearDown(() {
+      transport.dispose();
+    });
+
+    test('mixin can read int MMR via readMmrInt', () async {
+      transport.queueMmrResponseInt(MMRItem.fanThreshold, 42);
+      expect(await de1.readFan(), 42);
+    });
+
+    test('readMmrInt throws on scaledFloat address', () async {
+      // targetSteamFlow.kind == scaledFloat — wrong helper.
+      await expectLater(
+        de1.readFanViaWrongHelper(),
+        throwsA(isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          allOf(contains('readMmrInt'), contains('kind')),
+        )),
+      );
+    });
+
+    test('readMmrScaled throws on int32 address', () async {
+      // fanThreshold.kind == int32 — wrong helper.
+      await expectLater(
+        de1.readScaledViaWrongHelper(),
+        throwsA(isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          allOf(contains('readMmrScaled'), contains('kind')),
+        )),
+      );
+    });
+  });
+}

--- a/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
@@ -1,14 +1,12 @@
-import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
-import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:reaprime/src/models/device/transport/logical_endpoint.dart';
-import 'package:rxdart/rxdart.dart';
+
+import '../../../../../../helpers/fake_ble_transport.dart';
 
 // The mixin-on-UnifiedDe1 setup below (`_TestCapability` + `_TestDe1`) is
 // itself the load-bearing demonstration that the protected surface is
@@ -18,153 +16,6 @@ import 'package:rxdart/rxdart.dart';
 // would let the test class reach the protected members through plain
 // subclassing and stop proving what we actually need to prove (mixins
 // can call them).
-
-/// Programmable BLE transport that intercepts writes to the
-/// `writeToMMR` characteristic and synthesizes a matching `readFromMMR`
-/// notification with a queued integer payload. The DE1 firmware
-/// normally echoes the address bytes and appends the value as a
-/// little-endian int32 on the readFromMMR characteristic — this stub
-/// keeps that contract so `_mmrRead` finds its matching response.
-class _ProgrammableBleTransport extends BLETransport {
-  final _connState =
-      BehaviorSubject<ConnectionState>.seeded(ConnectionState.connected);
-  final Map<String, void Function(Uint8List)> _subscribers = {};
-
-  /// Map address (full 32-bit) -> integer to emit on the next matching
-  /// MMR read request.
-  final Map<int, int> _intResponses = {};
-
-  /// Map address -> raw 16-byte payload (bytes 4..19 of the 20-byte
-  /// MMR notification frame). Takes precedence over [_intResponses]
-  /// when both are queued for the same address.
-  final Map<int, List<int>> _rawResponses = {};
-
-  /// Captures each frame written to a non-MMR-read characteristic so
-  /// tests can assert on the bytes that hit the wire. Specifically used
-  /// for `Endpoint.writeToMMR` capture in the writeMmr* tests.
-  final List<({String characteristicUUID, Uint8List data, bool withResponse})>
-      writes = [];
-
-  void queueMmrResponseInt(MmrAddress addr, int value) {
-    _intResponses[addr.address] = value;
-  }
-
-  void queueMmrResponseRaw(MmrAddress addr, List<int> payload) {
-    _rawResponses[addr.address] = payload;
-  }
-
-  @override
-  String get id => 'programmable-ble';
-
-  @override
-  String get name => 'ProgrammableBle';
-
-  @override
-  Stream<ConnectionState> get connectionState => _connState.stream;
-
-  @override
-  Future<void> connect() async {}
-
-  @override
-  Future<void> disconnect() async {}
-
-  @override
-  Future<List<String>> discoverServices() async => [de1ServiceUUID];
-
-  @override
-  Future<Uint8List> read(String serviceUUID, String characteristicUUID,
-          {Duration? timeout}) async =>
-      // 20-byte zero buffer matches the MMR/state response width;
-      // tolerated by parsers during onConnect.
-      Uint8List(20);
-
-  @override
-  Future<void> subscribe(String serviceUUID, String characteristicUUID,
-      void Function(Uint8List) callback) async {
-    _subscribers[characteristicUUID] = callback;
-  }
-
-  @override
-  Future<void> setTransportPriority(bool prioritized) async {}
-
-  @override
-  Future<void> write(
-      String serviceUUID, String characteristicUUID, Uint8List data,
-      {bool withResponse = true, Duration? timeout}) async {
-    // Capture every write so tests can assert on bytes that hit the
-    // wire (used for writeMmr* coverage).
-    writes.add((
-      characteristicUUID: characteristicUUID,
-      data: data,
-      withResponse: withResponse,
-    ));
-
-    // Only react to MMR write-read requests on the writeToMMR
-    // characteristic (`Endpoint.readFromMMR.uuid` is what `_mmrRead`
-    // actually writes to — the firmware overloads the read endpoint
-    // with a write to request a payload, then notifies the same UUID).
-    // Looking at `_mmrRead`, it writes to `Endpoint.readFromMMR`.
-    if (characteristicUUID != Endpoint.readFromMMR.uuid) return;
-    if (data.length < 4) return;
-    final addrMid1 = data[1];
-    final addrMid2 = data[2];
-    final addrLow = data[3];
-    int? matchedRawAddr;
-    for (final addr in _rawResponses.keys) {
-      final bytes = ByteData(4)..setInt32(0, addr, Endian.big);
-      if (bytes.getUint8(1) == addrMid1 &&
-          bytes.getUint8(2) == addrMid2 &&
-          bytes.getUint8(3) == addrLow) {
-        matchedRawAddr = addr;
-        break;
-      }
-    }
-    if (matchedRawAddr != null) {
-      final payload = _rawResponses.remove(matchedRawAddr)!;
-      final resp = Uint8List(20);
-      resp[0] = data[0];
-      resp[1] = addrMid1;
-      resp[2] = addrMid2;
-      resp[3] = addrLow;
-      for (var i = 0; i < payload.length && i + 4 < 20; i++) {
-        resp[i + 4] = payload[i];
-      }
-      final cb = _subscribers[Endpoint.readFromMMR.uuid];
-      if (cb != null) {
-        scheduleMicrotask(() => cb(resp));
-      }
-      return;
-    }
-
-    int? matchedAddr;
-    for (final addr in _intResponses.keys) {
-      final bytes = ByteData(4)..setInt32(0, addr, Endian.big);
-      if (bytes.getUint8(1) == addrMid1 &&
-          bytes.getUint8(2) == addrMid2 &&
-          bytes.getUint8(3) == addrLow) {
-        matchedAddr = addr;
-        break;
-      }
-    }
-    if (matchedAddr == null) return;
-    final value = _intResponses.remove(matchedAddr)!;
-    final resp = Uint8List(20);
-    final view = ByteData.sublistView(resp);
-    view.setUint8(0, data[0]);
-    view.setUint8(1, addrMid1);
-    view.setUint8(2, addrMid2);
-    view.setUint8(3, addrLow);
-    view.setInt32(4, value, Endian.little);
-    final cb = _subscribers[Endpoint.readFromMMR.uuid];
-    if (cb != null) {
-      // Emit asynchronously so `_mmrRead`'s firstWhere subscription is
-      // set up before the value lands.
-      scheduleMicrotask(() => cb(resp));
-    }
-  }
-
-  void dispose() => _connState.close();
-}
 
 // Capability-style mixin that exercises the protected surface.
 mixin _TestCapability on UnifiedDe1 {
@@ -243,21 +94,15 @@ class _TestDe1 extends UnifiedDe1 with _TestCapability {
 
 void main() {
   group('UnifiedDe1 protected surface', () {
-    late _ProgrammableBleTransport transport;
+    late FakeBleTransport transport;
     late _TestDe1 de1;
 
     setUp(() async {
-      transport = _ProgrammableBleTransport();
+      transport = FakeBleTransport();
       de1 = _TestDe1(transport: transport);
       // Subscribe wiring needs the BLE connect path to run; queue the
       // MMR reads `onConnect` performs so it can complete.
-      transport
-        ..queueMmrResponseInt(MMRItem.v13Model, 1)
-        ..queueMmrResponseInt(MMRItem.ghcInfo, 0)
-        ..queueMmrResponseInt(MMRItem.serialN, 12345)
-        ..queueMmrResponseInt(MMRItem.cpuFirmwareBuild, 1300)
-        ..queueMmrResponseInt(MMRItem.heaterV, 230)
-        ..queueMmrResponseInt(MMRItem.refillKitPresent, 0);
+      transport.queueOnConnectResponses();
       await de1.onConnect();
     });
 
@@ -383,7 +228,7 @@ void main() {
             .first,
         completion(isA<ByteData>()),
       );
-      final cb = transport._subscribers[Endpoint.shotSample.uuid];
+      final cb = transport.subscribers[Endpoint.shotSample.uuid];
       expect(cb, isNotNull,
           reason: 'transport must have subscribed to shotSample on connect');
       cb!(marker);

--- a/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
@@ -7,7 +7,17 @@ import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/models/device/transport/logical_endpoint.dart';
 import 'package:rxdart/rxdart.dart';
+
+// The mixin-on-UnifiedDe1 setup below (`_TestCapability` + `_TestDe1`) is
+// itself the load-bearing demonstration that the protected surface is
+// reachable from real capability code: any future Bengle/scale/etc.
+// capability uses the exact same `mixin Foo on UnifiedDe1` pattern. Do
+// not refactor `_TestCapability` into helpers on `_TestDe1` — that
+// would let the test class reach the protected members through plain
+// subclassing and stop proving what we actually need to prove (mixins
+// can call them).
 
 /// Programmable BLE transport that intercepts writes to the
 /// `writeToMMR` characteristic and synthesizes a matching `readFromMMR`
@@ -24,8 +34,22 @@ class _ProgrammableBleTransport extends BLETransport {
   /// MMR read request.
   final Map<int, int> _intResponses = {};
 
+  /// Map address -> raw 16-byte payload (bytes 4..19 of the 20-byte
+  /// MMR notification frame). Takes precedence over [_intResponses]
+  /// when both are queued for the same address.
+  final Map<int, List<int>> _rawResponses = {};
+
+  /// Captures each frame written to a non-MMR-read characteristic so
+  /// tests can assert on the bytes that hit the wire. Specifically used
+  /// for `Endpoint.writeToMMR` capture in the writeMmr* tests.
+  final List<({String characteristicUUID, Uint8List data})> writes = [];
+
   void queueMmrResponseInt(MmrAddress addr, int value) {
     _intResponses[addr.address] = value;
+  }
+
+  void queueMmrResponseRaw(MmrAddress addr, List<int> payload) {
+    _rawResponses[addr.address] = payload;
   }
 
   @override
@@ -49,6 +73,8 @@ class _ProgrammableBleTransport extends BLETransport {
   @override
   Future<Uint8List> read(String serviceUUID, String characteristicUUID,
           {Duration? timeout}) async =>
+      // 20-byte zero buffer matches the MMR/state response width;
+      // tolerated by parsers during onConnect.
       Uint8List(20);
 
   @override
@@ -64,6 +90,10 @@ class _ProgrammableBleTransport extends BLETransport {
   Future<void> write(
       String serviceUUID, String characteristicUUID, Uint8List data,
       {bool withResponse = true, Duration? timeout}) async {
+    // Capture every write so tests can assert on bytes that hit the
+    // wire (used for writeMmr* coverage).
+    writes.add((characteristicUUID: characteristicUUID, data: data));
+
     // Only react to MMR write-read requests on the writeToMMR
     // characteristic (`Endpoint.readFromMMR.uuid` is what `_mmrRead`
     // actually writes to — the firmware overloads the read endpoint
@@ -74,6 +104,33 @@ class _ProgrammableBleTransport extends BLETransport {
     final addrMid1 = data[1];
     final addrMid2 = data[2];
     final addrLow = data[3];
+    int? matchedRawAddr;
+    for (final addr in _rawResponses.keys) {
+      final bytes = ByteData(4)..setInt32(0, addr, Endian.big);
+      if (bytes.getUint8(1) == addrMid1 &&
+          bytes.getUint8(2) == addrMid2 &&
+          bytes.getUint8(3) == addrLow) {
+        matchedRawAddr = addr;
+        break;
+      }
+    }
+    if (matchedRawAddr != null) {
+      final payload = _rawResponses.remove(matchedRawAddr)!;
+      final resp = Uint8List(20);
+      resp[0] = data[0];
+      resp[1] = addrMid1;
+      resp[2] = addrMid2;
+      resp[3] = addrLow;
+      for (var i = 0; i < payload.length && i + 4 < 20; i++) {
+        resp[i + 4] = payload[i];
+      }
+      final cb = _subscribers[Endpoint.readFromMMR.uuid];
+      if (cb != null) {
+        scheduleMicrotask(() => cb(resp));
+      }
+      return;
+    }
+
     int? matchedAddr;
     for (final addr in _intResponses.keys) {
       final bytes = ByteData(4)..setInt32(0, addr, Endian.big);
@@ -108,8 +165,61 @@ class _ProgrammableBleTransport extends BLETransport {
 mixin _TestCapability on UnifiedDe1 {
   Future<int> readFan() => readMmrInt(MMRItem.fanThreshold);
   Future<int> readFanViaWrongHelper() => readMmrInt(MMRItem.targetSteamFlow);
-  Future<double> readScaledViaWrongHelper() =>
+  // Intentionally calls `readMmrScaled` on an int32 address (fanThreshold)
+  // — exercises the kind-mismatch StateError path.
+  Future<double> readFanAsScaledFloat() =>
       readMmrScaled(MMRItem.fanThreshold, readScale: 0.1);
+
+  // Re-exports so tests can drive these from a mixin context (the only
+  // legitimate access path for `@protected` members).
+  Future<List<int>> capRead(MmrAddress addr) => readMmrRaw(addr);
+  Future<void> capWrite(MmrAddress addr, List<int> bytes) =>
+      writeMmrRaw(addr, bytes);
+  Future<double> capReadScaled(MmrAddress addr, double scale) =>
+      readMmrScaled(addr, readScale: scale);
+  Future<void> capWriteScaled(MmrAddress addr, double v,
+          {required double scale, int? min, int? max}) =>
+      writeMmrScaled(addr, v, writeScale: scale, min: min, max: max);
+  Stream<ByteData> capNotifications(LogicalEndpoint ep) =>
+      notificationsFor(ep);
+  Future<void> capWriteEndpoint(LogicalEndpoint ep, Uint8List data,
+          {bool withResponse = true}) =>
+      writeEndpoint(ep, data, withResponse: withResponse);
+}
+
+/// Capability-supplied MMR address that is *not* a [MMRItem]. Mirrors
+/// what e.g. `BengleCupWarmerMmr` will look like.
+class _CapabilityAddr implements MmrAddress {
+  @override
+  final int address;
+  @override
+  final int length;
+  @override
+  final String name;
+  @override
+  final MmrValueKind kind;
+  const _CapabilityAddr({
+    required this.address,
+    required this.length,
+    required this.name,
+    required this.kind,
+  });
+}
+
+/// LogicalEndpoint that isn't part of the [Endpoint] enum — mirrors
+/// what a future capability subscription will look like.
+class _StubLogicalEndpoint implements LogicalEndpoint {
+  @override
+  final String? uuid;
+  @override
+  final String? representation;
+  @override
+  final String name;
+  const _StubLogicalEndpoint({
+    required this.uuid,
+    required this.representation,
+    required this.name,
+  });
 }
 
 class _TestDe1 extends UnifiedDe1 with _TestCapability {
@@ -160,11 +270,132 @@ void main() {
     test('readMmrScaled throws on int32 address', () async {
       // fanThreshold.kind == int32 — wrong helper.
       await expectLater(
-        de1.readScaledViaWrongHelper(),
+        de1.readFanAsScaledFloat(),
         throwsA(isA<StateError>().having(
           (e) => e.message,
           'message',
           allOf(contains('readMmrScaled'), contains('kind')),
+        )),
+      );
+    });
+
+    test('readMmrRaw returns bytes for non-MMRItem MmrAddress', () async {
+      const addr = _CapabilityAddr(
+        address: 0x00802800,
+        length: 4,
+        name: 'cupWarmerStatus',
+        kind: MmrValueKind.bytes,
+      );
+      transport.queueMmrResponseRaw(addr, [0xDE, 0xAD, 0xBE, 0xEF]);
+      final result = await de1.capRead(addr);
+      // Result is the full 20-byte MMR frame: bytes 0..3 are the
+      // length+address echo from the request, bytes 4..7 are the
+      // queued payload.
+      expect(result.sublist(4, 8), [0xDE, 0xAD, 0xBE, 0xEF]);
+    });
+
+    test('writeMmrRaw sends the bytes on the wire for non-MMRItem', () async {
+      const addr = _CapabilityAddr(
+        address: 0x00803000,
+        length: 4,
+        name: 'cupWarmerSet',
+        kind: MmrValueKind.bytes,
+      );
+      transport.writes.clear();
+      await de1.capWrite(addr, [0x01, 0x02, 0x03, 0x04]);
+      // Find the writeToMMR frame.
+      final frame = transport.writes.firstWhere(
+        (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
+      );
+      // Frame: [length, addrMid1, addrMid2, addrLow, payload..., 0...]
+      expect(frame.data[0], 4); // length byte
+      final addrBytes = ByteData(4)..setInt32(0, addr.address, Endian.big);
+      expect(frame.data[1], addrBytes.getUint8(1));
+      expect(frame.data[2], addrBytes.getUint8(2));
+      expect(frame.data[3], addrBytes.getUint8(3));
+      expect(frame.data.sublist(4, 8), [0x01, 0x02, 0x03, 0x04]);
+    });
+
+    test('readMmrScaled returns raw * readScale for non-MMRItem', () async {
+      const addr = _CapabilityAddr(
+        address: 0x00803800,
+        length: 4,
+        name: 'cupWarmerTemp',
+        kind: MmrValueKind.scaledFloat,
+      );
+      // raw int32 = 250, little-endian -> [0xFA, 0x00, 0x00, 0x00]
+      transport.queueMmrResponseRaw(addr, [0xFA, 0x00, 0x00, 0x00]);
+      final result = await de1.capReadScaled(addr, 0.1);
+      expect(result, closeTo(25.0, 1e-9));
+    });
+
+    test('writeMmrScaled clamps to min/max and writes scaled int', () async {
+      const addr = _CapabilityAddr(
+        address: 0x00804000,
+        length: 4,
+        name: 'cupWarmerSetTemp',
+        kind: MmrValueKind.scaledFloat,
+      );
+      transport.writes.clear();
+      // value 99.9 * writeScale 10.0 = 999, clamped to 500.
+      await de1.capWriteScaled(addr, 99.9, scale: 10.0, min: 0, max: 500);
+      final frame = transport.writes.firstWhere(
+        (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
+      );
+      // bytes 4..7 are the little-endian int payload.
+      final payload = ByteData.sublistView(frame.data, 4, 8);
+      expect(payload.getInt32(0, Endian.little), 500);
+    });
+
+    test('notificationsFor(shotSample) routes to transport shotSample',
+        () async {
+      // The transport's BLE subscriber for the shotSample characteristic
+      // pushes onto the underlying BehaviorSubject. We emit synthetic
+      // bytes through that callback and verify the protected method's
+      // stream observes them — proving the dispatch table routes
+      // Endpoint.shotSample to the right subject.
+      final stream = de1.capNotifications(Endpoint.shotSample);
+      final marker = Uint8List(19);
+      // Sentinel byte the seeded value won't have.
+      marker[0] = 0x7F;
+      final received = expectLater(
+        stream
+            .where((d) => d.lengthInBytes >= 1 && d.getUint8(0) == 0x7F)
+            .first,
+        completion(isA<ByteData>()),
+      );
+      final cb = transport._subscribers[Endpoint.shotSample.uuid];
+      expect(cb, isNotNull,
+          reason: 'transport must have subscribed to shotSample on connect');
+      cb!(marker);
+      await received;
+    });
+
+    test('notificationsFor throws for non-Endpoint LogicalEndpoint', () {
+      const ep = _StubLogicalEndpoint(
+        uuid: 'C001',
+        representation: 'Z',
+        name: 'stub',
+      );
+      expect(
+        () => de1.capNotifications(ep),
+        throwsA(isA<UnimplementedError>().having(
+          (e) => e.message,
+          'message',
+          contains('runtime subscription'),
+        )),
+      );
+    });
+
+    test('writeEndpoint(withResponse: false) throws UnimplementedError',
+        () async {
+      await expectLater(
+        de1.capWriteEndpoint(Endpoint.requestedState, Uint8List(1),
+            withResponse: false),
+        throwsA(isA<UnimplementedError>().having(
+          (e) => e.message,
+          'message',
+          contains('withResponse=false'),
         )),
       );
     });

--- a/test/unit/models/device/transport/logical_endpoint_test.dart
+++ b/test/unit/models/device/transport/logical_endpoint_test.dart
@@ -1,16 +1,175 @@
-import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
-import 'package:reaprime/src/models/device/transport/logical_endpoint.dart';
+import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/models/device/transport/logical_endpoint.dart';
+import 'package:reaprime/src/models/device/transport/serial_port.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// Minimal LogicalEndpoint stub for exercising the guards in
+/// `UnifiedDe1Transport.{read,write,writeWithResponse}`. Not a Dart enum,
+/// so the `is! Endpoint` check fires on the serial path.
+class _StubEndpoint implements LogicalEndpoint {
+  @override
+  final String? uuid;
+  @override
+  final String? representation;
+  @override
+  final String name;
+  const _StubEndpoint({this.uuid, this.representation, required this.name});
+}
+
+class _StubBleTransport extends BLETransport {
+  final _connState =
+      BehaviorSubject<ConnectionState>.seeded(ConnectionState.connected);
+
+  @override
+  String get id => 'stub-ble';
+
+  @override
+  String get name => 'StubBle';
+
+  @override
+  Stream<ConnectionState> get connectionState => _connState.stream;
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<List<String>> discoverServices() async => [];
+
+  @override
+  Future<Uint8List> read(String serviceUUID, String characteristicUUID,
+          {Duration? timeout}) async =>
+      Uint8List(0);
+
+  @override
+  Future<void> subscribe(String serviceUUID, String characteristicUUID,
+      void Function(Uint8List) callback) async {}
+
+  @override
+  Future<void> write(
+      String serviceUUID, String characteristicUUID, Uint8List data,
+      {bool withResponse = true, Duration? timeout}) async {}
+
+  @override
+  Future<void> setTransportPriority(bool prioritized) async {}
+
+  void dispose() => _connState.close();
+}
+
+class _StubSerialTransport extends SerialTransport {
+  final _connState =
+      BehaviorSubject<ConnectionState>.seeded(ConnectionState.connected);
+
+  @override
+  String get id => 'stub-serial';
+
+  @override
+  String get name => 'StubSerial';
+
+  @override
+  Stream<ConnectionState> get connectionState => _connState.stream;
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Stream<String> get readStream => const Stream.empty();
+
+  @override
+  Stream<Uint8List> get rawStream => const Stream.empty();
+
+  @override
+  Future<void> writeCommand(String command) async {}
+
+  @override
+  Future<void> writeHexCommand(Uint8List command) async {}
+
+  void dispose() => _connState.close();
+}
 
 void main() {
   group('LogicalEndpoint', () {
-    test('every Endpoint value implements LogicalEndpoint with non-null wire ids', () {
+    test(
+        'every Endpoint value implements LogicalEndpoint with non-null wire ids',
+        () {
       for (final ep in Endpoint.values) {
-        expect(ep, isA<LogicalEndpoint>(), reason: '${ep.name} must implement LogicalEndpoint');
+        expect(ep, isA<LogicalEndpoint>(),
+            reason: '${ep.name} must implement LogicalEndpoint');
         expect(ep.uuid, isNotNull, reason: '${ep.name} uuid');
-        expect(ep.representation, isNotNull, reason: '${ep.name} representation');
+        expect(ep.representation, isNotNull,
+            reason: '${ep.name} representation');
         expect(ep.name, isNotEmpty);
       }
+    });
+  });
+
+  group('UnifiedDe1Transport wire-support guards', () {
+    test('read() on BLE with null uuid throws StateError mentioning '
+        '"no BLE wire support"', () async {
+      final transport = _StubBleTransport();
+      addTearDown(transport.dispose);
+      final unified = UnifiedDe1Transport(transport: transport);
+      const stub = _StubEndpoint(
+          uuid: null, representation: 'Z', name: 'stubNoUuid');
+
+      await expectLater(
+        unified.read(stub),
+        throwsA(isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          contains('no BLE wire support'),
+        )),
+      );
+    });
+
+    test('read() on serial with non-Endpoint LogicalEndpoint throws '
+        'StateError mentioning "is not a DE1 Endpoint"', () async {
+      final transport = _StubSerialTransport();
+      addTearDown(transport.dispose);
+      final unified = UnifiedDe1Transport(transport: transport);
+      // Has both uuid and representation set so the only failing guard is
+      // the `is! Endpoint` one.
+      const stub = _StubEndpoint(
+          uuid: 'A0FF', representation: 'Z', name: 'stubNotEndpoint');
+
+      await expectLater(
+        unified.read(stub),
+        throwsA(isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          contains('is not a DE1 Endpoint'),
+        )),
+      );
+    });
+
+    test('write() on serial with null representation throws StateError '
+        'mentioning "no serial wire support"', () async {
+      final transport = _StubSerialTransport();
+      addTearDown(transport.dispose);
+      final unified = UnifiedDe1Transport(transport: transport);
+      const stub = _StubEndpoint(
+          uuid: 'A0FF', representation: null, name: 'stubNoRepr');
+
+      await expectLater(
+        unified.write(stub, Uint8List(0)),
+        throwsA(isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          contains('no serial wire support'),
+        )),
+      );
     });
   });
 }

--- a/test/unit/models/device/transport/logical_endpoint_test.dart
+++ b/test/unit/models/device/transport/logical_endpoint_test.dart
@@ -5,10 +5,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart';
-import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:reaprime/src/models/device/transport/logical_endpoint.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
 import 'package:rxdart/rxdart.dart';
+
+import '../../../../helpers/fake_ble_transport.dart';
 
 /// Minimal LogicalEndpoint stub for exercising the guards in
 /// `UnifiedDe1Transport.{read,write,writeWithResponse}`. Not a Dart enum,
@@ -23,48 +24,9 @@ class _StubEndpoint implements LogicalEndpoint {
   const _StubEndpoint({this.uuid, this.representation, required this.name});
 }
 
-class _StubBleTransport extends BLETransport {
-  final _connState =
-      BehaviorSubject<ConnectionState>.seeded(ConnectionState.connected);
-
-  @override
-  String get id => 'stub-ble';
-
-  @override
-  String get name => 'StubBle';
-
-  @override
-  Stream<ConnectionState> get connectionState => _connState.stream;
-
-  @override
-  Future<void> connect() async {}
-
-  @override
-  Future<void> disconnect() async {}
-
-  @override
-  Future<List<String>> discoverServices() async => [];
-
-  @override
-  Future<Uint8List> read(String serviceUUID, String characteristicUUID,
-          {Duration? timeout}) async =>
-      Uint8List(0);
-
-  @override
-  Future<void> subscribe(String serviceUUID, String characteristicUUID,
-      void Function(Uint8List) callback) async {}
-
-  @override
-  Future<void> write(
-      String serviceUUID, String characteristicUUID, Uint8List data,
-      {bool withResponse = true, Duration? timeout}) async {}
-
-  @override
-  Future<void> setTransportPriority(bool prioritized) async {}
-
-  void dispose() => _connState.close();
-}
-
+/// Inline serial-transport stub: `FakeBleTransport` is BLE-only by
+/// design (the consolidated helper is used across the BLE-facing
+/// tests), so the small serial stub stays here for the wire-gap tests.
 class _StubSerialTransport extends SerialTransport {
   final _connState =
       BehaviorSubject<ConnectionState>.seeded(ConnectionState.connected);
@@ -118,7 +80,7 @@ void main() {
   group('UnifiedDe1Transport wire-support guards', () {
     test('read() on BLE with null uuid throws StateError mentioning '
         '"no BLE wire support"', () async {
-      final transport = _StubBleTransport();
+      final transport = FakeBleTransport();
       addTearDown(transport.dispose);
       final unified = UnifiedDe1Transport(transport: transport);
       const stub = _StubEndpoint(

--- a/test/unit/models/device/transport/logical_endpoint_test.dart
+++ b/test/unit/models/device/transport/logical_endpoint_test.dart
@@ -1,0 +1,16 @@
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/transport/logical_endpoint.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LogicalEndpoint', () {
+    test('every Endpoint value implements LogicalEndpoint with non-null wire ids', () {
+      for (final ep in Endpoint.values) {
+        expect(ep, isA<LogicalEndpoint>(), reason: '${ep.name} must implement LogicalEndpoint');
+        expect(ep.uuid, isNotNull, reason: '${ep.name} uuid');
+        expect(ep.representation, isNotNull, reason: '${ep.name} representation');
+        expect(ep.name, isNotEmpty);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Lifts `Endpoint` enum to `LogicalEndpoint` interface and `MMRItem` enum to `MmrAddress` interface (with `MmrValueKind`) so future Bengle capability mixins (LED, integrated scale, cup warmer, milk probe) can ship their own enums without modifying the closed DE1 surface.
- Adds an `@protected` surface on `UnifiedDe1` (endpoint primitives + MMR helpers with kind validation + `Logger get log`) so capability mixins declared `on UnifiedDe1` reach the transport without touching private fields.
- Adds a `beforeFirmwareUpload()` template-method hook on `UnifiedDe1` (default no-op); `Bengle` overrides it to request `MachineState.fwUpgrade` (state `0x22`) between `requestState(sleeping)` and `.dat` upload — resolves the long-standing `unified_de1.firmware.dart:13-14` TODO.

## Why

Foundation step. After this branch lands, `Bengle` is functionally identical to `UnifiedDe1` (FW prelude aside) — capability impls (cup warmer / scale / LED / milk probe) ship in subsequent branches without further base-class churn. Architecture documented in `doc/plans/archive/bengle-foundation/`.