### PR TITLE
fix(ble): prevent LINK_SUPERVISION_TIMEOUT on machine wake with concurrent scale connect

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -156,6 +156,9 @@ void main() async {
   Logger.root.info(
     "build: ${BuildInfo.commitShort}, branch: ${BuildInfo.branch}",
   );
+  Logger.root.info(
+    "version: ${BuildInfo.version}, platform: ${Platform.operatingSystem}",
+  );
 
   // Initialize Firebase on supported platforms (not Linux/Windows, not debug, not simulate)
   final isDebugOrSimulate =

--- a/lib/src/controllers/de1_state_manager.dart
+++ b/lib/src/controllers/de1_state_manager.dart
@@ -49,6 +49,11 @@ class De1StateManager with WidgetsBindingObserver {
   // Track previous machine state for scale power management
   MachineState? _previousMachineState;
 
+  /// Cancellable timer for deferred scale reconnect after machine wake.
+  /// Prevents BLE radio starvation that causes LINK_SUPERVISION_TIMEOUT
+  /// on the DE1 when scale service discovery monopolizes the shared radio.
+  Timer? _deferredScaleScan;
+
   // Platform-specific background states
   final Set<AppLifecycleState> _backgroundStates;
 
@@ -298,9 +303,17 @@ class De1StateManager with WidgetsBindingObserver {
       }
 
       // Trigger device scan if no scale connected.
+      // Defer by 3s to let DE1 BLE connection stabilize after wake.
+      // Immediate scale connect/service-discovery starves the shared
+      // Android BLE radio and causes LINK_SUPERVISION_TIMEOUT on the DE1.
       if (!scaleConnected) {
-        _logger.info('Scale disconnected after sleep, triggering device scan');
-        _triggerScaleScan();
+        _logger.info('Scale disconnected after sleep, deferring scan 3s '
+            'to avoid BLE radio starvation');
+        _deferredScaleScan?.cancel();
+        _deferredScaleScan = Timer(const Duration(seconds: 3), () {
+          _deferredScaleScan = null;
+          _triggerScaleScan();
+        });
       }
     }
   }
