### PR TITLE
fix(scale): emit WeightSnapshot on /ws/v1/scale/snapshot

### DIFF
--- a/assets/api/websocket_v1.yml
+++ b/assets/api/websocket_v1.yml
@@ -40,10 +40,10 @@ channels:
         $ref: '#/components/messages/WaterLevels'
   ScaleSnapshot:
     description: >
-      Real-time scale weight and battery data. The socket is held open across
-      scale connect/disconnect cycles — clients should not reconnect on scale
-      disconnect. On open and on every scale connection-state change the
-      server emits a status frame (`{"status":"connected"}` or
+      Real-time scale weight, smoothed flow, and battery data. The socket is
+      held open across scale connect/disconnect cycles — clients should not
+      reconnect on scale disconnect. On open and on every scale connection-state
+      change the server emits a status frame (`{"status":"connected"}` or
       `{"status":"disconnected"}`). Snapshot frames (see ScaleSnapshot
       schema) are only sent while a scale is connected.
     address: ws/v1/scale/snapshot
@@ -293,14 +293,24 @@ components:
           description: Freeform diagnostic payload; shape varies by kind.
     ScaleSnapshot:
       type: object
+      description: >
+        Smoothed weight + flow frame emitted on `ws/v1/scale/snapshot`. Mirrors
+        the controller-level `WeightSnapshot` (raw scale frames are processed
+        through the flow calculator before broadcast).
       properties:
         timestamp:
           type: string
           format: date-time
         weight:
           type: number
-        batteryLevel:
+          description: Current weight reading in grams.
+        weightFlow:
+          type: number
+          description: Smoothed weight-derived flow in g/s (moving average over the smoothing window).
+        battery:
           type: integer
+          nullable: true
+          description: Scale battery level (0–100). Null if the scale does not report battery.
         timerValue:
           type: integer
           nullable: true

--- a/lib/src/controllers/scale_controller.dart
+++ b/lib/src/controllers/scale_controller.dart
@@ -142,6 +142,7 @@ class WeightSnapshot {
       "timestamp": timestamp.toIso8601String(),
       "weight": weight,
       "weightFlow": weightFlow,
+      "battery": battery,
       "timerValue": timerValue?.inMilliseconds,
     };
   }
@@ -151,6 +152,7 @@ class WeightSnapshot {
       timestamp: DateTime.parse(json["timestamp"]),
       weight: json["weight"],
       weightFlow: json["weightFlow"],
+      battery: json["battery"],
       timerValue: json["timerValue"] != null
           ? Duration(milliseconds: json["timerValue"])
           : null,

--- a/lib/src/services/webserver/scale_handler.dart
+++ b/lib/src/services/webserver/scale_handler.dart
@@ -49,10 +49,10 @@ class ScaleHandler {
     app.get('/ws/v1/scale/snapshot', sws.webSocketHandler(_handleSnapshot));
   }
 
-  _handleSnapshot(WebSocketChannel socket, String? protocol) async {
+  Future<void> _handleSnapshot(WebSocketChannel socket, String? protocol) async {
     _log.fine("handling websocket connection");
 
-    StreamSubscription<ScaleSnapshot>? snapshotSub;
+    StreamSubscription<WeightSnapshot>? snapshotSub;
 
     void sendStatus(String status) {
       try {
@@ -63,14 +63,13 @@ class ScaleHandler {
     void attachSnapshots() {
       snapshotSub?.cancel();
       snapshotSub = null;
-      final Scale scale;
       try {
-        scale = _controller.connectedScale();
+        _controller.connectedScale();
       } catch (e) {
         _log.warning('connected state reported but no scale: $e');
         return;
       }
-      snapshotSub = scale.currentSnapshot.listen((snapshot) {
+      snapshotSub = _controller.weightSnapshot.listen((snapshot) {
         try {
           socket.sink.add(jsonEncode(snapshot.toJson()));
         } catch (e, st) {


### PR DESCRIPTION
## What

- Switch `ScaleHandler._handleSnapshot` to subscribe to `ScaleController.weightSnapshot` (smoothed `WeightSnapshot`) instead of the raw `Scale.currentSnapshot` (`ScaleSnapshot`).
- Add `battery` to `WeightSnapshot.toJson()` / `fromJson()`.
- Realign `ScaleSnapshot` schema in `assets/api/websocket_v1.yml` (drop `batteryLevel`, add `weightFlow` + nullable `battery`).

## Why

The handler was advertising "weight, flow, battery" in `doc/Api.md` but actually emitting `ScaleSnapshot.toJson()` — which has `batteryLevel` and no `weightFlow`. Skins relying on `weightFlow` were silently getting nothing.

## Test plan

- Smoke-tested via `scripts/sb-dev.sh` + `websocat` in simulate mode against `ws/v1/scale/snapshot`. Wire payload is now `{timestamp, weight, weightFlow, battery, timerValue}`.
- `flutter analyze` clean on touched files.