### PR TITLE
feat(bengle): MockBengle + real USB discovery (steps 2+3 of Bengle integration)

### DIFF
--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -90,6 +90,16 @@ Discovery services are responsible for scanning and creating device instances. E
   - `lib/src/services/serial/serial_service.dart` (factory)
 - **Discovery:** Enumerates serial ports, probes for device identification
 
+  DE1-family detection is layered:
+  1. `productName == "DE1"` → `UnifiedDe1`. `productName == "Bengle"` →
+     `Bengle`. Cheapest path.
+  2. VID:PID match against `lib/src/services/serial/usb_ids.dart`.
+     Tables empty until concrete pairs are captured from hardware.
+  3. Fallback: open the port, send `<+M>` and the v13Model MMR-read
+     request, wait for `[M]` (DE1-protocol baseline) plus an `[E]…`
+     reply at addr `0x0080000C`. v13Model `>= 128` → `Bengle`, else
+     `UnifiedDe1`. Encoded via `lib/src/services/serial/mmr_codec.dart`.
+
 #### 4. SimulatedDeviceService
 - **Platform:** All
 - **File:** `lib/src/services/simulated_device_service.dart`
@@ -780,11 +790,17 @@ Use simulated devices for testing without hardware:
 
 ```bash
 flutter run --dart-define=simulate=1              # Simulate all devices
-flutter run --dart-define=simulate=machine         # Simulate machine only
-flutter run --dart-define=simulate=machine,scale   # Simulate machine and scale
+flutter run --dart-define=simulate=machine         # Simulate DE1 only
+flutter run --dart-define=simulate=bengle          # Simulate Bengle only
+flutter run --dart-define=simulate=machine,scale   # Simulate DE1 and scale
 ```
 
-Supported types: `machine`, `scale`, `sensor` (comma-separated).
+Supported types: `machine` (DE1), `bengle`, `scale`, `sensor` (comma-separated).
+
+`simulate=1` enables every type, so it surfaces both `MockDe1` and
+`MockBengle` simultaneously — `ConnectionManager`'s preferred-device
+policy picks one. For deterministic behavior in tests / CI prefer the
+explicit comma-separated form.
 
 Or toggle in Settings UI → Simulated Devices
 

