### PR TITLE
CI harness for outside contributors + analyzer cleanup

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -61,8 +61,19 @@ jobs:
       - name: Flutter analyze
         run: flutter analyze
 
+      # flutter_js' QuickJS bridge ships a prebuilt .so inside its pub-cache
+      # checkout. macOS resolves it via @rpath automatically, but on Linux the
+      # test runner needs LD_LIBRARY_PATH pointed at it.
       - name: Flutter test
-        run: flutter test --reporter=expanded
+        run: |
+          QUICKJS_LIB_DIR=$(find "$HOME/.pub-cache/git" -path '*dart_js*/linux/shared' -type d | head -1)
+          if [ -z "$QUICKJS_LIB_DIR" ]; then
+            echo "Could not locate flutter_js native lib dir under ~/.pub-cache/git"
+            exit 1
+          fi
+          echo "Using QuickJS lib dir: $QUICKJS_LIB_DIR"
+          LD_LIBRARY_PATH="$QUICKJS_LIB_DIR:${LD_LIBRARY_PATH:-}" \
+            flutter test --reporter=expanded
 
   build-smoke:
     name: Linux build smoke

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -28,8 +28,29 @@ jobs:
           channel: stable
           cache: true
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: packages/dye2-plugin/package-lock.json
+
       - name: Flutter pub get
         run: flutter pub get
+
+      # pubspec references assets/plugins/dye2.reaplugin/ and
+      # assets/bundled_skins/. Both are build outputs, not checked in,
+      # so populate them before any flutter command that touches assets
+      # (analyze emits asset_directory_does_not_exist; test loads the
+      # bundled_skins manifest at runtime).
+      - name: Build DYE2 plugin
+        working-directory: packages/dye2-plugin
+        run: |
+          npm ci
+          npm run build
+
+      - name: Bundle skins
+        run: bash bundle_skins.sh
 
       # Format check is advisory until the codebase has been mass-reformatted
       # for Dart 3.7+ "tall style". Once that lands, drop continue-on-error.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,12 +16,8 @@ permissions:
 jobs:
   flutter:
     name: Format / analyze / test
-    # Runs on macOS to match the author's dev env. The test suite contains
-    # platform-coupled tests (display_controller_test brightness/battery-cap
-    # cases) that assume Platform.isMacOS; running them on Linux fails.
-    # The Linux build itself is still exercised by build-smoke below.
-    runs-on: macos-latest
-    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -65,8 +61,19 @@ jobs:
       - name: Flutter analyze
         run: flutter analyze
 
+      # flutter_js' QuickJS bridge ships a prebuilt .so inside its pub-cache
+      # checkout. macOS resolves it via @rpath automatically, but on Linux the
+      # test runner needs LD_LIBRARY_PATH pointed at it.
       - name: Flutter test
-        run: flutter test --reporter=expanded
+        run: |
+          QUICKJS_LIB_DIR=$(find "$HOME/.pub-cache/git" -path '*dart_js*/linux/shared' -type d | head -1)
+          if [ -z "$QUICKJS_LIB_DIR" ]; then
+            echo "Could not locate flutter_js native lib dir under ~/.pub-cache/git"
+            exit 1
+          fi
+          echo "Using QuickJS lib dir: $QUICKJS_LIB_DIR"
+          LD_LIBRARY_PATH="$QUICKJS_LIB_DIR:${LD_LIBRARY_PATH:-}" \
+            flutter test --reporter=expanded
 
   build-smoke:
     name: Linux build smoke

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,8 +16,12 @@ permissions:
 jobs:
   flutter:
     name: Format / analyze / test
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Runs on macOS to match the author's dev env. The test suite contains
+    # platform-coupled tests (display_controller_test brightness/battery-cap
+    # cases) that assume Platform.isMacOS; running them on Linux fails.
+    # The Linux build itself is still exercised by build-smoke below.
+    runs-on: macos-latest
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -61,19 +65,8 @@ jobs:
       - name: Flutter analyze
         run: flutter analyze
 
-      # flutter_js' QuickJS bridge ships a prebuilt .so inside its pub-cache
-      # checkout. macOS resolves it via @rpath automatically, but on Linux the
-      # test runner needs LD_LIBRARY_PATH pointed at it.
       - name: Flutter test
