### PR TITLE
fix(telemetry): silence serial port-already-open noise

### DIFF
--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -370,7 +370,7 @@ class AndroidSerialPort implements SerialTransport {
   @override
   Future<void> connect() async {
     if (await _open.first == ConnectionState.connected) {
-      _log.warning('port already open');
+      _log.fine('port already open');
       return;
     }
     if (await _port.open() == false) {

--- a/lib/src/services/telemetry/telemetry_forwarder_filter.dart
+++ b/lib/src/services/telemetry/telemetry_forwarder_filter.dart
@@ -5,9 +5,7 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/errors.dart';
 
 const _webUiStorageLoggerName = 'WebUIStorage';
-const _serialLoggerPrefix = 'Serial:';
 const _skinAlreadyExistsPrefix = 'Skin already exists';
-const _portAlreadyOpenMessage = 'port already open';
 const _benignNetworkErrorPrefixes = [
   'Exception: Failed to fetch GitHub release:',
   'Exception: Failed to download:',
@@ -41,13 +39,6 @@ bool shouldForwardToTelemetry(LogRecord record) {
 
   if (record.loggerName == _webUiStorageLoggerName &&
       record.message.startsWith(_skinAlreadyExistsPrefix)) {
-    return false;
-  }
-
-  // `Serial:...` port already-open is expected state on Android USB
-  // re-connect — not a crash signal.
-  if (record.loggerName.startsWith(_serialLoggerPrefix) &&
-      record.message == _portAlreadyOpenMessage) {
     return false;
   }
 

--- a/lib/src/services/telemetry/telemetry_forwarder_filter.dart
+++ b/lib/src/services/telemetry/telemetry_forwarder_filter.dart
@@ -5,7 +5,9 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/errors.dart';
 
 const _webUiStorageLoggerName = 'WebUIStorage';
+const _serialLoggerPrefix = 'Serial:';
 const _skinAlreadyExistsPrefix = 'Skin already exists';
+const _portAlreadyOpenMessage = 'port already open';
 const _benignNetworkErrorPrefixes = [
   'Exception: Failed to fetch GitHub release:',
   'Exception: Failed to download:',
@@ -39,6 +41,13 @@ bool shouldForwardToTelemetry(LogRecord record) {
 
   if (record.loggerName == _webUiStorageLoggerName &&
       record.message.startsWith(_skinAlreadyExistsPrefix)) {
+    return false;
+  }
+
+  // `Serial:...` port already-open is expected state on Android USB
+  // re-connect — not a crash signal.
+  if (record.loggerName.startsWith(_serialLoggerPrefix) &&
+      record.message == _portAlreadyOpenMessage) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

`AndroidSerialPort.connect()` logs at WARNING when port is already connected — normal on USB re-connect after app resume. WARNING+ logs get forwarded to telemetry, generating noise.

## Changes

- **`serial_service_android.dart`**: downgrade `_log.warning` → `_log.fine('port already open')`