### PR TITLE
feat: float32 MMR support + machine capability discovery surface

### DIFF
--- a/.agents/skills/streamline-bridge/scenarios/bengle-cup-warmer.md
+++ b/.agents/skills/streamline-bridge/scenarios/bengle-cup-warmer.md
@@ -1,0 +1,76 @@
+# Scenario: Bengle cup-warmer + capability discovery
+
+Verifies the first Bengle peripheral surface end-to-end: `GET /api/v1/machine/capabilities` lists `cupWarmer` when a Bengle is connected, `GET /api/v1/machine/cupWarmer` returns the current setpoint, `POST /api/v1/machine/cupWarmer` writes a new setpoint, and out-of-range writes are rejected at 400 before reaching the device.
+
+## Preconditions
+
+```bash
+scripts/sb-dev.sh start --connect-machine MockBengle --connect-scale MockScale
+```
+
+## Steps
+
+### 1. Capability discovery
+
+```bash
+curl -sf http://localhost:8080/api/v1/machine/capabilities | jq -e '.capabilities | index("cupWarmer") != null'
+```
+
+Exit 0 → `cupWarmer` present in the capability list.
+
+### 2. Read initial setpoint (off)
+
+```bash
+curl -sf http://localhost:8080/api/v1/machine/cupWarmer | jq -e '.temperature == 0'
+```
+
+MockBengle boots with `_cupWarmerTemp = 0.0`. Exit 0 → off.
+
+### 3. Set a valid setpoint
+
+```bash
+curl -sf -X POST http://localhost:8080/api/v1/machine/cupWarmer \
+  -H 'Content-Type: application/json' \
+  -d '{"temperature": 60}' \
+  -o /dev/null -w '%{http_code}\n'
+```
+
+Expected: `202`.
+
+### 4. Confirm the new setpoint
+
+```bash
+curl -sf http://localhost:8080/api/v1/machine/cupWarmer | jq -e '.temperature == 60'
+```
+
+Exit 0 → MockBengle stored the value.
+
+### 5. Reject out-of-range
+
+```bash
+curl -s -X POST http://localhost:8080/api/v1/machine/cupWarmer \
+  -H 'Content-Type: application/json' \
+  -d '{"temperature": 100}' \
+  -o /dev/null -w '%{http_code}\n'
+```
+
+Expected: `400`. App enforces 0.0–80.0 °C before hitting the wire.
+
+### 6. Capability discovery returns empty list when DE1 is connected
+
+Restart the app with a plain MockDe1 to verify the capability list reflects the connected machine, not the build:
+
+```bash
+scripts/sb-dev.sh stop
+scripts/sb-dev.sh start --connect-machine MockDe1 --connect-scale MockScale
+curl -sf http://localhost:8080/api/v1/machine/capabilities | jq -e '.capabilities == []'
+curl -s http://localhost:8080/api/v1/machine/cupWarmer -o /dev/null -w '%{http_code}\n'
+```
+
+Expected: empty `capabilities`, and the cupWarmer GET returns `404`.
+
+## Postconditions
+
+```bash
+scripts/sb-dev.sh stop
+```

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -208,6 +208,62 @@ paths:
       responses:
         "200":
           description: Shot settings updated successfully
+  /api/v1/machine/capabilities:
+    get:
+      summary: List machine capabilities
+      description: |
+        Returns the optional capability surfaces the currently connected
+        machine exposes. Plain DE1s return an empty list; Bengle returns
+        `["cupWarmer"]` plus any future capabilities (LED strip,
+        integrated scale, milk probe) as they ship. Skins should query
+        this endpoint once after connect to decide which UI to render
+        and which `/api/v1/machine/...` capability endpoints to call.
+      tags: [Machine]
+      responses:
+        "200":
+          description: Capability list for the currently connected machine
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MachineCapabilities"
+  /api/v1/machine/cupWarmer:
+    get:
+      summary: Get cup-warmer setpoint
+      description: |
+        Read the current cup-warmer mat target temperature in °C.
+        Returns 404 when the connected machine is not a Bengle.
+      tags: [Machine]
+      responses:
+        "200":
+          description: Current cup-warmer setpoint
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CupWarmerState"
+        "404":
+          description: Machine connected but does not support cup warmer
+    post:
+      summary: Set cup-warmer setpoint
+      description: |
+        Set the cup-warmer mat target temperature in °C. Range
+        `0.0`–`80.0`; `0.0` turns the mat off (there is no separate
+        enable flag). Out-of-range values return 400; the app does not
+        rely on FW-side clamping so callers see immediate feedback.
+        Returns 404 when the connected machine is not a Bengle.
+      tags: [Machine]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CupWarmerState"
+      responses:
+        "202":
+          description: Setpoint accepted
+        "400":
+          description: Temperature missing or out of range 0.0–80.0
+        "404":
+          description: Machine connected but does not support cup warmer
   /api/v1/machine/settings:
     get:
       summary: Get machine settings
@@ -3432,6 +3488,36 @@ components:
         extra:
           type: object
           description: various extra information