-        run: |
-          QUICKJS_LIB_DIR=$(find "$HOME/.pub-cache/git" -path '*dart_js*/linux/shared' -type d | head -1)
-          if [ -z "$QUICKJS_LIB_DIR" ]; then
-            echo "Could not locate flutter_js native lib dir under ~/.pub-cache/git"
-            exit 1
-          fi
-          echo "Using QuickJS lib dir: $QUICKJS_LIB_DIR"
-          LD_LIBRARY_PATH="$QUICKJS_LIB_DIR:${LD_LIBRARY_PATH:-}" \
-            flutter test --reporter=expanded
+        run: flutter test --reporter=expanded
 
   build-smoke:
     name: Linux build smoke

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,82 @@
+name: PR checks
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: pr-checks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  flutter:
+    name: Format / analyze / test
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      # Format check is advisory until the codebase has been mass-reformatted
+      # for Dart 3.7+ "tall style". Once that lands, drop continue-on-error.
+      - name: Dart format check (advisory)
+        continue-on-error: true
+        run: dart format --output=none --set-exit-if-changed lib test
+
+      - name: Flutter analyze
+        run: flutter analyze
+
+      - name: Flutter test
+        run: flutter test --reporter=expanded
+
+  build-smoke:
+    name: Linux build smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Linux dependencies
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: packages/dye2-plugin/package-lock.json
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build DYE2 plugin
+        working-directory: packages/dye2-plugin
+        run: |
+          npm ci
+          npm run build
+
+      - name: Build Linux app (unsigned)
+        run: flutter build linux --release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing to Decent.app
+
+Thanks for taking the time to contribute. This guide covers the basics so your PR lands smoothly.
+
+> **Naming note:** The display name is **Decent.app**. The repo, package, and bundle ID still use legacy `reaprime` / `streamline-bridge` identifiers — see the naming table in [`CLAUDE.md`](CLAUDE.md) before renaming anything.
+
+## Before you start
+
+For non-trivial features, open an issue first to align on scope. Small fixes can go straight to a PR.
+
+## Local setup
+
+Requirements:
+
+- Flutter (stable channel)
+- Node.js 20+ (for the bundled DYE2 plugin)
+- Optional: a DE1 / Bengle machine and a compatible scale, or use simulated devices.
+
+```bash
+flutter pub get
+(cd packages/dye2-plugin && npm ci && npm run build)
+
+# Run with simulated hardware (no machine/scale required):
+flutter run --dart-define=simulate=1
+```
+
+See [`CLAUDE.md`](CLAUDE.md) for the full command reference and architecture overview.
+
+## Branch & PR workflow
+
+- Branch from `main`. Push the branch to your fork and open a PR against `tadelv/reaprime:main`.
+- Keep PRs focused — one feature or fix per PR.
+- Reference the issue you're closing in the PR description (`Fixes #123`).
+- A maintainer will review; expect a few rounds of feedback.
+
+## Required checks
+
+Every PR runs through [`.github/workflows/pr-checks.yml`](.github/workflows/pr-checks.yml). Before pushing, run the same checks locally:
+
+```bash
+dart format --output=none --set-exit-if-changed lib test  # advisory for now
+flutter analyze
+flutter test
+(cd packages/dye2-plugin && npm run build)
+```
+
+`dart format` is currently **advisory** in CI — the codebase predates the Dart 3.7 "tall style" formatter and a mass-reformat hasn't happened yet. Format your own changes (`dart format lib test`) but don't reformat untouched files in the same PR.
+
+## Tests
+
+The project uses three test tiers:
+
+| Tier | Where | Mocks |
+|------|-------|-------|
+| Unit | `test/` | Direct collaborators |
+| Integration | `test/integration/` | Only the transport edge |
+| End-to-end | `.agents/skills/decent-app/scenarios/` (markdown recipes) | App runs in `simulate=1` mode |
+
+**New behavior needs a test.** API handlers in `lib/src/services/webserver/` have a strong unit-test convention — see `test/services/webserver/de1handler_cup_warmer_test.dart` for a template.
+
+For the end-to-end smoke-test recipe (start app, drive it via `curl` / `websocat`), see [`.agents/skills/decent-app/verification.md`](.agents/skills/decent-app/verification.md).
+
+## Documentation obligations
+
+These are not optional — the spec and docs are part of the API contract:
+
+- **REST or WebSocket change** → update `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` **in the same PR**.
+- **User-facing API change** → update `doc/Api.md`.
+- **Plugin / skin / profile / device-management surface change** → update the matching file under `doc/`.
+
+Stale specs mislead clients and downstream agents.
+
+## Code style
+
+- `dart format` is the source of truth. CI fails on unformatted code.
+- `flutter analyze` must be clean. Don't merge with new warnings.
+- No 3rd-party BLE library imports outside `lib/src/services/ble/` — wrap library-specific types at the transport boundary.
+- Constructor dependency injection, no service locators.
+- See [`CLAUDE.md`](CLAUDE.md) → *Conventions & Gotchas* for the full list (RxDart patterns, StreamBuilder rules, BLE discovery, workflow dual-representation, etc.).
+
+## Commit messages
+
+Conventional Commits style (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`). Keep the subject ≤72 chars; explain the *why* in the body when it isn't obvious from the diff.
+
+## License & sign-off
+
+By submitting a PR you agree your contribution is licensed under the same terms as the rest of the repository. No CLA required.
+
+## Questions
+
+Open an issue or start a discussion. For agent-specific guidance (Claude Code / Cursor / etc.), see `AGENTS.md` and `CLAUDE.md`.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,6 +9,12 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+# Formatter configuration (Dart 3.7+). `dart format` and CI's
+# `dart format --set-exit-if-changed lib test` use this.
+formatter:
+  page_width: 80
+  trailing_commas: preserve
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:ui';
 import 'package:collection/collection.dart';
 // import 'package:flutter/scheduler.dart';
-import 'package:hive_ce/hive.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:path_provider/path_provider.dart';
 

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/main.dart';
 // import 'package:flutter_gen/gen_l10n/app_localizations.dart';

--- a/lib/src/controllers/device_controller.dart
+++ b/lib/src/controllers/device_controller.dart
@@ -22,6 +22,7 @@ class DeviceController implements DeviceScanner {
 
   final BehaviorSubject<bool> _scanningStream = BehaviorSubject.seeded(false);
 
+  @override
   Stream<bool> get scanningStream => _scanningStream.stream;
   bool get isScanning => _scanningStream.value;
 
@@ -81,6 +82,7 @@ class DeviceController implements DeviceScanner {
   /// telemetry + scan-cleanup were paying the fold cost per call).
   List<Device>? _flatDevicesCache;
 
+  @override
   List<Device> get devices {
     final cached = _flatDevicesCache;
     if (cached != null) return cached;
@@ -231,6 +233,7 @@ class DeviceController implements DeviceScanner {
   }
 
   /// Stop all in-progress scans across all discovery services.
+  @override
   void stopScan() {
     for (final service in _services) {
       service.stopScan();

--- a/lib/src/controllers/display_controller.dart
+++ b/lib/src/controllers/display_controller.dart
@@ -127,6 +127,7 @@ class DisplayController {
     Future<void> Function()? resetBrightness,
     Future<void> Function()? enableWakeLock,
     Future<void> Function()? disableWakeLock,
+    DisplayPlatformSupport? platformSupport,
   })  : _de1Controller = de1Controller,
         _settingsController = settingsController,
         _batteryStateStream = batteryStateStream,
@@ -136,11 +137,14 @@ class DisplayController {
             _defaultScreenBrightness.resetApplicationScreenBrightness,
         _enableWakeLock = enableWakeLock ?? WakelockPlus.enable,
         _disableWakeLock = disableWakeLock ?? WakelockPlus.disable {
-    _platformSupport = DisplayPlatformSupport(
-      brightness:
-          Platform.isAndroid || Platform.isIOS || Platform.isMacOS || Platform.isWindows,
-      wakeLock: true, // wakelock_plus supports all platforms
-    );
+    _platformSupport = platformSupport ??
+        DisplayPlatformSupport(
+          brightness: Platform.isAndroid ||
+              Platform.isIOS ||
+              Platform.isMacOS ||
+              Platform.isWindows,
+          wakeLock: true, // wakelock_plus supports all platforms
+        );
 
     _stateSubject = BehaviorSubject.seeded(DisplayState(
       wakeLockEnabled: false,

--- a/lib/src/controllers/scale_controller.dart
+++ b/lib/src/controllers/scale_controller.dart
@@ -98,7 +98,7 @@ class ScaleController {
     windowDuration: smoothingWindowDuration,
   );
 
-  _processSnapshot(ScaleSnapshot snapshot) {
+  void _processSnapshot(ScaleSnapshot snapshot) {
     final flow = _flowCalculator.addSample(snapshot.timestamp, snapshot.weight);
 
     weightFlowAverage.add(flow); // Use your existing average queue
@@ -114,7 +114,7 @@ class ScaleController {
     );
   }
 
-  _processConnection(ConnectionState d) {
+  void _processConnection(ConnectionState d) {
     log.info('scale connection update: ${d.name}');
     _connectionController.add(d);
     if (d == ConnectionState.disconnected) {

--- a/lib/src/controllers/shot_controller.dart
+++ b/lib/src/controllers/shot_controller.dart
@@ -126,7 +126,7 @@ class ShotController {
   bool _scaleLost = false;
   StreamSubscription<device.ConnectionState>? _scaleConnectionSubscription;
 
-  _processSnapshot(ShotSnapshot snapshot) {
+  void _processSnapshot(ShotSnapshot snapshot) {
     _log.finest("Processing snapshot");
 
     // Update volume calculation

--- a/lib/src/home_feature/tiles/profile_tile.dart
+++ b/lib/src/home_feature/tiles/profile_tile.dart
@@ -55,7 +55,7 @@ class _ProfileState extends State<ProfileTile> {
     super.dispose();
   }
 
-  _workflowChange() {
+  void _workflowChange() {
     setState(() {
       if (loadedProfile != widget.workflowController.currentWorkflow.profile) {
         _log.info(
@@ -591,7 +591,7 @@ class _ProfileState extends State<ProfileTile> {
                             labelText: 'Select grinder',
                             isDense: true,
                           ),
-                          value: selectedGrinder?.id,
+                          initialValue: selectedGrinder?.id,
                           hint: const Text('Choose a grinder...'),
                           isExpanded: true,
                           items: grinders.map((g) {
@@ -1106,7 +1106,7 @@ class _BeanBatchPickerWidgetState extends State<_BeanBatchPickerWidget> {
                   labelText: 'Select coffee bean',
                   isDense: true,
                 ),
-                value: _selectedBeanId,
+                initialValue: _selectedBeanId,
                 hint: const Text('Choose a bean...'),
                 isExpanded: true,
                 items: widget.beans.map((b) {
@@ -1167,7 +1167,7 @@ class _BeanBatchPickerWidgetState extends State<_BeanBatchPickerWidget> {
                 labelText: 'Select batch',
                 isDense: true,
               ),
-              value: widget.currentBatchId != null &&
+              initialValue: widget.currentBatchId != null &&
                       _batches.any((b) => b.id == widget.currentBatchId)
                   ? widget.currentBatchId
                   : null,

--- a/lib/src/home_feature/tiles/profile_tile.dart
+++ b/lib/src/home_feature/tiles/profile_tile.dart
@@ -953,16 +953,6 @@ class _ProfileState extends State<ProfileTile> {
     );
   }
 
-  // Keep for backward compatibility (used in tests)
-  Column _coffeeDataForm() {
-    final ctx = widget.workflowController.currentWorkflow.context ?? WorkflowContext();
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        _coffeeFreeformFields(ctx, (fn) => fn()),
-      ],
-    );
-  }
 }
 
 /// Two-step bean → batch picker widget with its own state for batch loading.

--- a/lib/src/home_feature/tiles/profile_tile.dart
+++ b/lib/src/home_feature/tiles/profile_tile.dart
@@ -241,14 +241,13 @@ class _ProfileState extends State<ProfileTile> {
     double seconds = 0;
     double previousTarget = 0.0;
     bool previousFlow = false;
-    for (final (index, step) in profile.steps.indexed) {
+    for (final (_, step) in profile.steps.indexed) {
       final isFlow = step is ProfileStepFlow;
       final isFast = step.transition == TransitionType.fast;
       final flow = isFlow ? step.getTarget() : 0.0;
       final pressure = isFlow ? 0.0 : step.getTarget();
       final flowLimit = isFlow ? 0.0 : step.limiter?.value ?? 0.0;
       final pressureLimit = isFlow ? step.limiter?.value ?? 0.0 : 0.0;
-      final isSwitched = (isFlow && !previousFlow) || (!isFlow && previousFlow);
       if (isFast) {
         previousTarget = isFlow ? flow : pressure;
       }

--- a/lib/src/home_feature/tiles/status_tile.dart
+++ b/lib/src/home_feature/tiles/status_tile.dart
@@ -467,7 +467,7 @@ class _StatusTileState extends State<StatusTile> {
                 children: [
                   SizedBox(
                     width: 100,
-                    child: Text("${_machineSnapshot!.state.state.name}"),
+                    child: Text(_machineSnapshot!.state.state.name),
                   ),
                   SizedBox(
                     width: boxWidth,

--- a/lib/src/import/widgets/import_result_view.dart
+++ b/lib/src/import/widgets/import_result_view.dart
@@ -239,7 +239,9 @@ class _ImportResultViewState extends State<ImportResultView> {
       }
 
       if (Platform.isAndroid || Platform.isIOS) {
-        await Share.shareXFiles([XFile(reportFile.path)]);
+        await SharePlus.instance.share(
+          ShareParams(files: [XFile(reportFile.path)]),
+        );
       } else {
         final bytes = await reportFile.readAsBytes();
         await FilePicker.saveFile(

--- a/lib/src/landing_feature/landing_feature.dart
+++ b/lib/src/landing_feature/landing_feature.dart
@@ -259,26 +259,6 @@ class _LandingState extends State<LandingFeature> {
     );
   }
 
-  Widget _buildLoadingView() {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Semantics(
-          label: 'Starting WebUI server',
-          child: CircularProgressIndicator(),
-        ),
-        const SizedBox(height: 16),
-        Semantics(
-          liveRegion: true,
-          child: Text(
-            'Starting WebUI server...',
-            style: Theme.of(context).textTheme.bodyLarge,
-          ),
-        ),
-      ],
-    );
-  }
-
   Widget _buildSkinSelectionView() {
     final skins = widget.webUIStorage.installedSkins;
 

--- a/lib/src/models/data/json_utils.dart
+++ b/lib/src/models/data/json_utils.dart
@@ -1,4 +1,5 @@
 /// Utility functions for JSON manipulation
+library;
 
 /// Deep merges two JSON objects.
 /// 

--- a/lib/src/models/data/profile.dart
+++ b/lib/src/models/data/profile.dart
@@ -134,7 +134,7 @@ class StepLimiter extends Equatable {
   final double value;
   final double range;
 
-  StepLimiter({required this.value, required this.range});
+  const StepLimiter({required this.value, required this.range});
 
   factory StepLimiter.fromJson(Map<String, dynamic> json) {
     return StepLimiter(
@@ -165,7 +165,7 @@ abstract class ProfileStep extends Equatable {
   final TemperatureSensor sensor;
   final StepLimiter? limiter;
 
-  ProfileStep({
+  const ProfileStep({
     required this.name,
     required this.transition,
     this.exit,
@@ -199,7 +199,7 @@ abstract class ProfileStep extends Equatable {
 class ProfileStepPressure extends ProfileStep {
   final double pressure;
 
-  ProfileStepPressure({
+  const ProfileStepPressure({
     required super.name,
     required super.transition,
     super.exit,
@@ -286,7 +286,7 @@ class ProfileStepPressure extends ProfileStep {
 class ProfileStepFlow extends ProfileStep {
   final double flow;
 
-  ProfileStepFlow({
+  const ProfileStepFlow({
     required super.name,
     required super.transition,
     super.exit,
@@ -374,7 +374,7 @@ class StepExitCondition extends Equatable {
   final ExitCondition condition;
   final double value;
 
-  StepExitCondition({
+  const StepExitCondition({
     required this.type,
     required this.condition,
     required this.value,

--- a/lib/src/models/data/profile_record.dart
+++ b/lib/src/models/data/profile_record.dart
@@ -51,7 +51,7 @@ extension VisibilityExtension on Visibility {
 @immutable
 class ProfileRecord extends Equatable {
   /// Unique identifier based on profile content hash
-  /// Format: profile:<first_20_chars_of_hash>
+  /// Format: `profile:<first_20_chars_of_hash>`
   final String id;
 
   /// The actual profile data

--- a/lib/src/models/data/shot_snapshot.dart
+++ b/lib/src/models/data/shot_snapshot.dart
@@ -8,7 +8,7 @@ class ShotSnapshot {
 
   ShotSnapshot({required this.machine, this.scale, this.volume});
 
-  copyWith({MachineSnapshot? machine, WeightSnapshot? scale, double? volume}) {
+  ShotSnapshot copyWith({MachineSnapshot? machine, WeightSnapshot? scale, double? volume}) {
     return ShotSnapshot(
       machine: machine ?? this.machine,
       scale: scale ?? this.scale,
@@ -16,7 +16,7 @@ class ShotSnapshot {
     );
   }
 
-  toJson() {
+  Map<String, Object?> toJson() {
     return {
       "machine": machine.toJson(),
       "scale": scale?.toJson(),

--- a/lib/src/models/device/impl/bengle/bengle.dart
+++ b/lib/src/models/device/impl/bengle/bengle.dart
@@ -2,7 +2,6 @@ import 'package:flutter/foundation.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
-import 'package:reaprime/src/models/device/led_strip.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 
 class Bengle extends UnifiedDe1
@@ -58,19 +57,8 @@ class Bengle extends UnifiedDe1
 
   // --- LED strip ---
 
-  @override
-  Stream<LedStripState> get ledStripState => super.ledStripState;
 
-  @override
-  Future<LedStripState> getLedStripState() => super.getLedStripState();
 
-  @override
-  Future<void> setLedStrip(LedStripState state) =>
-      super.setLedStrip(state);
 
-  @override
-  Future<void> commitLedStrip() => super.commitLedStrip();
 
-  @override
-  Future<void> resetLedStrip() => super.resetLedStrip();
 }

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:logging/logging.dart';

--- a/lib/src/models/device/impl/mock_de1/mock_de1.dart
+++ b/lib/src/models/device/impl/mock_de1/mock_de1.dart
@@ -462,7 +462,6 @@ class MockDe1 implements De1Interface {
     }
   }
 
-  @override
   Future<void> onDisconnect() async {
     _stateTimer?.cancel();
   }

--- a/lib/src/models/device/impl/mock_de1/mock_de1.dart
+++ b/lib/src/models/device/impl/mock_de1/mock_de1.dart
@@ -15,7 +15,7 @@ enum _SimulationType { espresso, steam, hotWater, idle }
 class MockDe1 implements De1Interface {
   MockDe1({String deviceId = "MockDe1"}) : _deviceId = deviceId;
 
-  StreamController<MachineSnapshot> _snapshotStream =
+  final StreamController<MachineSnapshot> _snapshotStream =
       StreamController.broadcast();
 
   final _log = Logger("MockDe1");
@@ -56,7 +56,7 @@ class MockDe1 implements De1Interface {
   @override
   Stream<MachineSnapshot> get currentSnapshot => _snapshotStream.stream;
 
-  String _deviceId = "MockDe1";
+  final String _deviceId;
 
   @override
   String get deviceId => _deviceId;
@@ -127,7 +127,7 @@ class MockDe1 implements De1Interface {
   DeviceType get type => DeviceType.machine;
 
   DateTime lastIdleSnapshot = DateTime.now();
-  _simulateState() {
+  void _simulateState() {
     _snapshotStream.add(_lastSnapshot);
 
     _stateTimer = Timer.periodic(Duration(milliseconds: 100), (t) {
@@ -196,7 +196,7 @@ class MockDe1 implements De1Interface {
   int _espressoTickCount = 0;
   int _pouringDoneTicks = 0;
 
-  _simulateEspresso() {
+  MachineSnapshot _simulateEspresso() {
     MachineSubstate substate = _lastSnapshot.state.substate;
 
     // Determine substate based on pressure

--- a/lib/src/models/device/impl/mock_de1/mock_de1.dart
+++ b/lib/src/models/device/impl/mock_de1/mock_de1.dart
@@ -10,6 +10,8 @@ import 'package:reaprime/src/models/device/de1_rawmessage.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:rxdart/subjects.dart';
 
+// steam and hotWater are placeholders for future simulation modes.
+// ignore: unused_field
 enum _SimulationType { espresso, steam, hotWater, idle }
 
 class MockDe1 implements De1Interface {

--- a/lib/src/models/device/impl/mock_de1/mock_de1.dart
+++ b/lib/src/models/device/impl/mock_de1/mock_de1.dart
@@ -448,22 +448,6 @@ class MockDe1 implements De1Interface {
     }
   }
 
-  double _calculateValueTowardTarget({
-    required double current,
-    required double target,
-    required double rate,
-    double maxValue = double.infinity,
-  }) {
-    if ((current - target).abs() < rate) {
-      return target;
-    }
-    if (current < target) {
-      return min(current + rate, min(target, maxValue));
-    } else {
-      return max(current - rate, target);
-    }
-  }
-
   Future<void> onDisconnect() async {
     _stateTimer?.cancel();
   }

--- a/lib/src/models/device/impl/sensor/debug_port.dart
+++ b/lib/src/models/device/impl/sensor/debug_port.dart
@@ -30,7 +30,7 @@ class DebugPort implements Sensor {
   Stream<Map<String, dynamic>> get data => _streamSubject.asBroadcastStream();
 
   @override
-  String get deviceId => "${_transport.id}";
+  String get deviceId => _transport.id;
 
   @override
   disconnect() async { 

--- a/lib/src/models/device/impl/sensor/debug_port.dart
+++ b/lib/src/models/device/impl/sensor/debug_port.dart
@@ -114,7 +114,7 @@ class DebugPort implements Sensor {
     Map<String, dynamic> values = {};
     values['timestamp'] = DateTime.now().toIso8601String();
 
-    values['output'] = AnsiParser(_buffer + split.first).removeAll();
+    values['output'] = Parser(_buffer + split.first).removeAll();
     _streamSubject.add(values);
 
     _buffer = split[1].replaceAll('\n', '');

--- a/lib/src/models/device/impl/sensor/sensor_basket.dart
+++ b/lib/src/models/device/impl/sensor/sensor_basket.dart
@@ -25,7 +25,7 @@ class SensorBasket implements Sensor {
   Stream<Map<String, dynamic>> get data => _streamSubject.asBroadcastStream();
 
   @override
-  String get deviceId => "${_transport.id}";
+  String get deviceId => _transport.id;
 
   @override
   disconnect() async {

--- a/lib/src/permissions_feature/permissions_view.dart
+++ b/lib/src/permissions_feature/permissions_view.dart
@@ -62,7 +62,7 @@ class _PermissionsViewState extends State<PermissionsView> {
     );
   }
 
-  Widget _permissions(context) {
+  Widget _permissions(BuildContext context) {
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -199,9 +199,6 @@ class PluginLoaderService {
 
     _log.info('Reloading plugin: $pluginId');
 
-    // Get current settings to preserve them
-    final settings = await pluginSettings(pluginId);
-
     // Unload the plugin
     await unloadPlugin(pluginId);
 

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -321,7 +321,7 @@ class PluginManager {
         };
         
         // Inject and evaluate the plugin code
-        ${jsCode}
+        $jsCode
         
         // The plugin must export a function named 'createPlugin'
         if (typeof createPlugin !== 'function') {

--- a/lib/src/realtime_steam_feature/realtime_steam_feature.dart
+++ b/lib/src/realtime_steam_feature/realtime_steam_feature.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/models/data/shot_snapshot.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
@@ -29,6 +30,8 @@ class RealtimeSteamFeature extends StatefulWidget {
 }
 
 class _RealtimeSteamFeatureState extends State<RealtimeSteamFeature> {
+  static final _log = Logger('RealtimeSteamFeature');
+
   late De1Controller _de1Controller;
   final List<ShotSnapshot> _steamSnapshots = [];
   late StreamSubscription<ShotSnapshot> _steamSubscription;
@@ -71,7 +74,7 @@ class _RealtimeSteamFeatureState extends State<RealtimeSteamFeature> {
 
               // Add snapshot only when actively steaming
               if (_steamActive) {
-                print("adding snap");
+                _log.finest("adding snap");
                 _steamSnapshots.add(snapshot);
               }
             });
@@ -100,7 +103,7 @@ class _RealtimeSteamFeatureState extends State<RealtimeSteamFeature> {
   }
 
   void _stopSteam() {
-    print("stop steam $_steamActive");
+    _log.fine("stop steam $_steamActive");
     if (_steamActive) {
       setState(() {
         _steamActive = false;

--- a/lib/src/realtime_steam_feature/realtime_steam_feature.dart
+++ b/lib/src/realtime_steam_feature/realtime_steam_feature.dart
@@ -100,7 +100,7 @@ class _RealtimeSteamFeatureState extends State<RealtimeSteamFeature> {
   }
 
   void _stopSteam() {
-    print("stop steam ${_steamActive}");
+    print("stop steam $_steamActive");
     if (_steamActive) {
       setState(() {
         _steamActive = false;

--- a/lib/src/services/ble/linux_ble_discovery_service.dart
+++ b/lib/src/services/ble/linux_ble_discovery_service.dart
@@ -256,14 +256,6 @@ class LinuxBleDiscoveryService extends BleDiscoveryService {
         "Scan complete. Found ${_pendingDevices.length} device(s) to process");
   }
 
-  bool _isBleDeviceId(String deviceId) {
-    final macPattern = RegExp(r'^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$');
-    final uuidPattern = RegExp(
-      r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$',
-    );
-    return macPattern.hasMatch(deviceId) || uuidPattern.hasMatch(deviceId);
-  }
-
   @override
   void stopScan() {
     // Refresh scan runs post-main-scan to reset BlueZ's internal

--- a/lib/src/services/blue_plus_discovery_service.dart
+++ b/lib/src/services/blue_plus_discovery_service.dart
@@ -30,8 +30,6 @@ class BluePlusDiscoveryService extends BleDiscoveryService {
   // to avoid BlueZ le-connection-abort-by-local errors
   final List<_PendingDevice> _pendingDevices = [];
 
-  StreamSubscription<String>? _logSubscription;
-
   BluePlusDiscoveryService();
 
   @override
@@ -91,9 +89,6 @@ class BluePlusDiscoveryService extends BleDiscoveryService {
   @override
   Future<void> initialize() async {
     await FlutterBluePlus.setLogLevel(LogLevel.warning);
-    _logSubscription = FlutterBluePlus.logs.listen((logMessage) {
-      _log.fine("BP Native: $logMessage");
-    });
     await FlutterBluePlus.setOptions(showPowerAlert: true);
     _log.info("initialized");
   }

--- a/lib/src/services/blue_plus_discovery_service.dart
+++ b/lib/src/services/blue_plus_discovery_service.dart
@@ -98,16 +98,6 @@ class BluePlusDiscoveryService extends BleDiscoveryService {
     _log.info("initialized");
   }
 
-  bool _isBleDeviceId(String deviceId) {
-    // MAC address format: AA:BB:CC:DD:EE:FF
-    final macPattern = RegExp(r'^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$');
-    // UUID format: 8-4-4-4-12 hex chars
-    final uuidPattern = RegExp(
-      r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$',
-    );
-    return macPattern.hasMatch(deviceId) || uuidPattern.hasMatch(deviceId);
-  }
-
   @override
   void stopScan() {
     _cancelScanDurationWait();

--- a/lib/src/services/blue_plus_discovery_service.dart
+++ b/lib/src/services/blue_plus_discovery_service.dart
@@ -229,7 +229,7 @@ class BluePlusDiscoveryService extends BleDiscoveryService {
       final useFilter = filter != null && filter.isFiltered;
       if (useFilter) {
         final guidList = <Guid>[];
-        if (filter!.deviceTypes != null) {
+        if (filter.deviceTypes != null) {
           for (final type in filter.deviceTypes!) {
             guidList.addAll(
               DeviceMatcher.serviceUuidsFor(type).map((s) => Guid(s)),

--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -17,6 +17,8 @@ import 'usb_ids.dart';
 import 'utils.dart';
 import 'package:rxdart/subjects.dart';
 
+// usb_serial is pulled in transitively via flutter_libserialport's git source.
+// ignore: depend_on_referenced_packages
 import 'package:usb_serial/usb_serial.dart';
 
 class SerialServiceAndroid implements DeviceDiscoveryService {

--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -22,7 +22,7 @@ import 'package:usb_serial/usb_serial.dart';
 class SerialServiceAndroid implements DeviceDiscoveryService {
   final _log = Logger("Android Serial service");
 
-  List<Device> _devices = [];
+  final List<Device> _devices = [];
   
   // Guard against concurrent scans
   bool _isScanning = false;
@@ -37,7 +37,7 @@ class SerialServiceAndroid implements DeviceDiscoveryService {
   @override
   Future<void> initialize() async {
     List<UsbDevice> devices = await UsbSerial.listDevices();
-    _log.info("found ${devices}");
+    _log.info("found $devices");
 
     UsbSerial.usbEventStream?.listen((data) async {
       switch (data.event) {
@@ -262,7 +262,7 @@ class SerialServiceAndroid implements DeviceDiscoveryService {
       _log.info(
         "Collected serial data: ${combined.map((e) => e.toRadixString(16).padLeft(2, '0'))}",
       );
-      _log.info("parsed into strings: ${strings}");
+      _log.info("parsed into strings: $strings");
 
       // Heuristic checks for device type
       if (strings.any((s) => s.startsWith('R '))) {

--- a/lib/src/services/serial/serial_service_desktop.dart
+++ b/lib/src/services/serial/serial_service_desktop.dart
@@ -297,7 +297,7 @@ class SerialServiceDesktop implements DeviceDiscoveryService {
         _log.warning("failed to decode:", e);
       }
       _log.info("Collected serial data: ${combined.map((e) => e.toRadixString(16).padLeft(2,'0'))}");
-      _log.info("parsed into strings: ${strings}");
+      _log.info("parsed into strings: $strings");
       if (combined.isEmpty && strings.isEmpty) {
         throw ('no data collected');
       }
@@ -536,7 +536,7 @@ class _DesktopSerialPort implements SerialTransport {
           disconnect();
         },
       );
-      _log.fine("port subscribed: ${_portSubscription} ($readerTag)");
+      _log.fine("port subscribed: $_portSubscription ($readerTag)");
     });
     _open.add(ConnectionState.connected);
   }

--- a/lib/src/services/serial/serial_service_desktop.dart
+++ b/lib/src/services/serial/serial_service_desktop.dart
@@ -19,6 +19,8 @@ import 'utils.dart';
 
 import 'package:rxdart/subjects.dart';
 
+// libserialport is supplied via dependency_overrides (git fork).
+// ignore: depend_on_referenced_packages
 import 'package:libserialport/libserialport.dart';
 
 class SerialServiceDesktop implements DeviceDiscoveryService {

--- a/lib/src/services/serial/utils.dart
+++ b/lib/src/services/serial/utils.dart
@@ -1,9 +1,13 @@
 import 'dart:typed_data';
 
+import 'package:logging/logging.dart';
+
+final _log = Logger('SerialUtils');
+
 // ---- Device-specific detection helpers ----
 final _hdsRegex = RegExp(r'\d+ Weight: .*');
 bool isDecentScale(List<String> messages, List<Uint8List> captures) {
-  print("is HDS: checking ${messages.length}, $messages");
+  _log.finer("is HDS: checking ${messages.length}, $messages");
   return captures.any(
         (Uint8List bytes) =>
             bytes.length > 5 &&
@@ -24,7 +28,7 @@ bool isSensorBasket(List<String> messages) {
 }
 
 bool isDE1(List<String> data, List<int> bytes) {
-  print("figuring out $data");
+  _log.finer("figuring out $data");
   return data.any((e) => e.startsWith("[M]"));
 }
 

--- a/lib/src/services/serial/utils.dart
+++ b/lib/src/services/serial/utils.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data';
 // ---- Device-specific detection helpers ----
 final _hdsRegex = RegExp(r'\d+ Weight: .*');
 bool isDecentScale(List<String> messages, List<Uint8List> captures) {
-  print("is HDS: checking ${messages.length}, ${messages}");
+  print("is HDS: checking ${messages.length}, $messages");
   return captures.any(
         (Uint8List bytes) =>
             bytes.length > 5 &&

--- a/lib/src/services/telemetry/firebase_crashlytics_telemetry_service.dart
+++ b/lib/src/services/telemetry/firebase_crashlytics_telemetry_service.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -65,14 +65,6 @@ class UniversalBleDiscoveryService extends BleDiscoveryService {
     }
   }
 
-  bool _isBleDeviceId(String deviceId) {
-    final macPattern = RegExp(r'^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$');
-    final uuidPattern = RegExp(
-      r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$',
-    );
-    return macPattern.hasMatch(deviceId) || uuidPattern.hasMatch(deviceId);
-  }
-
   @override
   void stopScan() {
     UniversalBle.stopScan();

--- a/lib/src/services/update_check_service.dart
+++ b/lib/src/services/update_check_service.dart
@@ -16,7 +16,7 @@ class UpdateCheckService {
   Timer? _periodicTimer;
   UpdateInfo? _availableUpdate;
   
-  static const Duration _checkInterval = (const String.fromEnvironment("simulate") == "1") ? Duration(hours: 1) : Duration(hours: 12);
+  static const Duration _checkInterval = (String.fromEnvironment("simulate") == "1") ? Duration(hours: 1) : Duration(hours: 12);
 
   UpdateCheckService({
     required SettingsService settingsService,

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -368,7 +368,7 @@ class De1Handler {
     });
   }
 
-  _handleSnapshot(WebSocketChannel socket, String? protocol) async {
+  Future<void> _handleSnapshot(WebSocketChannel socket, String? protocol) async {
     log.fine("handling websocket connection");
     _withDe1Ws(socket, (de1) {
       var sub = de1.currentSnapshot.listen((snapshot) {
@@ -387,7 +387,7 @@ class De1Handler {
     });
   }
 
-  _handleShotSettings(WebSocketChannel socket, String? protocol) async {
+  Future<void> _handleShotSettings(WebSocketChannel socket, String? protocol) async {
     log.fine('handling shot settings connection');
     _withDe1Ws(socket, (de1) {
       var sub = de1.shotSettings.listen((data) {
@@ -406,7 +406,7 @@ class De1Handler {
     });
   }
 
-  _handleWaterLevels(WebSocketChannel socket, String? protocol) async {
+  Future<void> _handleWaterLevels(WebSocketChannel socket, String? protocol) async {
     log.fine('handling water levels connection');
     _withDe1Ws(socket, (de1) {
       var sub = de1.waterLevels.listen((data) {
@@ -425,7 +425,7 @@ class De1Handler {
     });
   }
 
-  _handleRawSocket(WebSocketChannel socket, String? protocol) async {
+  Future<void> _handleRawSocket(WebSocketChannel socket, String? protocol) async {
     _withDe1Ws(socket, (de1) {
       var sub = de1.rawOutStream.listen((data) {
         try {

--- a/lib/src/services/webserver/devices_handler.dart
+++ b/lib/src/services/webserver/devices_handler.dart
@@ -375,9 +375,12 @@ class DevicesHandler {
           if (quick) {
             _controller.scanForDevices();
           } else {
-            _controller.scanForDevices().catchError((e) {
-              socket.sink.add(jsonEncode({'error': 'Scan failed: $e'}));
-            });
+            _controller.scanForDevices().then<void>(
+              (_) {},
+              onError: (e) {
+                socket.sink.add(jsonEncode({'error': 'Scan failed: $e'}));
+              },
+            );
           }
         }
 

--- a/lib/src/services/webserver/devices_handler.dart
+++ b/lib/src/services/webserver/devices_handler.dart
@@ -184,21 +184,15 @@ class DevicesStateAggregator {
 
 class DevicesHandler {
   final DeviceController _controller;
-  final De1Controller _de1Controller;
-  final ScaleController _scaleController;
   final ConnectionManager _connectionManager;
   final Logger _log = Logger("Devices handler");
   final DevicesStateAggregator _aggregator;
 
   DevicesHandler({
     required DeviceController controller,
-    required De1Controller de1Controller,
-    required ScaleController scaleController,
     BatteryController? batteryController,
     required ConnectionManager connectionManager,
   })  : _controller = controller,
-        _de1Controller = de1Controller,
-        _scaleController = scaleController,
         _connectionManager = connectionManager,
         _aggregator = DevicesStateAggregator(
           controller: controller,

--- a/lib/src/services/webserver/devices_handler.dart
+++ b/lib/src/services/webserver/devices_handler.dart
@@ -210,7 +210,7 @@ class DevicesHandler {
     _aggregator.dispose();
   }
 
-  addRoutes(RouterPlus app) {
+  void addRoutes(RouterPlus app) {
     app.get('/api/v1/devices', () async {
       log.info("handling devices");
       try {

--- a/lib/src/services/webserver/scale_handler.dart
+++ b/lib/src/services/webserver/scale_handler.dart
@@ -8,7 +8,7 @@ class ScaleHandler {
   ScaleHandler({required ScaleController controller})
       : _controller = controller;
 
-  addRoutes(RouterPlus app) {
+  void addRoutes(RouterPlus app) {
     app.put('/api/v1/scale/<command>', (request, command) async {
       switch (command) {
         case 'tare':

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -116,8 +116,6 @@ Future<void> startWebServer(
   final scaleHandler = ScaleHandler(controller: scaleController);
   final deviceHandler = DevicesHandler(
     controller: deviceController,
-    de1Controller: de1Controller,
-    scaleController: scaleController,
     batteryController: batteryController,
     connectionManager: connectionManager,
   );

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
-import 'dart:typed_data';
-import 'dart:collection';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart' hide Router, Visibility, ConnectionState;
 import 'package:flutter/services.dart';
@@ -59,7 +57,6 @@ import 'package:shelf/shelf_io.dart' as io;
 import 'package:shelf_web_socket/shelf_web_socket.dart' as sws;
 import 'package:shelf_cors_headers/shelf_cors_headers.dart';
 import 'package:reaprime/src/models/device/de1_rawmessage.dart';
-import 'package:reaprime/src/models/feedback/feedback_request.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
 import 'package:reaprime/src/services/feedback_service.dart';
 import 'package:reaprime/src/controllers/battery_controller.dart';

--- a/lib/src/services/webview_compatibility_checker.dart
+++ b/lib/src/services/webview_compatibility_checker.dart
@@ -23,11 +23,9 @@ class CompatibilityResult {
       issue = null;
 
   const CompatibilityResult.incompatible(
-    String reason,
-    CompatibilityIssue issue,
-  ) : isCompatible = false,
-      reason = reason,
-      issue = issue;
+    this.reason,
+    this.issue,
+  ) : isCompatible = false;
 }
 
 enum CompatibilityIssue {

--- a/lib/src/settings/update_dialog.dart
+++ b/lib/src/settings/update_dialog.dart
@@ -48,7 +48,7 @@ class _UpdateDialogState extends State<UpdateDialog> {
               SizedBox(height: 8),
               Chip(
                 label: Text('Pre-release'),
-                backgroundColor: Colors.orange.withOpacity(0.2),
+                backgroundColor: Colors.orange.withValues(alpha: 0.2),
               ),
             ],
             SizedBox(height: 16),
@@ -73,7 +73,7 @@ class _UpdateDialogState extends State<UpdateDialog> {
               Container(
                 padding: EdgeInsets.all(8),
                 decoration: BoxDecoration(
-                  color: Colors.red.withOpacity(0.1),
+                  color: Colors.red.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(4),
                 ),
                 child: Text(

--- a/lib/src/webui_support/webui_storage.dart
+++ b/lib/src/webui_support/webui_storage.dart
@@ -222,7 +222,7 @@ class WebUIStorage {
   WebUISkin? get defaultSkin {
     // Try to get skin from preference
     final preferredSkinId = _settingsController.defaultSkinId;
-    _log.info("selecting preferred skin: $preferredSkinId, in: ${_installedSkins}");
+    _log.info("selecting preferred skin: $preferredSkinId, in: $_installedSkins");
     if (_installedSkins.containsKey(preferredSkinId)) {
       return _installedSkins[preferredSkinId];
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1822,7 +1822,7 @@ packages:
     source: hosted
     version: "1.0.1"
   web_socket_channel:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web_socket_channel
       sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -89,6 +89,7 @@ dependencies:
   sqlite3_flutter_libs: ^0.6.0+eol
   pretty_qr_code: ^3.6.0
   mime: ^2.0.0
+  web_socket_channel: ^3.0.3
   # path: ../flutter_libserialport
   # git:
   #   url: https://github.com/tadelv/flutter_libserialport.git

--- a/test/controllers/de1_controller_test.dart
+++ b/test/controllers/de1_controller_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
@@ -48,7 +47,7 @@ void main() {
         expect(de1Controller.connectedDe1OrNull, same(testDe1));
 
         testDe1.dispose();
-      }, (_, __) {});
+      }, (_, _) {});
     });
 
     test('returns null again after disconnect', () async {
@@ -70,7 +69,7 @@ void main() {
         expect(de1Controller.connectedDe1OrNull, isNull);
 
         testDe1.dispose();
-      }, (_, __) {});
+      }, (_, _) {});
     });
   });
 

--- a/test/controllers/display_controller_test.dart
+++ b/test/controllers/display_controller_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' show Platform;
 import 'dart:typed_data';
 
 import 'package:fake_async/fake_async.dart';
@@ -226,10 +227,16 @@ class _TestBatteryController {
 
 /// Creates a DisplayController with no-op platform operations for testing.
 /// This allows tests to verify actual state transitions without platform deps.
+///
+/// Defaults [platformSupport] to brightness+wakeLock enabled so tests focused
+/// on brightness/battery-cap behavior don't depend on the host CI platform
+/// (DisplayController's auto-detection treats Linux as brightness-unsupported,
+/// which would otherwise short-circuit those tests on a Linux runner).
 DisplayController _createController(
   _TestDe1Controller de1Controller, {
   required SettingsController settingsController,
   _TestBatteryController? batteryController,
+  DisplayPlatformSupport? platformSupport,
 }) {
   return DisplayController(
     de1Controller: de1Controller,
@@ -239,6 +246,8 @@ DisplayController _createController(
     resetBrightness: () async {},
     enableWakeLock: () async {},
     disableWakeLock: () async {},
+    platformSupport: platformSupport ??
+        const DisplayPlatformSupport(brightness: true, wakeLock: true),
   );
 }
 
@@ -279,16 +288,30 @@ void main() {
 
     test('platformSupported reports correct values', () {
       fakeAsync((async) {
-        final controller = _createController(de1Controller,
-            settingsController: settingsCtrl);
+        // Construct DisplayController directly so the auto-detected
+        // platformSupport is exercised (the _createController helper
+        // injects a brightness-enabled default for the brightness/cap
+        // tests, which would hide the auto-detection logic here).
+        final controller = DisplayController(
+          de1Controller: de1Controller,
+          settingsController: settingsCtrl,
+          setBrightness: (_) async {},
+          resetBrightness: () async {},
+          enableWakeLock: () async {},
+          disableWakeLock: () async {},
+        );
         controller.initialize();
         async.flushMicrotasks();
 
         final state = controller.currentState;
-        // wakeLock is always true (wakelock_plus supports all platforms)
+        // wakeLock is always true (wakelock_plus supports all platforms).
         expect(state.platformSupported.wakeLock, isTrue);
-        // brightness depends on platform — on macOS (test env) it should be true
-        expect(state.platformSupported.brightness, isTrue);
+        // brightness is gated to Android/iOS/macOS/Windows; Linux is excluded.
+        final expectedBrightness = Platform.isAndroid ||
+            Platform.isIOS ||
+            Platform.isMacOS ||
+            Platform.isWindows;
+        expect(state.platformSupported.brightness, expectedBrightness);
 
         controller.dispose();
       });
@@ -545,6 +568,8 @@ void main() {
           },
           enableWakeLock: () async {},
           disableWakeLock: () async {},
+          platformSupport:
+              const DisplayPlatformSupport(brightness: true, wakeLock: true),
         );
         controller.initialize();
         async.flushMicrotasks();

--- a/test/database/bean_dao_test.dart
+++ b/test/database/bean_dao_test.dart
@@ -14,7 +14,7 @@ void main() {
     await db.close();
   });
 
-  BeansCompanion _makeBean({
+  BeansCompanion makeBean({
     String id = 'bean-1',
     String roaster = 'Test Roaster',
     String name = 'Test Bean',
@@ -31,7 +31,7 @@ void main() {
     );
   }
 
-  BeanBatchesCompanion _makeBatch({
+  BeanBatchesCompanion makeBatch({
     String id = 'batch-1',
     String beanId = 'bean-1',
     double? weight,
@@ -52,7 +52,7 @@ void main() {
 
   group('BeanDao - Beans', () {
     test('inserts and retrieves a bean', () async {
-      await db.beanDao.insertBean(_makeBean());
+      await db.beanDao.insertBean(makeBean());
       final beans = await db.beanDao.getAllBeans();
       expect(beans, hasLength(1));
       expect(beans.first.roaster, 'Test Roaster');
@@ -60,8 +60,8 @@ void main() {
     });
 
     test('filters archived beans by default', () async {
-      await db.beanDao.insertBean(_makeBean(id: 'b1'));
-      await db.beanDao.insertBean(_makeBean(id: 'b2', archived: true));
+      await db.beanDao.insertBean(makeBean(id: 'b1'));
+      await db.beanDao.insertBean(makeBean(id: 'b2', archived: true));
 
       final active = await db.beanDao.getAllBeans();
       expect(active, hasLength(1));
@@ -72,7 +72,7 @@ void main() {
     });
 
     test('gets bean by ID', () async {
-      await db.beanDao.insertBean(_makeBean(id: 'b1', name: 'Special'));
+      await db.beanDao.insertBean(makeBean(id: 'b1', name: 'Special'));
       final bean = await db.beanDao.getBeanById('b1');
       expect(bean, isNotNull);
       expect(bean!.name, 'Special');
@@ -84,7 +84,7 @@ void main() {
     });
 
     test('updates a bean', () async {
-      await db.beanDao.insertBean(_makeBean(id: 'b1', name: 'Original'));
+      await db.beanDao.insertBean(makeBean(id: 'b1', name: 'Original'));
       await db.beanDao.updateBean(BeansCompanion(
         id: const Value('b1'),
         name: const Value('Updated'),
@@ -95,7 +95,7 @@ void main() {
     });
 
     test('deletes a bean', () async {
-      await db.beanDao.insertBean(_makeBean(id: 'b1'));
+      await db.beanDao.insertBean(makeBean(id: 'b1'));
       await db.beanDao.deleteBean('b1');
       final beans = await db.beanDao.getAllBeans(includeArchived: true);
       expect(beans, isEmpty);
@@ -104,8 +104,8 @@ void main() {
     test('watches bean changes', () async {
       final stream = db.beanDao.watchAllBeans();
 
-      await db.beanDao.insertBean(_makeBean(id: 'b1'));
-      await db.beanDao.insertBean(_makeBean(id: 'b2'));
+      await db.beanDao.insertBean(makeBean(id: 'b1'));
+      await db.beanDao.insertBean(makeBean(id: 'b2'));
 
       // First emission after both inserts should have 2 beans
       final beans = await stream.first;
@@ -115,20 +115,20 @@ void main() {
 
   group('BeanDao - BeanBatches', () {
     test('inserts and retrieves batches for a bean', () async {
-      await db.beanDao.insertBean(_makeBean(id: 'bean-1'));
-      await db.beanDao.insertBatch(_makeBatch(id: 'batch-1'));
+      await db.beanDao.insertBean(makeBean(id: 'bean-1'));
+      await db.beanDao.insertBatch(makeBatch(id: 'batch-1'));
       await db.beanDao.insertBatch(
-          _makeBatch(id: 'batch-2', beanId: 'bean-1'));
+          makeBatch(id: 'batch-2', beanId: 'bean-1'));
 
       final batches = await db.beanDao.getBatchesForBean('bean-1');
       expect(batches, hasLength(2));
     });
 
     test('filters archived batches by default', () async {
-      await db.beanDao.insertBean(_makeBean(id: 'bean-1'));
-      await db.beanDao.insertBatch(_makeBatch(id: 'b1'));
+      await db.beanDao.insertBean(makeBean(id: 'bean-1'));
+      await db.beanDao.insertBatch(makeBatch(id: 'b1'));
       await db.beanDao
-          .insertBatch(_makeBatch(id: 'b2', archived: true));
+          .insertBatch(makeBatch(id: 'b2', archived: true));
 
       final active = await db.beanDao.getBatchesForBean('bean-1');
       expect(active, hasLength(1));
@@ -139,9 +139,9 @@ void main() {
     });
 
     test('decrements batch weight', () async {
-      await db.beanDao.insertBean(_makeBean(id: 'bean-1'));
+      await db.beanDao.insertBean(makeBean(id: 'bean-1'));
       await db.beanDao.insertBatch(
-          _makeBatch(id: 'batch-1', weight: 250.0, weightRemaining: 250.0));
+          makeBatch(id: 'batch-1', weight: 250.0, weightRemaining: 250.0));
 
       await db.beanDao.decrementBatchWeight('batch-1', 18.0);
 
@@ -150,9 +150,9 @@ void main() {
     });
 
     test('weight does not go below zero', () async {
-      await db.beanDao.insertBean(_makeBean(id: 'bean-1'));
+      await db.beanDao.insertBean(makeBean(id: 'bean-1'));
       await db.beanDao.insertBatch(
-          _makeBatch(id: 'batch-1', weight: 10.0, weightRemaining: 5.0));
+          makeBatch(id: 'batch-1', weight: 10.0, weightRemaining: 5.0));
 
       await db.beanDao.decrementBatchWeight('batch-1', 20.0);
 
@@ -163,7 +163,7 @@ void main() {
     test('foreign key enforced - cannot insert batch for nonexistent bean',
         () async {
       expect(
-        () => db.beanDao.insertBatch(_makeBatch(beanId: 'no-such-bean')),
+        () => db.beanDao.insertBatch(makeBatch(beanId: 'no-such-bean')),
         throwsA(anything),
       );
     });

--- a/test/database/grinder_dao_test.dart
+++ b/test/database/grinder_dao_test.dart
@@ -14,7 +14,7 @@ void main() {
     await db.close();
   });
 
-  GrindersCompanion _makeGrinder({
+  GrindersCompanion makeGrinder({
     String id = 'grinder-1',
     String model = 'Test Grinder',
     bool archived = false,
@@ -30,16 +30,16 @@ void main() {
   }
 
   test('inserts and retrieves a grinder', () async {
-    await db.grinderDao.insertGrinder(_makeGrinder());
+    await db.grinderDao.insertGrinder(makeGrinder());
     final grinders = await db.grinderDao.getAllGrinders();
     expect(grinders, hasLength(1));
     expect(grinders.first.model, 'Test Grinder');
   });
 
   test('filters archived grinders by default', () async {
-    await db.grinderDao.insertGrinder(_makeGrinder(id: 'g1'));
+    await db.grinderDao.insertGrinder(makeGrinder(id: 'g1'));
     await db.grinderDao
-        .insertGrinder(_makeGrinder(id: 'g2', archived: true));
+        .insertGrinder(makeGrinder(id: 'g2', archived: true));
 
     final active = await db.grinderDao.getAllGrinders();
     expect(active, hasLength(1));
@@ -50,7 +50,7 @@ void main() {
 
   test('gets grinder by ID', () async {
     await db.grinderDao
-        .insertGrinder(_makeGrinder(id: 'g1', model: 'Niche Zero'));
+        .insertGrinder(makeGrinder(id: 'g1', model: 'Niche Zero'));
     final grinder = await db.grinderDao.getGrinderById('g1');
     expect(grinder, isNotNull);
     expect(grinder!.model, 'Niche Zero');
@@ -58,7 +58,7 @@ void main() {
 
   test('updates a grinder', () async {
     await db.grinderDao
-        .insertGrinder(_makeGrinder(id: 'g1', model: 'Old'));
+        .insertGrinder(makeGrinder(id: 'g1', model: 'Old'));
     await db.grinderDao.updateGrinder(GrindersCompanion(
       id: const Value('g1'),
       model: const Value('New'),
@@ -69,7 +69,7 @@ void main() {
   });
 
   test('deletes a grinder', () async {
-    await db.grinderDao.insertGrinder(_makeGrinder(id: 'g1'));
+    await db.grinderDao.insertGrinder(makeGrinder(id: 'g1'));
     await db.grinderDao.deleteGrinder('g1');
     final grinders =
         await db.grinderDao.getAllGrinders(includeArchived: true);
@@ -78,7 +78,7 @@ void main() {
 
   test('watches grinder changes', () async {
     final stream = db.grinderDao.watchAllGrinders();
-    await db.grinderDao.insertGrinder(_makeGrinder(id: 'g1'));
+    await db.grinderDao.insertGrinder(makeGrinder(id: 'g1'));
     final grinders = await stream.first;
     expect(grinders, hasLength(1));
   });

--- a/test/database/profile_dao_test.dart
+++ b/test/database/profile_dao_test.dart
@@ -14,7 +14,7 @@ void main() {
     await db.close();
   });
 
-  ProfileRecordsCompanion _makeProfile({
+  ProfileRecordsCompanion makeProfile({
     String id = 'profile:abc12345678901234567',
     String title = 'Test Profile',
     String visibility = 'visible',
@@ -47,22 +47,22 @@ void main() {
 
   group('ProfileDao - CRUD', () {
     test('inserts and retrieves a profile', () async {
-      await db.profileDao.insertProfile(_makeProfile());
+      await db.profileDao.insertProfile(makeProfile());
       final profiles = await db.profileDao.getAllProfiles();
       expect(profiles, hasLength(1));
       expect(profiles.first.profileJson['title'], 'Test Profile');
     });
 
     test('filters by visibility', () async {
-      await db.profileDao.insertProfile(_makeProfile(
+      await db.profileDao.insertProfile(makeProfile(
         id: 'p1',
         visibility: 'visible',
       ));
-      await db.profileDao.insertProfile(_makeProfile(
+      await db.profileDao.insertProfile(makeProfile(
         id: 'p2',
         visibility: 'hidden',
       ));
-      await db.profileDao.insertProfile(_makeProfile(
+      await db.profileDao.insertProfile(makeProfile(
         id: 'p3',
         visibility: 'deleted',
       ));
@@ -77,42 +77,42 @@ void main() {
     });
 
     test('checks if profile exists', () async {
-      await db.profileDao.insertProfile(_makeProfile(id: 'p1'));
+      await db.profileDao.insertProfile(makeProfile(id: 'p1'));
       expect(await db.profileDao.profileExists('p1'), isTrue);
       expect(await db.profileDao.profileExists('p2'), isFalse);
     });
 
     test('gets all profile IDs', () async {
-      await db.profileDao.insertProfile(_makeProfile(id: 'p1'));
-      await db.profileDao.insertProfile(_makeProfile(id: 'p2'));
+      await db.profileDao.insertProfile(makeProfile(id: 'p1'));
+      await db.profileDao.insertProfile(makeProfile(id: 'p2'));
       final ids = await db.profileDao.getAllProfileIds();
       expect(ids, hasLength(2));
       expect(ids, containsAll(['p1', 'p2']));
     });
 
     test('gets by parent ID', () async {
-      await db.profileDao.insertProfile(_makeProfile(id: 'parent'));
+      await db.profileDao.insertProfile(makeProfile(id: 'parent'));
       await db.profileDao.insertProfile(
-          _makeProfile(id: 'child1', parentId: 'parent'));
+          makeProfile(id: 'child1', parentId: 'parent'));
       await db.profileDao.insertProfile(
-          _makeProfile(id: 'child2', parentId: 'parent'));
+          makeProfile(id: 'child2', parentId: 'parent'));
       await db.profileDao.insertProfile(
-          _makeProfile(id: 'other', parentId: 'other-parent'));
+          makeProfile(id: 'other', parentId: 'other-parent'));
 
       final children = await db.profileDao.getByParentId('parent');
       expect(children, hasLength(2));
     });
 
     test('counts profiles by visibility', () async {
-      await db.profileDao.insertProfile(_makeProfile(
+      await db.profileDao.insertProfile(makeProfile(
         id: 'p1',
         visibility: 'visible',
       ));
-      await db.profileDao.insertProfile(_makeProfile(
+      await db.profileDao.insertProfile(makeProfile(
         id: 'p2',
         visibility: 'visible',
       ));
-      await db.profileDao.insertProfile(_makeProfile(
+      await db.profileDao.insertProfile(makeProfile(
         id: 'p3',
         visibility: 'hidden',
       ));
@@ -126,7 +126,7 @@ void main() {
     });
 
     test('updates a profile', () async {
-      await db.profileDao.insertProfile(_makeProfile(id: 'p1'));
+      await db.profileDao.insertProfile(makeProfile(id: 'p1'));
       await db.profileDao.updateProfile(ProfileRecordsCompanion(
         id: const Value('p1'),
         visibility: const Value('hidden'),
@@ -137,15 +137,15 @@ void main() {
     });
 
     test('deletes a profile', () async {
-      await db.profileDao.insertProfile(_makeProfile(id: 'p1'));
+      await db.profileDao.insertProfile(makeProfile(id: 'p1'));
       await db.profileDao.deleteProfile('p1');
       final profiles = await db.profileDao.getAllProfiles();
       expect(profiles, isEmpty);
     });
 
     test('clears all profiles', () async {
-      await db.profileDao.insertProfile(_makeProfile(id: 'p1'));
-      await db.profileDao.insertProfile(_makeProfile(id: 'p2'));
+      await db.profileDao.insertProfile(makeProfile(id: 'p1'));
+      await db.profileDao.insertProfile(makeProfile(id: 'p2'));
       await db.profileDao.clearAll();
       final profiles = await db.profileDao.getAllProfiles();
       expect(profiles, isEmpty);
@@ -153,9 +153,9 @@ void main() {
 
     test('batch inserts profiles', () async {
       await db.profileDao.insertAllProfiles([
-        _makeProfile(id: 'p1', title: 'Profile 1'),
-        _makeProfile(id: 'p2', title: 'Profile 2'),
-        _makeProfile(id: 'p3', title: 'Profile 3'),
+        makeProfile(id: 'p1', title: 'Profile 1'),
+        makeProfile(id: 'p2', title: 'Profile 2'),
+        makeProfile(id: 'p3', title: 'Profile 3'),
       ]);
       final profiles = await db.profileDao.getAllProfiles();
       expect(profiles, hasLength(3));
@@ -166,7 +166,7 @@ void main() {
     test('watches profile changes', () async {
       final stream =
           db.profileDao.watchAllProfiles(visibility: 'visible');
-      await db.profileDao.insertProfile(_makeProfile(id: 'p1'));
+      await db.profileDao.insertProfile(makeProfile(id: 'p1'));
       final profiles = await stream.first;
       expect(profiles, hasLength(1));
     });

--- a/test/database/shot_dao_test.dart
+++ b/test/database/shot_dao_test.dart
@@ -16,7 +16,7 @@ void main() {
     await db.close();
   });
 
-  ShotRecordsCompanion _makeShot({
+  ShotRecordsCompanion makeShot({
     String id = 'shot-1',
     DateTime? timestamp,
     String profileTitle = 'Test Profile',
@@ -60,7 +60,7 @@ void main() {
 
   group('ShotDao - CRUD', () {
     test('inserts and retrieves a shot', () async {
-      await db.shotDao.insertShot(_makeShot());
+      await db.shotDao.insertShot(makeShot());
       final shot = await db.shotDao.getShotById('shot-1');
       expect(shot, isNotNull);
       expect(shot!.id, 'shot-1');
@@ -68,19 +68,19 @@ void main() {
     });
 
     test('gets all shot IDs', () async {
-      await db.shotDao.insertShot(_makeShot(id: 's1'));
-      await db.shotDao.insertShot(_makeShot(id: 's2'));
+      await db.shotDao.insertShot(makeShot(id: 's1'));
+      await db.shotDao.insertShot(makeShot(id: 's2'));
       final ids = await db.shotDao.getAllShotIds();
       expect(ids, hasLength(2));
       expect(ids, containsAll(['s1', 's2']));
     });
 
     test('gets all shots ordered by timestamp desc', () async {
-      await db.shotDao.insertShot(_makeShot(
+      await db.shotDao.insertShot(makeShot(
         id: 's1',
         timestamp: DateTime.parse('2024-01-01T10:00:00Z'),
       ));
-      await db.shotDao.insertShot(_makeShot(
+      await db.shotDao.insertShot(makeShot(
         id: 's2',
         timestamp: DateTime.parse('2024-01-02T10:00:00Z'),
       ));
@@ -91,7 +91,7 @@ void main() {
     });
 
     test('updates a shot', () async {
-      await db.shotDao.insertShot(_makeShot(espressoNotes: 'original'));
+      await db.shotDao.insertShot(makeShot(espressoNotes: 'original'));
       await db.shotDao.updateShot(ShotRecordsCompanion(
         id: const Value('shot-1'),
         espressoNotes: const Value('updated'),
@@ -101,18 +101,18 @@ void main() {
     });
 
     test('deletes a shot', () async {
-      await db.shotDao.insertShot(_makeShot());
+      await db.shotDao.insertShot(makeShot());
       await db.shotDao.deleteShot('shot-1');
       final shot = await db.shotDao.getShotById('shot-1');
       expect(shot, isNull);
     });
 
     test('gets latest shot', () async {
-      await db.shotDao.insertShot(_makeShot(
+      await db.shotDao.insertShot(makeShot(
         id: 's1',
         timestamp: DateTime.parse('2024-01-01T10:00:00Z'),
       ));
-      await db.shotDao.insertShot(_makeShot(
+      await db.shotDao.insertShot(makeShot(
         id: 's2',
         timestamp: DateTime.parse('2024-01-02T10:00:00Z'),
       ));
@@ -123,9 +123,9 @@ void main() {
 
     test('upserts a shot', () async {
       await db.shotDao.upsertShot(
-          _makeShot(id: 's1', espressoNotes: 'first'));
+          makeShot(id: 's1', espressoNotes: 'first'));
       await db.shotDao.upsertShot(
-          _makeShot(id: 's1', espressoNotes: 'second'));
+          makeShot(id: 's1', espressoNotes: 'second'));
 
       final shots = await db.shotDao.getAllShots();
       expect(shots, hasLength(1));
@@ -136,7 +136,7 @@ void main() {
   group('ShotDao - Pagination & Filtering', () {
     test('paginates shots', () async {
       for (int i = 0; i < 10; i++) {
-        await db.shotDao.insertShot(_makeShot(
+        await db.shotDao.insertShot(makeShot(
           id: 'shot-$i',
           timestamp:
               DateTime.parse('2024-01-01T10:00:00Z').add(Duration(hours: i)),
@@ -155,10 +155,10 @@ void main() {
 
     test('filters by grinderModel', () async {
       await db.shotDao
-          .insertShot(_makeShot(id: 's1', grinderModel: 'Niche'));
+          .insertShot(makeShot(id: 's1', grinderModel: 'Niche'));
       await db.shotDao
-          .insertShot(_makeShot(id: 's2', grinderModel: 'DF64'));
-      await db.shotDao.insertShot(_makeShot(id: 's3'));
+          .insertShot(makeShot(id: 's2', grinderModel: 'DF64'));
+      await db.shotDao.insertShot(makeShot(id: 's3'));
 
       final filtered = await db.shotDao
           .getShotsPaginated(grinderModel: 'Niche');
@@ -168,9 +168,9 @@ void main() {
 
     test('filters by coffeeRoaster', () async {
       await db.shotDao
-          .insertShot(_makeShot(id: 's1', coffeeRoaster: 'Sey'));
+          .insertShot(makeShot(id: 's1', coffeeRoaster: 'Sey'));
       await db.shotDao
-          .insertShot(_makeShot(id: 's2', coffeeRoaster: 'Other'));
+          .insertShot(makeShot(id: 's2', coffeeRoaster: 'Other'));
 
       final filtered = await db.shotDao
           .getShotsPaginated(coffeeRoaster: 'Sey');
@@ -180,9 +180,9 @@ void main() {
 
     test('filters by profileTitle', () async {
       await db.shotDao.insertShot(
-          _makeShot(id: 's1', profileTitle: 'Blooming Espresso'));
+          makeShot(id: 's1', profileTitle: 'Blooming Espresso'));
       await db.shotDao
-          .insertShot(_makeShot(id: 's2', profileTitle: 'Rao'));
+          .insertShot(makeShot(id: 's2', profileTitle: 'Rao'));
 
       final filtered = await db.shotDao
           .getShotsPaginated(profileTitle: 'Blooming Espresso');
@@ -191,11 +191,11 @@ void main() {
 
     test('counts shots with filters', () async {
       await db.shotDao
-          .insertShot(_makeShot(id: 's1', coffeeRoaster: 'Sey'));
+          .insertShot(makeShot(id: 's1', coffeeRoaster: 'Sey'));
       await db.shotDao
-          .insertShot(_makeShot(id: 's2', coffeeRoaster: 'Sey'));
+          .insertShot(makeShot(id: 's2', coffeeRoaster: 'Sey'));
       await db.shotDao
-          .insertShot(_makeShot(id: 's3', coffeeRoaster: 'Other'));
+          .insertShot(makeShot(id: 's3', coffeeRoaster: 'Other'));
 
       final total = await db.shotDao.countShots();
       expect(total, 3);

--- a/test/database/workflow_dao_test.dart
+++ b/test/database/workflow_dao_test.dart
@@ -14,7 +14,7 @@ void main() {
     await db.close();
   });
 
-  Map<String, dynamic> _makeWorkflowJson({String name = 'Test Workflow'}) {
+  Map<String, dynamic> makeWorkflowJson({String name = 'Test Workflow'}) {
     return {
       'id': 'wf-1',
       'name': name,
@@ -60,7 +60,7 @@ void main() {
 
   test('saves and loads current workflow', () async {
     await db.workflowDao.saveCurrentWorkflow(WorkflowsCompanion(
-      workflowJson: Value(_makeWorkflowJson(name: 'My Workflow')),
+      workflowJson: Value(makeWorkflowJson(name: 'My Workflow')),
       updatedAt: Value(DateTime.now()),
     ));
 
@@ -71,11 +71,11 @@ void main() {
 
   test('upserts workflow (replaces existing)', () async {
     await db.workflowDao.saveCurrentWorkflow(WorkflowsCompanion(
-      workflowJson: Value(_makeWorkflowJson(name: 'First')),
+      workflowJson: Value(makeWorkflowJson(name: 'First')),
       updatedAt: Value(DateTime.now()),
     ));
     await db.workflowDao.saveCurrentWorkflow(WorkflowsCompanion(
-      workflowJson: Value(_makeWorkflowJson(name: 'Second')),
+      workflowJson: Value(makeWorkflowJson(name: 'Second')),
       updatedAt: Value(DateTime.now()),
     ));
 

--- a/test/device_discovery_view_test.dart
+++ b/test/device_discovery_view_test.dart
@@ -87,7 +87,9 @@ void main() {
       final origOnError = FlutterError.onError;
       FlutterError.onError = (details) {
         if (details.toString().contains('overflowed') ||
-            details.toString().contains('deactivated')) return;
+            details.toString().contains('deactivated')) {
+          return;
+        }
         origOnError?.call(details);
       };
       addTearDown(() => FlutterError.onError = origOnError);
@@ -111,7 +113,9 @@ void main() {
       final origOnError = FlutterError.onError;
       FlutterError.onError = (details) {
         if (details.toString().contains('overflowed') ||
-            details.toString().contains('deactivated')) return;
+            details.toString().contains('deactivated')) {
+          return;
+        }
         origOnError?.call(details);
       };
       addTearDown(() => FlutterError.onError = origOnError);
@@ -153,7 +157,9 @@ void main() {
       final origOnError = FlutterError.onError;
       FlutterError.onError = (details) {
         if (details.toString().contains('overflowed') ||
-            details.toString().contains('deactivated')) return;
+            details.toString().contains('deactivated')) {
+          return;
+        }
         origOnError?.call(details);
       };
       addTearDown(() => FlutterError.onError = origOnError);
@@ -180,7 +186,9 @@ void main() {
       final origOnError = FlutterError.onError;
       FlutterError.onError = (details) {
         if (details.toString().contains('overflowed') ||
-            details.toString().contains('deactivated')) return;
+            details.toString().contains('deactivated')) {
+          return;
+        }
         origOnError?.call(details);
       };
       addTearDown(() => FlutterError.onError = origOnError);
@@ -209,7 +217,9 @@ void main() {
       final origOnError = FlutterError.onError;
       FlutterError.onError = (details) {
         if (details.toString().contains('overflowed') ||
-            details.toString().contains('deactivated')) return;
+            details.toString().contains('deactivated')) {
+          return;
+        }
         origOnError?.call(details);
       };
       addTearDown(() => FlutterError.onError = origOnError);

--- a/test/devices_handler_test.dart
+++ b/test/devices_handler_test.dart
@@ -45,8 +45,6 @@ void main() {
 
     devicesHandler = DevicesHandler(
       controller: deviceController,
-      de1Controller: de1Controller,
-      scaleController: scaleController,
       connectionManager: connectionManager,
     );
 

--- a/test/devices_handler_test.dart
+++ b/test/devices_handler_test.dart
@@ -3,8 +3,6 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/device/device.dart';
-import 'package:shelf/shelf.dart';
-import 'package:shelf_router/shelf_router.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 import 'package:reaprime/src/controllers/connection_error.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';

--- a/test/devices_ws_test.dart
+++ b/test/devices_ws_test.dart
@@ -48,8 +48,6 @@ void main() {
 
     devicesHandler = DevicesHandler(
       controller: deviceController,
-      de1Controller: de1Controller,
-      scaleController: scaleController,
       connectionManager: connectionManager,
     );
 

--- a/test/info_handler_test.dart
+++ b/test/info_handler_test.dart
@@ -3,8 +3,6 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/services/webserver/info_handler.dart';
-import 'package:shelf/shelf.dart';
-import 'package:shelf_router/shelf_router.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
 void main() {
@@ -19,7 +17,7 @@ void main() {
   });
 
   Future<Response> sendGet(String path) async {
-    return await handler(Request('GET', Uri.parse('http://localhost' + path)));
+    return await handler(Request('GET', Uri.parse('http://localhost$path')));
   }
 
   group('InfoHandler', () {

--- a/test/models/device/impl/bengle/mock_bengle_saw_integration_test.dart
+++ b/test/models/device/impl/bengle/mock_bengle_saw_integration_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
 import 'package:reaprime/src/models/device/machine.dart';
-import 'package:reaprime/src/models/device/scale.dart';
 
 /// SAW (stop-at-weight) profile: step0 preinfusion, step1 pours until weight hits exit.
 Profile _sawProfile() {

--- a/test/models/device/impl/bengle/mock_bengle_weight_test.dart
+++ b/test/models/device/impl/bengle/mock_bengle_weight_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/data/profile.dart';

--- a/test/models/device/impl/mock_de1/mock_de1_flow_pressure_test.dart
+++ b/test/models/device/impl/mock_de1/mock_de1_flow_pressure_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/data/profile.dart';

--- a/test/models/device/impl/mock_de1/mock_de1_skip_step_test.dart
+++ b/test/models/device/impl/mock_de1/mock_de1_skip_step_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/data/profile.dart';

--- a/test/models/device/impl/mock_de1/mock_de1_transition_test.dart
+++ b/test/models/device/impl/mock_de1/mock_de1_transition_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/data/profile.dart';

--- a/test/services/webserver/feedback_handler_test.dart
+++ b/test/services/webserver/feedback_handler_test.dart
@@ -10,6 +10,7 @@ import 'package:shelf_plus/shelf_plus.dart';
 
 /// A stub FeedbackService for testing the handler in isolation.
 class _StubFeedbackService implements FeedbackService {
+  @override
   final bool isConfigured;
   final FeedbackSubmissionResult Function(FeedbackRequest)? onSubmitted;
 

--- a/test/services/webserver/profile_handler_defaults_test.dart
+++ b/test/services/webserver/profile_handler_defaults_test.dart
@@ -5,8 +5,6 @@ import 'package:reaprime/src/controllers/profile_controller.dart';
 import 'package:reaprime/src/models/data/profile_record.dart';
 import 'package:reaprime/src/services/storage/profile_storage_service.dart';
 import 'package:reaprime/src/services/webserver_service.dart';
-import 'package:shelf/shelf.dart';
-import 'package:shelf_router/shelf_router.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
 class _StubStorage implements ProfileStorageService {


### PR DESCRIPTION
## What

- New `pull_request`-triggered workflow (`.github/workflows/pr-checks.yml`) runs `flutter analyze`, `flutter test`, and a Linux build smoke on every PR (including forks). No secrets required.
- `CONTRIBUTING.md` covering local setup, branch flow, test tiers, and the spec-update obligation from `CLAUDE.md`.
- `analysis_options.yaml` gains an explicit `formatter:` section (page_width 80, trailing_commas preserve).
- `dart fix --apply` + manual cleanup pass takes `flutter analyze` from **114 issues to 0**. Full test suite (1228 tests) still green.

## Why

PR #230 had an empty status check rollup because nothing was wired to run on outside-contributor PRs. This puts a baseline gate in place so reviewers don't have to drive every contribution through their own checkout. Format enforcement is wired in as `continue-on-error` until the codebase is mass-reformatted for Dart 3.7+ tall style — flipping it to required is a one-line change once that lands.