### PR TITLE
Fix: show update dialog on manual check even when version was skipped (#221)

### DIFF
--- a/lib/src/services/update_check_service.dart
+++ b/lib/src/services/update_check_service.dart
@@ -95,10 +95,12 @@ class UpdateCheckService {
         if (skipped != null && skipped == updateInfo.version) {
           _log.info('Update ${updateInfo.version} skipped by user');
           _availableUpdate = null;
-          return null;
+          // Still return updateInfo — manual "Check for updates" button
+          // should show the dialog even if auto-banner is suppressed.
+        } else {
+          _log.info('Update available: ${updateInfo.version}');
+          _availableUpdate = updateInfo;
         }
-        _log.info('Update available: ${updateInfo.version}');
-        _availableUpdate = updateInfo;
       } else {
         _log.info('No update available');
         _availableUpdate = null;


### PR DESCRIPTION
Previously, `checkForUpdate()` returned `null` when the available version matched a user-skipped version. The manual "Check for updates" button interpreted this as "no update available" and showed "You are on the latest version."

Now skip only suppresses the auto-update banner (`_availableUpdate`); the return value still carries the `UpdateInfo` so the manual dialog shows the available version.

| Before | After |
|--------|-------|
| Button says "on latest version" ✗ | Dialog shows available update ✓ |
| Banner hidden for skipped ✓ | Banner hidden for skipped ✓ |

Closes #221