### PR TITLE
feat: macOS Bluetooth troubleshooting wizard + system-device detection (#125, #126)

### DIFF
--- a/lib/src/onboarding_feature/widgets/troubleshooting_wizard.dart
+++ b/lib/src/onboarding_feature/widgets/troubleshooting_wizard.dart
@@ -31,11 +31,14 @@ class TroubleshootingStep {
 ///
 /// Exposed for testing so that shouldShow logic can be unit-tested directly.
 /// [isIOS] defaults to `Platform.isIOS` but can be overridden in tests.
+/// [isMacOS] defaults to `Platform.isMacOS` but can be overridden in tests.
 List<TroubleshootingStep> troubleshootingSteps({
   required AdapterState adapterState,
   bool? isIOS,
+  bool? isMacOS,
 }) {
   final runningOnIOS = isIOS ?? Platform.isIOS;
+  final runningOnMacOS = isMacOS ?? Platform.isMacOS;
 
   return [
     TroubleshootingStep(
@@ -73,6 +76,14 @@ List<TroubleshootingStep> troubleshootingSteps({
           'Only one app can connect to your machine via Bluetooth at a time. Close any other Decent apps (e.g., the original Decent app) and try again.',
       buttonText: "I've closed other apps",
       shouldShow: () => true,
+    ),
+    TroubleshootingStep(
+      id: 'system_bt',
+      title: 'Check System Bluetooth Settings',
+      description:
+          'On macOS, if your DE1 appears as "Connected" in System Settings > Bluetooth, the system may hide it from app-level scans. Disconnect it there, then try scanning again.',
+      buttonText: "I've checked",
+      shouldShow: () => runningOnMacOS,
     ),
   ];
 }

--- a/lib/src/services/blue_plus_discovery_service.dart
+++ b/lib/src/services/blue_plus_discovery_service.dart
@@ -259,6 +259,37 @@ class BluePlusDiscoveryService extends BleDiscoveryService {
       // (comms-harden #11).
       await _waitForScanDuration(const Duration(seconds: 15));
 
+      // On macOS, CoreBluetooth may hide system-connected BLE devices from
+      // scan results. Check for them explicitly so users who paired the DE1
+      // via System Settings can still discover it (#126).
+      if (Platform.isMacOS) {
+        try {
+          final systemDevices =
+              await FlutterBluePlus.systemDevices([Guid('1800')]);
+          _log.fine(
+            'System-connected devices check: ${systemDevices.length} found',
+          );
+          for (final device in systemDevices) {
+            final deviceId = device.remoteId.str;
+            final name = device.platformName;
+            if (_devices.any((d) => d.deviceId == deviceId)) {
+              _log.fine('System device $deviceId already discovered, skipping');
+              continue;
+            }
+            if (_devicesBeingCreated.contains(deviceId)) {
+              _log.fine(
+                'System device $deviceId already being created, skipping',
+              );
+              continue;
+            }
+            _devicesBeingCreated.add(deviceId);
+            _createDeviceFromName(deviceId, name);
+          }
+        } catch (e, st) {
+          _log.fine('System device check failed: $e', e, st);
+        }
+      }
+
       if (Platform.isLinux && _pendingDevices.isNotEmpty) {
         // On Linux/BlueZ, we must stop scanning before connecting to
         // devices. The 15s (or shorter, on early-stop) scan above has

--- a/lib/src/services/blue_plus_discovery_service.dart
+++ b/lib/src/services/blue_plus_discovery_service.dart
@@ -262,10 +262,18 @@ class BluePlusDiscoveryService extends BleDiscoveryService {
       // On macOS, CoreBluetooth may hide system-connected BLE devices from
       // scan results. Check for them explicitly so users who paired the DE1
       // via System Settings can still discover it (#126).
+      // Query with DE1 + scale service UUIDs to avoid pulling in unrelated
+      // peripherals (keyboards, mice, etc.).
       if (Platform.isMacOS) {
         try {
+          final serviceUuids = <Guid>{};
+          for (final type in [DeviceType.machine, DeviceType.scale]) {
+            for (final uuid in DeviceMatcher.serviceUuidsFor(type)) {
+              serviceUuids.add(Guid(uuid));
+            }
+          }
           final systemDevices =
-              await FlutterBluePlus.systemDevices([Guid('1800')]);
+              await FlutterBluePlus.systemDevices(serviceUuids.toList());
           _log.fine(
             'System-connected devices check: ${systemDevices.length} found',
           );

--- a/test/onboarding/troubleshooting_wizard_test.dart
+++ b/test/onboarding/troubleshooting_wizard_test.dart
@@ -115,15 +115,23 @@ void main() {
       await tester.tap(find.text("Yes, it's on"));
       await tester.pump();
 
-      // Step 2 (final on non-iOS): other apps
+      // Step 2: other apps
       expect(find.text('Is another app connected?'), findsOneWidget);
       await tester.tap(find.text("I've closed other apps"));
       await tester.pump();
+
+      // Step 3 (macOS only): system BT. Tap to dismiss.
+      if (find.text("I've checked").evaluate().isNotEmpty) {
+        await tester.tap(find.text("I've checked"));
+        await tester.pump();
+      }
+
       await tester.pump(const Duration(milliseconds: 300));
 
-      // Dialog should be dismissed
-      expect(find.text('Is another app connected?'), findsNothing);
+      // Dialog should be fully dismissed — no step content visible
       expect(find.text('Is your machine powered on?'), findsNothing);
+      expect(find.text('Is another app connected?'), findsNothing);
+      expect(find.text('Check System Bluetooth Settings'), findsNothing);
     });
 
     group('step shouldShow logic', () {
@@ -156,6 +164,44 @@ void main() {
         );
         final btStep = steps.firstWhere((s) => s.id == 'bluetooth');
         expect(btStep.shouldShow(), isFalse);
+      });
+
+      test('system_bt step shouldShow returns true on macOS', () {
+        final steps = troubleshootingSteps(
+          adapterState: AdapterState.poweredOn,
+          isMacOS: true,
+        );
+        final sysBtStep = steps.firstWhere((s) => s.id == 'system_bt');
+        expect(sysBtStep.shouldShow(), isTrue);
+      });
+
+      test('system_bt step shouldShow returns false on non-macOS', () {
+        final steps = troubleshootingSteps(
+          adapterState: AdapterState.poweredOn,
+          isMacOS: false,
+        );
+        final sysBtStep = steps.firstWhere((s) => s.id == 'system_bt');
+        expect(sysBtStep.shouldShow(), isFalse);
+      });
+
+      test('macOS flow skips bluetooth step, includes system_bt', () {
+        final steps = troubleshootingSteps(
+          adapterState: AdapterState.poweredOff,
+          isIOS: false,
+          isMacOS: true,
+        );
+        final visibleIds = steps.where((s) => s.shouldShow()).map((s) => s.id);
+        expect(visibleIds, ['machine_power', 'other_apps', 'system_bt']);
+      });
+
+      test('non-macOS/non-iOS flow excludes bluetooth and system_bt', () {
+        final steps = troubleshootingSteps(
+          adapterState: AdapterState.poweredOn,
+          isIOS: false,
+          isMacOS: false,
+        );
+        final visibleIds = steps.where((s) => s.shouldShow()).map((s) => s.id);
+        expect(visibleIds, ['machine_power', 'other_apps']);
       });
     });
 


### PR DESCRIPTION
## Summary

Two-part fix for macOS Bluetooth discovery: add a troubleshooting wizard step warning about system-level BT connections, and automatically check for system-connected DE1/scale devices that CoreBluetooth hides from app scans.

## Changes

### 1. Troubleshooting wizard — macOS system BT step (#125)

`lib/src/onboarding_feature/widgets/troubleshooting_wizard.dart`

- New `system_bt` step shown on macOS only, after "other apps" step
- Warns: if DE1 appears as "Connected" in System Settings > Bluetooth, disconnect it there first
- `troubleshootingSteps()` gains optional `isMacOS` param (mirrors existing `isIOS`)

### 2. BluePlusDiscoveryService — system-connected device check (#126)

`lib/src/services/blue_plus_discovery_service.dart`

- After BLE scan completes, on macOS: queries `FlutterBluePlus.systemDevices()` with DE1 + scale service UUIDs (via `DeviceMatcher.serviceUuidsFor()`)
- Creates devices for any system-connected peripherals not already discovered via scan
- Deduplicates against existing `_devices` list and in-flight `_devicesBeingCreated`

### 3. Tests

`test/onboarding/troubleshooting_wizard_test.dart`

- `system_bt` shows on macOS, hides on non-macOS
- macOS flow: `machine_power → other_apps → system_bt`
- Non-macOS/non-iOS flow: `machine_power → other_apps` (neither bt nor system_bt)
- Dismissal test hardened to handle platform-varying step count

## Verification

- `flutter test`: 1223/1223 pass
- `flutter analyze`: 0 new issues

Closes #125
Closes #126