### PR TITLE
feat(api): document POST /api/v1/feedback + tests + standalone handler

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3507,6 +3507,46 @@ paths:
         "404":
           description: Unknown command or endpoint not available (non-simulate build)
 
+  /api/v1/feedback:
+    post:
+      summary: Submit feedback
+      description: |
+        Submits user feedback as a GitHub issue. Logs and system info are
+        attached as a private Gist when requested. Requires the app to be
+        built with `--dart-define=GITHUB_FEEDBACK_TOKEN=<token>`.
+      tags: [System]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FeedbackRequest"
+      responses:
+        "201":
+          description: Feedback submitted successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeedbackResponse"
+        "400":
+          description: Missing or empty description
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Submission failed or internal error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: Feedback service not configured (no GitHub token)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
 components:
   schemas:
     Error:
@@ -3516,6 +3556,43 @@ components:
           type: string
         st:
           type: string
+
+    FeedbackRequest:
+      type: object
+      required: [description, type]
+      properties:
+        description:
+          type: string
+          description: Description of the feedback
+        type:
+          type: string
+          enum: [bug, feature, question, other]
+          description: Type of feedback
+        includeLogs:
+          type: boolean
+          default: true
+          description: Whether to include application logs
+        includeSystemInfo:
+          type: boolean
+          default: true
+          description: Whether to include system information
+
+    FeedbackResponse:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+          description: Whether the submission was successful
+        issueUrl:
+          type: string
+          description: URL of the created GitHub issue (on success)
+        issueNumber:
+          type: integer
+          description: Issue number (on success)
+        errorMessage:
+          type: string
+          description: Error message (on failure)
 
     ConnectionError:
       type: object

--- a/lib/src/services/webserver/feedback_handler.dart
+++ b/lib/src/services/webserver/feedback_handler.dart
@@ -1,7 +1,15 @@
-part of '../webserver_service.dart';
+import 'dart:convert';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/feedback/feedback_request.dart';
+import 'package:reaprime/src/services/feedback_service.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+import 'json_response.dart';
 
 /// REST API handler for submitting user feedback as GitHub issues
 class FeedbackHandler {
+  final Logger _log = Logger('FeedbackHandler');
   final FeedbackService _service;
 
   FeedbackHandler({required FeedbackService service}) : _service = service;
@@ -43,7 +51,7 @@ class FeedbackHandler {
         return jsonError(result.toJson());
       }
     } catch (e, st) {
-      log.severe('Error in _handleSubmitFeedback', e, st);
+      _log.severe('Error in _handleSubmitFeedback', e, st);
       return jsonError({'error': 'Internal server error', 'message': '$e'});
     }
   }

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -75,6 +75,8 @@ import 'package:reaprime/src/services/webserver/debug_handler.dart';
 import 'package:mime/mime.dart';
 import 'package:path/path.dart' as p;
 
+import 'webserver/feedback_handler.dart';
+
 part 'webserver/de1handler.dart';
 part 'webserver/scale_handler.dart';
 part 'webserver/devices_handler.dart';
@@ -84,7 +86,6 @@ part 'webserver/kv_store_handler.dart';
 part 'webserver/plugins_handler.dart';
 part 'webserver/profile_handler.dart';
 part 'webserver/webui_handler.dart';
-part 'webserver/feedback_handler.dart';
 part 'webserver/logs_handler.dart';
 part 'webserver/webview_logs_handler.dart';
 part 'webserver/presence_handler.dart';