+
+    MachineCapabilities:
+      type: object
+      required: [capabilities]
+      properties:
+        capabilities:
+          type: array
+          description: |
+            Capability identifiers supported by the currently connected
+            machine. Plain DE1 returns an empty array. Future Bengle
+            peripherals (LED strip, integrated scale, milk probe) will
+            append their identifiers as they ship.
+          items:
+            type: string
+            enum: [cupWarmer]
+          example: [cupWarmer]
+
+    CupWarmerState:
+      type: object
+      required: [temperature]
+      properties:
+        temperature:
+          type: number
+          format: float
+          minimum: 0.0
+          maximum: 80.0
+          description: |
+            Cup-warmer mat target temperature in °C. `0.0` turns the
+            mat off — there is no separate enable flag.
+          example: 60.0
 
     ScaleSnapshot:
       type: object

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -50,6 +50,9 @@ For browser clients on a different origin, `ETag` is exposed via `Access-Control
 | POST | `/api/v1/machine/profile` | Upload profile to machine | |
 | POST | `/api/v1/machine/usb-charger` | Toggle USB charger | |
 | POST | `/api/v1/machine/water-threshold` | Update water level threshold | |
+| GET | `/api/v1/machine/capabilities` | List capability identifiers (e.g. `cupWarmer`) supported by the connected machine | |
+| GET | `/api/v1/machine/cupWarmer` | Read cup-warmer setpoint °C — Bengle only, 404 elsewhere | |
+| POST | `/api/v1/machine/cupWarmer` | Set cup-warmer setpoint °C (range 0.0–80.0, `0.0` = off) — Bengle only | |
 
 ### Scale
 

--- a/doc/plans/archive/bengle-cup-warmer-phase-1/2026-05-04-bengle-cup-warmer-phase-1.md
+++ b/doc/plans/archive/bengle-cup-warmer-phase-1/2026-05-04-bengle-cup-warmer-phase-1.md
@@ -1,0 +1,289 @@
+# Bengle cup warmer — Phase 1
+
+Branch: `feat/bengle-cup-warmer-phase-1`. Will be copied to `doc/plans/` on the feature branch before implementation per CLAUDE.md (design docs live with the code).
+
+## Context
+
+Bengle is the next-gen Decent espresso machine; SB needs to expose its peripherals (cup warmer, integrated scale, LED, milk probe) via REST so skins can drive them. Foundation shipped (PR #207, #208): `Bengle extends UnifiedDe1`, `LogicalEndpoint` + `MmrAddress` interfaces, `@protected` MMR helpers. **Phase 1 lands the first capability — cup warmer — and the discovery pattern that steps 5–7 will reuse.** Schedule (preheat-cups-before-wake) is deferred to Phase 2 pending FW data on whether the mat heats while machine sleeps.
+
+FW info (Vid, 2026-05-04):
+- MMR `MatSetPoint` at `0x00803874`, length 4, perm RWD.
+- Raw IEEE-754 float32, little-endian (matches existing MMR endianness).
+- Range 0.0 – 80.0 °C, FW-clamped. App clamps before write to avoid silent rejects.
+- `0.0` = off. No separate enable flag.
+- API: `setCupWarmerTemperature(double)` / `getCupWarmerTemperature()`. No boolean.
+- No actual-temperature MMR confirmed → no WS topic in Phase 1.
+
+## Approach
+
+### 1. New MMR value kind: `float32`
+
+Add to existing `MmrValueKind` enum in `lib/src/models/device/impl/de1/mmr_address.dart:12-30`:
+
+```dart
+/// IEEE-754 float32 stored as raw 4 bytes (little-endian on the wire).
+/// Bounds declared via [MmrAddress.minDouble] / [MmrAddress.maxDouble].
+float32,
+```
+
+Add to `MmrAddress` interface (same file, after the `int? max` getter):
+
+```dart
+/// Optional minimum bound for float32 kind; null = no lower clamp.
+double? get minDouble => null;
+
+/// Optional maximum bound for float32 kind; null = no upper clamp.
+double? get maxDouble => null;
+```
+
+No clash — `int? min`/`max` and `double? minDouble`/`maxDouble` coexist. Existing `_writeMMRInt` / `writeMmrScaled` callers untouched.
+
+### 2. Float32 read/write helpers on `UnifiedDe1`
+
+Two new `@protected` methods in `lib/src/models/device/impl/de1/unified_de1/unified_de1.dart` (after `writeMmrScaled` at line 593):
+
+```dart
+@protected
+Future<double> readMmrFloat32(MmrAddress addr) async {
+  _assertKind(addr, const {MmrValueKind.float32}, 'readMmrFloat32');
+  final raw = (addr is MMRItem) ? await _mmrRead(addr) : await _mmrReadRaw(addr.address);
+  return _unpackMMRFloat32(raw);
+}
+
+@protected
+Future<void> writeMmrFloat32(MmrAddress addr, double value) async {
+  _assertKind(addr, const {MmrValueKind.float32}, 'writeMmrFloat32');
+  final clamped = (addr.minDouble != null && addr.maxDouble != null)
+      ? value.clamp(addr.minDouble!, addr.maxDouble!)
+      : value;
+  final bytes = _packMMRFloat32(clamped.toDouble());
+  if (addr is MMRItem) return _mmrWrite(addr, bytes);
+  return _mmrWriteRaw(addr.address, bytes);
+}
+```
+
+Pack/unpack helpers in `lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart` paralleling `_packMMRInt` / `_unpackMMRInt`:
+
+```dart
+double _unpackMMRFloat32(List<int> buffer) {
+  if (buffer.length < 20) {
+    throw StateError('MMR response buffer too short (got ${buffer.length}, need 20)');
+  }
+  final bytes = ByteData(20);
+  for (var i = 0; i < 20; i++) { bytes.setUint8(i, buffer[i]); }
+  return bytes.getFloat32(4, Endian.little);
+}
+
+Uint8List _packMMRFloat32(double value) {
+  final bytes = ByteData(4);
+  bytes.setFloat32(0, value, Endian.little);
+  return bytes.buffer.asUint8List();
+}
+```
+
+### 3. Bengle cup warmer surface
+
+**New file** `lib/src/models/device/impl/bengle/bengle_mmr.dart`:
+
+```dart
+import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
+
+/// Bengle-only MMR addresses. Future Bengle peripherals (LED, integrated
+/// scale, milk probe) add entries here as their FW MMR slots are confirmed.
+enum BengleMmr implements MmrAddress {
+  matSetPoint(0x00803874, 4, MmrValueKind.float32, 'MatSetPoint',
+      minDouble: 0.0, maxDouble: 80.0);
+
+  const BengleMmr(this.address, this.length, this.kind, this.description,
+      {this.minDouble, this.maxDouble});
+
+  @override final int address;
+  @override final int length;
+  @override final MmrValueKind kind;
+  final String description;
+  @override final double? minDouble;
+  @override final double? maxDouble;
+
+  @override
+  String get name => (this as Enum).name;
+}
+```
+
+**Edit** `lib/src/models/device/bengle_interface.dart` — add 2 abstract methods:
+
+```dart
+/// Set cup-warmer mat target temperature in °C. Range 0.0–80.0.
+/// `0.0` turns the mat off. Values outside the range are clamped.
+Future<void> setCupWarmerTemperature(double celsius);
+
+/// Read the current cup-warmer mat setpoint in °C.
+Future<double> getCupWarmerTemperature();
+```
+
+**Edit** `lib/src/models/device/impl/bengle/bengle.dart` — implement:
+
+```dart
+@override
+Future<void> setCupWarmerTemperature(double celsius) =>
+    writeMmrFloat32(BengleMmr.matSetPoint, celsius);
+
+@override
+Future<double> getCupWarmerTemperature() =>
+    readMmrFloat32(BengleMmr.matSetPoint);
+```
+
+Cup warmer is stateless — no mixin needed, no `onConnect` override. Direct calls to the protected MMR helpers prove the abstraction works.
+
+### 4. MockBengle in-memory mirror
+
+**Edit** `lib/src/models/device/impl/bengle/mock_bengle.dart` — add field + 2 method overrides (matches `MockDe1` pattern A from `mock_de1.dart`):
+
+```dart
+double _cupWarmerTemp = 0.0;
+
+@override
+Future<void> setCupWarmerTemperature(double celsius) async {
+  _cupWarmerTemp = celsius.clamp(0.0, 80.0);
+}
+
+@override
+Future<double> getCupWarmerTemperature() async => _cupWarmerTemp;
+```
+
+### 5. REST endpoints
+
+**Edit** `lib/src/services/webserver/de1handler.dart`. Add 3 routes inside `addRoutes`:
+
+```dart
+app.get('/api/v1/machine/capabilities', (Request _) async {
+  return withDe1((de1) async {
+    final caps = <String>[];
+    if (de1 is BengleInterface) caps.add('cupWarmer');
+    return jsonOk({'capabilities': caps});
+  });
+});
+
+app.get('/api/v1/machine/cupWarmer', (Request _) async {
+  return withDe1((de1) async {
+    if (de1 is! BengleInterface) {
+      return Response.notFound(jsonEncode({'error': 'cupWarmer not supported'}));
+    }
+    final t = await de1.getCupWarmerTemperature();
+    return jsonOk({'temperature': t});
+  });
+});
+
+app.post('/api/v1/machine/cupWarmer', (Request r) async {
+  return withDe1((de1) async {
+    if (de1 is! BengleInterface) {
+      return Response.notFound(jsonEncode({'error': 'cupWarmer not supported'}));
+    }
+    final json = jsonDecode(await r.readAsString());
+    if (json['temperature'] == null) {
+      return Response.badRequest(body: jsonEncode({'error': 'temperature required'}));
+    }
+    final t = parseDouble(json['temperature']);
+    if (t < 0.0 || t > 80.0) {
+      return Response.badRequest(body: jsonEncode({'error': 'temperature out of range 0.0-80.0'}));
+    }
+    await de1.setCupWarmerTemperature(t);
+    return jsonAccepted();
+  });
+});
+```
+
+Notes:
+- `BengleInterface` import added at top of `de1handler.dart`.
+- 404 (not 500) when machine connected but isn't Bengle — explicit "feature absent" vs. "no machine".
+- 400 for out-of-range — surfaced to clients before silent FW clamp.
+- POST + 202 mirrors existing `/machine/settings` convention.
+
+### 6. OpenAPI spec
+
+**Edit** `assets/api/rest_v1.yml`. Add 3 paths in the `/api/v1/machine/...` section, plus 2 components schemas (`CupWarmerState`, `Capabilities`). Mirror the existing `/machine/info` (GET) and `/machine/profile` (POST) entry styles.
+
+### 7. doc/Api.md
+
+**Edit** `doc/Api.md` — add 3 rows to the Machine table:
+
+```markdown
+| GET | `/api/v1/machine/capabilities` | List of capability strings supported by current machine | `de1handler.dart` |
+| GET | `/api/v1/machine/cupWarmer` | Read cup-warmer setpoint (Bengle only) | `de1handler.dart` |
+| POST | `/api/v1/machine/cupWarmer` | Set cup-warmer setpoint °C 0.0-80.0 (Bengle only) | `de1handler.dart` |
+```
+
+### 8. Tests
+
+**Tier breakdown** (per `tdd-workflow` skill):
+
+**Unit:**
+- `test/models/device/mmr_address_test.dart` — new `MmrValueKind.float32` exists; `minDouble`/`maxDouble` default null.
+- `test/models/device/unified_de1_float32_test.dart` — write+read round-trip for `BengleMmr.matSetPoint` using `FakeBleTransport`. Cover: round-trip mid-range value (50.0 °C), clamp on over-range write (90.0 → clamped), clamp on negative (-5.0 → 0.0). Add `queueMmrResponseFloat32(addr, value)` helper to `test/helpers/fake_ble_transport.dart` (small wrapper around `queueMmrResponseRaw` + `setFloat32(0, value, little)` packing).
+- `test/models/device/unified_de1_assert_kind_test.dart` (extend existing or new) — `readMmrFloat32` on a non-float32 address throws `StateError`; `readMmrInt` on float32 address throws.
+- `test/models/device/mock_bengle_test.dart` — set then get round-trip; clamp behavior.
+
+**Integration:**
+- `test/services/webserver/de1handler_cup_warmer_test.dart` — three handler tests via in-process router: `GET /capabilities` returns `cupWarmer` when DE1 controller has Bengle, empty list otherwise; `GET /cupWarmer` 404 on plain DE1, 200 with body on MockBengle; `POST /cupWarmer` 400 on out-of-range body, 202 + state mutation on valid body.
+
+**End-to-end:**
+- `.agents/skills/streamline-bridge/scenarios/bengle-cup-warmer.md` — new recipe. Boots app via `scripts/sb-dev.sh start --connect-machine MockBengle`, exercises:
+  1. `curl /capabilities` → assert `["cupWarmer"]`.
+  2. `curl /cupWarmer` → assert `temperature: 0.0`.
+  3. `curl POST /cupWarmer {temperature: 60}` → 202.
+  4. `curl /cupWarmer` → assert `temperature: 60.0`.
+  5. `curl POST /cupWarmer {temperature: 100}` → 400.
+
+## Files
+
+| Path | Change |
+|---|---|
+| `lib/src/models/device/impl/de1/mmr_address.dart` | Add `float32` to enum, add `minDouble`/`maxDouble` getters |
+| `lib/src/models/device/impl/de1/unified_de1/unified_de1.dart` | Add `readMmrFloat32`/`writeMmrFloat32` protected methods |
+| `lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart` | Add `_packMMRFloat32`/`_unpackMMRFloat32` |
+| `lib/src/models/device/impl/bengle/bengle_mmr.dart` | NEW — `BengleMmr` enum |
+| `lib/src/models/device/bengle_interface.dart` | Add 2 abstract methods |
+| `lib/src/models/device/impl/bengle/bengle.dart` | Implement 2 methods |
+| `lib/src/models/device/impl/bengle/mock_bengle.dart` | Add field + 2 method overrides |
+| `lib/src/services/webserver/de1handler.dart` | Add 3 routes (capabilities, cupWarmer GET/POST) |
+| `assets/api/rest_v1.yml` | Add 3 paths + 2 schemas |
+| `doc/Api.md` | Add 3 table rows |
+| `test/helpers/fake_ble_transport.dart` | Add `queueMmrResponseFloat32` helper |
+| `test/models/device/unified_de1_float32_test.dart` | NEW — float32 round-trip + clamp |
+| `test/models/device/unified_de1_assert_kind_test.dart` | NEW — kind mismatch errors |
+| `test/models/device/mock_bengle_test.dart` | NEW — mock state mirror |
+| `test/services/webserver/de1handler_cup_warmer_test.dart` | NEW — handler integration |
+| `.agents/skills/streamline-bridge/scenarios/bengle-cup-warmer.md` | NEW — e2e recipe |
+| `doc/plans/2026-05-04-bengle-cup-warmer-phase-1.md` | NEW — copy this plan onto branch (per CLAUDE.md) |
+
+## Reused
+
+- `withDe1`, `jsonOk`, `jsonAccepted`, `parseDouble` — webserver_service helpers (`de1handler.dart:44+`).
+- `FakeBleTransport.queueOnConnectResponses` — boots a fake DE1 to `connected` state for tests.
+- `FakeBleTransport.queueMmrResponseRaw` — base for the new float32 helper.
+- `_mmrRead` / `_mmrReadRaw` / `_mmrWrite` / `_mmrWriteRaw` (`unified_de1.mmr.dart`) — wire-protocol layer the new helpers ride on, no changes.
+- `_assertKind` (`unified_de1.dart:606`) — kind validation.
+- `MockDe1` Pattern A (field + getter, e.g. `_flushFlow`) — MockBengle mirror.
+
+## Verification
+
+1. `flutter analyze` — must be clean.
+2. `flutter test` — full suite + the 4 new test files.
+3. End-to-end smoke via `.agents/skills/streamline-bridge/scenarios/bengle-cup-warmer.md`:
+   - `scripts/sb-dev.sh start --connect-machine MockBengle`
+   - Walk steps 1–5 with `curl` + `jq -e` assertions.
+   - `scripts/sb-dev.sh stop`.
+4. Regression sweep: walk `.agents/skills/streamline-bridge/scenarios/build-info.md` and any existing `/machine/*` recipe to confirm no neighbouring breakage.
+5. Real-hw smoke deferred (no bench Bengle right now); will run when available.
+
+## Out of scope (Phase 2 / later)
+
+- Cup-warmer wake schedule integration (`WakeSchedule.cupWarmerLeadMinutes` + `cupWarmerTemperature`). Gated on FW: does the mat heat while machine `sleeping`?
+- WS topic for actual mat temperature. Gated on FW: is there a readable mat-temp MMR?
+- App-side runaway protection / auto-off. Gated on FW: does FW have its own?
+- Capability negotiation in plugin/skin permission system.
+
+## Branch + PR
+
+- Branch already created: `feat/bengle-cup-warmer-phase-1` (off `main`).
+- Commit per logical step (helpers / Bengle wiring / mock / REST + spec + doc / tests / scenario).
+- PR on `main` after `flutter test` + `flutter analyze` + e2e scenario all green. PR body: what + why per global instructions.

--- a/lib/src/models/device/bengle_interface.dart
+++ b/lib/src/models/device/bengle_interface.dart
@@ -10,4 +10,12 @@ import 'package:reaprime/src/models/device/de1_interface.dart';
 /// `Capability` mixins on `UnifiedDe1` (see the protected surface in
 /// `UnifiedDe1` for the contract: `readMmrInt`, `readMmrScaled`,
 /// `writeMmrInt`, `writeMmrScaled`, `notificationsFor`, etc.).
-abstract class BengleInterface extends De1Interface {}
+abstract class BengleInterface extends De1Interface {
+  /// Set the cup-warmer mat target temperature in °C. Range 0.0–80.0.
+  /// `0.0` turns the mat off — there is no separate enable flag in FW.
+  /// Implementations clamp out-of-range values before writing.
+  Future<void> setCupWarmerTemperature(double celsius);
+
+  /// Read the current cup-warmer mat setpoint in °C.
+  Future<double> getCupWarmerTemperature();
+}

--- a/lib/src/models/device/impl/bengle/bengle.dart
+++ b/lib/src/models/device/impl/bengle/bengle.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 
@@ -8,6 +9,14 @@ class Bengle extends UnifiedDe1 implements BengleInterface {
 
   @override
   String get name => "Bengle";
+
+  @override
+  Future<void> setCupWarmerTemperature(double celsius) =>
+      writeMmrFloat32(BengleMmr.matSetPoint, celsius);
+
+  @override
+  Future<double> getCupWarmerTemperature() =>
+      readMmrFloat32(BengleMmr.matSetPoint);
 
   /// Bengle FW requires entering state 0x22 (`MachineState.fwUpgrade`) between
   /// the `requestState(sleeping)` step and the start of `.dat` upload.

--- a/lib/src/models/device/impl/bengle/bengle_mmr.dart
+++ b/lib/src/models/device/impl/bengle/bengle_mmr.dart
@@ -1,0 +1,58 @@
+import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
+
+/// Bengle-only MMR addresses. Future Bengle peripherals (LED strip,
+/// integrated scale, milk probe) declare their addresses here as the FW
+/// slots are confirmed. Addresses live with the capability that owns
+/// them — shared DE1 MMRs stay in `de1.models.dart#MMRItem`.
+enum BengleMmr implements MmrAddress {
+  /// Cup-warmer mat target temperature in °C, stored as raw IEEE-754
+  /// float32 (little-endian). Range `0.0..80.0`; `0.0` = off.
+  /// FW name: `MatSetPoint`. Permission RWD.
+  matSetPoint(
+    0x00803874,
+    4,
+    MmrValueKind.float32,
+    'MatSetPoint',
+    minDouble: 0.0,
+    maxDouble: 80.0,
+  );
+
+  const BengleMmr(
+    this.address,
+    this.length,
+    this.kind,
+    this.description, {
+    this.minDouble,
+    this.maxDouble,
+  });
+
+  @override
+  final int address;
+  @override
+  final int length;
+  @override
+  final MmrValueKind kind;
+  final String description;
+  @override
+  final double? minDouble;
+  @override
+  final double? maxDouble;
+
+  // float32 entries don't use the int-based scale/clamp fields.
+  // Concrete defaults satisfy the `implements MmrAddress` contract.
+  @override
+  double get readScale => 1.0;
+  @override
+  double get writeScale => 1.0;
+  @override
+  int? get min => null;
+  @override
+  int? get max => null;
+
+  /// Dart enums auto-synthesize `name`, but the analyzer doesn't see it
+  /// as satisfying `MmrAddress.name` through `implements` — the cast
+  /// forces dispatch to the synthesized `Enum.name`. See `MMRItem` for
+  /// the same pattern + history (553550d / b7b8ed7).
+  @override
+  String get name => (this as Enum).name;
+}

--- a/lib/src/models/device/impl/bengle/mock_bengle.dart
+++ b/lib/src/models/device/impl/bengle/mock_bengle.dart
@@ -1,5 +1,6 @@
 import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+import 'package:reaprime/src/models/device/machine.dart';
 
 /// Simulated Bengle. Reuses [MockDe1]'s state machine — Bengle's behavior
 /// today is functionally identical to a DE1 plus the FW-prelude hook
@@ -24,4 +25,13 @@ class MockBengle extends MockDe1 implements BengleInterface {
 
   @override
   Future<double> getCupWarmerTemperature() async => _cupWarmerTemp;
+
+  @override
+  MachineInfo get machineInfo => MachineInfo(
+    version: "1.0",
+    model: "Bengle",
+    serialNumber: "110010101",
+    groupHeadControllerPresent: true,
+    extra: {'voltage': 220, 'refillKit': false},
+  );
 }

--- a/lib/src/models/device/impl/bengle/mock_bengle.dart
+++ b/lib/src/models/device/impl/bengle/mock_bengle.dart
@@ -14,4 +14,14 @@ class MockBengle extends MockDe1 implements BengleInterface {
 
   @override
   String get name => 'MockBengle';
+
+  double _cupWarmerTemp = 0.0;
+
+  @override
+  Future<void> setCupWarmerTemperature(double celsius) async {
+    _cupWarmerTemp = celsius.clamp(0.0, 80.0).toDouble();
+  }
+
+  @override
+  Future<double> getCupWarmerTemperature() async => _cupWarmerTemp;
 }

--- a/lib/src/models/device/impl/de1/de1.models.dart
+++ b/lib/src/models/device/impl/de1/de1.models.dart
@@ -377,6 +377,14 @@ enum MMRItem implements MmrAddress {
   @override
   final int? max;
 
+  // No DE1 MMRItem entry is float32 today; defaults satisfy the
+  // `implements MmrAddress` contract added when capability mixins
+  // gained float32 support.
+  @override
+  double? get minDouble => null;
+  @override
+  double? get maxDouble => null;
+
   const MMRItem(
     this.address,
     this.length,

--- a/lib/src/models/device/impl/de1/mmr_address.dart
+++ b/lib/src/models/device/impl/de1/mmr_address.dart
@@ -27,6 +27,10 @@ enum MmrValueKind {
 
   /// null-terminated or length-prefixed string
   string,
+
+  /// raw IEEE-754 float32 (4 bytes, little-endian on the wire). Bounds
+  /// declared via [MmrAddress.minDouble] / [MmrAddress.maxDouble].
+  float32,
 }
 
 /// Wire-agnostic identifier for a single MMR slot.
@@ -64,4 +68,12 @@ abstract class MmrAddress {
 
   /// Optional maximum bound; null means no upper clamp.
   int? get max => null;
+
+  /// Optional minimum bound for [MmrValueKind.float32] addresses; null
+  /// means no lower clamp.
+  double? get minDouble => null;
+
+  /// Optional maximum bound for [MmrValueKind.float32] addresses; null
+  /// means no upper clamp.
+  double? get maxDouble => null;
 }

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -591,6 +591,32 @@ class UnifiedDe1 implements De1Interface {
     return _mmrWriteRaw(addr.address, _packMMRInt(clamped));
   }
 
+  /// Reads a [MmrValueKind.float32] address as an IEEE-754 little-endian
+  /// float. Capability mixins use this for FW MMR slots that store
+  /// floats raw (e.g. `BengleMmr.matSetPoint`).
+  @protected
+  Future<double> readMmrFloat32(MmrAddress addr) async {
+    _assertKind(addr, const {MmrValueKind.float32}, 'readMmrFloat32');
+    final raw = (addr is MMRItem)
+        ? await _mmrRead(addr)
+        : await _mmrReadRaw(addr.address);
+    return _unpackMMRFloat32(raw);
+  }
+
+  /// Writes [value] as an IEEE-754 little-endian float to [addr].
+  /// Clamps to `[addr.minDouble, addr.maxDouble]` when both are set
+  /// (avoids silent FW-side clamps surprising callers).
+  @protected
+  Future<void> writeMmrFloat32(MmrAddress addr, double value) async {
+    _assertKind(addr, const {MmrValueKind.float32}, 'writeMmrFloat32');
+    final clamped = (addr.minDouble != null && addr.maxDouble != null)
+        ? value.clamp(addr.minDouble!, addr.maxDouble!).toDouble()
+        : value;
+    final bytes = _packMMRFloat32(clamped);
+    if (addr is MMRItem) return _mmrWrite(addr, bytes);
+    return _mmrWriteRaw(addr.address, bytes);
+  }
+
   @protected
   Future<List<int>> readMmrRaw(MmrAddress addr) async {
     if (addr is MMRItem) return _mmrRead(addr);

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart
@@ -124,4 +124,28 @@ extension UnifiedDe1MMR on UnifiedDe1 {
     final scaledValue = (value * item.writeScale).toInt();
     await _writeMMRInt(item, scaledValue);
   }
+
+  /// IEEE-754 little-endian unpack for [MmrValueKind.float32] addresses.
+  /// Mirrors [_unpackMMRInt] but reads `getFloat32(4, Endian.little)`.
+  double _unpackMMRFloat32(List<int> buffer) {
+    if (buffer.length < 20) {
+      throw StateError(
+        'MMR response buffer too short (got ${buffer.length} bytes, '
+        'expected at least 20)',
+      );
+    }
+    final bytes = ByteData(20);
+    for (var i = 0; i < 20; i++) {
+      bytes.setUint8(i, buffer[i]);
+    }
+    return bytes.getFloat32(4, Endian.little);
+  }
+
+  /// IEEE-754 little-endian pack for [MmrValueKind.float32] addresses.
+  /// Returns the 4 raw bytes ready to ride on `Endpoint.writeToMMR`.
+  Uint8List _packMMRFloat32(double value) {
+    final bytes = ByteData(4);
+    bytes.setFloat32(0, value, Endian.little);
+    return bytes.buffer.asUint8List();
+  }
 }

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -28,6 +28,43 @@ class De1Handler {
     });
     app.post('/api/v1/machine/shotSettings', _shotSettingsHandler);
 
+    app.get('/api/v1/machine/capabilities', (Request _) async {
+      return withDe1((de1) async {
+        final caps = <String>[];
+        if (de1 is BengleInterface) caps.add('cupWarmer');
+        return jsonOk({'capabilities': caps});
+      });
+    });
+
+    app.get('/api/v1/machine/cupWarmer', (Request _) async {
+      return withDe1((de1) async {
+        if (de1 is! BengleInterface) {
+          return jsonNotFound({'error': 'cupWarmer not supported'});
+        }
+        final t = await de1.getCupWarmerTemperature();
+        return jsonOk({'temperature': t});
+      });
+    });
+
+    app.post('/api/v1/machine/cupWarmer', (Request r) async {
+      return withDe1((de1) async {
+        if (de1 is! BengleInterface) {
+          return jsonNotFound({'error': 'cupWarmer not supported'});
+        }
+        final json = jsonDecode(await r.readAsString());
+        if (json is! Map || json['temperature'] == null) {
+          return jsonBadRequest({'error': 'temperature required'});
+        }
+        final t = parseDouble(json['temperature']);
+        if (t < 0.0 || t > 80.0) {
+          return jsonBadRequest(
+              {'error': 'temperature out of range 0.0-80.0'});
+        }
+        await de1.setCupWarmerTemperature(t);
+        return jsonAccepted();
+      });
+    });
+
     // Sockets
     app.get('/ws/v1/machine/snapshot', sws.webSocketHandler(_handleSnapshot));
     app.get(

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -52,6 +52,7 @@ import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'dart:convert';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:shelf/shelf_io.dart' as io;
 import 'package:shelf_web_socket/shelf_web_socket.dart' as sws;

--- a/test/models/device/bengle_cup_warmer_test.dart
+++ b/test/models/device/bengle_cup_warmer_test.dart
@@ -1,0 +1,80 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+
+import '../../helpers/fake_ble_transport.dart';
+
+/// Wires the real `Bengle` class through `FakeBleTransport` to confirm the
+/// public cup-warmer API (setCupWarmerTemperature / getCupWarmerTemperature)
+/// rides the float32 MMR helpers and the `BengleMmr.matSetPoint` address.
+///
+/// This is the integration point between `BengleInterface`,
+/// `Bengle`'s extension on `UnifiedDe1`'s `@protected` MMR helpers, and the
+/// new `MmrValueKind.float32` plumbing. The unit-level mechanics
+/// (clamping, packing, kind-mismatch errors) live in
+/// `test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart`.
+void main() {
+  group('Bengle cup warmer wiring', () {
+    late FakeBleTransport transport;
+    late Bengle bengle;
+
+    setUp(() async {
+      transport = FakeBleTransport();
+      bengle = Bengle(transport: transport);
+      transport.queueOnConnectResponses(v13Model: 128); // Bengle marker
+      await bengle.onConnect();
+    });
+
+    tearDown(() {
+      transport.dispose();
+    });
+
+    test(
+      'setCupWarmerTemperature writes a float32 to BengleMmr.matSetPoint',
+      () async {
+        transport.writes.clear();
+        await bengle.setCupWarmerTemperature(60.0);
+
+        final frame = transport.writes.firstWhere(
+          (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
+        );
+
+        // Address bytes [1..3] match BengleMmr.matSetPoint (0x00803874).
+        final addr = ByteData(4)
+          ..setInt32(0, BengleMmr.matSetPoint.address, Endian.big);
+        expect(frame.data[1], addr.getUint8(1));
+        expect(frame.data[2], addr.getUint8(2));
+        expect(frame.data[3], addr.getUint8(3));
+
+        // Payload bytes [4..7] = float32 little-endian 60.0.
+        final payload = ByteData.sublistView(frame.data, 4, 8);
+        expect(payload.getFloat32(0, Endian.little), closeTo(60.0, 1e-6));
+      },
+    );
+
+    test('getCupWarmerTemperature reads a float32 back from the wire',
+        () async {
+      // Pre-queue a 50.0 °C float32 response at the matSetPoint address.
+      final bytes = ByteData(4)..setFloat32(0, 50.0, Endian.little);
+      transport.queueMmrResponseRaw(BengleMmr.matSetPoint,
+          List<int>.generate(4, (i) => bytes.getUint8(i)));
+
+      final result = await bengle.getCupWarmerTemperature();
+      expect(result, closeTo(50.0, 1e-6));
+    });
+
+    test('setCupWarmerTemperature clamps over-range writes', () async {
+      transport.writes.clear();
+      await bengle.setCupWarmerTemperature(120.0); // FW max is 80.0
+
+      final frame = transport.writes.firstWhere(
+        (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
+      );
+      final payload = ByteData.sublistView(frame.data, 4, 8);
+      expect(payload.getFloat32(0, Endian.little), closeTo(80.0, 1e-6));
+    });
+  });
+}

--- a/test/models/device/mock_bengle_test.dart
+++ b/test/models/device/mock_bengle_test.dart
@@ -37,4 +37,29 @@ void main() {
       expect(m.deviceId, equals('CustomBengleId'));
     });
   });
+
+  group('MockBengle cup warmer', () {
+    test('initial setpoint is 0.0 (off)', () async {
+      final m = MockBengle();
+      expect(await m.getCupWarmerTemperature(), 0.0);
+    });
+
+    test('setCupWarmerTemperature stores the value', () async {
+      final m = MockBengle();
+      await m.setCupWarmerTemperature(60.0);
+      expect(await m.getCupWarmerTemperature(), 60.0);
+    });
+
+    test('clamps over-range values to 80.0', () async {
+      final m = MockBengle();
+      await m.setCupWarmerTemperature(120.0);
+      expect(await m.getCupWarmerTemperature(), 80.0);
+    });
+
+    test('clamps negative values to 0.0', () async {
+      final m = MockBengle();
+      await m.setCupWarmerTemperature(-10.0);
+      expect(await m.getCupWarmerTemperature(), 0.0);
+    });
+  });
 }

--- a/test/services/webserver/de1handler_cup_warmer_test.dart
+++ b/test/services/webserver/de1handler_cup_warmer_test.dart
@@ -1,0 +1,125 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+import 'package:reaprime/src/models/errors.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+import '../../helpers/mock_device_discovery_service.dart';
+
+class _FixedDe1Controller extends De1Controller {
+  _FixedDe1Controller({required super.controller, this.device});
+
+  De1Interface? device;
+
+  @override
+  De1Interface connectedDe1() {
+    final d = device;
+    if (d == null) throw const DeviceNotConnectedException.machine();
+    return d;
+  }
+}
+
+void main() {
+  late Handler handler;
+  late _FixedDe1Controller controller;
+
+  Future<void> wireWith(De1Interface? device) async {
+    final deviceController =
+        DeviceController([MockDeviceDiscoveryService()]);
+    await deviceController.initialize();
+    controller =
+        _FixedDe1Controller(controller: deviceController, device: device);
+    final de1Handler = De1Handler(controller: controller);
+    final app = Router().plus;
+    de1Handler.addRoutes(app);
+    handler = app.call;
+  }
+
+  Future<Response> get(String path) async =>
+      await handler(Request('GET', Uri.parse('http://localhost$path')));
+
+  Future<Response> post(String path, Object body) async =>
+      await handler(Request(
+        'POST',
+        Uri.parse('http://localhost$path'),
+        body: jsonEncode(body),
+        headers: {HttpHeaders.contentTypeHeader: 'application/json'},
+      ));
+
+  group('GET /api/v1/machine/capabilities', () {
+    test('returns cupWarmer when a Bengle is connected', () async {
+      await wireWith(MockBengle());
+      final res = await get('/api/v1/machine/capabilities');
+      expect(res.statusCode, 200);
+      final body = jsonDecode(await res.readAsString());
+      expect(body['capabilities'], contains('cupWarmer'));
+    });
+
+    test('returns empty list for a plain DE1', () async {
+      await wireWith(MockDe1());
+      final res = await get('/api/v1/machine/capabilities');
+      expect(res.statusCode, 200);
+      final body = jsonDecode(await res.readAsString());
+      expect(body['capabilities'], isEmpty);
+    });
+  });
+
+  group('GET /api/v1/machine/cupWarmer', () {
+    test('200 + initial setpoint 0.0 on MockBengle', () async {
+      await wireWith(MockBengle());
+      final res = await get('/api/v1/machine/cupWarmer');
+      expect(res.statusCode, 200);
+      final body = jsonDecode(await res.readAsString());
+      expect(body['temperature'], 0.0);
+    });
+
+    test('404 on plain DE1 (machine connected but capability absent)',
+        () async {
+      await wireWith(MockDe1());
+      final res = await get('/api/v1/machine/cupWarmer');
+      expect(res.statusCode, 404);
+    });
+  });
+
+  group('POST /api/v1/machine/cupWarmer', () {
+    test('202 + writes setpoint into MockBengle', () async {
+      final bengle = MockBengle();
+      await wireWith(bengle);
+
+      final res = await post('/api/v1/machine/cupWarmer', {'temperature': 60});
+      expect(res.statusCode, 202);
+      expect(await bengle.getCupWarmerTemperature(), 60.0);
+    });
+
+    test('400 on out-of-range temperature', () async {
+      await wireWith(MockBengle());
+      final res = await post('/api/v1/machine/cupWarmer', {'temperature': 100});
+      expect(res.statusCode, 400);
+    });
+
+    test('400 on negative temperature', () async {
+      await wireWith(MockBengle());
+      final res = await post('/api/v1/machine/cupWarmer', {'temperature': -5});
+      expect(res.statusCode, 400);
+    });
+
+    test('400 when temperature key is missing', () async {
+      await wireWith(MockBengle());
+      final res = await post('/api/v1/machine/cupWarmer', {});
+      expect(res.statusCode, 400);
+    });
+
+    test('404 on plain DE1', () async {
+      await wireWith(MockDe1());
+      final res = await post('/api/v1/machine/cupWarmer', {'temperature': 60});
+      expect(res.statusCode, 404);
+    });
+  });
+}

--- a/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
@@ -34,6 +34,9 @@ mixin _TestCapability on UnifiedDe1 {
   Future<double> capReadScaled(MmrAddress addr) => readMmrScaled(addr);
   Future<void> capWriteScaled(MmrAddress addr, double v) =>
       writeMmrScaled(addr, v);
+  Future<double> capReadFloat32(MmrAddress addr) => readMmrFloat32(addr);
+  Future<void> capWriteFloat32(MmrAddress addr, double v) =>
+      writeMmrFloat32(addr, v);
   Stream<ByteData> capNotifications(LogicalEndpoint ep) =>
       notificationsFor(ep);
   Future<void> capWriteEndpoint(LogicalEndpoint ep, Uint8List data,
@@ -60,6 +63,10 @@ class _CapabilityAddr implements MmrAddress {
   final int? min;
   @override
   final int? max;
+  @override
+  final double? minDouble;
+  @override
+  final double? maxDouble;
   const _CapabilityAddr({
     required this.address,
     required this.length,
@@ -69,6 +76,8 @@ class _CapabilityAddr implements MmrAddress {
     this.writeScale = 1.0,
     this.min,
     this.max,
+    this.minDouble,
+    this.maxDouble,
   });
 }
 
@@ -247,6 +256,85 @@ void main() {
           (e) => e.message,
           'message',
           contains('runtime subscription'),
+        )),
+      );
+    });
+
+    test('readMmrFloat32 round-trips an IEEE-754 float32 value', () async {
+      const addr = _CapabilityAddr(
+        address: 0x00803874,
+        length: 4,
+        name: 'matSetPoint',
+        kind: MmrValueKind.float32,
+        minDouble: 0.0,
+        maxDouble: 80.0,
+      );
+      // Pack 50.0 as little-endian float32 bytes.
+      final bytes = ByteData(4)..setFloat32(0, 50.0, Endian.little);
+      transport.queueMmrResponseRaw(addr,
+          List<int>.generate(4, (i) => bytes.getUint8(i)));
+      final result = await de1.capReadFloat32(addr);
+      expect(result, closeTo(50.0, 1e-6));
+    });
+
+    test('writeMmrFloat32 packs a float32 little-endian and clamps to bounds',
+        () async {
+      const addr = _CapabilityAddr(
+        address: 0x00803874,
+        length: 4,
+        name: 'matSetPoint',
+        kind: MmrValueKind.float32,
+        minDouble: 0.0,
+        maxDouble: 80.0,
+      );
+
+      transport.writes.clear();
+      // 90.0 over the max → clamped to 80.0.
+      await de1.capWriteFloat32(addr, 90.0);
+      var frame = transport.writes.firstWhere(
+        (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
+      );
+      var payload = ByteData.sublistView(frame.data, 4, 8);
+      expect(payload.getFloat32(0, Endian.little), closeTo(80.0, 1e-6));
+
+      transport.writes.clear();
+      // -5.0 below min → clamped to 0.0.
+      await de1.capWriteFloat32(addr, -5.0);
+      frame = transport.writes.firstWhere(
+        (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
+      );
+      payload = ByteData.sublistView(frame.data, 4, 8);
+      expect(payload.getFloat32(0, Endian.little), closeTo(0.0, 1e-6));
+
+      transport.writes.clear();
+      // In-range value passed through unchanged.
+      await de1.capWriteFloat32(addr, 60.0);
+      frame = transport.writes.firstWhere(
+        (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
+      );
+      payload = ByteData.sublistView(frame.data, 4, 8);
+      expect(payload.getFloat32(0, Endian.little), closeTo(60.0, 1e-6));
+    });
+
+    test('readMmrFloat32 throws on a non-float32 address', () async {
+      // fanThreshold.kind == int32 — wrong helper.
+      await expectLater(
+        de1.capReadFloat32(MMRItem.fanThreshold),
+        throwsA(isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          allOf(contains('readMmrFloat32'), contains('kind')),
+        )),
+      );
+    });
+
+    test('writeMmrFloat32 throws on a non-float32 address', () async {
+      await expectLater(
+        de1.capWriteFloat32(MMRItem.fanThreshold, 1.0),
+        throwsA(isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          allOf(contains('writeMmrFloat32'), contains('kind')),
         )),
       );
     });


### PR DESCRIPTION
## Summary
- Adds `MmrValueKind.float32` + protected `readMmrFloat32` / `writeMmrFloat32` helpers on `UnifiedDe1`, paralleling the existing int / scaled paths. Bounds travel with the address via new `MmrAddress.minDouble` / `maxDouble`.
- Adds `GET /api/v1/machine/capabilities` so clients can discover optional surfaces on the currently connected machine. Plain DE1 returns `[]`.
- Lands a first capability behind that surface (`/api/v1/machine/cupWarmer` GET / POST) as the proof case for the discovery pattern.

## Why
Peripheral support for the next-gen machine is in early scaffolding. We need (a) MMR plumbing for FW slots that store raw IEEE floats and (b) a discovery contract clients can rely on as more capabilities ship. Both are designed to extend cleanly — addresses + bounds travel with the type, capability list grows by appending strings.

The first capability is intentionally small and write+read only — surface shape, value semantics, and FW behaviour are all subject to change as more data comes in.

## Test plan
- `flutter test` — 1135/1135 passing, 25 new
- `flutter analyze` — clean for changed files
- End-to-end via `scripts/sb-dev.sh` + `curl`: capability list reflects connected machine, setpoint round-trips, out-of-range → 400, non-Bengle → 404
- Real-hardware smoke deferred — no bench unit available