### PR TITLE
feat(webui): cross-skin asset sharing endpoint

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -2647,6 +2647,55 @@ paths:
                   message:
                     type: string
 
+  /api/v1/webui/skin-assets/{id}/{filepath}:
+    get:
+      summary: Fetch an asset from an installed skin
+      description: |
+        Returns a file from another installed skin's folder. Lets a skin
+        reference shared assets (icons, fonts, components) hosted by a
+        different installed skin instead of duplicating them.
+
+        The `id` is the target skin's installed id. `filepath` is the path
+        inside that skin's folder, relative to its root. The response body
+        is the raw file bytes; `Content-Type` is sniffed from the file
+        contents and extension.
+      tags: [WebUI]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Installed skin id (as returned by `GET /api/v1/webui/skins`).
+        - name: filepath
+          in: path
+          required: true
+          schema:
+            type: string
+          description: |
+            Path of the asset relative to the skin's root folder
+            (e.g. `assets/logo.svg`). May contain forward slashes.
+      responses:
+        "200":
+          description: Asset bytes
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        "404":
+          description: Skin or asset not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Failed to read asset
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   # Presence API
   #
   # User presence detection and wake schedule management.

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -154,6 +154,7 @@ Settings fields include: `gatewayMode`, `themeMode`, `logLevel`, `weightFlowMult
 | GET | `/api/v1/webui/server/status` | Server status (`{serving, path, port, ip}`) | |
 | POST | `/api/v1/webui/server/start` | Start serving default skin on port 3000 | |
 | POST | `/api/v1/webui/server/stop` | Stop serving | |
+| GET | `/api/v1/webui/skin-assets/:id/:filepath` | Fetch a file from another installed skin (cross-skin asset sharing) | |
 
 ### Plugins
 

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -2859,6 +2859,30 @@ ApplicationDocuments/
     └── .rea_metadata.json    # Version tracking (managed by REA)
 ```
 
+### Cross-Skin Asset Sharing
+
+A skin can fetch files from any other installed skin via:
+
+```
+GET /api/v1/webui/skin-assets/{id}/{filepath}
+```
+
+- `{id}` — installed skin id (see `GET /api/v1/webui/skins`).
+- `{filepath}` — path inside that skin's folder (e.g. `assets/logo.svg`, `components/widget.js`).
+
+The response is the raw file bytes; `Content-Type` is sniffed from the file. This lets a skin reuse icons, fonts, web components, or shared scripts hosted by another installed skin instead of duplicating them.
+
+```html
+<!-- pulling a shared logo from another installed skin -->
+<img src="/api/v1/webui/skin-assets/shared-assets/icons/logo.svg" />
+
+<!-- loading a component module from a "components" skin -->
+<script type="module"
+        src="/api/v1/webui/skin-assets/sb-components/dist/gauge.js"></script>
+```
+
+The endpoint only serves files from already-installed skins — install the asset-providing skin first via the normal install flow.
+
 ### Skin Metadata: manifest.json
 
 While optional, including a `manifest.json` helps Streamline-Bridge display better skin information:

--- a/lib/src/services/webserver/webui_handler.dart
+++ b/lib/src/services/webserver/webui_handler.dart
@@ -345,17 +345,30 @@ class WebUIHandler {
     String id,
     String filepath,
   ) async {
+    log.fine("serving $filepath for $id");
+
+    if (!_storage.isSkinInstalled(id)) {
+      return jsonNotFound({'error': 'Skin not found: $id'});
+    }
+
+    final base = p.normalize(p.absolute(_storage.getSkinPath(id)));
+    final target = p.normalize(p.absolute(p.join(base, filepath)));
+    if (target != base && !p.isWithin(base, target)) {
+      log.warning('rejected skin-asset path traversal: $id -> $filepath');
+      return jsonForbidden({'error': 'Invalid asset path'});
+    }
+
+    final resource = File(target);
+    if (!await resource.exists()) {
+      return jsonNotFound({'error': 'Asset not found'});
+    }
+
     try {
-      log.fine("serving $filepath for $id");
-
-      final path = _storage.getSkinPath(id);
-
-      final File resource = File('$path/$filepath');
       final content = await resource.readAsBytes();
-      final type = lookupMimeType(
-        resource.path,
-        headerBytes: content.sublist(0, 32),
-      );
+      final headerBytes = content.length < 32
+          ? content
+          : content.sublist(0, 32);
+      final type = lookupMimeType(resource.path, headerBytes: headerBytes);
       return Response.ok(
         content,
         headers: {'content-type': type ?? 'application/octet-stream'},

--- a/lib/src/services/webserver/webui_handler.dart
+++ b/lib/src/services/webserver/webui_handler.dart
@@ -6,13 +6,13 @@ class WebUIHandler {
   final WebUIService _service;
   final bool _appStoreMode;
 
-  WebUIHandler(
-      {required WebUIStorage storage,
-      required WebUIService service,
-      bool? appStoreMode})
-      : _storage = storage,
-        _service = service,
-        _appStoreMode = appStoreMode ?? BuildInfo.appStore;
+  WebUIHandler({
+    required WebUIStorage storage,
+    required WebUIService service,
+    bool? appStoreMode,
+  }) : _storage = storage,
+       _service = service,
+       _appStoreMode = appStoreMode ?? BuildInfo.appStore;
 
   void addRoutes(RouterPlus app) {
     // List all installed skins
@@ -28,10 +28,16 @@ class WebUIHandler {
     app.get('/api/v1/webui/skins/<id>', _handleGetSkin);
 
     // Install skin from GitHub release
-    app.post('/api/v1/webui/skins/install/github-release', _handleInstallFromGitHubRelease);
+    app.post(
+      '/api/v1/webui/skins/install/github-release',
+      _handleInstallFromGitHubRelease,
+    );
 
     // Install skin from GitHub branch
-    app.post('/api/v1/webui/skins/install/github-branch', _handleInstallFromGitHubBranch);
+    app.post(
+      '/api/v1/webui/skins/install/github-branch',
+      _handleInstallFromGitHubBranch,
+    );
 
     // Install skin from URL
     app.post('/api/v1/webui/skins/install/url', _handleInstallFromUrl);
@@ -46,6 +52,9 @@ class WebUIHandler {
     app.get('/api/v1/webui/server/status', _handleServerStatus);
     app.post('/api/v1/webui/server/start', _handleServerStart);
     app.post('/api/v1/webui/server/stop', _handleServerStop);
+
+    // Skin assets - support loading individual skin assets from other skins
+    app.get('/api/v1/webui/skin-assets/<id>/<path|.*>', _handleGetSkinAssets);
   }
 
   /// GET /api/v1/webui/skins
@@ -92,14 +101,15 @@ class WebUIHandler {
 
   /// PUT /api/v1/webui/skins/default
   /// Set the default skin
-  /// 
+  ///
   /// Body:
   /// {
   ///   "skinId": "my-skin-id"
   /// }
   Future<Response> _handleSetDefaultSkin(Request request) async {
     try {
-      final body = jsonDecode(await request.readAsString()) as Map<String, dynamic>;
+      final body =
+          jsonDecode(await request.readAsString()) as Map<String, dynamic>;
       final skinId = body['skinId'] as String?;
 
       if (skinId == null || skinId.isEmpty) {
@@ -125,7 +135,7 @@ class WebUIHandler {
 
   /// POST /api/v1/webui/skins/install/github-release
   /// Install skin from GitHub release
-  /// 
+  ///
   /// Body:
   /// {
   ///   "repo": "username/repo",
@@ -134,10 +144,13 @@ class WebUIHandler {
   /// }
   Future<Response> _handleInstallFromGitHubRelease(Request request) async {
     if (_appStoreMode) {
-      return jsonForbidden({'error': 'Skin installation is not available on this platform'});
+      return jsonForbidden({
+        'error': 'Skin installation is not available on this platform',
+      });
     }
     try {
-      final body = jsonDecode(await request.readAsString()) as Map<String, dynamic>;
+      final body =
+          jsonDecode(await request.readAsString()) as Map<String, dynamic>;
       final repo = body['repo'] as String?;
 
       if (repo == null || repo.isEmpty) {
@@ -168,7 +181,7 @@ class WebUIHandler {
 
   /// POST /api/v1/webui/skins/install/github-branch
   /// Install skin from GitHub branch
-  /// 
+  ///
   /// Body:
   /// {
   ///   "repo": "username/repo",
@@ -176,10 +189,13 @@ class WebUIHandler {
   /// }
   Future<Response> _handleInstallFromGitHubBranch(Request request) async {
     if (_appStoreMode) {
-      return jsonForbidden({'error': 'Skin installation is not available on this platform'});
+      return jsonForbidden({
+        'error': 'Skin installation is not available on this platform',
+      });
     }
     try {
-      final body = jsonDecode(await request.readAsString()) as Map<String, dynamic>;
+      final body =
+          jsonDecode(await request.readAsString()) as Map<String, dynamic>;
       final repo = body['repo'] as String?;
 
       if (repo == null || repo.isEmpty) {
@@ -206,17 +222,20 @@ class WebUIHandler {
 
   /// POST /api/v1/webui/skins/install/url
   /// Install skin from direct URL
-  /// 
+  ///
   /// Body:
   /// {
   ///   "url": "https://example.com/skin.zip"
   /// }
   Future<Response> _handleInstallFromUrl(Request request) async {
     if (_appStoreMode) {
-      return jsonForbidden({'error': 'Skin installation is not available on this platform'});
+      return jsonForbidden({
+        'error': 'Skin installation is not available on this platform',
+      });
     }
     try {
-      final body = jsonDecode(await request.readAsString()) as Map<String, dynamic>;
+      final body =
+          jsonDecode(await request.readAsString()) as Map<String, dynamic>;
       final url = body['url'] as String?;
 
       if (url == null || url.isEmpty) {
@@ -316,6 +335,34 @@ class WebUIHandler {
       return jsonOk({'message': 'WebUI server stopped'});
     } catch (e) {
       return jsonError({'error': 'Failed to stop: $e'});
+    }
+  }
+
+  /// GET /api/v1/webui/skin-assets/{id}/{filepath}
+  /// returns a file from the skin folder
+  Future<Response> _handleGetSkinAssets(
+    Request request,
+    String id,
+    String filepath,
+  ) async {
+    try {
+      log.fine("serving $filepath for $id");
+
+      final path = _storage.getSkinPath(id);
+
+      final File resource = File('$path/$filepath');
+      final content = await resource.readAsBytes();
+      final type = lookupMimeType(
+        resource.path,
+        headerBytes: content.sublist(0, 32),
+      );
+      return Response.ok(
+        content,
+        headers: {'content-type': type ?? 'application/octet-stream'},
+      );
+    } catch (e, st) {
+      log.warning('unable to serve requested skin asset', e, st);
+      return jsonError({'exception': e.toString()});
     }
   }
 }

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -70,6 +70,7 @@ import 'package:reaprime/src/services/webview_log_service.dart';
 import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/services/webserver/info_handler.dart';
 import 'package:reaprime/src/services/webserver/debug_handler.dart';
+import 'package:mime/mime.dart';
 
 part 'webserver/de1handler.dart';
 part 'webserver/scale_handler.dart';

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -71,6 +71,7 @@ import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/services/webserver/info_handler.dart';
 import 'package:reaprime/src/services/webserver/debug_handler.dart';
 import 'package:mime/mime.dart';
+import 'package:path/path.dart' as p;
 
 part 'webserver/de1handler.dart';
 part 'webserver/scale_handler.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -944,7 +944,7 @@ packages:
     source: hosted
     version: "1.17.0"
   mime:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: mime
       sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -88,6 +88,7 @@ dependencies:
   drift_flutter: ^0.3.0
   sqlite3_flutter_libs: ^0.6.0+eol
   pretty_qr_code: ^3.6.0
+  mime: ^2.0.0
   # path: ../flutter_libserialport
   # git:
   #   url: https://github.com/tadelv/flutter_libserialport.git


### PR DESCRIPTION
## What
- New `GET /api/v1/webui/skin-assets/{id}/{filepath}` endpoint serving files from any installed skin's folder.
- Path traversal hardening: normalized path containment check, plus 404/403 status codes for unknown skin / missing asset / out-of-tree path.
- Spec + docs updated (`assets/api/rest_v1.yml`, `doc/Api.md`, `doc/Skins.md`).

## Why
Lets a skin reference shared assets (icons, fonts, web components) hosted by another installed skin instead of duplicating them across skins.