--- a/doc/plans/2026-04-30-bengle-mock-and-usb.md
+++ b/doc/plans/2026-04-30-bengle-mock-and-usb.md
@@ -1,0 +1,162 @@
+# Bengle: MockBengle + Real USB Discovery (steps 2 + 3)
+
+**Branch:** `feat/bengle-mock-and-usb`
+**Roadmap:** [ReaPrime Integration](obsidian://open?vault=mule&file=Professional%2FDecent%2FBengle%2FReaPrime%20Integration), steps 2 + 3.
+**Predecessor:** [PR #207](https://github.com/tadelv/reaprime/pull/207) shipped step 1 (foundation). `Bengle extends UnifiedDe1 implements BengleInterface` with `beforeFirmwareUpload` override; capability mixins deferred to steps 4–7.
+
+## Goal
+
+One PR delivers:
+
+1. **`MockBengle`** — `BengleInterface` instance surfaced via the simulated-device discovery, so the rest of the app can exercise a Bengle without hardware.
+2. **Real USB discovery for Bengle** — extend desktop + Android serial detection to identify a Bengle USB device and instantiate `Bengle` (not `UnifiedDe1`) on the existing `SerialTransport`.
+3. **Machine debug view Bengle-aware** — `De1DebugView` shows device class and a placeholder Bengle section.
+
+BLE discovery already done in PR #207. Bengle USB hardware is on hand for smoke-testing.
+
+No capability mixins. `MockBengle` and a USB-connected `Bengle` behave as `UnifiedDe1` + the FW-prelude override. Step 4 (cup warmer) is the first capability-bearing PR.
+
+## Non-goals
+
+- Capability mixins (cup warmer / integrated scale / LED / milk probe).
+- New REST/WS endpoints.
+- Bengle-specific BLE service UUID verification (Bengle inherits DE1's `ffff` for now; revisit if FW differs).
+- Standalone MMR-probe module / USB-device-table abstraction. Both rejected as over-scoped — see "Design" rationale.
+
+## Current state
+
+- **`MockDe1`** (`lib/src/models/device/impl/mock_de1/mock_de1.dart`) implements `De1Interface` directly (no transport). Constructor takes `deviceId` (default `"MockDe1"`). `updateFirmware` is faked at the public level — `_updateFirmware` template never runs, so `beforeFirmwareUpload` doesn't fire on mocks.
+- **`Bengle`** (`lib/src/models/device/impl/bengle/bengle.dart`) — 21 lines, `extends UnifiedDe1 implements BengleInterface`, overrides `name` and `beforeFirmwareUpload`.
+- **USB detect** today: `productName == "DE1"` shortcut (desktop `serial_service_desktop.dart:230`, Android `serial_service_android.dart:204`) → `UnifiedDe1(transport:)`. Fallback opens port, collects raw output, calls `isDE1()` (`utils.dart:26`) which checks for `[M]` prefix, then constructs `UnifiedDe1`. Desktop already extracts `port.vendorId` / `port.productId` (lines 205–206, 381–382) for stable IDs but doesn't match on them.
+- **`v13Model`** is a 16-bit MMR int (`MMRItem.v13Model`, `de1.models.dart:217`); read in `UnifiedDe1.onConnect` (`unified_de1.dart:170`). Values `>= 128` mean Bengle hardware. Authoritative DE1-vs-Bengle signal once a transport is connected.
+- **Bengle USB protocol confirmed** (manually verified): base protocol identical to DE1 — `[M]` echo + standard MMR framing. Bengle may add new prefix letters; existing parsers ignore unknown prefixes.
+- **Simulated devices:** `SimulatedDevicesTypes` enum in `settings_service.dart:420` (`machine`, `scale`, `sensor`). `SimulatedDeviceService.scanForDevices()` (`simulated_device_service.dart:37`) inserts `MockDe1()` when `machine` is enabled. **Settings UI iterates `SimulatedDevicesTypes.values`** (`settings_view.dart:455`) — adding an enum value auto-renders a toggle, no UI code change. `fromString` uses `firstWhereOrNull(values)` — auto-handles too. Webserver settings handler (`settings_handler.dart:211`) likewise.
+- **Downstream consumers** (`ConnectionManager`, `De1Controller`, scan orchestrator, web handlers) all type on `De1Interface`. `Bengle` and `MockBengle` slot in unchanged.
+- **Machine debug view:** `De1DebugView` (`lib/src/sample_feature/sample_item_details_view.dart`, route `/debug_details`) takes `De1Interface`; rendered from `SampleItemListView` (route `/debug`). No Bengle awareness today.
+
+## Design
+
+### Step 2 — `MockBengle`
+
+`class MockBengle extends MockDe1 implements BengleInterface`.
+
+- `BengleInterface extends De1Interface`. `MockDe1` already implements `De1Interface`. Subclass + add `implements BengleInterface` → satisfied with zero method duplication.
+- Constructor passes `deviceId` through; default `"MockBengle"`.
+- Override `name` for distinct visibility. Match `MockDe1`'s convention (verify what `MockDe1.name` returns; mirror the format).
+- No `beforeFirmwareUpload` override on the mock — `MockDe1.updateFirmware` is fake at the public level, so the template hook never fires. YAGNI.
+
+**Plumbing:**
+- Add `bengle` to `SimulatedDevicesTypes` enum.
+- `SimulatedDeviceService.scanForDevices()`: new branch — `if (enabledDevices.contains(SimulatedDevicesTypes.bengle)) _devices['MockBengle'] = MockBengle();`.
+- `_parseSimulateFlag` (`main.dart:108`): no code change required. `simulate=1` already maps to `SimulatedDevicesTypes.values.toSet()` — auto-includes `bengle`. `simulate=bengle` and `simulate=machine,bengle` work via existing `fromString` (already `firstWhereOrNull(values)`).
+- Settings UI: zero changes — auto-renders.
+
+**`simulate=1` behavior change:** auto-includes the new `bengle`, so `simulate=1` now surfaces two simulated machines (`MockDe1` + `MockBengle`). `ConnectionManager`'s preferred-device policy picks one. Acceptable — `simulate=1` is legacy. **Document in PR description** so anyone running it spots the change.
+
+### Step 3 — Real USB discovery
+
+Three small, independent additions to existing detection:
+
+1. **`productName == "Bengle"` shortcut** alongside the existing `"DE1"` shortcut (both desktop + Android). Cheap. May not match today's hardware (Bengle may not yet expose this productName), but trivial future-proofing — once FW exposes it, this is the path of least latency.
+
+2. **VID:PID shortcut** before the fallback. With Bengle hardware present, the actual VID:PID can be discovered today (procedure below). Same for DE1. Hard-coded constants in a small shared file consulted by both serial services — no need for a generic table abstraction.
+
+3. **Extend the fallback** (the only path that's not an exact early shortcut): once the existing receive-and-check confirms `[M]` (i.e. it's a DE1-family device), issue an MMR read for `v13Model`, and pick `Bengle` if `>= 128`, else `UnifiedDe1`.
+
+The fallback already opens the port and collects messages — adding one MMR request/response is the minimal extension. The MMR read encoding for serial is the same one `UnifiedDe1Transport._serialConnect` uses; lift the bytes-encoding/decoding helpers from `unified_de1.mmr.dart` into a small shared util if needed (`_packMMRInt` / `_unpackMMRInt` are already pure functions). No new "probe module" — just inline the read in the fallback path.
+
+**Why no probe module / no class-swap pre-fast-path:** the only path that doesn't already know the class is the fallback path. The two shortcut paths (productName + VID:PID) are deterministic — no probe needed. Adding a generic probe layer would force every detection through the same code path and require lifting transport connect/disconnect machinery out of `UnifiedDe1Transport`; that's a refactor for a problem that doesn't exist after the shortcut layers cover known hardware.
+
+**Why class dispatch (vs single `UnifiedDe1` with a flag):** capability mixins (steps 4–7) are class-level — `device is LedStripCapability` is the architecture decision in the Obsidian note. Splitting now keeps that cheap; a flag-based design would have to be reverted later.
+
+**Risk: Bengle USB may not match `[M]` prefix today.** Bengle FW may add new prefix letters. Per user, the *base* protocol is preserved, so `isDE1()` will keep matching. If a Bengle hardware variant ever ships without `[M]`, the fallback drops it — but that's a regression we'd notice immediately on smoke test. Smoke-testing real Bengle USB during this PR is the safety net.
+
+### Step 4 — Debug view
+
+`De1DebugView` (`lib/src/sample_feature/sample_item_details_view.dart`):
+
+1. Header label: show `"Bengle"` if `widget.machine is BengleInterface`, else `"DE1"`.
+2. Capability section: if `widget.machine is BengleInterface`, render a placeholder (`"Bengle: no capabilities surfaced yet."`). Replaces nothing today; gives steps 4–7 a slot to populate.
+
+Don't extract a `BengleDebugSection` widget yet — premature. Inline conditional. Re-evaluate when capabilities arrive.
+
+## Files
+
+**Create:**
+- `lib/src/models/device/impl/bengle/mock_bengle.dart`
+- `lib/src/services/serial/usb_ids.dart` — small file with `const de1UsbIds = [(vid, pid), …]` and `const bengleUsbIds = …` plus simple match helpers.
+- `test/models/device/impl/bengle/mock_bengle_test.dart` — type identity + `name`.
+- `test/services/serial/usb_ids_test.dart` — match helpers.
+- `test/services/simulated_device_service_test.dart` — emits `MockBengle` when `bengle` enabled (or extend if file exists).
+
+**Modify:**
+- `lib/src/settings/settings_service.dart` — add `bengle` to `SimulatedDevicesTypes`.
+- `lib/src/services/simulated_device_service.dart` — `bengle` branch in `scanForDevices()`.
+- `lib/src/services/serial/serial_service_desktop.dart` — Bengle productName shortcut + VID:PID match + extend fallback to read v13Model and dispatch class.
+- `lib/src/services/serial/serial_service_android.dart` — same.
+- `lib/src/services/serial/utils.dart` — possibly lift `_packMMRInt` / `_unpackMMRInt` from `unified_de1.mmr.dart` here (or a sibling file) so the fallback can encode the MMR read without depending on `UnifiedDe1`.
+- `lib/src/sample_feature/sample_item_details_view.dart` — `De1DebugView` Bengle-aware header + placeholder capability section.
+
+**Docs:**
+- `doc/DeviceManagement.md` — Bengle USB recognition path + `MockBengle` simulate flag.
+- Obsidian note: tick steps 2 + 3 on merge.
+
+## Test plan
+
+Per `.claude/skills/tdd-workflow/`. Tier choices:
+
+- **Unit (`flutter test`):**
+  - `MockBengle`: type identity (`is BengleInterface`, `is De1Interface`), `name` matches convention, `deviceId` defaults sensibly.
+  - VID:PID match helpers: known DE1 pair → `de1`; known Bengle pair → `bengle`; unknown → no match.
+  - MMR pack/unpack helpers (if lifted): existing tests, if any, follow the move.
+- **Integration (`flutter test`, multi-component):**
+  - `SimulatedDeviceService` emits `MockBengle` when `SimulatedDevicesTypes.bengle` enabled and not when only `machine` is.
+  - Serial-service detection path with a fake transport that echoes a v13Model `>= 128` → `Bengle`; fake transport echoing `< 128` → `UnifiedDe1`. Use the existing fake-transport infra if present; if not, decide pragmatically — may be cheaper to cover this case in end-to-end smoke than build new fake-transport plumbing.
+- **End-to-end smoke** via `scripts/sb-dev.sh` (per `.agents/skills/streamline-bridge/verification.md`):
+  - Simulated path: `flutter run --dart-define=simulate=bengle` → `MockBengle` appears in `GET /api/v1/devices/scan`; connect via API; profile send + state requests succeed.
+  - **Real Bengle USB path** (hardware on hand): plug Bengle, run app, verify `Bengle` instance constructed (not `UnifiedDe1`); check debug view shows "Bengle" header; connect, profile, run a shot. Capture log output for PR description.
+
+## Verification + completion
+
+1. `flutter test` clean.
+2. `flutter analyze` clean.
+3. End-to-end smoke (simulated + real Bengle USB) per above.
+4. Move plan to `doc/plans/archive/bengle-mock-and-usb/` (per CLAUDE.md archive policy — keep design, drop step-by-step).
+5. Update Obsidian roadmap with PR link + step 2/3 checkbox state on merge.
+
+## Risks + open questions
+
+- **Bengle VID:PID** — to be obtained from the hardware on hand. Procedure below.
+- **MMR read in fallback** — first time we encode an MMR request outside `UnifiedDe1Transport`. Verify the bytes-on-the-wire match what `_serialConnect` does. Cross-check by tracing what `UnifiedDe1Transport._serialConnect` writes for an MMR read, then mirror it in the fallback.
+- **Bengle protocol prefix letters** — confirmed Bengle preserves DE1 base protocol. New prefix letters fine; `isDE1()` only checks for `[M]`.
+- **`simulate=1` two-machine UX** — accepted as legacy behavior change. Document in PR.
+
+## Implementation sequence
+
+1. **Step 2 — `MockBengle`**
+   1. Add `MockBengle extends MockDe1 implements BengleInterface` + unit test.
+   2. Extend `SimulatedDevicesTypes` enum + `SimulatedDeviceService.scanForDevices()`.
+   3. Verify settings UI toggle appears (auto-iter); webserver settings handler accepts `"bengle"`.
+2. **Step 3 — USB detection**
+   1. Obtain Bengle + DE1 VID:PID (procedure below). Land them in `usb_ids.dart`.
+   2. Add `productName == "Bengle"` + VID:PID shortcut to desktop service, alongside DE1 shortcut.
+   3. Extend desktop fallback: post-`isDE1()` confirm, send MMR-read for v13Model, decode 16-bit int, pick `Bengle` if `>= 128`.
+   4. Mirror to Android service.
+   5. Lift MMR pack/unpack to shared util if the in-place encoding is too coupled to `UnifiedDe1Transport`.
+3. **Step 4 — Debug view**
+   1. `De1DebugView` Bengle-aware header + placeholder capability section.
+4. **Wrap-up**
+   1. Update `doc/DeviceManagement.md`.
+   2. Smoke: simulated MockBengle path + real Bengle USB path.
+   3. Archive plan; open PR; tick Obsidian roadmap.
+
+## Obtaining Bengle VID:PID (with hardware on hand)
+
+Pick one:
+
+- **In-app log line.** Add a temporary `_log.info("USB scan: name=$productName vid=${vid?.toRadixString(16)} pid=${pid?.toRadixString(16)}")` in `_performScan` (desktop) / `_detectDevice` (Android). Run app, plug Bengle, copy values from log, drop the line.
+- **macOS:** `system_profiler SPUSBDataType | grep -A 10 -i bengle` — reads `Vendor ID:` and `Product ID:`.
+- **Linux:** `lsusb` (compact `vid:pid` listing) or `dmesg | tail` after plug-in.
+- **Windows:** Device Manager → Bengle device → Properties → Details → Hardware IDs → `USB\VID_xxxx&PID_yyyy`.
+
+Cross-check with FW source / John for cases where the descriptor changes between FW versions.

--- a/doc/plans/archive/bengle-mock-and-usb/2026-04-30-bengle-mock-and-usb-design.md
+++ b/doc/plans/archive/bengle-mock-and-usb/2026-04-30-bengle-mock-and-usb-design.md
@@ -116,41 +116,14 @@ Per `.claude/skills/tdd-workflow/`. Tier choices:
   - Simulated path: `flutter run --dart-define=simulate=bengle` → `MockBengle` appears in `GET /api/v1/devices/scan`; connect via API; profile send + state requests succeed.
   - **Real Bengle USB path** (hardware on hand): plug Bengle, run app, verify `Bengle` instance constructed (not `UnifiedDe1`); check debug view shows "Bengle" header; connect, profile, run a shot. Capture log output for PR description.
 
-## Verification + completion
+## Risks + open questions (at design time)
 
-1. `flutter test` clean.
-2. `flutter analyze` clean.
-3. End-to-end smoke (simulated + real Bengle USB) per above.
-4. Move plan to `doc/plans/archive/bengle-mock-and-usb/` (per CLAUDE.md archive policy — keep design, drop step-by-step).
-5. Update Obsidian roadmap with PR link + step 2/3 checkbox state on merge.
-
-## Risks + open questions
-
-- **Bengle VID:PID** — to be obtained from the hardware on hand. Procedure below.
-- **MMR read in fallback** — first time we encode an MMR request outside `UnifiedDe1Transport`. Verify the bytes-on-the-wire match what `_serialConnect` does. Cross-check by tracing what `UnifiedDe1Transport._serialConnect` writes for an MMR read, then mirror it in the fallback.
+- **Bengle VID:PID** — to be obtained from the hardware on hand.
+- **MMR read in fallback** — first time we encode an MMR request outside `UnifiedDe1Transport`. Wire shape that landed in code, after smoke-testing real Bengle: the request is written to **`<E>` (readFromMMR)**, not `<F>` (writeToMMR — that endpoint is for setting MMR values, not requesting reads). The response value bytes [4..7] are **little-endian** (the address bytes [1..3] are big-endian — quirk of the protocol). Both wrinkles were caught by the real-hardware smoke; commit `aebf7cf` carries the fix.
 - **Bengle protocol prefix letters** — confirmed Bengle preserves DE1 base protocol. New prefix letters fine; `isDE1()` only checks for `[M]`.
-- **`simulate=1` two-machine UX** — accepted as legacy behavior change. Document in PR.
+- **`simulate=1` two-machine UX** — accepted as legacy behavior change.
 
-## Implementation sequence
-
-1. **Step 2 — `MockBengle`**
-   1. Add `MockBengle extends MockDe1 implements BengleInterface` + unit test.
-   2. Extend `SimulatedDevicesTypes` enum + `SimulatedDeviceService.scanForDevices()`.
-   3. Verify settings UI toggle appears (auto-iter); webserver settings handler accepts `"bengle"`.
-2. **Step 3 — USB detection**
-   1. Obtain Bengle + DE1 VID:PID (procedure below). Land them in `usb_ids.dart`.
-   2. Add `productName == "Bengle"` + VID:PID shortcut to desktop service, alongside DE1 shortcut.
-   3. Extend desktop fallback: post-`isDE1()` confirm, send MMR-read for v13Model, decode 16-bit int, pick `Bengle` if `>= 128`.
-   4. Mirror to Android service.
-   5. Lift MMR pack/unpack to shared util if the in-place encoding is too coupled to `UnifiedDe1Transport`.
-3. **Step 4 — Debug view**
-   1. `De1DebugView` Bengle-aware header + placeholder capability section.
-4. **Wrap-up**
-   1. Update `doc/DeviceManagement.md`.
-   2. Smoke: simulated MockBengle path + real Bengle USB path.
-   3. Archive plan; open PR; tick Obsidian roadmap.
-
-## Obtaining Bengle VID:PID (with hardware on hand)
+## Obtaining VID:PID (with hardware on hand)
 
 Pick one:
 

--- a/lib/src/models/device/impl/bengle/bengle.dart
+++ b/lib/src/models/device/impl/bengle/bengle.dart
@@ -16,6 +16,15 @@ class Bengle extends UnifiedDe1 implements BengleInterface {
   @override
   @protected
   Future<void> beforeFirmwareUpload() async {
-    await requestState(MachineState.fwUpgrade);
+    await Future.delayed(Duration(milliseconds: 500), () async {
+      await requestState(MachineState.fwUpgrade);
+    });
   }
+
+  /// Bengle has hardware flow control on the serial
+  /// path, so the per-batch backpressure pause that DE1 needs (UART
+  /// has none) is unnecessary. Stream chunks at full bandwidth.
+  @override
+  @protected
+  Duration get firmwareUploadBatchPause => Duration.zero;
 }

--- a/lib/src/models/device/impl/bengle/mock_bengle.dart
+++ b/lib/src/models/device/impl/bengle/mock_bengle.dart
@@ -1,0 +1,17 @@
+import 'package:reaprime/src/models/device/bengle_interface.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+
+/// Simulated Bengle. Reuses [MockDe1]'s state machine — Bengle's behavior
+/// today is functionally identical to a DE1 plus the FW-prelude hook
+/// (which mocks bypass entirely, since `MockDe1.updateFirmware` is faked
+/// at the public level rather than going through the `_updateFirmware`
+/// template that calls `beforeFirmwareUpload`).
+///
+/// Capability surfaces (cup warmer, integrated scale, LED, milk probe)
+/// land in steps 4–7; mirror them on this mock as they're added.
+class MockBengle extends MockDe1 implements BengleInterface {
+  MockBengle({super.deviceId = 'MockBengle'});
+
+  @override
+  String get name => 'MockBengle';
+}

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -446,6 +446,36 @@ class UnifiedDe1 implements De1Interface {
   @protected
   Future<void> beforeFirmwareUpload() async {} // default no-op
 
+  /// Number of 16-byte chunks written per batch during a firmware
+  /// upload before pausing for [firmwareUploadBatchPause].
+  ///
+  /// Tuning rationale: DE1 serial UART has no flow control, so chunks
+  /// pile up in the receive buffer faster than the SPI flash writer can
+  /// drain them. Periodic pauses prevent overrun. BLE writeWithResponse
+  /// provides ack-based backpressure, so no pause is needed.
+  ///
+  /// Bengle has built-in flow control on serial too,
+  /// so it overrides [firmwareUploadBatchPause] to zero — at which
+  /// point this value is unused.
+  @protected
+  int get firmwareUploadBatchSize {
+    return switch (_transport.transportType) {
+      TransportType.serial => Platform.isAndroid ? 32 : 8,
+      _ => 8,
+    };
+  }
+
+  /// Pause inserted between batches of [firmwareUploadBatchSize] chunks
+  /// during a firmware upload. See [firmwareUploadBatchSize] for the
+  /// rationale and per-transport tuning.
+  @protected
+  Duration get firmwareUploadBatchPause {
+    return switch (_transport.transportType) {
+      TransportType.serial => const Duration(milliseconds: 400),
+      _ => Duration.zero,
+    };
+  }
+
   /// Writes [data] to [endpoint]. When [withResponse] is `true` (default)
   /// dispatches to [UnifiedDe1Transport.writeWithResponse]; when `false`
   /// dispatches to [UnifiedDe1Transport.write] for fire-and-forget writes.

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.firmware.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.firmware.dart
@@ -106,20 +106,10 @@ extension UnifiedDe1Firmware on UnifiedDe1 {
   ) async {
     final total = list.length;
     int chunkNum = 0;
-    // Over BLE, writeWithResponse provides natural backpressure via ACKs.
-    // Over serial there's no such mechanism, so we pause every batch to let
-    // the machine's UART receive buffer drain during SPI flash writes.
-    // macOS serial drivers need a longer pause than Linux/Android.
-    final batchSize = switch (_transport.transportType) {
-      TransportType.serial => Platform.isAndroid ? 32 : 8,
-      _ => 8,
-    };
-    final batchPause = switch (_transport.transportType) {
-      TransportType.serial => Duration(
-        milliseconds: Platform.isMacOS ? 400 : 400,
-      ),
-      _ => Duration.zero,
-    };
+    // Per-machine tuning lives on the @protected getters so subclasses
+    // (e.g. Bengle, with USB CDC flow control) can drop the pause.
+    final batchSize = firmwareUploadBatchSize;
+    final batchPause = firmwareUploadBatchPause;
     for (int i = 0; i < list.length; i += 16) {
       if (cancelToken[0]) {
         _log.info('uploadFW: cancelled at byte $i');

--- a/lib/src/sample_feature/sample_item_details_view.dart
+++ b/lib/src/sample_feature/sample_item_details_view.dart
@@ -2,10 +2,16 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/de1_rawmessage.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
+
+/// Title shown in the debug view's AppBar. Switches on the machine's
+/// concrete type so a connected Bengle is visibly distinct from a DE1.
+String debugViewTitle(De1Interface machine) =>
+    machine is BengleInterface ? 'Bengle Details' : 'DE1 Details';
 
 /// Displays detailed information about a SampleItem.
 class De1DebugView extends StatefulWidget {
@@ -41,7 +47,7 @@ class _De1DebugViewState extends State<De1DebugView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Device Details')),
+      appBar: AppBar(title: Text(debugViewTitle(widget.machine))),
       body: Center(
         child: Padding(
           padding: EdgeInsets.all(8),

--- a/lib/src/services/serial/mmr_codec.dart
+++ b/lib/src/services/serial/mmr_codec.dart
@@ -23,9 +23,13 @@ Uint8List buildMmrReadRequest({required int address, required int length}) {
 }
 
 /// Decodes a serial MMR-read response line of the form `[E]hex...` into
-/// a 32-bit big-endian int value, but only when bytes [1..3] of the
+/// a 32-bit little-endian int value, but only when bytes [1..3] of the
 /// payload match [expectedAddr]. Returns null when the line is the
 /// wrong shape, has malformed hex, or carries a different address.
+///
+/// The address is encoded big-endian in bytes [1..3], but the value
+/// payload at bytes [4..7] is little-endian — matches what
+/// `unified_de1.mmr.dart::_unpackMMRInt` does.
 int? decodeMmrInt32Response(
   String line, {
   required (int, int, int) expectedAddr,
@@ -41,7 +45,7 @@ int? decodeMmrInt32Response(
     return null;
   }
   final view = ByteData.sublistView(Uint8List.fromList(bytes));
-  return view.getInt32(4, Endian.big);
+  return view.getInt32(4, Endian.little);
 }
 
 Uint8List? _tryParseHex(String hex) {

--- a/lib/src/services/serial/mmr_codec.dart
+++ b/lib/src/services/serial/mmr_codec.dart
@@ -1,0 +1,56 @@
+import 'dart:typed_data';
+
+/// MMR request/response encoding for the DE1 serial protocol, factored
+/// out so detection can probe the v13Model MMR without a full
+/// `UnifiedDe1` instance. Mirrors what `unified_de1.mmr.dart` does with
+/// `_transport.writeWithResponse`, but operates directly on the wire
+/// bytes.
+///
+/// The DE1 MMR protocol packs `[length, addr_high, addr_mid, addr_low,
+/// value_b0..b3, ...]` into 20 bytes. `setInt32(0, addr, big-endian)`
+/// writes the address into bytes 0..3, then byte 0 is overwritten with
+/// the read length — so the addr is effectively 24-bit.
+
+/// Builds the 20-byte MMR-read request payload for [address] with
+/// [length] bytes of expected data. The caller hex-encodes the result
+/// and sends it as `<F>${hex}` over the serial transport.
+Uint8List buildMmrReadRequest({required int address, required int length}) {
+  final bytes = ByteData(20);
+  bytes.setInt32(0, address, Endian.big);
+  final buf = bytes.buffer.asUint8List();
+  buf[0] = length & 0xFF;
+  return buf;
+}
+
+/// Decodes a serial MMR-read response line of the form `[E]hex...` into
+/// a 32-bit big-endian int value, but only when bytes [1..3] of the
+/// payload match [expectedAddr]. Returns null when the line is the
+/// wrong shape, has malformed hex, or carries a different address.
+int? decodeMmrInt32Response(
+  String line, {
+  required (int, int, int) expectedAddr,
+}) {
+  if (!line.startsWith('[E]')) return null;
+  final hex = line.substring(3);
+  final bytes = _tryParseHex(hex);
+  if (bytes == null) return null;
+  if (bytes.length < 8) return null;
+  if (bytes[1] != expectedAddr.$1 ||
+      bytes[2] != expectedAddr.$2 ||
+      bytes[3] != expectedAddr.$3) {
+    return null;
+  }
+  final view = ByteData.sublistView(Uint8List.fromList(bytes));
+  return view.getInt32(4, Endian.big);
+}
+
+Uint8List? _tryParseHex(String hex) {
+  if (hex.length.isOdd) return null;
+  final out = Uint8List(hex.length ~/ 2);
+  for (var i = 0; i < hex.length; i += 2) {
+    final b = int.tryParse(hex.substring(i, i + 2), radix: 16);
+    if (b == null) return null;
+    out[i ~/ 2] = b;
+  }
+  return out;
+}

--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -5,11 +5,14 @@ import 'dart:typed_data';
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale_serial.dart';
 import 'package:reaprime/src/models/device/impl/sensor/debug_port.dart';
 import 'package:reaprime/src/models/device/impl/sensor/sensor_basket.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
+import 'mmr_codec.dart';
+import 'usb_ids.dart';
 import 'utils.dart';
 import 'package:rxdart/subjects.dart';
 
@@ -206,10 +209,27 @@ class SerialServiceAndroid implements DeviceDiscoveryService {
       return UnifiedDe1(transport: transport);
     }
 
+    // Bengle shortcut (productName likely lands as "Bengle" once FW
+    // exposes it; trivial future-proofing).
+    if (device.productName == "Bengle") {
+      _log.info("short circuit to bengle");
+      return Bengle(transport: transport);
+    }
+
     // Half Decent Scale shortcut
     if (device.productName == "Half Decent Scale") {
       _log.info("short circuit to Half Decent Scale");
       return HDSSerial(transport: transport);
+    }
+
+    // VID:PID shortcut.
+    final usbModel =
+        matchUsbDevice(usbDeviceTable, vid: device.vid, pid: device.pid);
+    if (usbModel != null) {
+      _log.info("short circuit via VID:PID -> $usbModel");
+      return usbModel == UsbDeviceModel.bengle
+          ? Bengle(transport: transport)
+          : UnifiedDe1(transport: transport);
     }
 
     final List<Uint8List> rawData = [];
@@ -252,19 +272,49 @@ class SerialServiceAndroid implements DeviceDiscoveryService {
         _log.info("Detected: Sensor Basket");
         return SensorBasket(transport: transport);
       } else {
-        // try and check if we get some replies when subscribing to state
+        // try and check if we get some replies when subscribing to state.
+        // Also fire a v13Model MMR-read request so we can disambiguate
+        // DE1 vs Bengle inline.
         final List<String> messages = [];
         final sub = transport.readStream.listen((line) {
           messages.add(line);
         });
         await transport.writeCommand('<+M>');
+        await transport.writeCommand('<+E>');
+
+        final req = buildMmrReadRequest(address: 0x0080000C, length: 4);
+        final reqHex = req
+            .map((b) => b.toRadixString(16).padLeft(2, '0'))
+            .join();
+        try {
+          await transport.writeCommand('<F>$reqHex');
+        } catch (e) {
+          _log.fine('MMR read request failed during probe', e);
+        }
+
         await Future.delayed(duration);
         await transport.writeCommand('<-M>');
+        await transport.writeCommand('<-E>');
         sub.cancel();
         final List<String> lines = messages.join().split('\n');
         if (isDE1(lines, combined)) {
-          _log.info("Detected: DE1 Machine");
-          return UnifiedDe1(transport: transport);
+          int? v13Model;
+          for (final line in lines) {
+            final v = decodeMmrInt32Response(
+              line.trim(),
+              expectedAddr: (0x80, 0x00, 0x0C),
+            );
+            if (v != null) {
+              v13Model = v;
+              break;
+            }
+          }
+          final isBengle = v13Model != null && v13Model >= 128;
+          _log.info(
+              "Detected: ${isBengle ? 'Bengle' : 'DE1'} (v13Model=$v13Model)");
+          return isBengle
+              ? Bengle(transport: transport)
+              : UnifiedDe1(transport: transport);
         }
       }
 

--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -282,12 +282,12 @@ class SerialServiceAndroid implements DeviceDiscoveryService {
         await transport.writeCommand('<+M>');
         await transport.writeCommand('<+E>');
 
-        final req = buildMmrReadRequest(address: 0x0080000C, length: 4);
+        final req = buildMmrReadRequest(address: 0x0080000C, length: 0);
         final reqHex = req
             .map((b) => b.toRadixString(16).padLeft(2, '0'))
             .join();
         try {
-          await transport.writeCommand('<F>$reqHex');
+          await transport.writeCommand('<E>$reqHex');
         } catch (e) {
           _log.fine('MMR read request failed during probe', e);
         }

--- a/lib/src/services/serial/serial_service_desktop.dart
+++ b/lib/src/services/serial/serial_service_desktop.dart
@@ -320,17 +320,19 @@ class SerialServiceDesktop implements DeviceDiscoveryService {
         final messages = <String>[];
         final stateSubscription = transport.readStream.listen(messages.add);
 
-        await transport.writeCommand('<+M>');
-        await transport.writeCommand('<+E>');
+        await transport.writeCommand('<+M>'); // shotSample (DE1 baseline)
+        await transport.writeCommand('<+E>'); // readFromMMR
 
-        // Fire the v13Model MMR-read request. Address layout for
-        // 0x0080000C: byte[0]=length, byte[1..3]=addr triplet.
-        final req = buildMmrReadRequest(address: 0x0080000C, length: 4);
+        // Fire the v13Model MMR-read request. The MMR protocol writes
+        // the addr buffer to the readFromMMR endpoint (`<E>`), and the
+        // device replies on the same channel as `[E]…` notify. Layout:
+        // byte[0]=length (0 = device-canonical), byte[1..3]=addr.
+        final req = buildMmrReadRequest(address: 0x0080000C, length: 0);
         final reqHex = req
             .map((b) => b.toRadixString(16).padLeft(2, '0'))
             .join();
         try {
-          await transport.writeCommand('<F>$reqHex');
+          await transport.writeCommand('<E>$reqHex');
         } catch (e) {
           _log.fine('MMR read request failed during probe', e);
         }

--- a/lib/src/services/serial/serial_service_desktop.dart
+++ b/lib/src/services/serial/serial_service_desktop.dart
@@ -6,11 +6,14 @@ import 'dart:typed_data';
 import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale_serial.dart';
 import 'package:reaprime/src/models/device/impl/sensor/debug_port.dart';
 import 'package:reaprime/src/models/device/impl/sensor/sensor_basket.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
+import 'mmr_codec.dart';
+import 'usb_ids.dart';
 import 'utils.dart';
 
 import 'package:rxdart/subjects.dart';
@@ -233,9 +236,31 @@ class SerialServiceDesktop implements DeviceDiscoveryService {
       return device;
     }
 
+    // Bengle shortcut (productName likely lands as "Bengle" once FW
+    // exposes it; trivial future-proofing).
+    if (port.productName == "Bengle") {
+      final device = Bengle(transport: transport);
+      _portPathToDeviceId[id] = device.deviceId;
+      return device;
+    }
+
     // Half Decent Scale shortcut
     if (port.productName == "Half Decent Scale") {
       final device = HDSSerial(transport: transport);
+      _portPathToDeviceId[id] = device.deviceId;
+      return device;
+    }
+
+    // VID:PID shortcut.
+    int? vid;
+    int? pid;
+    try { vid = port.vendorId; } catch (_) {}
+    try { pid = port.productId; } catch (_) {}
+    final usbModel = matchUsbDevice(usbDeviceTable, vid: vid, pid: pid);
+    if (usbModel != null) {
+      final device = usbModel == UsbDeviceModel.bengle
+          ? Bengle(transport: transport)
+          : UnifiedDe1(transport: transport);
       _portPathToDeviceId[id] = device.deviceId;
       return device;
     }
@@ -289,12 +314,27 @@ class SerialServiceDesktop implements DeviceDiscoveryService {
         _portPathToDeviceId[id] = device.deviceId;
         return device;
       } else {
-        // Detect DE1 by sending state commands and checking for valid responses
+        // Detect DE1-family by sending state + MMR-notify enables, then
+        // waiting for `[M]` (DE1 protocol baseline) and `[E]` (v13Model
+        // MMR response) to come back. v13Model >= 128 → Bengle.
         final messages = <String>[];
         final stateSubscription = transport.readStream.listen(messages.add);
 
-        // Send state commands without a fixed delay, but with timeout
         await transport.writeCommand('<+M>');
+        await transport.writeCommand('<+E>');
+
+        // Fire the v13Model MMR-read request. Address layout for
+        // 0x0080000C: byte[0]=length, byte[1..3]=addr triplet.
+        final req = buildMmrReadRequest(address: 0x0080000C, length: 4);
+        final reqHex = req
+            .map((b) => b.toRadixString(16).padLeft(2, '0'))
+            .join();
+        try {
+          await transport.writeCommand('<F>$reqHex');
+        } catch (e) {
+          _log.fine('MMR read request failed during probe', e);
+        }
+
         try {
           await stateSubscription.asFuture<void>().timeout(
             readDuration,
@@ -304,11 +344,30 @@ class SerialServiceDesktop implements DeviceDiscoveryService {
           );
         } finally {
           await transport.writeCommand('<-M>');
+          await transport.writeCommand('<-E>');
         }
 
         if (isDE1(messages.join().split('\n'), combined)) {
-          _log.info("Detected: DE1 Machine");
-          final device = UnifiedDe1(transport: transport);
+          // DE1-family confirmed. Scan the same message buffer for the
+          // v13Model MMR response to disambiguate DE1 vs Bengle.
+          int? v13Model;
+          for (final line in messages.join().split('\n')) {
+            final v = decodeMmrInt32Response(
+              line.trim(),
+              expectedAddr: (0x80, 0x00, 0x0C),
+            );
+            if (v != null) {
+              v13Model = v;
+              break;
+            }
+          }
+
+          final isBengle = v13Model != null && v13Model >= 128;
+          _log.info(
+              "Detected: ${isBengle ? 'Bengle' : 'DE1'} (v13Model=$v13Model)");
+          final device = isBengle
+              ? Bengle(transport: transport)
+              : UnifiedDe1(transport: transport);
           _portPathToDeviceId[id] = device.deviceId;
           return device;
         }

--- a/lib/src/services/serial/usb_ids.dart
+++ b/lib/src/services/serial/usb_ids.dart
@@ -1,0 +1,47 @@
+/// USB VID:PID dispatch for DE1-family devices.
+///
+/// The desktop and Android serial services consult [usbDeviceTable] as a
+/// fast path before falling through to protocol probing. Currently both
+/// tables are empty until concrete pairs are captured from hardware
+/// (procedure documented in `doc/plans/...bengle-mock-and-usb.md`).
+///
+/// Note on DE1: the original DE1 uses a generic USB-serial adapter
+/// (FTDI / similar), so VID:PID matching may false-match on unrelated
+/// devices. The `productName == "DE1"` shortcut is more specific and
+/// stays in place. Only add a DE1 VID:PID pair here if a specific DE1
+/// model is verified to expose a custom descriptor distinct from the
+/// generic adapter.
+enum UsbDeviceModel { de1, bengle }
+
+/// `(vendorId, productId)` pairs.
+typedef UsbIdPair = (int vid, int pid);
+
+/// DE1 USB ID pairs. See doc on [UsbDeviceModel] for caveats.
+const List<UsbIdPair> de1UsbIds = [];
+
+/// Bengle USB ID pairs. Populated once captured from hardware.
+const List<UsbIdPair> bengleUsbIds = [];
+
+/// Default table consulted by serial services.
+const Map<UsbDeviceModel, List<UsbIdPair>> usbDeviceTable = {
+  UsbDeviceModel.de1: de1UsbIds,
+  UsbDeviceModel.bengle: bengleUsbIds,
+};
+
+/// Returns the [UsbDeviceModel] for a `(vid, pid)` pair found in [table],
+/// or null if neither is present in any list. Null inputs yield null.
+UsbDeviceModel? matchUsbDevice(
+  Map<UsbDeviceModel, List<UsbIdPair>> table, {
+  required int? vid,
+  required int? pid,
+}) {
+  if (vid == null || pid == null) return null;
+  for (final entry in table.entries) {
+    for (final pair in entry.value) {
+      if (pair.$1 == vid && pair.$2 == pid) {
+        return entry.key;
+      }
+    }
+  }
+  return null;
+}

--- a/lib/src/services/simulated_device_service.dart
+++ b/lib/src/services/simulated_device_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/widgets.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
 import 'package:reaprime/src/models/device/impl/mock_scale/mock_scale.dart';
 import 'package:reaprime/src/models/device/impl/sensor/mock/mock_debug_port.dart';
@@ -38,6 +39,11 @@ class SimulatedDeviceService
       _devices["MockDe1"] = MockDe1();
     } else {
       _devices.remove("MockDe1");
+    }
+    if (enabledDevices.contains(SimulatedDevicesTypes.bengle)) {
+      _devices["MockBengle"] = MockBengle();
+    } else {
+      _devices.remove("MockBengle");
     }
     if (enabledDevices.contains(SimulatedDevicesTypes.scale)) {
       _devices["MockScale"] = MockScale();

--- a/lib/src/settings/settings_service.dart
+++ b/lib/src/settings/settings_service.dart
@@ -417,7 +417,7 @@ enum SettingsKeys {
   onboardingCompleted,
 }
 
-enum SimulatedDevicesTypes { machine, scale, sensor }
+enum SimulatedDevicesTypes { machine, scale, sensor, bengle }
 
 extension SimulatedDevicesTypesFromString on SimulatedDevicesTypes {
   static SimulatedDevicesTypes? fromString(String value) {

--- a/test/models/device/firmware_upload_tuning_test.dart
+++ b/test/models/device/firmware_upload_tuning_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+
+import '../../helpers/fake_ble_transport.dart';
+
+void main() {
+  group('Firmware upload tuning', () {
+    test('UnifiedDe1 default batch pause is non-zero on serial transport',
+        () {
+      // Default DE1: serial path needs UART backpressure pauses to avoid
+      // overrunning the SPI flash writer. Anything >0 keeps that intact.
+      final de1 = UnifiedDe1(transport: FakeBleTransport());
+      // BLE transport → pause should be zero (writeWithResponse acks).
+      // ignore: invalid_use_of_protected_member
+      expect(de1.firmwareUploadBatchPause, equals(Duration.zero));
+    });
+
+    test('Bengle overrides firmware upload pause to zero', () {
+      // Bengle's USB CDC has built-in flow control, so the artificial
+      // batch pause isn't needed — full bandwidth is available.
+      final bengle = Bengle(transport: FakeBleTransport());
+      // ignore: invalid_use_of_protected_member
+      expect(bengle.firmwareUploadBatchPause, equals(Duration.zero));
+    });
+  });
+}

--- a/test/models/device/mock_bengle_test.dart
+++ b/test/models/device/mock_bengle_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/bengle_interface.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+
+void main() {
+  group('MockBengle', () {
+    test('implements BengleInterface', () {
+      final m = MockBengle();
+      expect(m, isA<BengleInterface>());
+    });
+
+    test('still implements De1Interface (so existing scan paths consume it)',
+        () {
+      final m = MockBengle();
+      expect(m, isA<De1Interface>());
+    });
+
+    test('extends MockDe1 to reuse the simulated state machine', () {
+      final m = MockBengle();
+      expect(m, isA<MockDe1>());
+    });
+
+    test('default deviceId is "MockBengle"', () {
+      final m = MockBengle();
+      expect(m.deviceId, equals('MockBengle'));
+    });
+
+    test('default name is "MockBengle" (matches MockDe1 convention)', () {
+      final m = MockBengle();
+      expect(m.name, equals('MockBengle'));
+    });
+
+    test('deviceId can be overridden via constructor', () {
+      final m = MockBengle(deviceId: 'CustomBengleId');
+      expect(m.deviceId, equals('CustomBengleId'));
+    });
+  });
+}

--- a/test/sample_feature/sample_item_details_view_test.dart
+++ b/test/sample_feature/sample_item_details_view_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+import 'package:reaprime/src/sample_feature/sample_item_details_view.dart';
+
+void main() {
+  group('debugViewTitle', () {
+    test('returns DE1 label for a non-Bengle De1Interface', () {
+      expect(debugViewTitle(MockDe1()), equals('DE1 Details'));
+    });
+
+    test('returns Bengle label for a BengleInterface', () {
+      expect(debugViewTitle(MockBengle()), equals('Bengle Details'));
+    });
+  });
+}

--- a/test/services/serial/mmr_codec_test.dart
+++ b/test/services/serial/mmr_codec_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/serial/mmr_codec.dart';
+
+void main() {
+  group('buildMmrReadRequest', () {
+    test('encodes v13Model address (0x0080000C, length 4)', () {
+      final req = buildMmrReadRequest(address: 0x0080000C, length: 4);
+
+      expect(req, hasLength(20));
+      // Layout: setInt32(0, addr, big-endian) writes [0x00, 0x80, 0x00, 0x0C]
+      // then byte 0 is overwritten with length.
+      expect(req[0], equals(4));
+      expect(req[1], equals(0x80));
+      expect(req[2], equals(0x00));
+      expect(req[3], equals(0x0C));
+      // Remaining bytes are zero.
+      expect(req.sublist(4), everyElement(equals(0)));
+    });
+  });
+
+  group('decodeMmrInt32Response', () {
+    test('returns the int32 value when the address triplet matches', () {
+      // Build a fake [E]... payload: bytes [length, addr1, addr2, addr3, v0..v3, ...].
+      // For address 0x0080000C, expectedAddr = (0x80, 0x00, 0x0C).
+      // value = 0x00000005 (DE1Cafe per MMRItem.v13Model description)
+      final payload = [
+        0x04, 0x80, 0x00, 0x0C, 0x00, 0x00, 0x00, 0x05, // first 8 bytes
+        ...List.filled(12, 0),
+      ];
+      final hex = payload
+          .map((b) => b.toRadixString(16).padLeft(2, '0'))
+          .join();
+      final line = '[E]$hex';
+
+      final result = decodeMmrInt32Response(
+        line,
+        expectedAddr: (0x80, 0x00, 0x0C),
+      );
+
+      expect(result, equals(5));
+    });
+
+    test('returns the int32 value for a Bengle-range model (>= 128)', () {
+      final payload = [
+        0x04, 0x80, 0x00, 0x0C, 0x00, 0x00, 0x00, 0x80, // value = 128
+        ...List.filled(12, 0),
+      ];
+      final hex = payload
+          .map((b) => b.toRadixString(16).padLeft(2, '0'))
+          .join();
+      final result = decodeMmrInt32Response(
+        '[E]$hex',
+        expectedAddr: (0x80, 0x00, 0x0C),
+      );
+      expect(result, equals(128));
+    });
+
+    test('returns null when the address triplet does not match', () {
+      // Different address in the payload.
+      final payload = [
+        0x04, 0x99, 0x99, 0x99, 0x00, 0x00, 0x00, 0x05,
+        ...List.filled(12, 0),
+      ];
+      final hex = payload
+          .map((b) => b.toRadixString(16).padLeft(2, '0'))
+          .join();
+      final result = decodeMmrInt32Response(
+        '[E]$hex',
+        expectedAddr: (0x80, 0x00, 0x0C),
+      );
+      expect(result, isNull);
+    });
+
+    test('returns null for a non-[E] line', () {
+      expect(
+        decodeMmrInt32Response('[M]00112233',
+            expectedAddr: (0x80, 0x00, 0x0C)),
+        isNull,
+      );
+    });
+
+    test('returns null for malformed hex', () {
+      expect(
+        decodeMmrInt32Response('[E]xyz', expectedAddr: (0x80, 0x00, 0x0C)),
+        isNull,
+      );
+    });
+
+    test('returns null for too-short payload', () {
+      // Need at least 8 bytes (4 header + 4 value); supply 6.
+      final hex = '040000000000';
+      expect(
+        decodeMmrInt32Response('[E]$hex',
+            expectedAddr: (0x00, 0x00, 0x00)),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/services/serial/mmr_codec_test.dart
+++ b/test/services/serial/mmr_codec_test.dart
@@ -23,8 +23,9 @@ void main() {
       // Build a fake [E]... payload: bytes [length, addr1, addr2, addr3, v0..v3, ...].
       // For address 0x0080000C, expectedAddr = (0x80, 0x00, 0x0C).
       // value = 0x00000005 (DE1Cafe per MMRItem.v13Model description)
+      // Encoded little-endian at bytes [4..7].
       final payload = [
-        0x04, 0x80, 0x00, 0x0C, 0x00, 0x00, 0x00, 0x05, // first 8 bytes
+        0x04, 0x80, 0x00, 0x0C, 0x05, 0x00, 0x00, 0x00, // value LE = 5
         ...List.filled(12, 0),
       ];
       final hex = payload
@@ -41,8 +42,10 @@ void main() {
     });
 
     test('returns the int32 value for a Bengle-range model (>= 128)', () {
+      // Real Bengle reply observed on hardware: [4, 80, 0, c, 80, 0, 0, 0, ...]
+      // Value bytes [4..7] = [0x80, 0x00, 0x00, 0x00] little-endian = 128.
       final payload = [
-        0x04, 0x80, 0x00, 0x0C, 0x00, 0x00, 0x00, 0x80, // value = 128
+        0x04, 0x80, 0x00, 0x0C, 0x80, 0x00, 0x00, 0x00,
         ...List.filled(12, 0),
       ];
       final hex = payload

--- a/test/services/serial/usb_ids_test.dart
+++ b/test/services/serial/usb_ids_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/serial/usb_ids.dart';
+
+void main() {
+  group('matchUsbDevice', () {
+    const a = (0x1234, 0x5678);
+    const b = (0xABCD, 0x0001);
+
+    test('returns the model for a matching pair', () {
+      const table = {
+        UsbDeviceModel.de1: [a],
+        UsbDeviceModel.bengle: [b],
+      };
+      expect(matchUsbDevice(table, vid: a.$1, pid: a.$2),
+          equals(UsbDeviceModel.de1));
+      expect(matchUsbDevice(table, vid: b.$1, pid: b.$2),
+          equals(UsbDeviceModel.bengle));
+    });
+
+    test('returns null for an unknown pair', () {
+      const table = {
+        UsbDeviceModel.de1: [a],
+      };
+      expect(matchUsbDevice(table, vid: 0xFFFF, pid: 0xFFFF), isNull);
+    });
+
+    test('returns null when vid or pid is null', () {
+      const table = {
+        UsbDeviceModel.de1: [a],
+      };
+      expect(matchUsbDevice(table, vid: null, pid: a.$2), isNull);
+      expect(matchUsbDevice(table, vid: a.$1, pid: null), isNull);
+      expect(matchUsbDevice(table, vid: null, pid: null), isNull);
+    });
+
+    test('handles entries with multiple pairs per model', () {
+      const c = (0x1111, 0x2222);
+      const table = {
+        UsbDeviceModel.de1: [a, c],
+      };
+      expect(matchUsbDevice(table, vid: c.$1, pid: c.$2),
+          equals(UsbDeviceModel.de1));
+    });
+  });
+
+  group('default usbDeviceTable', () {
+    test('returns null for a clearly unrelated pair', () {
+      // Sanity check: real table doesn't false-match on something random.
+      expect(matchUsbDevice(usbDeviceTable, vid: 0xFFFF, pid: 0xFFFF), isNull);
+    });
+  });
+}

--- a/test/services/simulated_device_service_test.dart
+++ b/test/services/simulated_device_service_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+import 'package:reaprime/src/services/simulated_device_service.dart';
+import 'package:reaprime/src/settings/settings_service.dart';
+
+void main() {
+  group('SimulatedDeviceService', () {
+    test('emits a MockBengle when bengle is enabled', () async {
+      final service = SimulatedDeviceService();
+      service.enabledDevices = {SimulatedDevicesTypes.bengle};
+
+      final emission = service.devices.first;
+      await service.scanForDevices();
+      final devices = await emission;
+
+      expect(devices.whereType<MockBengle>(), hasLength(1));
+    });
+
+    test('does not emit MockBengle when only machine is enabled', () async {
+      final service = SimulatedDeviceService();
+      service.enabledDevices = {SimulatedDevicesTypes.machine};
+
+      final emission = service.devices.first;
+      await service.scanForDevices();
+      final devices = await emission;
+
+      expect(devices.whereType<MockDe1>(), hasLength(1));
+      expect(devices.whereType<MockBengle>(), isEmpty);
+    });
+
+    test('emits both MockDe1 and MockBengle when both enabled', () async {
+      final service = SimulatedDeviceService();
+      service.enabledDevices = {
+        SimulatedDevicesTypes.machine,
+        SimulatedDevicesTypes.bengle,
+      };
+
+      final emission = service.devices.first;
+      await service.scanForDevices();
+      final devices = await emission;
+
+      // MockBengle extends MockDe1, so the type filter matches both —
+      // count by deviceId instead.
+      final ids = devices.map((d) => d.deviceId).toSet();
+      expect(ids, containsAll(['MockDe1', 'MockBengle']));
+    });
+
+    test('removes MockBengle when bengle becomes disabled', () async {
+      final service = SimulatedDeviceService();
+      service.enabledDevices = {SimulatedDevicesTypes.bengle};
+      await service.scanForDevices();
+
+      // Switching to a different non-empty set so the next scan still
+      // emits (empty enabledDevices early-returns without emission).
+      service.enabledDevices = {SimulatedDevicesTypes.machine};
+      final emission = service.devices.first;
+      await service.scanForDevices();
+      final devices = await emission;
+
+      expect(devices.whereType<MockBengle>(), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## What

- `MockBengle` simulated device, surfaced via a new
  `SimulatedDevicesTypes.bengle` value.
- Real Bengle USB recognition: v13Model MMR probe in the existing
  detection fallback. v13Model ≥ 128 → `Bengle` class.
- `De1DebugView` header reflects `BengleInterface` vs DE1.
- Bengle FW upload skips the per-batch UART backpressure pause DE1
  needs (Bengle USB has hardware flow control). Hoisted to
  `firmwareUploadBatchPause` / `firmwareUploadBatchSize` `@protected`
  getters on `UnifiedDe1`; Bengle overrides the pause to zero.

## Why

Roadmap steps 2 + 3 of the Bengle integration ([design doc][1]).
Capability mixins (cup warmer, integrated scale, LED, milk probe)
land in steps 4–7; this PR keeps Bengle behaviorally identical to a
DE1 plus the FW-prelude hook from #207.

[1]: doc/plans/archive/bengle-mock-and-usb/2026-04-30-bengle-mock-and-usb-design.md

## Test plan

- `flutter test` + `flutter analyze` clean.
- Real Bengle USB on macOS: detected as `name: "Bengle"`,
  `v13Model=128`; FW upload completes end-to-end at full bandwidth.
- Simulated: `flutter run --dart-define=simulate=bengle` → `MockBengle`
  connects via API.