@@ -566,6 +579,9 @@ class De1StateManager with WidgetsBindingObserver {
     WidgetsBinding.instance.removeObserver(this);
 
     _cleanupShotController();
+
+    _deferredScaleScan?.cancel();
+    _deferredScaleScan = null;
 
     _snapshotSubscription?.cancel();
     _snapshotSubscription = null;

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -127,11 +127,6 @@ class UnifiedDe1Transport {
     await _transport.subscribe(de1ServiceUUID, Endpoint.fwMapRequest.uuid, (d) {
       _fwMapNotification(ByteData.sublistView(Uint8List.fromList(d)));
     });
-
-    if (Platform.isAndroid) {
-      _log.info("requesting priority for $this");
-      await _transport.setTransportPriority(true);
-    }
   }
 
   Future<void> _serialConnect() async {

--- a/lib/src/services/ble/android_blue_plus_transport.dart
+++ b/lib/src/services/ble/android_blue_plus_transport.dart
@@ -51,6 +51,12 @@ class AndroidBluePlusTransport implements BLETransport {
   // spuriously on every connect().
   bool _everConnected = false;
 
+  /// Throttle window for duplicate disconnect events.
+  /// Android's BLE stack can fire onConnectionStateChange 2-4 times
+  /// for a single LINK_SUPERVISION_TIMEOUT. Deduplicate within this window.
+  static const Duration _disconnectThrottleWindow = Duration(milliseconds: 100);
+  DateTime? _lastDisconnectTime;
+
   AndroidBluePlusTransport({required String remoteId})
     : _device = BluetoothDevice(remoteId: DeviceIdentifier(remoteId)),
       _log = Logger("AndroidBPTransport-$remoteId");
@@ -64,20 +70,32 @@ class AndroidBluePlusTransport implements BLETransport {
     _nativeConnectionSub = _device.connectionState.listen((state) {
       if (state == BluetoothConnectionState.connected) {
         _everConnected = true;
-      } else if (state == BluetoothConnectionState.disconnected &&
-          _everConnected) {
-        final reason = _device.disconnectReason;
-        _log.warning(
-          'Native disconnect: platform=${reason?.platform} '
-          'code=${reason?.code} description=${reason?.description}',
-        );
-        _everConnected = false;
+        _connectionStateSubject.add(device.ConnectionState.connected);
+        return;
       }
-      _connectionStateSubject.add(
-        state == BluetoothConnectionState.connected
-            ? device.ConnectionState.connected
-            : device.ConnectionState.disconnected,
-      );
+
+      // Always emit disconnected state — but throttle duplicates.
+      // Android fires onConnectionStateChange 2-4 times for a single
+      // LINK_SUPERVISION_TIMEOUT. Throttle prevents downstream handlers
+      // (De1Controller, DisconnectSupervisor) from running N times.
+      if (state == BluetoothConnectionState.disconnected) {
+        final now = DateTime.now();
+        if (_lastDisconnectTime != null &&
+            now.difference(_lastDisconnectTime!) < _disconnectThrottleWindow) {
+          return; // duplicate event within throttle window
+        }
+        _lastDisconnectTime = now;
+
+        if (_everConnected) {
+          final reason = _device.disconnectReason;
+          _log.warning(
+            'Native disconnect: platform=${reason?.platform} '
+            'code=${reason?.code} description=${reason?.description}',
+          );
+          _everConnected = false;
+        }
+        _connectionStateSubject.add(device.ConnectionState.disconnected);
+      }
     });
 
     if (_device.isConnected) {

--- a/lib/src/services/ble/android_blue_plus_transport.dart
+++ b/lib/src/services/ble/android_blue_plus_transport.dart
@@ -136,17 +136,6 @@ class AndroidBluePlusTransport implements BLETransport {
         "for BLE stack to settle");
     await Future.delayed(_postConnectDelay);
 
-    // Request high connection priority to speed up service discovery
-    // and GATT operations on slower BLE stacks.
-    try {
-      await _device.requestConnectionPriority(
-        connectionPriorityRequest: ConnectionPriority.high,
-      );
-      _log.fine("Requested high connection priority");
-    } catch (e) {
-      _log.fine("Connection priority request failed: $e");
-    }
-
     // Request higher MTU after connection is stable (best-effort).
     try {
       await _device.requestMtu(517);


### PR DESCRIPTION
## Summary

Fixes `LINK_SUPERVISION_TIMEOUT` (Android error code 8) that disconnects the DE1 when the machine wakes from sleep and the scale scan/connect begins immediately.

## Root Cause

Android's BLE controller shares a single radio across all connections. When the DE1 wakes from sleep and the scale scan begins, the scale's BLE connect + service discovery sequence (~1.6s) monopolizes the radio. The DE1's existing connection receives zero link-layer packets, its supervision timer expires, and Android disconnects with `LINK_SUPERVISION_TIMEOUT`.

Additionally, our code called `requestConnectionPriority(HIGH)` after every connect, which sets the supervision timeout to **5 seconds** on Android 8+ (AOSP commit `d32b2d4`). Not calling it keeps the default **20 seconds** negotiated during `connectGatt`.

## Changes

### 1. Defer scale scan 3s after machine wake (`3ed31a8`)
**File:** `lib/src/controllers/de1_state_manager.dart`

When DE1 transitions from `sleeping` → `idle` and no scale is connected, defer the scale reconnect scan by 3 seconds. This gives the BLE radio time to re-establish link-layer activity with the DE1 before the scale's service discovery monopolizes it.

The deferred timer is cancellable on `dispose()` and on subsequent state transitions.

### 2. Deduplicate disconnect events with 100ms throttle (`522b44c`)
**File:** `lib/src/services/ble/android_blue_plus_transport.dart`

Android's BLE stack fires `onConnectionStateChange` 2-4 times for a single `LINK_SUPERVISION_TIMEOUT`. flutter_blue_plus forwards every invocation. A 100ms throttle window now gates both the warning log and the `_connectionStateSubject` emission, preventing downstream handlers (`De1Controller._onDisconnect`, `DisconnectSupervisor`) from running N times for the same physical disconnect.

### 3. Drop `requestConnectionPriority(HIGH)` — keep default 20s timeout (`26ce901`)
**Files:** `lib/src/services/ble/android_blue_plus_transport.dart`, `lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart`

Calling `requestConnectionPriority()` with ANY value on Android 8+ sets supervision timeout to 5s. Not calling it keeps the default 20s timeout. DE1 MMR reads/writes are 20-byte payloads and state notifications arrive at ~100ms intervals — the 11ms connection interval (HIGH) vs 30ms (default) makes no practical difference for our data patterns.

## Testing

- ✅ REST API wake path — `sendUserPresent` + 3s deferral → DE1 stays connected through scale connect
- ✅ Overnight test — scale connected in morning, espresso shot pulled, no timeout
- ✅ No GATT 133 regression — connection stable with default 20s timeout
- ✅ No duplicate disconnect events — 100ms throttle working
- ✅ `flutter analyze` clean, all existing tests pass