--- a/test/services/webserver/feedback_handler_test.dart
+++ b/test/services/webserver/feedback_handler_test.dart
@@ -1,0 +1,129 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/feedback/feedback_request.dart';
+import 'package:reaprime/src/models/feedback/feedback_result.dart';
+import 'package:reaprime/src/services/feedback_service.dart';
+import 'package:reaprime/src/services/webserver/feedback_handler.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+/// A stub FeedbackService for testing the handler in isolation.
+class _StubFeedbackService implements FeedbackService {
+  final bool isConfigured;
+  final FeedbackSubmissionResult Function(FeedbackRequest)? onSubmitted;
+
+  _StubFeedbackService({
+    this.isConfigured = true,
+    this.onSubmitted,
+  });
+
+  @override
+  Future<FeedbackSubmissionResult> submitFeedback(
+    FeedbackRequest request,
+  ) async {
+    if (onSubmitted != null) return onSubmitted!(request);
+    return FeedbackSubmissionResult.succeeded(
+      issueUrl: 'https://github.com/tadelv/reaprime/issues/999',
+      issueNumber: 999,
+    );
+  }
+
+  @override
+  Future<String> generateHtmlReport(FeedbackRequest request) async {
+    return '<html></html>';
+  }
+}
+
+void main() {
+  late Handler handler;
+  late _StubFeedbackService service;
+
+  Future<void> wireWith({
+    bool isConfigured = true,
+    FeedbackSubmissionResult Function(FeedbackRequest)? onSubmitted,
+  }) async {
+    service = _StubFeedbackService(
+      isConfigured: isConfigured,
+      onSubmitted: onSubmitted,
+    );
+    final feedbackHandler = FeedbackHandler(service: service);
+    final app = Router().plus;
+    feedbackHandler.addRoutes(app);
+    handler = app.call;
+  }
+
+  Future<Response> post(String path, Object body) async =>
+      await handler(Request(
+        'POST',
+        Uri.parse('http://localhost$path'),
+        body: jsonEncode(body),
+        headers: {HttpHeaders.contentTypeHeader: 'application/json'},
+      ));
+
+  group('POST /api/v1/feedback', () {
+    test('returns 201 with issue URL and number on success', () async {
+      await wireWith();
+      final res = await post('/api/v1/feedback', {
+        'description': 'Test bug report',
+        'type': 'bug',
+      });
+
+      expect(res.statusCode, 201);
+      final body = jsonDecode(await res.readAsString()) as Map<String, dynamic>;
+      expect(body['success'], true);
+      expect(body['issueUrl'], 'https://github.com/tadelv/reaprime/issues/999');
+      expect(body['issueNumber'], 999);
+    });
+
+    test('returns 400 when description is missing', () async {
+      await wireWith();
+      final res = await post('/api/v1/feedback', {
+        'type': 'bug',
+      });
+
+      expect(res.statusCode, 400);
+      final body = jsonDecode(await res.readAsString()) as Map<String, dynamic>;
+      expect(body['error'], 'Missing required field');
+    });
+
+    test('returns 400 when description is empty', () async {
+      await wireWith();
+      final res = await post('/api/v1/feedback', {
+        'description': '   ',
+        'type': 'bug',
+      });
+
+      expect(res.statusCode, 400);
+      final body = jsonDecode(await res.readAsString()) as Map<String, dynamic>;
+      expect(body['error'], 'Missing required field');
+    });
+
+    test('returns 503 when service is not configured', () async {
+      await wireWith(isConfigured: false);
+      final res = await post('/api/v1/feedback', {
+        'description': 'Test bug report',
+        'type': 'bug',
+      });
+
+      expect(res.statusCode, 503);
+      final body = jsonDecode(await res.readAsString()) as Map<String, dynamic>;
+      expect(body['error'], 'Service unavailable');
+    });
+
+    test('returns 500 when submission fails', () async {
+      await wireWith(onSubmitted: (_) {
+        return FeedbackSubmissionResult.failed('GitHub API error');
+      });
+      final res = await post('/api/v1/feedback', {
+        'description': 'Test bug report',
+        'type': 'bug',
+      });
+
+      expect(res.statusCode, 500);
+      final body = jsonDecode(await res.readAsString()) as Map<String, dynamic>;
+      expect(body['success'], false);
+      expect(body['errorMessage'], 'GitHub API error');
+    });
+  });
+}


### PR DESCRIPTION
Convert FeedbackHandler from `part of` to standalone, add OpenAPI spec, add handler tests.

- **Handler**: standalone with own imports + logger (follows existing pattern)
- **Spec**: `POST /api/v1/feedback` documented with FeedbackRequest/FeedbackResponse schemas
- **Tests**: 5 cases — 201 success, 400 missing/empty desc, 503 no token, 500 failure
- No code changes needed — endpoint already wired and functional