### PR TITLE
fix: android ble scan when display is locked 

### DIFF
--- a/doc/plans/2026-05-07-ble-background-filtered-scan.md
+++ b/doc/plans/2026-05-07-ble-background-filtered-scan.md
@@ -1,0 +1,154 @@
+# Plan: BLE background filtered scan (#107)
+
+**Date:** 2026-05-07
+**Issue:** [#107 — BLE scan returns no results when screen is off](https://github.com/tadelv/reaprime/issues/107)
+**Priority:** P0
+**Status:** approved
+
+## Problem
+
+`scanAndConnectScale` (triggered by `De1StateManager` on wake-from-sleep) calls `ConnectionManager.connect(scaleOnly: true)`. This runs an unfiltered `FlutterBluePlus.startScan(oneByOne: true)`. Android throttles unfiltered BLE scans when screen is off → zero results. Filtered scans (by service UUID, remote ID) bypass throttling because filtering happens at hardware/firmware level.
+
+## Approach
+
+Add a **filtered scan path** using BLE service UUIDs + remote ID. The general `connect()` path stays unfiltered. Only `scaleOnly` on Android uses the filtered path.
+
+### Filter strategy
+
+Single scan with two filters (flutter_blue_plus "or" behavior):
+
+1. `withServices` — all known scale service UUIDs (aggregated from scale impl classes)
+2. `withRemoteIds: [preferredScaleId]` — only when a preferred scale ID is set
+
+No retry (user triggers manually). No change to non-preferred scale behavior (picker still raised, API clients can handle).
+
+### Decision summary
+
+| Decision | Choice |
+|----------|--------|
+| Filter type | `withServices` (scale service UUIDs) + `withRemoteIds` |
+| Name filtering? | No. Deferred. Service UUIDs are more universal and reliable. |
+| Retry? | No. Manual trigger by user. |
+| Non-preferred scale in background | Keep current behavior (picker). API clients may handle. |
+| Platform | Android only. `Platform.isAndroid` gate in ConnectionManager. |
+| ScanFilter model | `preferredDeviceId: String?` + `deviceTypes: Set<DeviceType>?` |
+| UUID aggregation | `DeviceMatcher.serviceUuidsFor(DeviceType)` — reads existing static `serviceIdentifier` fields |
+| Acaia UUIDs | New `advertisedServiceUuids` static getter on `AcaiaScale` (3 UUIDs) |
+| Plumb through chain | ConnectionManager → ScanOrchestrator → DeviceScanner → DeviceController → DeviceDiscoveryService → BluePlusDiscoveryService |
+| REST API exposure | Deferred. Added to Obsidian TODO. |
+| Serial/simulated services | Ignore ScanFilter for now. TODO in Obsidian. |
+| Full connect path | Unchanged — unfiltered scan. |
+
+### Architecture
+
+```
+ConnectionManager._connectImpl(scaleOnly: true)
+  → builds ScanFilter(preferredDeviceId: id, deviceTypes: {DeviceType.scale})  // Android only
+  → ScanOrchestrator.runScan(scaleFilter: filter)
+    → DeviceScanner.scanForDevices(filter: filter)
+      → DeviceController._runScan(filter: filter)
+        → BluePlusDiscoveryService.scanForDevices(filter: filter)
+          // At BLE edge: imports DeviceMatcher.serviceUuidsFor(DeviceType.scale)
+          // Converts String → Guid, builds withServices + withRemoteIds
+          // Calls FlutterBluePlus.startScan(withServices: [...], withRemoteIds: [...], oneByOne: true)
+        → Other services: filter is null → unfiltered scan (unchanged)
+```
+
+### New model
+
+```dart
+/// lib/src/models/device/scan_filter.dart (NEW)
+class ScanFilter {
+  final String? preferredDeviceId;
+  final Set<DeviceType>? deviceTypes;  // null = all, {scale} = only scales
+  
+  const ScanFilter({this.preferredDeviceId, this.deviceTypes});
+  
+  bool get isFiltered =>
+      preferredDeviceId != null ||
+      (deviceTypes != null && deviceTypes!.isNotEmpty);
+}
+```
+
+### New method
+
+```dart
+/// lib/src/services/device_matcher.dart
+static List<String> serviceUuidsFor(DeviceType type) => switch (type) {
+  DeviceType.scale => [
+    DecentScale.serviceIdentifier.long,
+    Skale2Scale.serviceIdentifier.long,
+    FelicitaArc.serviceIdentifier.long,
+    BlackCoffeeScale.serviceIdentifier.long,
+    BookooScale.serviceIdentifier.long,
+    EurekaScale.serviceIdentifier.long,
+    SmartChefScale.serviceIdentifier.long,
+    VariaAkuScale.serviceIdentifier.long,
+    DifluidScale.serviceIdentifier.long,
+    HiroiaScale.serviceIdentifier.long,
+    AtomheartScale.serviceIdentifier.long,
+    ...AcaiaScale.advertisedServiceUuids,
+  ],
+  DeviceType.machine => [
+    UnifiedDe1.serviceIdentifier.long,
+    Bengle.serviceIdentifier.long,
+  ],
+  DeviceType.sensor => [],  // No BLE sensors yet
+};
+```
+
+### New static getter
+
+```dart
+/// lib/src/models/device/impl/acaia/acaia_scale.dart
+static const advertisedServiceUuids = [
+  '49535343-fe7d-4ae5-8fa9-9fafd205e455',
+  '49535343-1e4d-4bd9-ba61-23c647249616',
+  '49535343-8841-43f4-a8d4-ecbe34729bb3',
+];
+```
+
+## Files to change
+
+| File | Change |
+|------|--------|
+| `lib/src/models/device/scan_filter.dart` | **New.** `ScanFilter` value class |
+| `lib/src/models/device/device.dart` | Add optional `ScanFilter?` param to `DeviceDiscoveryService.scanForDevices()` |
+| `lib/src/models/device/device_scanner.dart` | Add optional `ScanFilter?` param to `scanForDevices()` |
+| `lib/src/services/device_matcher.dart` | Add `serviceUuidsFor(DeviceType)` static method |
+| `lib/src/services/blue_plus_discovery_service.dart` | Import `ScanFilter`, `DeviceMatcher`. In `scanForDevices()`, if filter provided, call `startScan(withServices: ..., withRemoteIds: ..., oneByOne: true)` |
+| `lib/src/controllers/device_controller.dart` | Pass filter through to `service.scanForDevices(filter:)` |
+| `lib/src/controllers/connection/scan_orchestrator.dart` | Accept optional `ScanFilter?` in `runScan()`, pass to `_scanner.scanForDevices()` |
+| `lib/src/controllers/connection_manager.dart` | In `_connectImpl(scaleOnly: true)`: build `ScanFilter` when `Platform.isAndroid`, pass to `runScan()` |
+| `lib/src/models/device/impl/acaia/acaia_scale.dart` | Add `advertisedServiceUuids` static const getter |
+
+All other discovery services (`LinuxBleDiscoveryService`, `UniversalBleDiscoveryService`, serial services, simulated) — no changes (filter param added to interface, ignored in body).
+
+## Testing
+
+### Unit tests
+
+- `ScanFilter.isFiltered` for null/empty/populated cases
+- `DeviceMatcher.serviceUuidsFor(DeviceType.scale)` returns expected UUIDs
+- `DeviceMatcher.serviceUuidsFor(DeviceType.machine)` returns expected UUIDs
+- `BluePlusDiscoveryService` passes `withServices` + `withRemoteIds` when filter is provided
+- `AcaiaScale.advertisedServiceUuids` returns 3 UUIDs
+
+### Integration tests
+
+- `scanAndConnectScale` with mock discovery service: verify filter params reach `startScan`
+- Full connect path: verify no filter (unfiltered scan unchanged)
+
+### End-to-end
+
+- Real hardware: lock screen, wake DE1, verify scale reconnects via filtered scan
+- Simulated mode: verify `FlutterBluePlus.startScan` receives correct filter parameters
+
+## Open questions (resolved)
+
+1. ~~Names vs service UUIDs for filtering?~~ → Service UUIDs. More universal, works at hardware level.
+2. ~~Retry?~~ → No. User triggers manually.
+3. ~~Non-preferred scale auto-connect?~~ → Keep current behavior. API clients handle picker.
+4. ~~Apply on all platforms?~~ → Android only.
+5. ~~Where to aggregate UUIDs?~~ → `DeviceMatcher.serviceUuidsFor()`, reading existing static `serviceIdentifier` fields.
+6. ~~Acaia runtime UUIDs?~~ → New `advertisedServiceUuids` static getter with all 3 variants.

--- a/lib/src/controllers/connection/scan_orchestrator.dart
+++ b/lib/src/controllers/connection/scan_orchestrator.dart
@@ -10,6 +10,7 @@ import 'package:reaprime/src/controllers/connection_manager.dart'
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device_scanner.dart';
 import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/errors.dart';
 
 /// Outcome of [ScanOrchestrator.runScan].
@@ -85,6 +86,7 @@ class ScanOrchestrator {
     required bool earlyStopEnabled,
     required void Function() onEarlyAttemptComplete,
     required DateTime scanStartTime,
+    ScanFilter? scaleFilter,
   }) async {
     final reportBuilder = ScanReportBuilder(scanStartTime: scanStartTime)
       ..recordAdapterStateAtStart(_scanner.currentAdapterState);
@@ -112,12 +114,12 @@ class ScanOrchestrator {
     );
     earlyConnect.start();
 
-    // Run full unfiltered scan. The scanner awaits every service's
-    // scan and returns a ScanResult carrying per-service failures;
-    // only a catastrophic, scan-wide error throws out of the Future.
+    // Run scan. If a scaleFilter is provided (Android scaleOnly path),
+    // discovery services that support filtering will use it to bypass
+    // background throttling; others ignore it.
     final ScanResult scanResult;
     try {
-      scanResult = await _scanner.scanForDevices();
+      scanResult = await _scanner.scanForDevices(filter: scaleFilter);
     } catch (e) {
       earlyConnect.stop();
       _emitScanStartError(e);

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_blue_plus/flutter_blue_plus.dart'
@@ -17,8 +18,10 @@ import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle_virtual_scale.dart';
 import 'package:reaprime/src/models/adapter_state.dart';
+import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_scanner.dart';
 import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/scan_report.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:rxdart/rxdart.dart';
@@ -335,12 +338,23 @@ class ConnectionManager {
         !scaleOnly && preferredMachineId != null && preferredScaleId != null;
 
     final scanStartTime = DateTime.now();
+
+    // Build a filtered scan for Android scaleOnly path to bypass
+    // background throttling. Full connect stays unfiltered.
+    final scaleFilter = scaleOnly && Platform.isAndroid
+        ? ScanFilter(
+            preferredDeviceId: preferredScaleId,
+            deviceTypes: {DeviceType.scale},
+          )
+        : null;
+
     final scanRun = await _scanOrchestrator.runScan(
       preferredMachineId: preferredMachineId,
       preferredScaleId: preferredScaleId,
       earlyStopEnabled: earlyStopEnabled,
       onEarlyAttemptComplete: () => _checkEarlyStop(earlyStopEnabled),
       scanStartTime: scanStartTime,
+      scaleFilter: scaleFilter,
     );
     if (scanRun == null) {
       // Scan failed catastrophically; orchestrator already emitted

--- a/lib/src/controllers/de1_state_manager.dart
+++ b/lib/src/controllers/de1_state_manager.dart
@@ -194,9 +194,10 @@ class De1StateManager with WidgetsBindingObserver {
   void _handleSnapshot(MachineSnapshot snapshot) {
     final gatewayMode = _settingsController.gatewayMode;
     final currentState = snapshot.state.state;
+    final currentSubstate = snapshot.state.substate;
 
-    _logger.finest(
-      'Handling state: $currentState in mode: ${gatewayMode.name} (app foreground: $_appIsInForeground, platform: ${Platform.operatingSystem})',
+    _logger.fine(
+      'Handling state: $currentState, substate: $currentSubstate in mode: ${gatewayMode.name} (app foreground: $_appIsInForeground, platform: ${Platform.operatingSystem})',
     );
 
     // Handle scale power management based on state transitions

--- a/lib/src/controllers/device_controller.dart
+++ b/lib/src/controllers/device_controller.dart
@@ -5,6 +5,7 @@ import 'package:reaprime/src/controllers/connection/connection_timings.dart';
 import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_scanner.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/services/ble/ble_discovery_service.dart';
 import 'package:reaprime/src/services/telemetry/telemetry_service.dart';
 import 'package:rxdart/rxdart.dart';
@@ -139,13 +140,14 @@ class DeviceController implements DeviceScanner {
   Future<ScanResult>? _inFlightScan;
 
   @override
-  Future<ScanResult> scanForDevices() {
-    return _inFlightScan ??= _runScan().whenComplete(() {
+  @override
+  Future<ScanResult> scanForDevices({ScanFilter? filter}) {
+    return _inFlightScan ??= _runScan(filter).whenComplete(() {
       _inFlightScan = null;
     });
   }
 
-  Future<ScanResult> _runScan() async {
+  Future<ScanResult> _runScan(ScanFilter? filter) async {
     _scanningStream.add(true);
     final start = DateTime.now();
     try {
@@ -195,7 +197,7 @@ class DeviceController implements DeviceScanner {
         _services.map((service) async {
           try {
             _log.fine("starting scan for $service");
-            await service.scanForDevices();
+            await service.scanForDevices(filter: filter);
           } catch (e, st) {
             _log.warning("Service $service failed to scan:", e, st);
             failures.add(

--- a/lib/src/models/device/device.dart
+++ b/lib/src/models/device/device.dart
@@ -1,3 +1,5 @@
+import 'package:reaprime/src/models/device/scan_filter.dart';
+
 enum DeviceType { machine, scale, sensor }
 
 abstract class Device {
@@ -23,7 +25,7 @@ abstract class DeviceDiscoveryService {
     throw "Not implemented yet";
   }
 
-  Future<void> scanForDevices() async {
+  Future<void> scanForDevices({ScanFilter? filter}) async {
     throw "Not implemented yet";
   }
 

--- a/lib/src/models/device/device_scanner.dart
+++ b/lib/src/models/device/device_scanner.dart
@@ -1,5 +1,6 @@
 import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/device/scan_result.dart';
 
 export 'package:reaprime/src/models/device/scan_result.dart';
@@ -21,7 +22,7 @@ abstract class DeviceScanner {
   /// Per-service failures are reported via [ScanResult.failedServices];
   /// the Future rejects only on catastrophic, scan-wide errors (the
   /// scan could not even be attempted).
-  Future<ScanResult> scanForDevices();
+  Future<ScanResult> scanForDevices({ScanFilter? filter});
 
   void stopScan();
 

--- a/lib/src/models/device/impl/acaia/acaia_scale.dart
+++ b/lib/src/models/device/impl/acaia/acaia_scale.dart
@@ -34,6 +34,15 @@ class AcaiaScale implements Scale {
   static final _pyxisCmdChar =
       BleServiceIdentifier.long('49535343-8841-43f4-a8d4-ecbe34729bb3');
 
+  /// Service UUIDs advertised by Acaia scales (all Pyxis protocol variants).
+  /// Used for filtered BLE scans. The IPS protocol service (1820) is excluded
+  /// because it overlaps with other BLE devices (heart rate monitors, etc.).
+  static const advertisedServiceUuids = [
+    '49535343-fe7d-4ae5-8fa9-9fafd205e455',
+    '49535343-1e4d-4bd9-ba61-23c647249616',
+    '49535343-8841-43f4-a8d4-ecbe34729bb3',
+  ];
+
   static const int _maxInitRetries = 10;
 
   final Logger _log = Logger('AcaiaScale');

--- a/lib/src/models/device/scan_filter.dart
+++ b/lib/src/models/device/scan_filter.dart
@@ -1,0 +1,23 @@
+import 'package:reaprime/src/models/device/device.dart';
+
+/// Filter parameters for targeted BLE scans.
+///
+/// Carries intent (what to scan for), not implementation (how to filter).
+/// [BluePlusDiscoveryService] converts to platform-specific filter parameters
+/// at the BLE edge.
+class ScanFilter {
+  /// If set, filter scan results to this specific remote device ID.
+  /// Maps to `withRemoteIds` in flutter_blue_plus.
+  final String? preferredDeviceId;
+
+  /// If set, filter scan results to these device types.
+  /// `null` means all devices. `{DeviceType.scale}` means only scales.
+  /// Maps to `withServices` (by service UUID) in flutter_blue_plus.
+  final Set<DeviceType>? deviceTypes;
+
+  const ScanFilter({this.preferredDeviceId, this.deviceTypes});
+
+  bool get isFiltered =>
+      preferredDeviceId != null ||
+      (deviceTypes != null && deviceTypes!.isNotEmpty);
+}

--- a/lib/src/services/ble/linux_ble_discovery_service.dart
+++ b/lib/src/services/ble/linux_ble_discovery_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/services/ble/ble_discovery_service.dart';
 import 'package:reaprime/src/services/ble/linux_blue_plus_transport.dart';
 import 'package:reaprime/src/services/device_matcher.dart';
@@ -281,7 +282,8 @@ class LinuxBleDiscoveryService extends BleDiscoveryService {
   }
 
   @override
-  Future<void> scanForDevices() async {
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {
     if (_isScanning) {
       _log.warning('Scan already in progress, ignoring request');
       return;

--- a/lib/src/services/blue_plus_discovery_service.dart
+++ b/lib/src/services/blue_plus_discovery_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/services/ble/android_blue_plus_transport.dart';
 import 'package:reaprime/src/services/ble/ble_discovery_service.dart';
 import 'package:reaprime/src/services/ble/blue_plus_transport.dart';
@@ -145,7 +146,8 @@ class BluePlusDiscoveryService extends BleDiscoveryService {
   }
 
   @override
-  Future<void> scanForDevices() async {
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {
     if (_isScanning) {
       _log.warning('Scan already in progress, ignoring request');
       return;
@@ -221,8 +223,35 @@ class BluePlusDiscoveryService extends BleDiscoveryService {
       }
       _log.info("Adapter ready, starting scan...");
 
-      // Unfiltered scan — no withServices parameter
-      await FlutterBluePlus.startScan(oneByOne: true);
+      // Build filtered scan if ScanFilter is provided. When filtered,
+      // use withServices + withRemoteIds to bypass Android background
+      // throttling. Otherwise, run unfiltered scan.
+      final useFilter = filter != null && filter.isFiltered;
+      if (useFilter) {
+        final guidList = <Guid>[];
+        if (filter!.deviceTypes != null) {
+          for (final type in filter.deviceTypes!) {
+            guidList.addAll(
+              DeviceMatcher.serviceUuidsFor(type).map((s) => Guid(s)),
+            );
+          }
+        }
+        final remoteIds = filter.preferredDeviceId != null
+            ? <String>[filter.preferredDeviceId!]
+            : <String>[];
+        _log.info(
+          'Starting filtered scan: ${guidList.length} service UUIDs, '
+          '${remoteIds.length} remote IDs',
+        );
+        await FlutterBluePlus.startScan(
+          withServices: guidList,
+          withRemoteIds: remoteIds,
+          oneByOne: true,
+        );
+      } else {
+        // Unfiltered scan
+        await FlutterBluePlus.startScan(oneByOne: true);
+      }
 
       // Scan for up to 15s. External stopScan() cancels the timer and
       // completes the completer early so the scanner can free

--- a/lib/src/services/device_matcher.dart
+++ b/lib/src/services/device_matcher.dart
@@ -16,6 +16,33 @@ import 'package:reaprime/src/models/device/impl/varia/varia_aku_scale.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 
 class DeviceMatcher {
+  /// Service UUIDs advertised by devices of a given [type].
+  /// Used for filtered BLE scans to bypass Android background throttling.
+  ///
+  /// Returns 128-bit UUID strings. [BluePlusDiscoveryService] converts
+  /// them to platform-specific [Guid] objects at the BLE edge.
+  static List<String> serviceUuidsFor(DeviceType type) => switch (type) {
+    DeviceType.scale => [
+      DecentScale.serviceIdentifier.long,
+      Skale2Scale.serviceIdentifier.long,
+      FelicitaArc.serviceIdentifier.long,
+      BlackCoffeeScale.serviceIdentifier.long,
+      BookooScale.serviceIdentifier.long,
+      EurekaScale.serviceIdentifier.long,
+      SmartChefScale.serviceIdentifier.long,
+      VariaAkuScale.serviceIdentifier.long,
+      DifluidScale.serviceIdentifier.long,
+      HiroiaScale.serviceIdentifier.long,
+      AtomheartScale.serviceIdentifier.long,
+      ...AcaiaScale.advertisedServiceUuids,
+    ],
+    DeviceType.machine => [
+      UnifiedDe1.advertisingIdentifier.long,
+      // Bengle extends UnifiedDe1, inherits advertisingIdentifier.
+    ],
+    DeviceType.sensor => [], // No BLE sensors yet
+  };
+
   static Future<Device?> match({
     required BLETransport transport,
     required String advertisedName,

--- a/lib/src/services/serial/serial_service.dart
+++ b/lib/src/services/serial/serial_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/services/serial/serial_service_android.dart';
 import 'package:reaprime/src/services/serial/serial_service_desktop.dart';
 import 'package:rxdart/subjects.dart';
@@ -38,7 +39,8 @@ class NoOpSerialService implements DeviceDiscoveryService {
   Future<void> initialize() async {}
 
   @override
-  Future<void> scanForDevices() async {}
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
 
   @override
   void stopScan() {}

--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale_serial.dart';
@@ -92,7 +93,8 @@ class SerialServiceAndroid implements DeviceDiscoveryService {
   void stopScan() {} // Serial enumeration is instant, nothing to stop.
 
   @override
-  Future<void> scanForDevices() async {
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {
     // If already scanning, wait for that scan to complete
     if (_isScanning) {
       _log.info("Scan already in progress, waiting for completion");

--- a/lib/src/services/serial/serial_service_desktop.dart
+++ b/lib/src/services/serial/serial_service_desktop.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale_serial.dart';
@@ -57,7 +58,8 @@ class SerialServiceDesktop implements DeviceDiscoveryService {
   void stopScan() {} // Serial enumeration is instant, nothing to stop.
 
   @override
-  Future<void> scanForDevices() async {
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {
     // If already scanning, wait for that scan to complete
     if (_isScanning) {
       _log.info("Scan already in progress, waiting for completion");

--- a/lib/src/services/simulated_device_service.dart
+++ b/lib/src/services/simulated_device_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/widgets.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
 import 'package:reaprime/src/models/device/impl/mock_scale/mock_scale.dart';
@@ -31,7 +32,8 @@ class SimulatedDeviceService
   void stopScan() {} // Simulated scan completes instantly.
 
   @override
-  Future<void> scanForDevices() async {
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {
     if (enabledDevices.isEmpty) {
       return;
     }

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -3,6 +3,7 @@ import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/services/ble/ble_discovery_service.dart';
 import 'package:reaprime/src/services/ble/universal_ble_transport.dart';
 import 'package:reaprime/src/services/device_matcher.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart' as domain;
 import 'package:rxdart/rxdart.dart';
 import 'package:universal_ble/universal_ble.dart';
 import '../models/device/device.dart';
@@ -78,7 +79,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService {
   }
 
   @override
-  Future<void> scanForDevices() async {
+  Future<void> scanForDevices({domain.ScanFilter? filter}) async {
     if (_isScanning) {
       log.warning('Scan already in progress, ignoring request');
       return;

--- a/test/controllers/device_controller_test.dart
+++ b/test/controllers/device_controller_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/device/scan_result.dart';
 import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/services/telemetry/telemetry_service.dart';
@@ -20,7 +21,7 @@ class _FailingDiscoveryService implements DeviceDiscoveryService {
   Future<void> initialize() async {}
 
   @override
-  Future<void> scanForDevices() async {
+  Future<void> scanForDevices({ScanFilter? filter}) async {
     throw error;
   }
 
@@ -44,7 +45,7 @@ class _QuietDiscoveryService implements DeviceDiscoveryService {
   }
 
   @override
-  Future<void> scanForDevices() async {
+  Future<void> scanForDevices({ScanFilter? filter}) async {
     // Re-emit on scan so the DeviceController populates its aggregated view.
     _controller.add([device]);
   }
@@ -64,7 +65,7 @@ class _ManualDiscoveryService implements DeviceDiscoveryService {
   Future<void> initialize() async {}
 
   @override
-  Future<void> scanForDevices() async {}
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
 
   @override
   void stopScan() {}

--- a/test/controllers/display_controller_test.dart
+++ b/test/controllers/display_controller_test.dart
@@ -11,6 +11,7 @@ import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/de1_rawmessage.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/settings/charging_mode.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
@@ -29,7 +30,7 @@ class _FakeDiscoveryService implements DeviceDiscoveryService {
   @override
   Future<void> initialize() async {}
   @override
-  Future<void> scanForDevices() async {}
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
   @override
   void stopScan() {}
 }

--- a/test/controllers/presence_controller_test.dart
+++ b/test/controllers/presence_controller_test.dart
@@ -11,6 +11,7 @@ import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/de1_rawmessage.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/wake_schedule.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
@@ -29,7 +30,7 @@ class _FakeDiscoveryService implements DeviceDiscoveryService {
   @override
   Future<void> initialize() async {}
   @override
-  Future<void> scanForDevices() async {}
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
   @override
   void stopScan() {}
 }

--- a/test/controllers/shot_controller_test.dart
+++ b/test/controllers/shot_controller_test.dart
@@ -11,6 +11,7 @@ import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/data/shot_record.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/device/scale.dart';
@@ -33,7 +34,7 @@ class _FakeDiscoveryService extends DeviceDiscoveryService {
   Future<void> initialize() async {}
 
   @override
-  Future<void> scanForDevices() async {}
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
 }
 
 /// De1Controller subclass whose `connectedDe1()` returns our TestDe1.

--- a/test/helpers/mock_device_discovery_service.dart
+++ b/test/helpers/mock_device_discovery_service.dart
@@ -1,5 +1,6 @@
 import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/services/ble/ble_discovery_service.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -36,7 +37,7 @@ class MockDeviceDiscoveryService implements DeviceDiscoveryService {
   Future<void> initialize() async {}
 
   @override
-  Future<void> scanForDevices() async {}
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
 
   @override
   void stopScan() {}
@@ -82,7 +83,7 @@ class MockBleDiscoveryService extends BleDiscoveryService {
   Future<void> initialize() async {}
 
   @override
-  Future<void> scanForDevices() async {}
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
 
   @override
   void stopScan() {}

--- a/test/helpers/mock_device_scanner.dart
+++ b/test/helpers/mock_device_scanner.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_scanner.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:rxdart/rxdart.dart';
 
 /// A controllable [DeviceScanner] for testing [ConnectionManager].
@@ -75,7 +76,7 @@ class MockDeviceScanner implements DeviceScanner {
   }
 
   @override
-  Future<ScanResult> scanForDevices() async {
+  Future<ScanResult> scanForDevices({ScanFilter? filter}) async {
     if (failNextScanWith != null) {
       final e = failNextScanWith;
       failNextScanWith = null;


### PR DESCRIPTION
Use scan by id or by service ids when on Android and scanning for scale only. This solves the 'Android returns 0 results' when scanning while backgrounded and with locked display. Closes #107 