### PR TITLE
fix(telemetry): broaden forwarder filter + tighten noisy callers

### DIFF
--- a/lib/src/controllers/battery_controller.dart
+++ b/lib/src/controllers/battery_controller.dart
@@ -72,15 +72,22 @@ class BatteryController {
         'reason: ${decision.reason}',
       );
 
-      // Apply to DE1 — skip during BLE scan to avoid congesting the adapter
+      // Apply to DE1 — skip during BLE scan to avoid congesting the adapter,
+      // and skip when no machine is connected. Pre-checking avoids throwing
+      // DeviceNotConnectedException on every tick when the user has no
+      // machine, which used to log at WARNING and reach Crashlytics.
       if (_deviceController.isScanning) {
         _log.fine('Skipping USB charger mode update during BLE scan');
       } else {
-        try {
-          final de1 = _de1Controller.connectedDe1();
-          await de1.setUsbChargerMode(decision.shouldCharge);
-        } catch (e) {
-          _log.warning('Failed to set USB charger mode', e);
+        final de1 = _de1Controller.connectedDe1OrNull;
+        if (de1 == null) {
+          _log.fine('No machine connected, skipping USB charger mode update');
+        } else {
+          try {
+            await de1.setUsbChargerMode(decision.shouldCharge);
+          } catch (e) {
+            _log.warning('Failed to set USB charger mode', e);
+          }
         }
       }
 

--- a/lib/src/controllers/connection/status_publisher.dart
+++ b/lib/src/controllers/connection/status_publisher.dart
@@ -74,10 +74,18 @@ class StatusPublisher {
   /// Emit [err] on the status stream without changing the current
   /// phase. Logs at severe/warning depending on severity, then routes
   /// through [publish] so the same gatekeeper applies.
+  ///
+  /// Sticky kinds (`adapterOff`, `bluetoothPermissionDenied`, `scanFailed`)
+  /// describe environmental states that the user already sees in the UI
+  /// `ConnectionErrorBanner`. They aren't crash signals, so they log at
+  /// `info` instead of `severe`/`warning` — keeping them out of the
+  /// Crashlytics forwarder while preserving them in the file log.
   void emitError(ConnectionError err) {
     final msg = 'emit error: kind=${err.kind} message=${err.message} '
         'deviceId=${err.deviceId}';
-    if (err.severity == ConnectionErrorSeverity.error) {
+    if (ConnectionErrorKind.sticky.contains(err.kind)) {
+      _log.info(msg);
+    } else if (err.severity == ConnectionErrorSeverity.error) {
       _log.severe(msg);
     } else {
       _log.warning(msg);

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -221,6 +221,14 @@ class De1Controller {
     return _de1!;
   }
 
+  /// Non-throwing accessor for callers that already model the
+  /// "no machine connected" branch (e.g. periodic timers). Returning
+  /// `null` here keeps the expected case off the WARNING log path,
+  /// which would otherwise reach Crashlytics via the telemetry
+  /// forwarder. Use this whenever pre-checking is cheaper than
+  /// catching `DeviceNotConnectedException`.
+  De1Interface? get connectedDe1OrNull => _de1;
+
   Future<SteamFormSettings> steamSettings() async {
     if (_de1 == null) {
       throw const DeviceNotConnectedException.machine();

--- a/lib/src/controllers/presence_controller.dart
+++ b/lib/src/controllers/presence_controller.dart
@@ -168,8 +168,8 @@ class PresenceController {
     }
 
     _lastPresenceSent = now;
-    _de1?.sendUserPresent().catchError((e) {
-      _log.warning('Failed to send user present: $e');
+    _de1?.sendUserPresent().catchError((Object e) {
+      _log.warning('Failed to send user present', e);
     });
   }
 
@@ -218,8 +218,8 @@ class PresenceController {
     if (_currentMachineState == MachineState.idle ||
         _currentMachineState == MachineState.schedIdle) {
       _log.info('Sleep timeout fired, putting machine to sleep');
-      _de1!.requestState(MachineState.sleeping).catchError((e) {
-        _log.warning('Failed to request sleep: $e');
+      _de1!.requestState(MachineState.sleeping).catchError((Object e) {
+        _log.warning('Failed to request sleep', e);
       });
     }
   }
@@ -291,8 +291,8 @@ class PresenceController {
           _log.info(
               'Schedule ${schedule.id} matched at ${now.hour}:${now.minute}, waking machine');
           _firedScheduleIds.add(schedule.id);
-          _de1!.requestState(MachineState.schedIdle).catchError((e) {
-            _log.warning('Failed to request schedIdle: $e');
+          _de1!.requestState(MachineState.schedIdle).catchError((Object e) {
+            _log.warning('Failed to request schedIdle', e);
           });
           if (schedule.keepAwakeFor != null) {
             final newExpiry = now.add(Duration(minutes: schedule.keepAwakeFor!));
@@ -305,7 +305,7 @@ class PresenceController {
         }
       }
     } catch (e) {
-      _log.warning('Failed to parse wake schedules: $e');
+      _log.warning('Failed to parse wake schedules', e);
     }
   }
 }

--- a/lib/src/controllers/scan_state_guardian.dart
+++ b/lib/src/controllers/scan_state_guardian.dart
@@ -34,7 +34,10 @@ class ScanStateGuardian with WidgetsBindingObserver {
 
     if (previous == AdapterState.poweredOn &&
         state == AdapterState.poweredOff) {
-      _log.warning('BLE adapter turned off');
+      // Adapter on/off is a user-driven environmental state, surfaced to
+      // the UI through ScanStateEvent. Logging at WARNING used to push it
+      // through the telemetry forwarder as a Crashlytics non-fatal.
+      _log.info('BLE adapter turned off');
       _eventSubject.add(ScanStateEvent.adapterTurnedOff);
     } else if (previous == AdapterState.poweredOff &&
         state == AdapterState.poweredOn) {

--- a/lib/src/services/telemetry/telemetry_forwarder_filter.dart
+++ b/lib/src/services/telemetry/telemetry_forwarder_filter.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/errors.dart';
 
 const _webUiStorageLoggerName = 'WebUIStorage';
 const _skinAlreadyExistsPrefix = 'Skin already exists';
@@ -10,6 +11,19 @@ const _benignNetworkErrorPrefixes = [
   'Exception: Failed to download:',
 ];
 
+/// Loggers whose `WARNING+` records describe HTTP fetches we know can
+/// transiently fail in the field (DNS, offline, GitHub rate-limit). When
+/// the attached `error` is a transient network exception, the record is
+/// dropped from telemetry forwarding regardless of message.
+///
+/// Intentionally narrow — adding a logger here also opts it in to
+/// `_isTransientNetworkError` matching, so do not add loggers that should
+/// surface their own SocketExceptions (e.g. BLE transports).
+const _httpFetcherLoggers = <String>{
+  _webUiStorageLoggerName,
+  'AndroidUpdater',
+};
+
 /// Returns `false` for log records that match a known telemetry-noise pattern
 /// — caller should skip forwarding these to Crashlytics.
 ///
@@ -17,10 +31,22 @@ const _benignNetworkErrorPrefixes = [
 /// records below WARNING never reach Crashlytics today, so this predicate
 /// only describes WARNING+ records.
 bool shouldForwardToTelemetry(LogRecord record) {
-  if (record.loggerName == _webUiStorageLoggerName) {
-    if (record.message.startsWith(_skinAlreadyExistsPrefix)) return false;
-    if (_isTransientNetworkError(record.error)) return false;
+  // Drop typed transient exceptions regardless of source logger. These
+  // are part of the codebase's normal error model — connection drops,
+  // bounded MMR-read timeouts — not crash signals.
+  if (record.error is DeviceNotConnectedException) return false;
+  if (record.error is MmrTimeoutException) return false;
+
+  if (record.loggerName == _webUiStorageLoggerName &&
+      record.message.startsWith(_skinAlreadyExistsPrefix)) {
+    return false;
   }
+
+  if (_httpFetcherLoggers.contains(record.loggerName) &&
+      _isTransientNetworkError(record.error)) {
+    return false;
+  }
+
   return true;
 }
 

--- a/test/controllers/de1_controller_test.dart
+++ b/test/controllers/de1_controller_test.dart
@@ -22,6 +22,58 @@ De1ShotSettings _emptyShotSettings() => De1ShotSettings(
     );
 
 void main() {
+  group('connectedDe1OrNull accessor', () {
+    test('returns null when no machine connected', () async {
+      final deviceController =
+          DeviceController([MockDeviceDiscoveryService()]);
+      await deviceController.initialize();
+      final de1Controller = De1Controller(controller: deviceController);
+
+      expect(de1Controller.connectedDe1OrNull, isNull);
+    });
+
+    test('returns the connected DE1 once connectToDe1 completes', () async {
+      await runZonedGuarded(() async {
+        final deviceController =
+            DeviceController([MockDeviceDiscoveryService()]);
+        await deviceController.initialize();
+        final de1Controller = De1Controller(controller: deviceController);
+        final testDe1 = TestDe1();
+
+        await de1Controller.connectToDe1(testDe1);
+        // Unblock _initializeData so it does not leak into the test zone.
+        testDe1.emitShotSettings(_emptyShotSettings());
+        await Future<void>.delayed(Duration.zero);
+
+        expect(de1Controller.connectedDe1OrNull, same(testDe1));
+
+        testDe1.dispose();
+      }, (_, __) {});
+    });
+
+    test('returns null again after disconnect', () async {
+      await runZonedGuarded(() async {
+        final deviceController =
+            DeviceController([MockDeviceDiscoveryService()]);
+        await deviceController.initialize();
+        final de1Controller = De1Controller(controller: deviceController);
+        final testDe1 = TestDe1();
+
+        await de1Controller.connectToDe1(testDe1);
+        testDe1.emitShotSettings(_emptyShotSettings());
+        await Future<void>.delayed(Duration.zero);
+        expect(de1Controller.connectedDe1OrNull, isNotNull);
+
+        testDe1.setConnectionState(ConnectionState.disconnected);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(de1Controller.connectedDe1OrNull, isNull);
+
+        testDe1.dispose();
+      }, (_, __) {});
+    });
+  });
+
   group('shot-settings debounce race (comms-harden #5)', () {
     test(
       'disconnect during debounce does not leak an unhandled async error',

--- a/test/services/telemetry/telemetry_forwarder_filter_test.dart
+++ b/test/services/telemetry/telemetry_forwarder_filter_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/services/telemetry/telemetry_forwarder_filter.dart';
 
 LogRecord _record(
@@ -121,6 +122,103 @@ void main() {
           expect(shouldForwardToTelemetry(record), isTrue);
         },
       );
+    });
+
+    group('drops typed transient exceptions regardless of logger', () {
+      test('DeviceNotConnectedException.machine from any logger is dropped', () {
+        final record = _record(
+          Level.WARNING,
+          'BatteryController',
+          'Failed to set USB charger mode',
+          const DeviceNotConnectedException.machine(),
+        );
+        expect(shouldForwardToTelemetry(record), isFalse);
+      });
+
+      test('DeviceNotConnectedException.scale from any logger is dropped', () {
+        final record = _record(
+          Level.WARNING,
+          'PresenceController',
+          'Failed to send user present',
+          const DeviceNotConnectedException.scale(),
+        );
+        expect(shouldForwardToTelemetry(record), isFalse);
+      });
+
+      test('MmrTimeoutException from any logger is dropped', () {
+        final record = _record(
+          Level.SEVERE,
+          'De1Controller',
+          'shotSettings readback failed',
+          const MmrTimeoutException('flushFlowRate', Duration(seconds: 2)),
+        );
+        expect(shouldForwardToTelemetry(record), isFalse);
+      });
+
+      test('typed transient exception is dropped at SEVERE too', () {
+        final record = _record(
+          Level.SEVERE,
+          'AnyLogger',
+          'machine call failed',
+          const DeviceNotConnectedException.machine(),
+        );
+        expect(shouldForwardToTelemetry(record), isFalse);
+      });
+    });
+
+    group('extends transient-network-error skip to AndroidUpdater', () {
+      test('SocketException from AndroidUpdater is dropped', () {
+        final record = _record(
+          Level.WARNING,
+          'AndroidUpdater',
+          'checkForUpdate failed',
+          const SocketException(
+            'Failed host lookup: api.github.com',
+          ),
+        );
+        expect(shouldForwardToTelemetry(record), isFalse);
+      });
+
+      test('TimeoutException from AndroidUpdater is dropped', () {
+        final record = _record(
+          Level.WARNING,
+          'AndroidUpdater',
+          'checkForUpdate timed out',
+          TimeoutException('http get'),
+        );
+        expect(shouldForwardToTelemetry(record), isFalse);
+      });
+
+      test('Real bug from AndroidUpdater is kept', () {
+        final record = _record(
+          Level.SEVERE,
+          'AndroidUpdater',
+          'parse failed',
+          StateError('release manifest malformed'),
+        );
+        expect(shouldForwardToTelemetry(record), isTrue);
+      });
+    });
+
+    group('keeps genuinely-unexpected exceptions', () {
+      test('StateError from any logger is kept', () {
+        final record = _record(
+          Level.SEVERE,
+          'SomeController',
+          'invariant violated',
+          StateError('bad state'),
+        );
+        expect(shouldForwardToTelemetry(record), isTrue);
+      });
+
+      test('plain WARNING with no error is kept', () {
+        final record = _record(
+          Level.WARNING,
+          'SomeController',
+          'something unusual happened',
+        );
+        expect(shouldForwardToTelemetry(record), isTrue);
+      });
     });
   });
 }

--- a/tools/de1_serial_console.py
+++ b/tools/de1_serial_console.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""
+Interactive USB-serial console for DE1 / Bengle.
+
+Mirrors the protocol used by `UnifiedDe1Transport` over the serial path:
+
+  - Notification subscribe:    `<+X>` where X is the endpoint letter
+  - Notification unsubscribe:  `<-X>`
+  - Request state change:      `<B>NN` (NN = hex state byte)
+  - Notification frames:       `[X]<hex_payload>` terminated by `[` or `\n`
+
+Both DE1 and Bengle speak the same protocol over USB. Use the same script
+for either; just point `--port` at the right serial device.
+
+Usage:
+    python3 de1_serial_console.py /dev/cu.usbmodem1234
+
+Then at the `> ` prompt:
+    sub state water shot         # subscribe to the most useful streams
+    sub all                      # subscribe to state, water, shot, settings
+    state idle                   # request idle state
+    state 04                     # request espresso (raw hex)
+    raw <+J>                     # send arbitrary command
+    unsub all
+    quit
+
+Type `help` for a full command list.
+"""
+
+import argparse
+import re
+import sys
+import threading
+import time
+from datetime import datetime
+
+import serial
+
+# Endpoint letter → human label. Mirrors `Endpoint` enum in
+# lib/src/models/device/impl/de1/de1.models.dart.
+ENDPOINTS = {
+    "M": "shotSample",
+    "N": "stateInfo",
+    "Q": "waterLevels",
+    "K": "shotSettings",
+    "E": "readFromMMR",
+    "I": "fwMapRequest",
+    "B": "requestedState",
+}
+
+# Aliases accepted at the prompt.
+SUB_ALIASES = {
+    "state": "N",
+    "shot": "M",
+    "shotsample": "M",
+    "water": "Q",
+    "waterlevels": "Q",
+    "settings": "K",
+    "shotsettings": "K",
+    "mmr": "E",
+    "fwmap": "I",
+}
+SUB_ALL = ["N", "Q", "M", "K"]
+
+# State byte values from `De1StateEnum` in de1.models.dart.
+STATE_BY_NAME = {
+    "sleep": 0x00,
+    "goingtosleep": 0x01,
+    "idle": 0x02,
+    "busy": 0x03,
+    "espresso": 0x04,
+    "steam": 0x05,
+    "hotwater": 0x06,
+    "shortcal": 0x07,
+    "selftest": 0x08,
+    "longcal": 0x09,
+    "descale": 0x0A,
+    "fatalerror": 0x0B,
+    "init": 0x0C,
+    "norequest": 0x0D,
+    "skipnext": 0x0E,
+    "skiptonext": 0x0E,
+    "hotwaterrinse": 0x0F,
+    "flush": 0x0F,
+    "steamrinse": 0x10,
+    "refill": 0x11,
+    "clean": 0x12,
+    "bootloader": 0x13,
+    "airpurge": 0x14,
+    "schedidle": 0x15,
+    "fwupgrade": 0x22,
+}
+
+STATE_NAMES = {v: k for k, v in STATE_BY_NAME.items() if k != "skiptonext" and k != "flush"}
+
+SUBSTATE_NAMES = {
+    0x00: "noState",
+    0x01: "heatWaterTank",
+    0x02: "heatWaterHeater",
+    0x03: "stabilizeMixTemp",
+    0x04: "preInfuse",
+    0x05: "pour",
+    0x06: "end",
+    0x07: "steaming",
+    0x08: "descaleInt",
+    0x09: "descaleFillGroup",
+    0x0A: "descaleReturn",
+    0x0B: "descaleGroup",
+    0x0C: "descaleSteam",
+    0x0D: "cleanInit",
+    0x0E: "cleanFillGroup",
+    0x0F: "cleanSoak",
+    0x10: "cleanGroup",
+    0x11: "refill",
+    0x12: "pausedSteam",
+    0x13: "userNotPresent",
+    0x14: "puffing",
+}
+
+
+# Matches a complete `[X]hex` frame followed by `[` (next frame) or newline.
+# Mirrors the regex in `UnifiedDe1Transport._messagePattern`.
+MESSAGE_RE = re.compile(rb"(\[[A-Z]\][0-9A-Fa-f\s]*?)(?=\[|\n)")
+
+
+def ts():
+    return datetime.now().strftime("%H:%M:%S.%f")[:-3]
+
+
+def hex_to_bytes(s: str) -> bytes:
+    s = re.sub(r"\s+", "", s)
+    if len(s) % 2:
+        raise ValueError(f"odd-length hex: {s!r}")
+    return bytes.fromhex(s)
+
+
+def parse_state(payload: bytes) -> str:
+    if len(payload) < 2:
+        return f"short state frame ({len(payload)} bytes)"
+    state = payload[0]
+    sub = payload[1]
+    return (
+        f"state=0x{state:02X} ({STATE_NAMES.get(state, '?')})"
+        f"  sub=0x{sub:02X} ({SUBSTATE_NAMES.get(sub, '?')})"
+    )
+
+
+def parse_water(payload: bytes) -> str:
+    if len(payload) < 4:
+        return f"short water frame ({len(payload)} bytes)"
+    level = int.from_bytes(payload[0:2], "big") / 256.0
+    threshold = int.from_bytes(payload[2:4], "big") / 256.0
+    return f"level={level:.2f}mm  threshold={threshold:.2f}mm"
+
+
+def _u16(p: bytes, off: int) -> int:
+    return int.from_bytes(p[off : off + 2], "big")
+
+
+def parse_shot_sample(payload: bytes) -> str:
+    # Layout from `_parseStateAndShotSample` in unified_de1.parsing.dart.
+    if len(payload) < 19:
+        return f"short shot frame ({len(payload)} bytes)"
+    group_pressure = _u16(payload, 2) / (1 << 12)
+    group_flow = _u16(payload, 4) / (1 << 12)
+    mix_temp = _u16(payload, 6) / (1 << 8)
+    head_temp = ((payload[8] << 16) + (payload[9] << 8) + payload[10]) / (1 << 16)
+    set_mix = _u16(payload, 11) / (1 << 8)
+    set_head = _u16(payload, 13) / (1 << 8)
+    set_pressure = payload[15] / (1 << 4)
+    set_flow = payload[16] / (1 << 4)
+    frame = payload[17]
+    steam_temp = payload[18]
+    return (
+        f"P={group_pressure:5.2f}bar(t={set_pressure:4.2f}) "
+        f"F={group_flow:5.2f}ml/s(t={set_flow:4.2f}) "
+        f"mix={mix_temp:6.2f}C(t={set_mix:6.2f}) "
+        f"head={head_temp:6.2f}C(t={set_head:6.2f}) "
+        f"frame={frame} steam={steam_temp}C"
+    )
+
+
+def parse_shot_settings(payload: bytes) -> str:
+    if len(payload) < 9:
+        return f"short shotsettings frame ({len(payload)} bytes)"
+    target_group = _u16(payload, 7) / (1 << 8)
+    return (
+        f"steamBits=0x{payload[0]:02X} "
+        f"steamT={payload[1]}C steamLen={payload[2]}s "
+        f"waterT={payload[3]}C waterVol={payload[4]}ml waterLen={payload[5]}s "
+        f"esprVol={payload[6]}ml groupT={target_group:.2f}C"
+    )
+
+
+PARSERS = {
+    "N": ("state    ", parse_state),
+    "Q": ("water    ", parse_water),
+    "M": ("shot     ", parse_shot_sample),
+    "K": ("settings ", parse_shot_settings),
+}
+
+
+class Reader(threading.Thread):
+    """Background reader: drains the serial port, parses `[X]hex` frames."""
+
+    def __init__(self, port: serial.Serial):
+        super().__init__(daemon=True)
+        self._port = port
+        self._buf = b""
+        self._stop = threading.Event()
+        self._raw = False  # also print raw frames when True
+        self._lock = threading.Lock()
+
+    def stop(self):
+        self._stop.set()
+
+    def set_raw(self, raw: bool):
+        with self._lock:
+            self._raw = raw
+
+    def run(self):
+        while not self._stop.is_set():
+            try:
+                chunk = self._port.read(self._port.in_waiting or 1)
+            except serial.SerialException as e:
+                print(f"\n[{ts()}] serial error: {e}", file=sys.stderr)
+                return
+            if not chunk:
+                continue
+            self._buf += chunk
+            self._drain()
+
+    def _drain(self):
+        # Discard junk before the first `[`, mirroring the Dart side.
+        idx = self._buf.find(b"[")
+        if idx < 0:
+            self._buf = b""
+            return
+        if idx > 0:
+            self._buf = self._buf[idx:]
+
+        last_end = 0
+        for m in MESSAGE_RE.finditer(self._buf):
+            last_end = m.end()
+            frame = m.group(1).decode("ascii", errors="replace").strip()
+            self._handle_frame(frame)
+
+        if last_end:
+            self._buf = self._buf[last_end:].lstrip(b"\n")
+        elif len(self._buf) > 4096:
+            print(f"[{ts()}] buffer overflow, dropping {len(self._buf)} bytes")
+            self._buf = b""
+
+    def _handle_frame(self, frame: str):
+        if len(frame) < 3 or frame[0] != "[" or frame[2] != "]":
+            return
+        letter = frame[1]
+        hex_payload = frame[3:]
+        try:
+            payload = hex_to_bytes(hex_payload)
+        except ValueError as e:
+            print(f"[{ts()}] bad hex on [{letter}]: {e}")
+            return
+
+        with self._lock:
+            raw = self._raw
+
+        parser = PARSERS.get(letter)
+        if parser:
+            label, fn = parser
+            print(f"[{ts()}] {label} {fn(payload)}")
+            if raw:
+                print(f"           raw=[{letter}]{hex_payload}")
+        else:
+            ep = ENDPOINTS.get(letter, "?")
+            print(f"[{ts()}] {letter}({ep}) {hex_payload}")
+
+
+def write_command(port: serial.Serial, text: str):
+    line = (text + "\n").encode("ascii")
+    port.write(line)
+    port.flush()
+    print(f"[{ts()}] >> {text}")
+
+
+def resolve_endpoint_letters(args: list[str]) -> list[str]:
+    if not args:
+        raise ValueError("missing endpoint")
+    if len(args) == 1 and args[0].lower() == "all":
+        return SUB_ALL
+    out = []
+    for a in args:
+        key = a.lower()
+        if key in SUB_ALIASES:
+            out.append(SUB_ALIASES[key])
+        elif len(a) == 1 and a.upper() in ENDPOINTS:
+            out.append(a.upper())
+        else:
+            raise ValueError(f"unknown endpoint: {a}")
+    return out
+
+
+def resolve_state(arg: str) -> int:
+    key = arg.lower()
+    if key in STATE_BY_NAME:
+        return STATE_BY_NAME[key]
+    try:
+        v = int(arg, 16)
+    except ValueError:
+        raise ValueError(f"unknown state: {arg}")
+    if not 0 <= v <= 0xFF:
+        raise ValueError(f"state out of range: {arg}")
+    return v
+
+
+HELP = """\
+Commands:
+  sub <ep>...           Subscribe to endpoints. ep = state|water|shot|settings|mmr|fwmap|all
+  unsub <ep>...         Unsubscribe.
+  state <name|hex>      Request state change via <B>NN.
+                        Names: sleep idle espresso steam hotwater hotwaterrinse
+                               skipnext clean descale airpurge schedidle fwupgrade ...
+  raw <text>            Send <text> verbatim (newline appended).
+  rawnotify on|off      Also print raw hex of decoded frames.
+  help                  This help.
+  quit | exit | Ctrl-D  Quit (sends <-X> for the four common subscriptions first).
+"""
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("port", help="Serial port (e.g. /dev/cu.usbmodem1234, COM5)")
+    ap.add_argument("--baud", type=int, default=115200)
+    ap.add_argument(
+        "--auto-sub",
+        action="store_true",
+        help="Subscribe to state/water/shot/settings on connect",
+    )
+    args = ap.parse_args()
+
+    port = serial.Serial(
+        port=args.port,
+        baudrate=args.baud,
+        bytesize=serial.EIGHTBITS,
+        parity=serial.PARITY_NONE,
+        stopbits=serial.STOPBITS_ONE,
+        timeout=0.1,
+        write_timeout=5,
+    )
+
+    print(f"Opened {args.port} @ {args.baud}. Type 'help' for commands.")
+
+    reader = Reader(port)
+    reader.start()
+
+    if args.auto_sub:
+        for letter in SUB_ALL:
+            write_command(port, f"<+{letter}>")
+            time.sleep(0.05)
+        # Probe state so the first [N] arrives without a manual nudge —
+        # same bootstrap as `_serialConnect` in unified_de1_transport.dart.
+        write_command(port, "<B>02")
+
+    try:
+        while True:
+            try:
+                line = input("> ").strip()
+            except EOFError:
+                print()
+                break
+            if not line:
+                continue
+            parts = line.split()
+            cmd = parts[0].lower()
+            rest = parts[1:]
+
+            try:
+                if cmd in ("quit", "exit", "q"):
+                    break
+                elif cmd == "help":
+                    print(HELP)
+                elif cmd == "sub":
+                    for letter in resolve_endpoint_letters(rest):
+                        write_command(port, f"<+{letter}>")
+                elif cmd == "unsub":
+                    for letter in resolve_endpoint_letters(rest):
+                        write_command(port, f"<-{letter}>")
+                elif cmd == "state":
+                    if len(rest) != 1:
+                        print("usage: state <name|hex>")
+                        continue
+                    v = resolve_state(rest[0])
+                    write_command(port, f"<B>{v:02X}")
+                elif cmd == "raw":
+                    if not rest:
+                        print("usage: raw <text>")
+                        continue
+                    write_command(port, " ".join(rest))
+                elif cmd == "rawnotify":
+                    if len(rest) != 1 or rest[0].lower() not in ("on", "off"):
+                        print("usage: rawnotify on|off")
+                        continue
+                    reader.set_raw(rest[0].lower() == "on")
+                else:
+                    print(f"unknown command: {cmd}. type 'help'.")
+            except ValueError as e:
+                print(f"error: {e}")
+    finally:
+        # Best-effort unsubscribe so the firmware stops streaming when we go.
+        try:
+            for letter in SUB_ALL:
+                port.write(f"<-{letter}>\n".encode())
+            port.flush()
+        except Exception:
+            pass
+        reader.stop()
+        reader.join(timeout=1.0)
+        port.close()
+        print("Closed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Filter `DeviceNotConnectedException` / `MmrTimeoutException` regardless of source logger, and extend the transient-network skip to an HTTP-fetcher allowlist (`WebUIStorage` + `AndroidUpdater`). `BleTransport` `SocketException` still surfaces (existing test preserved).
- Tighten the noisy callers feeding the leaks: `BatteryController._tick` pre-checks a new `De1Controller.connectedDe1OrNull` (the Teclast P80X hot path that produced ~137 ev / 10 users / 7d in Android cluster `9b481fad`); `StatusPublisher.emitError` and `ScanStateGuardian` log adapter-off / sticky `ConnectionError` kinds at `info` instead of `warning`/`severe`; `PresenceController` passes its catch-block exceptions as `record.error` so the typed-exception filter actually matches them.

## Why

PR #204 silenced `WebUIStorage` skin-already-exists + transient network errors, but three Crashlytics clusters (Android `9b481fad`, iOS+macOS `bb1c4163`, iOS `833b6b01` + Android `0bb2f542`) kept climbing on v0.6.2 from the same root cause: `shouldForwardToTelemetry` only matched the `WebUIStorage` logger, so non-`WebUIStorage` expected-state events leaked through and showed up as Crashlytics non-fatals — drowning the real signal.