### PR TITLE
Fix/bengle cupwarmer mmr from float32 to scaledFloat

### DIFF
--- a/lib/src/models/device/impl/bengle/bengle.dart
+++ b/lib/src/models/device/impl/bengle/bengle.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 
@@ -14,11 +15,11 @@ class Bengle extends UnifiedDe1
 
   @override
   Future<void> setCupWarmerTemperature(double celsius) =>
-      writeMmrFloat32(BengleMmr.matSetPoint, celsius);
+      writeMmrScaled(BengleMmr.matSetPoint, celsius);
 
   @override
   Future<double> getCupWarmerTemperature() =>
-      readMmrFloat32(BengleMmr.matSetPoint);
+      readMmrScaled(BengleMmr.matSetPoint);
 
   /// Bengle FW requires entering state 0x22 (`MachineState.fwUpgrade`) between
   /// the `requestState(sleeping)` step and the start of `.dat` upload.

--- a/lib/src/models/device/impl/bengle/bengle.dart
+++ b/lib/src/models/device/impl/bengle/bengle.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart';
-import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 
@@ -57,6 +56,7 @@ class Bengle extends UnifiedDe1
   }
 
   // --- LED strip ---
+  // TODO: when LED api is available
 
 
 

--- a/lib/src/models/device/impl/bengle/bengle_mmr.dart
+++ b/lib/src/models/device/impl/bengle/bengle_mmr.dart
@@ -11,10 +11,12 @@ enum BengleMmr implements MmrAddress {
   matSetPoint(
     0x00803874,
     4,
-    MmrValueKind.float32,
+    MmrValueKind.scaledFloat,
     'MatSetPoint',
-    minDouble: 0.0,
-    maxDouble: 80.0,
+    min: 0,
+    max: 800,
+    readScale: 0.1,
+    writeScale: 10.0,
   ),
 
   /// Integrated-scale tare trigger. Address and value semantics are
@@ -35,8 +37,10 @@ enum BengleMmr implements MmrAddress {
     this.length,
     this.kind,
     this.description, {
-    this.minDouble,
-    this.maxDouble,
+    this.readScale = 1.0,
+    this.writeScale = 1.0,
+    this.min,
+    this.max,
   });
 
   @override
@@ -47,20 +51,13 @@ enum BengleMmr implements MmrAddress {
   final MmrValueKind kind;
   final String description;
   @override
-  final double? minDouble;
+  final double readScale;
   @override
-  final double? maxDouble;
-
-  // float32 entries don't use the int-based scale/clamp fields.
-  // Concrete defaults satisfy the `implements MmrAddress` contract.
+  final double writeScale;
   @override
-  double get readScale => 1.0;
+  final int? min;
   @override
-  double get writeScale => 1.0;
-  @override
-  int? get min => null;
-  @override
-  int? get max => null;
+  final int? max;
 
   /// Dart enums auto-synthesize `name`, but the analyzer doesn't see it
   /// as satisfying `MmrAddress.name` through `implements` — the cast

--- a/lib/src/models/device/impl/de1/de1.models.dart
+++ b/lib/src/models/device/impl/de1/de1.models.dart
@@ -377,14 +377,6 @@ enum MMRItem implements MmrAddress {
   @override
   final int? max;
 
-  // No DE1 MMRItem entry is float32 today; defaults satisfy the
-  // `implements MmrAddress` contract added when capability mixins
-  // gained float32 support.
-  @override
-  double? get minDouble => null;
-  @override
-  double? get maxDouble => null;
-
   const MMRItem(
     this.address,
     this.length,

--- a/lib/src/models/device/impl/de1/mmr_address.dart
+++ b/lib/src/models/device/impl/de1/mmr_address.dart
@@ -27,10 +27,6 @@ enum MmrValueKind {
 
   /// null-terminated or length-prefixed string
   string,
-
-  /// raw IEEE-754 float32 (4 bytes, little-endian on the wire). Bounds
-  /// declared via [MmrAddress.minDouble] / [MmrAddress.maxDouble].
-  float32,
 }
 
 /// Wire-agnostic identifier for a single MMR slot.
@@ -68,12 +64,4 @@ abstract class MmrAddress {
 
   /// Optional maximum bound; null means no upper clamp.
   int? get max => null;
-
-  /// Optional minimum bound for [MmrValueKind.float32] addresses; null
-  /// means no lower clamp.
-  double? get minDouble => null;
-
-  /// Optional maximum bound for [MmrValueKind.float32] addresses; null
-  /// means no upper clamp.
-  double? get maxDouble => null;
 }

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -609,32 +609,6 @@ class UnifiedDe1 implements De1Interface {
     return _mmrWriteRaw(addr.address, _packMMRInt(clamped));
   }
 
-  /// Reads a [MmrValueKind.float32] address as an IEEE-754 little-endian
-  /// float. Capability mixins use this for FW MMR slots that store
-  /// floats raw (e.g. `BengleMmr.matSetPoint`).
-  @protected
-  Future<double> readMmrFloat32(MmrAddress addr) async {
-    _assertKind(addr, const {MmrValueKind.float32}, 'readMmrFloat32');
-    final raw = (addr is MMRItem)
-        ? await _mmrRead(addr)
-        : await _mmrReadRaw(addr.address);
-    return _unpackMMRFloat32(raw);
-  }
-
-  /// Writes [value] as an IEEE-754 little-endian float to [addr].
-  /// Clamps to `[addr.minDouble, addr.maxDouble]` when both are set
-  /// (avoids silent FW-side clamps surprising callers).
-  @protected
-  Future<void> writeMmrFloat32(MmrAddress addr, double value) async {
-    _assertKind(addr, const {MmrValueKind.float32}, 'writeMmrFloat32');
-    final clamped = (addr.minDouble != null && addr.maxDouble != null)
-        ? value.clamp(addr.minDouble!, addr.maxDouble!).toDouble()
-        : value;
-    final bytes = _packMMRFloat32(clamped);
-    if (addr is MMRItem) return _mmrWrite(addr, bytes);
-    return _mmrWriteRaw(addr.address, bytes);
-  }
-
   @protected
   Future<List<int>> readMmrRaw(MmrAddress addr) async {
     if (addr is MMRItem) return _mmrRead(addr);

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart
@@ -124,28 +124,4 @@ extension UnifiedDe1MMR on UnifiedDe1 {
     final scaledValue = (value * item.writeScale).toInt();
     await _writeMMRInt(item, scaledValue);
   }
-
-  /// IEEE-754 little-endian unpack for [MmrValueKind.float32] addresses.
-  /// Mirrors [_unpackMMRInt] but reads `getFloat32(4, Endian.little)`.
-  double _unpackMMRFloat32(List<int> buffer) {
-    if (buffer.length < 20) {
-      throw StateError(
-        'MMR response buffer too short (got ${buffer.length} bytes, '
-        'expected at least 20)',
-      );
-    }
-    final bytes = ByteData(20);
-    for (var i = 0; i < 20; i++) {
-      bytes.setUint8(i, buffer[i]);
-    }
-    return bytes.getFloat32(4, Endian.little);
-  }
-
-  /// IEEE-754 little-endian pack for [MmrValueKind.float32] addresses.
-  /// Returns the 4 raw bytes ready to ride on `Endpoint.writeToMMR`.
-  Uint8List _packMMRFloat32(double value) {
-    final bytes = ByteData(4);
-    bytes.setFloat32(0, value, Endian.little);
-    return bytes.buffer.asUint8List();
-  }
 }

--- a/test/models/device/bengle_cup_warmer_test.dart
+++ b/test/models/device/bengle_cup_warmer_test.dart
@@ -51,14 +51,14 @@ void main() {
 
         // Payload bytes [4..7] = float32 little-endian 60.0.
         final payload = ByteData.sublistView(frame.data, 4, 8);
-        expect(payload.getFloat32(0, Endian.little), closeTo(60.0, 1e-6));
+        expect(payload.getUint32(0, Endian.little), closeTo(600, 1e-6));
       },
     );
 
     test('getCupWarmerTemperature reads a float32 back from the wire',
         () async {
       // Pre-queue a 50.0 °C float32 response at the matSetPoint address.
-      final bytes = ByteData(4)..setFloat32(0, 50.0, Endian.little);
+      final bytes = ByteData(4)..setUint32(0, 500, Endian.little);
       transport.queueMmrResponseRaw(BengleMmr.matSetPoint,
           List<int>.generate(4, (i) => bytes.getUint8(i)));
 
@@ -74,7 +74,7 @@ void main() {
         (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
       );
       final payload = ByteData.sublistView(frame.data, 4, 8);
-      expect(payload.getFloat32(0, Endian.little), closeTo(80.0, 1e-6));
+      expect(payload.getUint32(0, Endian.little), closeTo(800, 1e-6));
     });
   });
 }

--- a/test/models/device/bengle_cup_warmer_test.dart
+++ b/test/models/device/bengle_cup_warmer_test.dart
@@ -9,11 +9,11 @@ import '../../helpers/fake_ble_transport.dart';
 
 /// Wires the real `Bengle` class through `FakeBleTransport` to confirm the
 /// public cup-warmer API (setCupWarmerTemperature / getCupWarmerTemperature)
-/// rides the float32 MMR helpers and the `BengleMmr.matSetPoint` address.
+/// rides the scaledFloat MMR helpers and the `BengleMmr.matSetPoint` address.
 ///
 /// This is the integration point between `BengleInterface`,
 /// `Bengle`'s extension on `UnifiedDe1`'s `@protected` MMR helpers, and the
-/// new `MmrValueKind.float32` plumbing. The unit-level mechanics
+/// `MmrValueKind.scaledFloat` plumbing. The unit-level mechanics
 /// (clamping, packing, kind-mismatch errors) live in
 /// `test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart`.
 void main() {
@@ -33,7 +33,7 @@ void main() {
     });
 
     test(
-      'setCupWarmerTemperature writes a float32 to BengleMmr.matSetPoint',
+      'setCupWarmerTemperature writes a scaled uint32 to BengleMmr.matSetPoint',
       () async {
         transport.writes.clear();
         await bengle.setCupWarmerTemperature(60.0);
@@ -49,18 +49,19 @@ void main() {
         expect(frame.data[2], addr.getUint8(2));
         expect(frame.data[3], addr.getUint8(3));
 
-        // Payload bytes [4..7] = float32 little-endian 60.0.
+        // Payload bytes [4..7] = uint32 scaled 60.0.
         final payload = ByteData.sublistView(frame.data, 4, 8);
-        expect(payload.getUint32(0, Endian.little), closeTo(600, 1e-6));
+        expect(payload.getUint32(0, Endian.little), equals(600));
       },
     );
 
-    test('getCupWarmerTemperature reads a float32 back from the wire',
-        () async {
-      // Pre-queue a 50.0 °C float32 response at the matSetPoint address.
+    test('getCupWarmerTemperature reads a scaled uint32 back from the wire', () async {
+      // Pre-queue a 50.0 °C scaled uint32 response at the matSetPoint address.
       final bytes = ByteData(4)..setUint32(0, 500, Endian.little);
-      transport.queueMmrResponseRaw(BengleMmr.matSetPoint,
-          List<int>.generate(4, (i) => bytes.getUint8(i)));
+      transport.queueMmrResponseRaw(
+        BengleMmr.matSetPoint,
+        List<int>.generate(4, (i) => bytes.getUint8(i)),
+      );
 
       final result = await bengle.getCupWarmerTemperature();
       expect(result, closeTo(50.0, 1e-6));
@@ -74,7 +75,7 @@ void main() {
         (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
       );
       final payload = ByteData.sublistView(frame.data, 4, 8);
-      expect(payload.getUint32(0, Endian.little), closeTo(800, 1e-6));
+      expect(payload.getUint32(0, Endian.little), equals(800));
     });
   });
 }

--- a/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
@@ -34,9 +34,6 @@ mixin _TestCapability on UnifiedDe1 {
   Future<double> capReadScaled(MmrAddress addr) => readMmrScaled(addr);
   Future<void> capWriteScaled(MmrAddress addr, double v) =>
       writeMmrScaled(addr, v);
-  Future<double> capReadFloat32(MmrAddress addr) => readMmrFloat32(addr);
-  Future<void> capWriteFloat32(MmrAddress addr, double v) =>
-      writeMmrFloat32(addr, v);
   Stream<ByteData> capNotifications(LogicalEndpoint ep) =>
       notificationsFor(ep);
   Future<void> capWriteEndpoint(LogicalEndpoint ep, Uint8List data,
@@ -63,10 +60,6 @@ class _CapabilityAddr implements MmrAddress {
   final int? min;
   @override
   final int? max;
-  @override
-  final double? minDouble;
-  @override
-  final double? maxDouble;
   const _CapabilityAddr({
     required this.address,
     required this.length,
@@ -76,8 +69,6 @@ class _CapabilityAddr implements MmrAddress {
     this.writeScale = 1.0,
     this.min,
     this.max,
-    this.minDouble,
-    this.maxDouble,
   });
 }
 
@@ -256,85 +247,6 @@ void main() {
           (e) => e.message,
           'message',
           contains('runtime subscription'),
-        )),
-      );
-    });
-
-    test('readMmrFloat32 round-trips an IEEE-754 float32 value', () async {
-      const addr = _CapabilityAddr(
-        address: 0x00803874,
-        length: 4,
-        name: 'matSetPoint',
-        kind: MmrValueKind.float32,
-        minDouble: 0.0,
-        maxDouble: 80.0,
-      );
-      // Pack 50.0 as little-endian float32 bytes.
-      final bytes = ByteData(4)..setFloat32(0, 50.0, Endian.little);
-      transport.queueMmrResponseRaw(addr,
-          List<int>.generate(4, (i) => bytes.getUint8(i)));
-      final result = await de1.capReadFloat32(addr);
-      expect(result, closeTo(50.0, 1e-6));
-    });
-
-    test('writeMmrFloat32 packs a float32 little-endian and clamps to bounds',
-        () async {
-      const addr = _CapabilityAddr(
-        address: 0x00803874,
-        length: 4,
-        name: 'matSetPoint',
-        kind: MmrValueKind.float32,
-        minDouble: 0.0,
-        maxDouble: 80.0,
-      );
-
-      transport.writes.clear();
-      // 90.0 over the max → clamped to 80.0.
-      await de1.capWriteFloat32(addr, 90.0);
-      var frame = transport.writes.firstWhere(
-        (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
-      );
-      var payload = ByteData.sublistView(frame.data, 4, 8);
-      expect(payload.getFloat32(0, Endian.little), closeTo(80.0, 1e-6));
-
-      transport.writes.clear();
-      // -5.0 below min → clamped to 0.0.
-      await de1.capWriteFloat32(addr, -5.0);
-      frame = transport.writes.firstWhere(
-        (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
-      );
-      payload = ByteData.sublistView(frame.data, 4, 8);
-      expect(payload.getFloat32(0, Endian.little), closeTo(0.0, 1e-6));
-
-      transport.writes.clear();
-      // In-range value passed through unchanged.
-      await de1.capWriteFloat32(addr, 60.0);
-      frame = transport.writes.firstWhere(
-        (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
-      );
-      payload = ByteData.sublistView(frame.data, 4, 8);
-      expect(payload.getFloat32(0, Endian.little), closeTo(60.0, 1e-6));
-    });
-
-    test('readMmrFloat32 throws on a non-float32 address', () async {
-      // fanThreshold.kind == int32 — wrong helper.
-      await expectLater(
-        de1.capReadFloat32(MMRItem.fanThreshold),
-        throwsA(isA<StateError>().having(
-          (e) => e.message,
-          'message',
-          allOf(contains('readMmrFloat32'), contains('kind')),
-        )),
-      );
-    });
-
-    test('writeMmrFloat32 throws on a non-float32 address', () async {
-      await expectLater(
-        de1.capWriteFloat32(MMRItem.fanThreshold, 1.0),
-        throwsA(isA<StateError>().having(
-          (e) => e.message,
-          'message',
-          allOf(contains('writeMmrFloat32'), contains('kind')),
         )),
       );
     });


### PR DESCRIPTION
Remove float32 `MMRKind`, float not as portable as scaling integers.
Update tests
Remove mentions of float32 MMR kind 