### PR TITLE
Scaffold Bengle milk probe + SteamSequencer + steam records

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -215,7 +215,7 @@ paths:
         Returns the optional capability surfaces the currently connected
         machine exposes. Plain DE1s return an empty list; Bengle returns
         `["cupWarmer", "integratedScale"]` plus any future capabilities
-        (LED strip, milk probe) as they ship. Skins should query this
+        as they ship. Skins should query this
         endpoint once after connect to decide which UI to render and
         which `/api/v1/machine/...` capability endpoints to call.
       tags: [Machine]
@@ -1015,6 +1015,113 @@ paths:
                 properties:
                   error:
                     type: string
+
+  # Steams API
+  #
+  # Recorded steaming sessions. Mirrors the /shots surface for milk
+  # steaming. Each record is opened on entry to MachineState.steam and
+  # finalized when the machine leaves steam.
+  #
+  /api/v1/steams:
+    get:
+      summary: List all steam records
+      tags: [Steams History]
+      responses:
+        "200":
+          description: List of steam records (without measurements)
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SteamRecord"
+
+  /api/v1/steams/ids:
+    get:
+      summary: List steam record IDs
+      tags: [Steams History]
+      responses:
+        "200":
+          description: Array of steam record ids
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+
+  /api/v1/steams/latest:
+    get:
+      summary: Get the most recent steam record (metadata only)
+      tags: [Steams History]
+      responses:
+        "200":
+          description: Latest steam record metadata (no measurements)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SteamRecord"
+
+  /api/v1/steams/{id}:
+    get:
+      summary: Get a specific steam record by ID
+      tags: [Steams History]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Steam record found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SteamRecord"
+        "404":
+          description: Steam record not found
+
+    put:
+      summary: Update a steam record's annotations
+      description: |
+        Only annotations are updatable. Measurements and workflow are
+        immutable once persisted.
+      tags: [Steams History]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                annotations:
+                  type: object
+                  additionalProperties: true
+      responses:
+        "200":
+          description: Steam record updated
+        "404":
+          description: Steam record not found
+
+    delete:
+      summary: Delete a steam record
+      tags: [Steams History]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Steam record deleted
 
   # Beans API
   #
@@ -3664,8 +3771,9 @@ components:
             `stopAtWeight` (autonomous in-FW stop-at-weight driven by
             the integrated scale; the app reflects
             `WorkflowContext.targetYield` into the SAW MMR). Future
-            Bengle peripherals (milk probe) will append their
-            identifiers as they ship.
+            Bengle peripherals will append their identifiers as they
+            ship. Note: the milk-probe scaffolding lives in `/sensors`,
+            not here.
           items:
             type: string
             enum: [cupWarmer, integratedScale, ledStrip, stopAtWeight]
@@ -4350,6 +4458,19 @@ components:
           format: double
           description: Steam flow rate
           example: 0.8
+        stopAtTemperature:
+          type: number
+          format: double
+          description: >
+            Stop steaming when the milk-probe reading reaches this
+            temperature (°C). `0` disables the stop. Range 0..80.
+            Scaffolding only today — no machine in production has an
+            integrated probe wired, so the field round-trips but does
+            not affect machine behaviour. On Bengle with a future probe
+            firmware the stop is FW-autonomous; on other machines or
+            third-party probes the app stops via `requestState(idle)`.
+          example: 65.0
+          default: 0.0
 
     HotWaterData:
       type: object
@@ -4496,6 +4617,44 @@ components:
           format: double
           nullable: true
           description: Accumulated volume in milliliters (ml) since shot start, calculated by integrating machine flow over time. Only counted from profile frame specified in targetVolumeCountStart.
+
+    SteamSnapshot:
+      type: object
+      properties:
+        machine:
+          $ref: "#/components/schemas/MachineSnapshot"
+        milkTemperature:
+          type: number
+          format: double
+          nullable: true
+          description: >
+            Milk-probe temperature in °C at this sample. `null` when
+            no probe is registered (today no probe is registered in
+            production — scaffolding only).
+
+    SteamRecord:
+      type: object
+      properties:
+        id:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        measurements:
+          type: array
+          items:
+            $ref: "#/components/schemas/SteamSnapshot"
+          description: >
+            Per-frame samples collected during the steaming session.
+            Omitted from list / latest responses; only returned by
+            GET /api/v1/steams/{id}.
+        workflow:
+          $ref: "#/components/schemas/WorkflowRequest"
+        annotations:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: Optional annotations (tasting notes, ratings).
 
     WeightSnapshot:
       type: object

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -87,6 +87,25 @@ For browser clients on a different origin, `ETag` is exposed via `Access-Control
 | PUT | `/api/v1/shots/:id` | Update shot annotations | |
 | DELETE | `/api/v1/shots/:id` | Delete shot | |
 
+### Steams
+
+Recorded milk-steaming sessions. Each record is opened when the machine
+enters `steam` and finalized when it leaves. Today no probe is wired in
+production, so `SteamSnapshot.milkTemperature` is `null` on every frame —
+the API surface is scaffolding for skin developers and for future
+probe / FW support. `SteamSettings.stopAtTemperature` (in
+`/api/v1/workflow`) is the target the future FW-autonomous stop or
+in-app stop will trigger on.
+
+| Method | Path | Description | Handler |
+|--------|------|-------------|---------|
+| GET | `/api/v1/steams` | List all steam records (no measurements) | `steams_handler.dart` |
+| GET | `/api/v1/steams/ids` | All steam record IDs | |
+| GET | `/api/v1/steams/latest` | Most recent steam record (no measurements) | |
+| GET | `/api/v1/steams/:id` | Get steam record by ID (with measurements) | |
+| PUT | `/api/v1/steams/:id` | Update steam record annotations | |
+| DELETE | `/api/v1/steams/:id` | Delete steam record | |
+
 ### Profiles
 
 | Method | Path | Description | Handler |

--- a/doc/plans/archive/bengle-milk-probe-and-steam-sequencer/2026-05-18-bengle-milk-probe-and-steam-sequencer.md
+++ b/doc/plans/archive/bengle-milk-probe-and-steam-sequencer/2026-05-18-bengle-milk-probe-and-steam-sequencer.md
@@ -1,0 +1,153 @@
+# Bengle milk probe + Steam Sequencer + Steam recording
+
+> **Design source of truth:** `[[Bengle/ReaPrime Integration#Step 7 — Milk probe + Steam Sequencer (design 2026-05-18)]]` in the Obsidian vault. This plan turns that design into an implementation sequence — read the integration note first for rationale and rejected alternatives.
+
+## Context
+
+Bundles three concerns under one effort:
+
+1. **Bengle internal milk probe.** Optional hardware (jack on the machine, wired thermistor); FW reads the ADC and exposes temperature over the existing transport.
+2. **Stop-at-temperature for steam.** New `SteamSettings.stopAtTemperature` field; FW-autonomous when machine is Bengle and the active stop-source is the internal probe, app-driven otherwise.
+3. **Steam recording.** Closes the P3 `SteamingRecord` ask from `ReaPrime/TODO.md`. Mirrors `ShotRecord` shape and lifecycle.
+
+The unifying entry point is a new `SteamSequencer` — analogue of `ShotSequencer`. It earns its weight by owning probe-source resolution, app-side stop (with bypass for FW-autonomous case), per-frame snapshot collection, and record finalization on state-exit.
+
+## Approach
+
+> **Scope reality:** FW is not ready. No real milk-probe discovery, no real FW autonomous stop. This effort lands the API surface + scaffolding so skin developers can adapt now, and so the future FW drop slots in as: (a) publish the `stopAtTemperatureTarget` MMR address, (b) ship a probe device implementation (Bengle internal or 3rd-party). Today, all FW-gated paths are stubs/no-ops; `SteamSnapshot.milkTemperature` will be `null` in practice until probe support exists.
+
+Six surface changes (already locked in the integration note):
+
+1. `SteamSettings` gains `stopAtTemperature: double` (`0.0 = off`).
+2. `/api/v1/machine/capabilities` — **no change.** Universal feature; presence-of-probe gated via `/sensors`.
+3. `/api/v1/sensors` — transparent extension (any registered probe appears here; today nothing registers).
+4. New `/api/v1/steams` REST mirror of shots (list, ids, latest, get, put-annotations, delete).
+5. `PersistenceController.steamsChanged` mirror of `shotsChanged`.
+6. **No new live WS topic** — live steaming view = existing machine snapshot WS + `/ws/v1/sensors/<id>/snapshot`.
+
+Architecture: bridge + adapter pattern (matches `BengleVirtualScale` / `BengleSawBridge`):
+
+- `BengleMilkProbe implements Sensor` — adapter scaffold; wraps Bengle probe signals when they exist. Today the underlying signal streams are empty/never-emit on real `Bengle` (only `MockBengle` synthesises for tests).
+- `BengleProbeBridge` — listens to `De1Controller.de1` + Bengle's `probeAttached` stream; registers/unregisters adapter via `SensorController`. Today the stream never emits on real `Bengle`; bridge stays inert until FW lands.
+- `BengleSteamStopBridge` — single writer, reflects `stopAtTemperature` into Bengle MMR (debounced, generation-token, re-asserts on Bengle reconnect). Mirrors `BengleSawBridge`. Today writes to a stub MMR address (`0x00000000`) with log-once gate; flip-test pins the address.
+- `SteamSequencer` — top-level controller, wired in `main.dart` with `De1Controller` + `SensorController` + `WorkflowController` + `PersistenceController`.
+
+### Stop-source resolution
+
+The sequencer decides per-steam whether to stop in-app or defer to FW via:
+
+```
+useFwAutonomousStop =
+    machine is Bengle
+ && steamSettings.stopAtTemperature > 0
+ && bengleProbeAttached
+ && fwSupportsStopAtTempMmr   // derived: BengleSteamMmr.stopAtTemperatureTarget.address != 0x00000000
+```
+
+When `false`, the sequencer takes the app-side path: if any sensor is registered in `SensorController` AND its latest sample ≥ target, call `requestState(idle)`. **Today every term except `steamSettings.stopAtTemperature > 0` is false on real hardware**, so the predicate is `false` and the app-side branch is taken — but with no registered probe, no stop fires either. This is the intended scaffolding state. The future-FW path (`useFwAutonomousStop = true`) and the future-3rd-party-probe path (app-side stop with a registered sensor) are exercised only in tests via `MockBengle` / `TestSensor`.
+
+Explicit `stopSourceId` selection is out of scope (see Out of scope). "First registered sensor wins" is the rule until multi-probe complaint.
+
+### Snapshot collection
+
+- **Source:** DE1 `shotSample` stream (existing). Rate = whatever the machine emits; no resampling.
+- **Window:** sequencer starts collecting on entry to `steam` state; stops on exit *and* not in any pouring sub-state (see Record lifecycle).
+- **Milk temperature:** at snapshot construction, sequencer reads the latest value from the **first** sensor registered in `SensorController` (insertion order). If no sensor is registered, `milkTemperature` is `null`. No interpolation; latest-known-value is fine.
+- **`SteamSnapshot` = machine fields (steamTemperature/Flow/Pressure, requestedState, substate) + `milkTemperature?`** — analogue to `ShotSnapshot` combining machine + weight.
+
+### Record lifecycle
+
+- **Open:** on entry to `MachineState.steam`.
+- **Finalize:** when state is no longer `steam` **and** not in a pouring sub-state. Persists via `PersistenceController.recordSteam`, emits `steamsChanged`.
+- **Discard:** machine disconnect mid-steam → discard, do not persist a half-record. Transitions to `sleep`/`error` finalize the same as `idle` (record what was captured).
+
+## Files to change
+
+### New
+
+- `lib/src/models/data/steam_record.dart` — `SteamRecord { id, timestamp, measurements: List<SteamSnapshot>, workflow, annotations? }`.
+- `lib/src/models/data/steam_snapshot.dart` — `SteamSnapshot { timestamp, steamTemperature, steamFlow, steamPressure, requestedState, substate, milkTemperature? }`.
+- `lib/src/models/device/impl/bengle/bengle_milk_probe.dart` — `BengleMilkProbe implements Sensor` adapter.
+- `lib/src/controllers/bengle_probe_bridge.dart` — `BengleProbeBridge` (register/unregister into SensorController).
+- `lib/src/controllers/bengle_steam_stop_bridge.dart` — `BengleSteamStopBridge` (FW reflection).
+- `lib/src/controllers/steam_sequencer.dart` — `SteamSequencer` (orchestrator).
+- `lib/src/services/webserver/steams_handler.dart` — REST surface for steam records (mirror `shots_handler.dart`).
+- `lib/src/services/database/tables/steam_tables.dart` — Drift tables.
+- `lib/src/services/database/daos/steam_dao.dart` — DAO.
+- `lib/src/services/database/mappers/steam_mapper.dart` — Drift ↔ domain mapping.
+- Test files mirroring each new file under `test/`.
+
+### Modified
+
+- `lib/src/models/data/workflow.dart` — add `stopAtTemperature` to `SteamSettings` + `toJson`/`fromJson`/`copyWith`/`==`/`hashCode`/`defaults`.
+- `lib/src/models/device/impl/bengle/bengle_mmr.dart` — add `BengleSteamMmr` enum (or extend `BengleScaleMmr` namespace convention) with `stopAtTemperatureTarget` entry. Stub address `0x00000000`; `scaledFloat` **unsigned**, scale factor 10 (decicelsius on wire); range 0..80 °C. **Set/get target only** — this MMR is not a probe-detection mechanism; probe discovery/data transport is unknown and may end up being a separate characteristic.
+- `lib/src/models/device/impl/bengle/bengle.dart` — add `setStopAtTemperatureTarget(double)` / `getStopAtTemperatureTarget()` + probe-attached signal stream + probe-temperature signal stream. All three are cache-only-with-log-once until FW publishes addresses.
+- `lib/src/models/device/bengle_interface.dart` — add the three abstract methods/streams above.
+- `lib/src/models/device/impl/bengle/mock_bengle.dart` — implement all three: probe-attached default `true` (configurable for tests), synthesised probe temperature during steam state, honor `stopAtTemperature` (call `requestState(idle)` when synthesised temp reaches target).
+- `lib/src/controllers/sensor_controller.dart` — add `register(Sensor)` / `unregister(String deviceId)`; merge bridge-registered with `DeviceController`-sourced (dedupe by `deviceId`).
+- `lib/src/controllers/persistence_controller.dart` — add `recordSteam(SteamRecord)` + `steamsChanged: Stream<void>`.
+- `lib/src/services/storage/storage_service.dart` (+ Drift impl) — add steam record CRUD.
+- `lib/src/services/database/database.dart` — register new tables + DAO.
+- `lib/src/services/webserver/webserver_service.dart` — register `SteamsHandler.addRoutes`.
+- `lib/main.dart` — wire `BengleProbeBridge`, `BengleSteamStopBridge`, `SteamSequencer`.
+- `assets/api/rest_v1.yml` — `stopAtTemperature` field on SteamSettings schema; full `/steams` paths (mirror shots). Same commit as code per CLAUDE.md.
+- `doc/Api.md` — reflect new REST surface.
+
+### Codebase comment cleanups (drive-by, same PR)
+
+Forward-looking comments from before the bundle was scoped:
+
+- `lib/src/models/device/bengle_interface.dart:9` — drop "milk probe" from capability-mixin enumeration; mention probe lives in `/sensors`.
+- `lib/src/models/device/impl/bengle/bengle_mmr.dart:4` — adjust comment ("milk probe" no longer in this enum).
+- `lib/src/models/device/impl/bengle/mock_bengle.dart:17` — same.
+- `assets/api/rest_v1.yml:218, 3667` — remove "milk probe" from forward-looking cap-list comments.
+
+## Implementation sequence (TDD-friendly)
+
+Each chunk leaves the tree green (`flutter analyze` + `flutter test`).
+
+1. **`SteamSettings.stopAtTemperature` field** — pure model change. Add field + JSON round-trip + `copyWith`/`==`/`hashCode` tests. Default `0.0` in `SteamSettings.defaults()`.
+2. **`SteamRecord` + `SteamSnapshot` domain models** — mirror `ShotRecord`/`ShotSnapshot` shape. JSON round-trip tests with and without `milkTemperature`.
+3. **Drift schema + DAO + mapper** — `steam_tables.dart` adds two tables: `SteamRecords` (id, timestamp, workflow JSON, annotations JSON) and `SteamSnapshots` (FK steamRecordId, timestamp, steamTemperature, steamFlow, steamPressure, requestedState, substate, milkTemperature NULLABLE). `steam_dao.dart`, `steam_mapper.dart`. Bump `AppDatabase.schemaVersion` by 1 and add a forward-only migration step that creates the two tables (no backfill). DAO tests cover insert + load round-trip with and without `milkTemperature`.
+4. **`PersistenceController.recordSteam` + `steamsChanged`** — extend controller, unit-test stream emission on `recordSteam` call.
+5. **`BengleSteamMmr.stopAtTemperatureTarget` enum entry + `Bengle.setStopAtTemperatureTarget` cache-and-log stub** — stub address `0x00000000`, unsigned scaledFloat (scale 10), range 0..80 °C, `_logStopAtTempStubOnce` per-session log gate (mirror SAW's `_logSawStubOnce`). Pin test asserts `BengleSteamMmr.stopAtTemperatureTarget.address == 0x00000000` — flips intentionally when FW publishes and forces review.
+6. **`BengleInterface` abstract surface** — `setStopAtTemperatureTarget` / `getStopAtTemperatureTarget` / `stopAtTemperatureTarget` stream + `probeAttached` stream + `probeTemperature` stream. Stream semantics mirror SAW: `BehaviorSubject` for `stopAtTemperatureTarget` (replays last cached value, seeded with default), `BehaviorSubject<bool>` for `probeAttached` (seeded `false`), `PublishSubject<double>` for `probeTemperature` (no replay; latest-only consumers should track themselves). On real `Bengle`, `probeAttached` stays `false` and `probeTemperature` never emits — FW signal source TBD. `MockBengle` implements the synth path for tests.
+7. **`BengleMilkProbe` adapter** — `Sensor` impl wrapping Bengle's probe signals. Unit tests on `data` stream + `connectionState` semantics (probe-attach lifecycle, not machine-connect).
+8. **`SensorController.register` / `unregister`** — API addition + dedupe-by-deviceId merge. **Bridge-registered wins** when the same `deviceId` is also produced by `DeviceController` (bridge has fuller signal — knows probe-attach state, not just BLE presence). Document on the method. Unit tests covering: bridge-registered alone, DeviceController-sourced alone, both with same id (assert bridge instance is exposed), register/unregister churn.
+9. **`BengleProbeBridge`** — listen to `De1Controller.de1` + Bengle's `probeAttached` stream; register/unregister adapter. Tests with mocked controllers covering: probe attach mid-session, probe detach mid-session, machine disconnect with probe attached.
+10. **`BengleSteamStopBridge`** — mirror `BengleSawBridge` test structure. Debounce, re-assert on reconnect, generation-token cancellation on disconnect.
+11. **`SteamSequencer`** — orchestrator. Unit tests cover: stop-source predicate truth table (the four terms in `useFwAutonomousStop`), app-side stop fires when first registered sensor crosses target (use `TestSensor`), no-probe case (no stop fires, sequencer is inert on the stop path), snapshot collection accumulates `shotSample` frames during `steam`, `milkTemperature` populated from first registered sensor or `null` when empty, record finalize on state-exit (steam→idle, steam→sleep, steam→error), record discard on machine disconnect mid-steam.
+12. **`SteamSequencer` integration** — end-to-end with real `MockBengle` + real `SensorController` + real `PersistenceController` (in-memory `AppDatabase`) + fake `WorkflowController`. Drive a full simulated steam: state→steam, frames flow in, state→idle, assert `SteamRecord` persisted with expected snapshot count and (since no probe registered) all `milkTemperature: null`.
+13. **REST `SteamsHandler`** — mirror `ShotsHandler` routes. Integration tests via in-memory db.
+14. **Spec + doc** — `assets/api/rest_v1.yml` paths + `stopAtTemperature` schema; `doc/Api.md` entries. Smoke-test via `sb-dev` + curl per `.agents/skills/decent-app/verification.md`.
+15. **`main.dart` wiring** — instantiate bridges + sequencer; verify cold-boot smoke (`sb-dev start --simulate`). No unit tests at this layer; smoke-only.
+16. **Comment cleanups** — the four spots flagged above.
+
+## Test plan
+
+- **Unit:** each new file gets its own test (numbered with sequence above).
+- **Integration:** `SteamSequencer` with real `MockBengle`, real `SensorController` with `BengleProbeBridge`, fake `WorkflowController` — drive through a full simulated steaming session, assert `SteamRecord` shape on finalization.
+- **REST:** `steams_handler_test.dart` mirroring `shots_handler_test.dart` (in-memory `AppDatabase`, CRUD assertions).
+- **End-to-end smoke (`sb-dev`):** new scenario file `.agents/skills/decent-app/scenarios/bengle-milk-probe-steam-stop.md`:
+  - Simulate Bengle with probe attached (default).
+  - PUT workflow with `stopAtTemperature: 65.0`.
+  - `requestState(steam)`. Verify probe appears in `/sensors`.
+  - Subscribe `/ws/v1/sensors/<probeId>/snapshot`, watch temp rise.
+  - Verify machine returns to `idle` (MockBengle's autonomous stop fires).
+  - `GET /api/v1/steams/latest` — verify SteamRecord with `milkTemperature` on frames near the end.
+- **Pin tests:** `BengleSteamMmr.stopAtTemperatureTarget.address == 0x00000000` until FW publishes — flip-test forces review when address fills in.
+
+## Out of scope (deferred)
+
+- FW MMR addresses (probe presence, probe temperature notify, stopAtTemperature target) — all `0x00000000` + log-once + cache-only.
+- Explicit stop-source selection (`SteamSettings.stopSourceId`) — default rule sufficient until multi-probe complaint.
+- Multi-probe per-frame recording (`additionalProbeReadings` field) — additive future extension.
+- `StopAtTemperatureCapability` mixin refactor — defer until a non-Bengle machine ships with an integrated milk probe.
+- Sensor API simplification — rejected for this effort.
+- UI work (realtime steaming view, history-of-steams tile) — record surface only; UI is a separate effort.
+
+## Branch + completion
+
+- Branch: `feature/bengle-milk-temp` (current).
+- Completion: PR to `main` after each chunk lands green and end-to-end smoke passes. Commit chain mirrors SAW (small focused commits per chunk where natural; bundle when the diff is small).
+- Pre-merge: archive this plan doc to `doc/plans/archive/bengle-milk-probe-and-steam-sequencer/` per CLAUDE.md.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,7 +14,10 @@ import 'package:logging/logging.dart';
 import 'package:logging_appenders/logging_appenders.dart';
 import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/controllers/battery_controller.dart';
+import 'package:reaprime/src/controllers/bengle_probe_bridge.dart';
 import 'package:reaprime/src/controllers/bengle_saw_bridge.dart';
+import 'package:reaprime/src/controllers/bengle_steam_stop_bridge.dart';
+import 'package:reaprime/src/controllers/steam_sequencer.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
@@ -314,6 +317,37 @@ void main() async {
   final bengleSawBridge = BengleSawBridge(
     workflowController: workflowController,
     de1Controller: de1Controller,
+  );
+
+  // Reflects SteamSettings.stopAtTemperature into Bengle's stop-at-
+  // temperature MMR (currently stubbed FW slot — bridge keeps the
+  // cache consistent so the day FW publishes, writes hit the wire
+  // automatically). See [[bengle_steam_stop_bridge]].
+  // ignore: unused_local_variable
+  final bengleSteamStopBridge = BengleSteamStopBridge(
+    workflowController: workflowController,
+    de1Controller: de1Controller,
+  );
+
+  // Registers a BengleMilkProbe sensor adapter with SensorController
+  // when a Bengle's probe-attached signal flips true. Inert today —
+  // real `Bengle.probeAttached` never emits true until FW publishes
+  // a presence signal.
+  // ignore: unused_local_variable
+  final bengleProbeBridge = BengleProbeBridge(
+    de1Controller: de1Controller,
+    sensorController: sensorController,
+  );
+
+  // Records steaming sessions + scaffolding for stop-at-temperature.
+  // See [[steam_sequencer]] for the predicate truth table and
+  // record lifecycle.
+  // ignore: unused_local_variable
+  final steamSequencer = SteamSequencer(
+    de1Controller: de1Controller,
+    sensorController: sensorController,
+    workflowController: workflowController,
+    persistenceController: persistenceController,
   );
   final PluginLoaderService pluginService = PluginLoaderService(
     kvStore: HiveStoreService(defaultNamespace: "plugins")..initialize(),

--- a/lib/src/controllers/bengle_probe_bridge.dart
+++ b/lib/src/controllers/bengle_probe_bridge.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/sensor_controller.dart';
+import 'package:reaprime/src/models/device/bengle_interface.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle_milk_probe.dart';
+
+/// Registers a [BengleMilkProbe] adapter with [SensorController] when
+/// the connected machine is a Bengle AND its probe is attached. Removes
+/// the adapter on detach or on machine disconnect.
+///
+/// **Scaffolding.** Today real `Bengle.probeAttached` never emits
+/// `true` (FW signal source is TBD) — the bridge stays inert until FW
+/// publishes a presence signal. `MockBengle` defaults to attached for
+/// tests, so the bridge fires immediately.
+class BengleProbeBridge {
+  BengleProbeBridge({
+    required De1Controller de1Controller,
+    required SensorController sensorController,
+  })  : _de1 = de1Controller,
+        _sensors = sensorController {
+    _de1Sub = _de1.de1.listen(_onMachineChange);
+  }
+
+  final De1Controller _de1;
+  final SensorController _sensors;
+  final Logger _log = Logger('BengleProbeBridge');
+
+  StreamSubscription<De1Interface?>? _de1Sub;
+  StreamSubscription<bool>? _attachedSub;
+  BengleMilkProbe? _registeredProbe;
+  BengleInterface? _attachedBengle;
+
+  Future<void> _onMachineChange(De1Interface? device) async {
+    if (device is BengleInterface) {
+      if (identical(_attachedBengle, device)) return;
+      await _detachCurrent();
+      _attachedBengle = device;
+      _attachedSub = device.probeAttached.listen(_onAttachedChange);
+    } else {
+      await _detachCurrent();
+    }
+  }
+
+  Future<void> _onAttachedChange(bool attached) async {
+    final bengle = _attachedBengle;
+    if (bengle == null) return;
+    if (attached && _registeredProbe == null) {
+      final probe = BengleMilkProbe(bengle: bengle);
+      _registeredProbe = probe;
+      _log.info('Bengle milk probe attached — registering sensor');
+      await _sensors.register(probe);
+    } else if (!attached && _registeredProbe != null) {
+      final probe = _registeredProbe!;
+      _registeredProbe = null;
+      _log.info('Bengle milk probe detached — unregistering sensor');
+      await _sensors.unregister(probe.deviceId);
+    }
+  }
+
+  Future<void> _detachCurrent() async {
+    await _attachedSub?.cancel();
+    _attachedSub = null;
+    final probe = _registeredProbe;
+    if (probe != null) {
+      _registeredProbe = null;
+      await _sensors.unregister(probe.deviceId);
+    }
+    _attachedBengle = null;
+  }
+
+  Future<void> dispose() async {
+    await _de1Sub?.cancel();
+    _de1Sub = null;
+    await _detachCurrent();
+  }
+}

--- a/lib/src/controllers/bengle_steam_stop_bridge.dart
+++ b/lib/src/controllers/bengle_steam_stop_bridge.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/device/bengle_interface.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/errors.dart';
+
+/// Reflects `SteamSettings.stopAtTemperature` into the connected
+/// Bengle's `setStopAtTemperatureTarget` MMR endpoint. Mirrors
+/// [BengleSawBridge] — same debounce + generation-token + re-assert on
+/// reconnect shape.
+///
+/// **Scaffolding.** While the FW MMR slot is stubbed
+/// (`BengleSteamMmr.stopAtTemperatureTarget.address == 0x00000000`),
+/// `Bengle.setStopAtTemperatureTarget` caches the value locally and
+/// log-onces; this bridge keeps the cache consistent with the workflow
+/// so the day FW lands, the write hits the wire automatically with no
+/// app-side changes.
+class BengleSteamStopBridge {
+  BengleSteamStopBridge({
+    required WorkflowController workflowController,
+    required De1Controller de1Controller,
+    this.debounce = const Duration(milliseconds: 250),
+  })  : _workflow = workflowController,
+        _de1 = de1Controller {
+    _lastPushed = _currentTarget();
+    _workflow.addListener(_onWorkflowChange);
+    _de1Sub = _de1.de1.listen(_onDe1Change);
+  }
+
+  final WorkflowController _workflow;
+  final De1Controller _de1;
+  final Duration debounce;
+  final Logger _log = Logger('BengleSteamStopBridge');
+
+  StreamSubscription<De1Interface?>? _de1Sub;
+  Timer? _debounceTimer;
+  int _generation = 0;
+  double? _lastPushed;
+
+  double _currentTarget() =>
+      _workflow.currentWorkflow.steamSettings.stopAtTemperature;
+
+  void _onWorkflowChange() {
+    final next = _currentTarget();
+    if (next == _lastPushed) return;
+    _debounceTimer?.cancel();
+    final generation = ++_generation;
+    _debounceTimer = Timer(debounce, () => _push(next, generation));
+  }
+
+  void _onDe1Change(De1Interface? device) {
+    if (device is! BengleInterface) return;
+    final next = _currentTarget();
+    final generation = ++_generation;
+    _push(next, generation);
+  }
+
+  Future<void> _push(double celsius, int generation) async {
+    if (generation != _generation) {
+      _log.fine('Steam-stop write superseded '
+          '(gen=$generation, current=$_generation)');
+      return;
+    }
+    final machine = _de1.connectedDe1OrNull;
+    if (machine is! BengleInterface) {
+      _log.fine('Steam-stop write skipped — connected machine is not Bengle');
+      return;
+    }
+    try {
+      await machine.setStopAtTemperatureTarget(celsius);
+      if (generation == _generation) {
+        _lastPushed = celsius;
+      }
+      _log.info('Stop-at-temperature target written: $celsius°C');
+    } on DeviceNotConnectedException {
+      _log.fine('Steam-stop write aborted — machine disconnected mid-call');
+    } catch (e, st) {
+      _log.warning('Steam-stop write failed', e, st);
+    }
+  }
+
+  Future<void> dispose() async {
+    _workflow.removeListener(_onWorkflowChange);
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    await _de1Sub?.cancel();
+    _de1Sub = null;
+  }
+}

--- a/lib/src/controllers/persistence_controller.dart
+++ b/lib/src/controllers/persistence_controller.dart
@@ -1,5 +1,6 @@
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/data/shot_record.dart';
+import 'package:reaprime/src/models/data/steam_record.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/services/storage/storage_service.dart';
 import 'package:rxdart/rxdart.dart';
@@ -15,10 +16,18 @@ class PersistenceController {
   final _shotsChangedSubject = PublishSubject<void>();
   Stream<void> get shotsChanged => _shotsChangedSubject.stream;
 
+  /// Fires whenever steam records are added, updated, or deleted.
+  final _steamsChangedSubject = PublishSubject<void>();
+  Stream<void> get steamsChanged => _steamsChangedSubject.stream;
+
   /// Manually fire a shots-changed notification.
   /// Used after external mutations (e.g., ZIP import via REST endpoint).
   void notifyShotsChanged() {
     _shotsChangedSubject.add(null);
+  }
+
+  void notifySteamsChanged() {
+    _steamsChangedSubject.add(null);
   }
 
   Future<void> persistShot(ShotRecord record) async {
@@ -53,6 +62,38 @@ class PersistenceController {
     }
   }
 
+  Future<void> persistSteam(SteamRecord record) async {
+    _log.info("Storing steam record");
+    try {
+      await storageService.storeSteam(record);
+      _steamsChangedSubject.add(null);
+    } catch (e, st) {
+      _log.severe("Error saving steam record:", e, st);
+    }
+  }
+
+  Future<void> updateSteam(SteamRecord record) async {
+    _log.info("Updating steam record: ${record.id}");
+    try {
+      await storageService.updateSteam(record);
+      _steamsChangedSubject.add(null);
+    } catch (e, st) {
+      _log.severe("Error updating steam record:", e, st);
+      rethrow;
+    }
+  }
+
+  Future<void> deleteSteam(String id) async {
+    _log.info("Deleting steam record: $id");
+    try {
+      await storageService.deleteSteam(id);
+      _steamsChangedSubject.add(null);
+    } catch (e, st) {
+      _log.severe("Error deleting steam record:", e, st);
+      rethrow;
+    }
+  }
+
   Future<void> saveWorkflow(Workflow workflow) async {
     await storageService.storeCurrentWorkflow(workflow);
   }
@@ -63,5 +104,6 @@ class PersistenceController {
 
   void dispose() {
     _shotsChangedSubject.close();
+    _steamsChangedSubject.close();
   }
 }

--- a/lib/src/controllers/sensor_controller.dart
+++ b/lib/src/controllers/sensor_controller.dart
@@ -5,31 +5,78 @@ import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/sensor.dart';
 
+/// Aggregates sensors from two sources:
+///
+/// 1. [DeviceController] discovery — `Sensor` instances picked up via
+///    BLE/USB scans (e.g. SensorBasket).
+/// 2. Bridge-registered — `Sensor` adapters wrapping a non-discoverable
+///    signal source (e.g. `BengleMilkProbe`, which is a probe jack on
+///    the machine, not a discoverable BLE peripheral).
+///
+/// When the same `deviceId` appears in both sources, the
+/// bridge-registered instance wins — it carries fuller signal
+/// (probe-attach state, latest reading), where the discovered entry
+/// only knows BLE presence. See `BengleProbeBridge` for the canonical
+/// caller.
 class SensorController {
   final DeviceController _deviceController;
 
-  Map<String, Sensor> _sensors = {};
+  final Map<String, Sensor> _discovered = {};
+  final Map<String, Sensor> _bridgeRegistered = {};
 
   final Logger _log = Logger("SensorController");
-  
+
   StreamSubscription<List<Device>>? _deviceStreamSubscription;
 
   SensorController({required DeviceController controller})
       : _deviceController = controller {
-    _deviceStreamSubscription = _deviceController.deviceStream.listen(_processDevices);
+    _deviceStreamSubscription =
+        _deviceController.deviceStream.listen(_processDevices);
   }
 
   Future<void> _processDevices(List<Device> devices) async {
     final sensors = devices.whereType<Sensor>().toList();
     _log.info("received sensors: $sensors");
-    _sensors = sensors.fold({}, (val, s) {
-      val[s.deviceId] = s;
-      return val;
-    });
+    _discovered
+      ..clear()
+      ..addEntries(sensors.map((s) => MapEntry(s.deviceId, s)));
     await Future.wait(sensors.map((s) => s.onConnect()));
   }
 
-  Map<String, Sensor> get sensors => _sensors;
+  /// Register a sensor not surfaced by [DeviceController] (e.g. an
+  /// adapter wrapping a machine-integrated probe). The adapter's
+  /// `onConnect` is invoked so it can attach to its underlying signal
+  /// source. If a sensor with the same `deviceId` was already
+  /// bridge-registered it is replaced after disconnecting the previous
+  /// instance.
+  Future<void> register(Sensor sensor) async {
+    final id = sensor.deviceId;
+    final existing = _bridgeRegistered[id];
+    if (existing != null && !identical(existing, sensor)) {
+      await existing.disconnect();
+    }
+    _bridgeRegistered[id] = sensor;
+    if (!identical(existing, sensor)) {
+      await sensor.onConnect();
+    }
+  }
+
+  /// Remove a bridge-registered sensor and disconnect it. No-op on
+  /// `DeviceController`-sourced entries — those are owned by their
+  /// discovery service and removed when the device stream drops them.
+  Future<void> unregister(String deviceId) async {
+    final removed = _bridgeRegistered.remove(deviceId);
+    if (removed != null) {
+      await removed.disconnect();
+    }
+  }
+
+  /// Merged view of bridge-registered + discovered sensors. Bridge
+  /// entries take precedence on `deviceId` collisions.
+  Map<String, Sensor> get sensors => {
+        ..._discovered,
+        ..._bridgeRegistered,
+      };
 
   void dispose() {
     _deviceStreamSubscription?.cancel();

--- a/lib/src/controllers/steam_sequencer.dart
+++ b/lib/src/controllers/steam_sequencer.dart
@@ -1,0 +1,219 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/persistence_controller.dart';
+import 'package:reaprime/src/controllers/sensor_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/steam_record.dart';
+import 'package:reaprime/src/models/data/steam_snapshot.dart';
+import 'package:reaprime/src/models/data/workflow.dart';
+import 'package:reaprime/src/models/device/bengle_interface.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/sensor.dart';
+import 'package:uuid/uuid.dart';
+
+/// Long-lived service that records steaming sessions and orchestrates
+/// the stop-at-temperature scaffolding. Mirrors `ShotSequencer` shape
+/// but lives across the app lifetime (not per-shot) because steaming
+/// has no separate "begin shot" command — the user just enters the
+/// steam state on the machine.
+///
+/// **Today (FW not ready):**
+/// - Records persist via `PersistenceController.persistSteam`.
+/// - `SteamSnapshot.milkTemperature` is populated from the first
+///   sensor registered in `SensorController`. No probe is registered
+///   in production today, so the field is `null` in real recordings.
+/// - The stop-at-temperature path: the FW-autonomous branch is
+///   gated on `BengleSteamMmr.stopAtTemperatureTarget.address != 0`,
+///   which is `false` today — so the app-side branch is taken. With
+///   no sensor registered, the app-side branch is also inert. The
+///   test suite exercises both branches via `MockBengle` +
+///   `TestSensor`.
+class SteamSequencer {
+  SteamSequencer({
+    required De1Controller de1Controller,
+    required SensorController sensorController,
+    required WorkflowController workflowController,
+    required PersistenceController persistenceController,
+  })  : _de1 = de1Controller,
+        _sensors = sensorController,
+        _workflow = workflowController,
+        _persistence = persistenceController {
+    _de1Sub = _de1.de1.listen(_onMachineChange);
+  }
+
+  final De1Controller _de1;
+  final SensorController _sensors;
+  final WorkflowController _workflow;
+  final PersistenceController _persistence;
+  final Logger _log = Logger('SteamSequencer');
+
+  StreamSubscription<De1Interface?>? _de1Sub;
+  StreamSubscription<MachineSnapshot>? _snapshotSub;
+  StreamSubscription<Map<String, dynamic>>? _sensorSub;
+  De1Interface? _machine;
+  Sensor? _trackedSensor;
+  double? _latestSensorTemperature;
+
+  // Open record state.
+  String? _openId;
+  DateTime? _openTimestamp;
+  Workflow? _openWorkflow;
+  final List<SteamSnapshot> _measurements = [];
+  bool _appSideStopRequested = false;
+
+  bool get isRecording => _openId != null;
+
+  /// Stop-source predicate (see plan §Approach). Public for tests.
+  ///
+  /// `true` means the FW will autonomously stop the steam at the
+  /// target temperature — the sequencer must NOT request `idle`. Today
+  /// this is always `false` because the MMR address is stubbed.
+  bool useFwAutonomousStop({
+    required De1Interface? machine,
+    required bool probeAttached,
+    required double stopAtTemperature,
+  }) {
+    if (machine is! BengleInterface) return false;
+    if (stopAtTemperature <= 0) return false;
+    if (!probeAttached) return false;
+    if (BengleSteamMmr.stopAtTemperatureTarget.address == 0x00000000) {
+      return false;
+    }
+    return true;
+  }
+
+  Future<void> _onMachineChange(De1Interface? machine) async {
+    if (identical(_machine, machine)) return;
+    if (_machine != null && isRecording) {
+      // Mid-steam disconnect → discard the in-flight record.
+      _log.warning(
+          'Machine changed mid-steam; discarding incomplete record');
+      _discard();
+    }
+    await _snapshotSub?.cancel();
+    _snapshotSub = null;
+    _machine = machine;
+    if (machine != null) {
+      _snapshotSub = machine.currentSnapshot.listen(_onSnapshot);
+    }
+  }
+
+  void _onSnapshot(MachineSnapshot s) {
+    final inSteam = s.state.state == MachineState.steam;
+    final inPouring = s.state.substate == MachineSubstate.pouring;
+
+    if (inSteam && !isRecording) {
+      _openRecord();
+    }
+
+    if (isRecording) {
+      _measurements.add(SteamSnapshot(
+        machine: s,
+        milkTemperature: _latestSensorTemperature,
+      ));
+      _maybeAppSideStop(s);
+    }
+
+    if (!inSteam && !inPouring && isRecording) {
+      _finalize();
+    }
+  }
+
+  void _openRecord() {
+    _openId = const Uuid().v4();
+    _openTimestamp = DateTime.now();
+    _openWorkflow = _workflow.currentWorkflow;
+    _measurements.clear();
+    _appSideStopRequested = false;
+    _trackFirstSensor();
+    _log.info('Steam record opened: $_openId');
+  }
+
+  void _trackFirstSensor() {
+    _sensorSub?.cancel();
+    _sensorSub = null;
+    _trackedSensor = null;
+    _latestSensorTemperature = null;
+    final entries = _sensors.sensors.entries;
+    if (entries.isEmpty) return;
+    final sensor = entries.first.value;
+    _trackedSensor = sensor;
+    _sensorSub = sensor.data.listen((payload) {
+      final raw = payload['temperature'];
+      if (raw is num) _latestSensorTemperature = raw.toDouble();
+    });
+  }
+
+  void _maybeAppSideStop(MachineSnapshot s) {
+    if (_appSideStopRequested) return;
+    final wf = _openWorkflow ?? _workflow.currentWorkflow;
+    final target = wf.steamSettings.stopAtTemperature;
+    if (target <= 0) return;
+    final attached = _trackedSensor != null;
+    if (useFwAutonomousStop(
+        machine: _machine,
+        probeAttached: attached,
+        stopAtTemperature: target)) {
+      return;
+    }
+    final temp = _latestSensorTemperature;
+    if (temp == null) return;
+    if (temp < target) return;
+    _appSideStopRequested = true;
+    _log.info('App-side stop: probe $temp°C ≥ target $target°C');
+    final machine = _machine;
+    if (machine != null) {
+      // ignore: discarded_futures
+      machine.requestState(MachineState.idle);
+    }
+  }
+
+  Future<void> _finalize() async {
+    final id = _openId;
+    final ts = _openTimestamp;
+    final wf = _openWorkflow;
+    if (id == null || ts == null || wf == null) {
+      _resetOpenState();
+      return;
+    }
+    final record = SteamRecord(
+      id: id,
+      timestamp: ts,
+      measurements: List.unmodifiable(_measurements),
+      workflow: wf,
+    );
+    _resetOpenState();
+    _log.info('Steam record finalized: ${record.id} '
+        '(${record.measurements.length} frames)');
+    await _persistence.persistSteam(record);
+  }
+
+  void _discard() {
+    _resetOpenState();
+  }
+
+  void _resetOpenState() {
+    _openId = null;
+    _openTimestamp = null;
+    _openWorkflow = null;
+    _measurements.clear();
+    _appSideStopRequested = false;
+    _sensorSub?.cancel();
+    _sensorSub = null;
+    _trackedSensor = null;
+    _latestSensorTemperature = null;
+  }
+
+  Future<void> dispose() async {
+    await _de1Sub?.cancel();
+    _de1Sub = null;
+    await _snapshotSub?.cancel();
+    _snapshotSub = null;
+    await _sensorSub?.cancel();
+    _sensorSub = null;
+  }
+}

--- a/lib/src/home_feature/widgets/device_selection_widget.dart
+++ b/lib/src/home_feature/widgets/device_selection_widget.dart
@@ -117,25 +117,35 @@ class _DeviceSelectionWidgetState extends State<DeviceSelectionWidget> {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                ListTile(
-                  dense: true,
-                  visualDensity: VisualDensity(horizontal: -4, vertical: -4),
-                  contentPadding: EdgeInsets.symmetric(horizontal: 8),
-                  title: Text(device.name, style: Theme.of(context).textTheme.bodySmall),
-                  subtitle: Text(
-                    "ID: ${device.deviceId.length > 8 ? device.deviceId.substring(device.deviceId.length - 8) : device.deviceId}",
-                    style: Theme.of(context).textTheme.labelSmall,
+                // ShadCard wraps its children in a DecoratedBox with a
+                // background colour. Flutter's `ListTile` paints onto
+                // the nearest `Material` ancestor and asserts when a
+                // bg-coloured DecoratedBox sits between them. Wrap the
+                // ListTile in a transparent Material so the tile has
+                // its own paint surface; ShadCard's visuals are
+                // unaffected.
+                Material(
+                  type: MaterialType.transparency,
+                  child: ListTile(
+                    dense: true,
+                    visualDensity: VisualDensity(horizontal: -4, vertical: -4),
+                    contentPadding: EdgeInsets.symmetric(horizontal: 8),
+                    title: Text(device.name, style: Theme.of(context).textTheme.bodySmall),
+                    subtitle: Text(
+                      "ID: ${device.deviceId.length > 8 ? device.deviceId.substring(device.deviceId.length - 8) : device.deviceId}",
+                      style: Theme.of(context).textTheme.labelSmall,
+                    ),
+                    leading: isPreferred
+                        ? Icon(LucideIcons.check, size: 16, color: Theme.of(context).colorScheme.primary)
+                        : SizedBox(width: 16),
+                    trailing: DeviceConnectingIndicator(
+                      isConnecting: isConnecting,
+                    ),
+                    enabled: !isAnyConnecting,
+                    onTap: isAnyConnecting
+                        ? null
+                        : () => widget.onDeviceTapped(device),
                   ),
-                  leading: isPreferred
-                      ? Icon(LucideIcons.check, size: 16, color: Theme.of(context).colorScheme.primary)
-                      : SizedBox(width: 16),
-                  trailing: DeviceConnectingIndicator(
-                    isConnecting: isConnecting,
-                  ),
-                  enabled: !isAnyConnecting,
-                  onTap: isAnyConnecting
-                      ? null
-                      : () => widget.onDeviceTapped(device),
                 ),
               ],
             ),

--- a/lib/src/models/data/steam_record.dart
+++ b/lib/src/models/data/steam_record.dart
@@ -1,0 +1,72 @@
+import 'package:reaprime/src/models/data/shot_annotations.dart';
+import 'package:reaprime/src/models/data/steam_snapshot.dart';
+import 'package:reaprime/src/models/data/workflow.dart';
+
+/// Persisted record of one steaming session. Mirrors [ShotRecord]
+/// shape and lifecycle — opened on entry to `MachineState.steam`,
+/// finalized when the machine leaves `steam` (and is no longer
+/// pouring), discarded on mid-steam disconnect.
+class SteamRecord {
+  final String id;
+  final DateTime timestamp;
+  final List<SteamSnapshot> measurements;
+  final Workflow workflow;
+  final ShotAnnotations? annotations;
+
+  SteamRecord({
+    required this.id,
+    required this.timestamp,
+    required this.measurements,
+    required this.workflow,
+    this.annotations,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'timestamp': timestamp.toIso8601String(),
+      'measurements': measurements.map((e) => e.toJson()).toList(),
+      'workflow': workflow.toJson(),
+      if (annotations != null) 'annotations': annotations!.toJson(),
+    };
+  }
+
+  Map<String, dynamic> toJsonWithoutMeasurements() {
+    return {
+      'id': id,
+      'timestamp': timestamp.toIso8601String(),
+      'workflow': workflow.toJson(),
+      if (annotations != null) 'annotations': annotations!.toJson(),
+    };
+  }
+
+  factory SteamRecord.fromJson(Map<String, dynamic> json) {
+    return SteamRecord(
+      id: json['id'] as String,
+      timestamp: DateTime.parse(json['timestamp'] as String),
+      measurements: (json['measurements'] as List? ?? const [])
+          .map((e) => SteamSnapshot.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      workflow: Workflow.fromJson(json['workflow'] as Map<String, dynamic>),
+      annotations: json['annotations'] != null
+          ? ShotAnnotations.fromJson(json['annotations'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+
+  SteamRecord copyWith({
+    String? id,
+    DateTime? timestamp,
+    List<SteamSnapshot>? measurements,
+    Workflow? workflow,
+    ShotAnnotations? annotations,
+  }) {
+    return SteamRecord(
+      id: id ?? this.id,
+      timestamp: timestamp ?? this.timestamp,
+      measurements: measurements ?? this.measurements,
+      workflow: workflow ?? this.workflow,
+      annotations: annotations ?? this.annotations,
+    );
+  }
+}

--- a/lib/src/models/data/steam_snapshot.dart
+++ b/lib/src/models/data/steam_snapshot.dart
@@ -1,0 +1,33 @@
+import 'package:reaprime/src/models/device/machine.dart';
+
+/// One sample collected during steaming. Analogue of [ShotSnapshot]:
+/// wraps the full [MachineSnapshot] and adds the milk-probe reading
+/// when one is available. `milkTemperature` is `null` until a sensor
+/// is registered with `SensorController` and emits a reading.
+class SteamSnapshot {
+  final MachineSnapshot machine;
+  final double? milkTemperature;
+
+  SteamSnapshot({required this.machine, this.milkTemperature});
+
+  SteamSnapshot copyWith({MachineSnapshot? machine, double? milkTemperature}) {
+    return SteamSnapshot(
+      machine: machine ?? this.machine,
+      milkTemperature: milkTemperature ?? this.milkTemperature,
+    );
+  }
+
+  Map<String, Object?> toJson() {
+    return {
+      'machine': machine.toJson(),
+      'milkTemperature': milkTemperature,
+    };
+  }
+
+  factory SteamSnapshot.fromJson(Map<String, dynamic> json) {
+    return SteamSnapshot(
+      machine: MachineSnapshot.fromJson(json['machine']),
+      milkTemperature: (json['milkTemperature'] as num?)?.toDouble(),
+    );
+  }
+}

--- a/lib/src/models/data/workflow.dart
+++ b/lib/src/models/data/workflow.dart
@@ -119,22 +119,28 @@ class SteamSettings {
   int targetTemperature;
   int duration;
   double flow;
+  // 0.0 = off. Set/get target only; FW autonomous stop gated on a
+  // future MMR address (see [[bengle_steam_mmr]]).
+  double stopAtTemperature;
 
   SteamSettings({
     required this.targetTemperature,
     required this.duration,
     required this.flow,
+    this.stopAtTemperature = 0.0,
   });
 
   SteamSettings copyWith({
     int? targetTemperature,
     int? duration,
     double? flow,
+    double? stopAtTemperature,
   }) {
     return SteamSettings(
       targetTemperature: targetTemperature ?? this.targetTemperature,
       duration: duration ?? this.duration,
       flow: flow ?? this.flow,
+      stopAtTemperature: stopAtTemperature ?? this.stopAtTemperature,
     );
   }
 
@@ -143,6 +149,7 @@ class SteamSettings {
       'targetTemperature': targetTemperature,
       'duration': duration,
       'flow': flow,
+      'stopAtTemperature': stopAtTemperature,
     };
   }
 
@@ -151,11 +158,18 @@ class SteamSettings {
       targetTemperature: parseInt(json['targetTemperature']),
       duration: parseInt(json['duration']),
       flow: parseDouble(json['flow']),
+      stopAtTemperature: json.containsKey('stopAtTemperature')
+          ? parseDouble(json['stopAtTemperature'])
+          : 0.0,
     );
   }
 
   factory SteamSettings.defaults() {
-    return SteamSettings(targetTemperature: 150, duration: 50, flow: 0.8);
+    return SteamSettings(
+        targetTemperature: 150,
+        duration: 50,
+        flow: 0.8,
+        stopAtTemperature: 0.0);
   }
 
   @override
@@ -166,12 +180,16 @@ class SteamSettings {
 
     return other.targetTemperature == targetTemperature &&
         other.flow == flow &&
-        other.duration == duration;
+        other.duration == duration &&
+        other.stopAtTemperature == stopAtTemperature;
   }
 
   @override
   int get hashCode =>
-      targetTemperature.hashCode ^ flow.hashCode ^ duration.hashCode;
+      targetTemperature.hashCode ^
+      flow.hashCode ^
+      duration.hashCode ^
+      stopAtTemperature.hashCode;
 }
 
 class HotWaterData {

--- a/lib/src/models/device/bengle_interface.dart
+++ b/lib/src/models/device/bengle_interface.dart
@@ -2,11 +2,10 @@ import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/led_strip.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 
-/// Marker interface for Bengle-specific machine API. Currently empty —
-/// Bengle inherits the full DE1 surface unchanged.
+/// Marker interface for Bengle-specific machine API.
 ///
 /// **Future capability methods land here.** When a Bengle capability
-/// (cup warmer, integrated scale, LED strip, milk probe) needs a public
+/// (cup warmer, integrated scale, LED strip, etc.) needs a public
 /// API method, add it to this interface and implement it on `Bengle`.
 /// Capability-internal state and helpers belong in their own
 /// `Capability` mixins on `UnifiedDe1` (see the protected surface in
@@ -65,4 +64,36 @@ abstract class BengleInterface extends De1Interface {
 
   /// Reload the LED strip configuration from FW NVM, dropping uncommitted changes.
   Future<void> resetLedStrip();
+
+  // --- Milk-probe steam stop (scaffolding) -----------------------------------
+  //
+  // FW is not yet ready. The methods + streams below are the API surface
+  // skin developers can target now. On real `Bengle` the streams are inert
+  // (target replays cached value, probeAttached stays `false`,
+  // probeTemperature never emits) until FW publishes the wire spec. See
+  // [[bengle_steam_mmr]] for the MMR slot and [[bengle_milk_probe]] for
+  // the planned probe device wrapper.
+
+  /// Set the autonomous stop-at-temperature target in °C. `0.0` disables
+  /// the stop. Range `0..80`. Today: caches locally + log-once; no MMR
+  /// write until FW publishes the slot.
+  Future<void> setStopAtTemperatureTarget(double celsius);
+
+  /// Read the current stop-at-temperature target in °C.
+  Future<double> getStopAtTemperatureTarget();
+
+  /// Latest stop-at-temperature target stream (`0.0` = stop off).
+  /// `BehaviorSubject` — late subscribers see the cached current value.
+  Stream<double> get stopAtTemperatureTarget;
+
+  /// Whether the milk probe is physically attached to the machine.
+  /// `BehaviorSubject<bool>` seeded `false`. Real `Bengle` stays `false`
+  /// until FW publishes a presence signal; `MockBengle` defaults to
+  /// `true` for tests.
+  Stream<bool> get probeAttached;
+
+  /// Live milk-probe temperature stream (°C). `PublishSubject<double>` —
+  /// no replay, latest-only consumers should track themselves. Real
+  /// `Bengle` never emits today; `MockBengle` synthesises during steam.
+  Stream<double> get probeTemperature;
 }

--- a/lib/src/models/device/impl/bengle/bengle.dart
+++ b/lib/src/models/device/impl/bengle/bengle.dart
@@ -3,6 +3,7 @@ import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/machine.dart';
+import 'package:rxdart/rxdart.dart';
 
 class Bengle extends UnifiedDe1
     with IntegratedScaleCapability, LedStripCapability
@@ -39,6 +40,64 @@ class Bengle extends UnifiedDe1
   @protected
   Duration get firmwareUploadBatchPause => Duration.zero;
 
+  // --- Milk-probe steam stop (FW-stubbed scaffolding) -----------------------
+  //
+  // Mirrors `IntegratedScaleCapability`'s SAW stub: cache locally,
+  // log-once, no MMR write until FW publishes the slot. `probeAttached`
+  // stays `false` and `probeTemperature` never emits — probe discovery
+  // and data transport are TBD (may be a new BLE characteristic, not
+  // another MMR slot).
+  final BehaviorSubject<double> _stopAtTempTarget =
+      BehaviorSubject<double>.seeded(0.0);
+  final BehaviorSubject<bool> _probeAttached =
+      BehaviorSubject<bool>.seeded(false);
+  final PublishSubject<double> _probeTemperature = PublishSubject<double>();
+  int _stopAtTempStubWarningsEmitted = 0;
+
+  @override
+  Stream<double> get stopAtTemperatureTarget => _stopAtTempTarget.stream;
+
+  @override
+  Stream<bool> get probeAttached => _probeAttached.stream;
+
+  @override
+  Stream<double> get probeTemperature => _probeTemperature.stream;
+
+  @override
+  Future<void> setStopAtTemperatureTarget(double celsius) async {
+    final clamped = celsius.clamp(0.0, 80.0).toDouble();
+    if (!_stopAtTempTarget.isClosed) {
+      _stopAtTempTarget.add(clamped);
+    }
+    final addr = BengleSteamMmr.stopAtTemperatureTarget;
+    if (addr.address == 0x00000000) {
+      _logStopAtTempStubOnce(
+          'setStopAtTemperatureTarget($clamped) ignored. Awaiting FW.');
+      return;
+    }
+    await writeMmrScaled(addr, clamped);
+  }
+
+  @override
+  Future<double> getStopAtTemperatureTarget() async {
+    final addr = BengleSteamMmr.stopAtTemperatureTarget;
+    if (addr.address == 0x00000000) {
+      return _stopAtTempTarget.value;
+    }
+    final value = await readMmrScaled(addr);
+    if (!_stopAtTempTarget.isClosed) {
+      _stopAtTempTarget.add(value);
+    }
+    return value;
+  }
+
+  void _logStopAtTempStubOnce(String msg) {
+    if (_stopAtTempStubWarningsEmitted < 1) {
+      log.info('Bengle: stop-at-temperature endpoint unwired; $msg');
+      _stopAtTempStubWarningsEmitted++;
+    }
+  }
+
   // --- integrated scale lifecycle ---
 
   @override
@@ -52,6 +111,15 @@ class Bengle extends UnifiedDe1
   Future<void> onDisconnect() async {
     await disposeLedStrip();
     await disposeIntegratedScale();
+    if (!_stopAtTempTarget.isClosed) {
+      await _stopAtTempTarget.close();
+    }
+    if (!_probeAttached.isClosed) {
+      await _probeAttached.close();
+    }
+    if (!_probeTemperature.isClosed) {
+      await _probeTemperature.close();
+    }
     await super.onDisconnect();
   }
 }

--- a/lib/src/models/device/impl/bengle/bengle_milk_probe.dart
+++ b/lib/src/models/device/impl/bengle/bengle_milk_probe.dart
@@ -1,0 +1,102 @@
+import 'dart:async';
+
+import 'package:reaprime/src/models/device/bengle_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/sensor.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// `Sensor` adapter wrapping Bengle's internal milk-probe signals.
+///
+/// **Scaffolding** — real `Bengle` never emits on the probe streams
+/// today (probe discovery + data transport is TBD with FW). This
+/// adapter only carries data when wrapping a `MockBengle` (synthesised
+/// during steam) or once FW lands. The adapter is created and
+/// registered with `SensorController` by `BengleProbeBridge`.
+///
+/// Lifecycle is **probe-attached**, not machine-connected: the bridge
+/// instantiates this when `probeAttached` flips `true` and removes it
+/// when `false` (or when the machine disconnects).
+class BengleMilkProbe implements Sensor {
+  BengleMilkProbe({
+    required BengleInterface bengle,
+    String? deviceId,
+  })  : _bengle = bengle,
+        _deviceId = deviceId ?? '${_machineDeviceId(bengle)}-milkprobe';
+
+  static String _machineDeviceId(BengleInterface bengle) =>
+      (bengle as Device).deviceId;
+
+  final BengleInterface _bengle;
+  final String _deviceId;
+
+  final BehaviorSubject<ConnectionState> _connectionState =
+      BehaviorSubject.seeded(ConnectionState.disconnected);
+  final BehaviorSubject<Map<String, dynamic>> _data = BehaviorSubject();
+  StreamSubscription<bool>? _attachedSub;
+  StreamSubscription<double>? _tempSub;
+
+  @override
+  String get deviceId => _deviceId;
+
+  @override
+  String get name => 'Bengle Milk Probe';
+
+  @override
+  DeviceType get type => DeviceType.sensor;
+
+  @override
+  Stream<ConnectionState> get connectionState => _connectionState.stream;
+
+  @override
+  Stream<Map<String, dynamic>> get data => _data.stream;
+
+  @override
+  SensorInfo get info => SensorInfo(
+        name: name,
+        vendor: 'DecentEspresso',
+        dataChannels: [
+          DataChannel(key: 'timestamp', type: 'string'),
+          DataChannel(key: 'temperature', type: 'number', unit: '°C'),
+        ],
+        commands: const [],
+      );
+
+  @override
+  Future<Map<String, dynamic>> execute(
+      String commandId, Map<String, dynamic>? parameters) async {
+    // No commands exposed today.
+    return const {};
+  }
+
+  @override
+  Future<void> onConnect() async {
+    _attachedSub = _bengle.probeAttached.listen((attached) {
+      if (_connectionState.isClosed) return;
+      _connectionState.add(attached
+          ? ConnectionState.connected
+          : ConnectionState.disconnected);
+    });
+    _tempSub = _bengle.probeTemperature.listen((celsius) {
+      if (_data.isClosed) return;
+      _data.add({
+        'timestamp': DateTime.now().toIso8601String(),
+        'temperature': celsius,
+      });
+    });
+  }
+
+  @override
+  Future<void> disconnect() async {
+    await _attachedSub?.cancel();
+    _attachedSub = null;
+    await _tempSub?.cancel();
+    _tempSub = null;
+    if (!_connectionState.isClosed) {
+      _connectionState.add(ConnectionState.disconnected);
+      await _connectionState.close();
+    }
+    if (!_data.isClosed) {
+      await _data.close();
+    }
+  }
+}

--- a/lib/src/models/device/impl/bengle/bengle_mmr.dart
+++ b/lib/src/models/device/impl/bengle/bengle_mmr.dart
@@ -1,9 +1,10 @@
 import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
 
 /// Bengle-only MMR addresses. Future Bengle peripherals (LED strip,
-/// integrated scale, milk probe) declare their addresses here as the FW
-/// slots are confirmed. Addresses live with the capability that owns
-/// them — shared DE1 MMRs stay in `de1.models.dart#MMRItem`.
+/// integrated scale) declare their addresses here as the FW slots are
+/// confirmed. Addresses live with the capability that owns them —
+/// shared DE1 MMRs stay in `de1.models.dart#MMRItem`. The milk-probe
+/// stop-at-temperature target lives in [BengleSteamMmr].
 enum BengleMmr implements MmrAddress {
   /// Cup-warmer mat target temperature in °C, stored as raw IEEE-754
   /// float32 (little-endian). Range `0.0..80.0`; `0.0` = off.
@@ -63,6 +64,62 @@ enum BengleMmr implements MmrAddress {
   /// as satisfying `MmrAddress.name` through `implements` — the cast
   /// forces dispatch to the synthesized `Enum.name`. See `MMRItem` for
   /// the same pattern + history (553550d / b7b8ed7).
+  @override
+  String get name => (this as Enum).name;
+}
+
+/// MMR addresses for the milk-probe steam stop. Currently the
+/// stop-at-temperature target only — probe discovery / temperature
+/// transport is unknown and may end up as a separate characteristic
+/// rather than another MMR slot.
+///
+/// `stopAtTemperatureTarget` is a **set/get target** endpoint, not a
+/// presence/detection mechanism. Address is stubbed `0x00000000`; the
+/// `setStopAtTemperatureTarget` implementation no-ops on the wire and
+/// caches locally until FW publishes the slot. Pin tests assert the
+/// stub address so the day FW lands, the test flips and forces review.
+enum BengleSteamMmr implements MmrAddress {
+  /// Stop-at-temperature target in °C. `0.0` disables autonomous stop.
+  /// Encoded as `scaledFloat` with scale factor 10 — decicelsius on
+  /// the wire, unsigned. Range `0..80 °C`.
+  stopAtTemperatureTarget(
+    0x00000000, // TBD with FW
+    4,
+    MmrValueKind.scaledFloat,
+    'StopAtTemperatureTarget',
+    min: 0,
+    max: 800, // 80.0 °C
+    readScale: 0.1,
+    writeScale: 10.0,
+  );
+
+  const BengleSteamMmr(
+    this.address,
+    this.length,
+    this.kind,
+    this.description, {
+    this.readScale = 1.0,
+    this.writeScale = 1.0,
+    this.min,
+    this.max,
+  });
+
+  @override
+  final int address;
+  @override
+  final int length;
+  @override
+  final MmrValueKind kind;
+  final String description;
+  @override
+  final double readScale;
+  @override
+  final double writeScale;
+  @override
+  final int? min;
+  @override
+  final int? max;
+
   @override
   String get name => (this as Enum).name;
 }

--- a/lib/src/models/device/impl/bengle/mock_bengle.dart
+++ b/lib/src/models/device/impl/bengle/mock_bengle.dart
@@ -14,10 +14,16 @@ import 'package:rxdart/rxdart.dart';
 /// at the public level rather than going through the `_updateFirmware`
 /// template that calls `beforeFirmwareUpload`).
 ///
-/// Capability surfaces (cup warmer, integrated scale, LED, milk probe)
-/// land in steps 4–7; mirror them on this mock as they're added.
+/// Capability surfaces (cup warmer, integrated scale, LED) are
+/// mirrored here.
 class MockBengle extends MockDe1 implements BengleInterface {
-  MockBengle({super.deviceId = 'MockBengle'});
+  MockBengle({
+    super.deviceId = 'MockBengle',
+    bool probeAttached = true,
+  }) {
+    _probeAttachedSubject =
+        BehaviorSubject<bool>.seeded(probeAttached);
+  }
 
   @override
   String get name => 'MockBengle';
@@ -91,6 +97,22 @@ class MockBengle extends MockDe1 implements BengleInterface {
   final BehaviorSubject<double> _sawTargetSubject =
       BehaviorSubject<double>.seeded(0.0);
 
+  // --- milk probe / stop-at-temperature ---
+  /// `0.0` = stop disabled.
+  double _stopAtTempTarget = 0.0;
+  final BehaviorSubject<double> _stopAtTempTargetSubject =
+      BehaviorSubject<double>.seeded(0.0);
+  late final BehaviorSubject<bool> _probeAttachedSubject;
+  final PublishSubject<double> _probeTemperatureSubject =
+      PublishSubject<double>();
+
+  /// Simulated probe temperature in °C. Rises during `MachineState.steam`
+  /// starting from [_probeStartTemp] at [_probeRiseRate] °C per second.
+  static const double _probeStartTemp = 4.0;
+  static const double _probeRiseRate = 5.0;
+  double _probeTemp = _probeStartTemp;
+  DateTime? _lastProbeTickAt;
+
   @override
   Stream<ScaleSnapshot> get weightSnapshot => _weight.stream;
 
@@ -107,6 +129,36 @@ class MockBengle extends MockDe1 implements BengleInterface {
 
   @override
   Future<double> getStopAtWeightTarget() async => _sawTarget;
+
+  // --- milk probe surface ---
+
+  @override
+  Stream<double> get stopAtTemperatureTarget =>
+      _stopAtTempTargetSubject.stream;
+
+  @override
+  Stream<bool> get probeAttached => _probeAttachedSubject.stream;
+
+  @override
+  Stream<double> get probeTemperature => _probeTemperatureSubject.stream;
+
+  @override
+  Future<void> setStopAtTemperatureTarget(double celsius) async {
+    _stopAtTempTarget = celsius.clamp(0.0, 80.0).toDouble();
+    if (!_stopAtTempTargetSubject.isClosed) {
+      _stopAtTempTargetSubject.add(_stopAtTempTarget);
+    }
+  }
+
+  @override
+  Future<double> getStopAtTemperatureTarget() async => _stopAtTempTarget;
+
+  /// Test hook: toggle the simulated probe-attached state.
+  void setProbeAttached(bool attached) {
+    if (!_probeAttachedSubject.isClosed) {
+      _probeAttachedSubject.add(attached);
+    }
+  }
 
   @override
   Future<void> tareIntegratedScale() async {
@@ -149,6 +201,38 @@ class MockBengle extends MockDe1 implements BengleInterface {
     }
     _emit();
     _maybeTriggerSaw(s);
+    _tickProbeTemperature(s, now);
+  }
+
+  /// Synthesises milk-probe temperature during `MachineState.steam`.
+  /// Rises linearly from [_probeStartTemp]; resets when steam exits.
+  /// If [_stopAtTempTarget] is set and reached, requests `idle` — the
+  /// FW-autonomous stop behaviour the real Bengle will perform once
+  /// the MMR slot is published.
+  void _tickProbeTemperature(MachineSnapshot s, DateTime now) {
+    if (!(_probeAttachedSubject.hasValue && _probeAttachedSubject.value)) {
+      _lastProbeTickAt = null;
+      _probeTemp = _probeStartTemp;
+      return;
+    }
+    if (s.state.state != MachineState.steam) {
+      _lastProbeTickAt = null;
+      _probeTemp = _probeStartTemp;
+      return;
+    }
+    final last = _lastProbeTickAt;
+    _lastProbeTickAt = now;
+    if (last == null) return;
+    final dtSec = now.difference(last).inMilliseconds / 1000.0;
+    if (dtSec <= 0) return;
+    _probeTemp += _probeRiseRate * dtSec;
+    if (!_probeTemperatureSubject.isClosed) {
+      _probeTemperatureSubject.add(_probeTemp);
+    }
+    if (_stopAtTempTarget > 0.0 && _probeTemp >= _stopAtTempTarget) {
+      // ignore: discarded_futures
+      requestState(MachineState.idle);
+    }
   }
 
   /// Simulated autonomous SAW. Once the post-tare weight reaches the
@@ -181,6 +265,15 @@ class MockBengle extends MockDe1 implements BengleInterface {
     }
     if (!_sawTargetSubject.isClosed) {
       await _sawTargetSubject.close();
+    }
+    if (!_stopAtTempTargetSubject.isClosed) {
+      await _stopAtTempTargetSubject.close();
+    }
+    if (!_probeAttachedSubject.isClosed) {
+      await _probeAttachedSubject.close();
+    }
+    if (!_probeTemperatureSubject.isClosed) {
+      await _probeTemperatureSubject.close();
     }
     await super.onDisconnect();
   }

--- a/lib/src/services/database/daos/steam_dao.dart
+++ b/lib/src/services/database/daos/steam_dao.dart
@@ -1,0 +1,67 @@
+import 'package:drift/drift.dart';
+import 'package:reaprime/src/services/database/database.dart';
+import 'package:reaprime/src/services/database/tables/steam_tables.dart';
+
+part 'steam_dao.g.dart';
+
+@DriftAccessor(tables: [SteamRecords])
+class SteamDao extends DatabaseAccessor<AppDatabase> with _$SteamDaoMixin {
+  SteamDao(super.db);
+
+  Future<List<String>> getAllSteamIds() async {
+    final query = selectOnly(steamRecords)..addColumns([steamRecords.id]);
+    final rows = await query.get();
+    return rows.map((row) => row.read(steamRecords.id)!).toList();
+  }
+
+  Future<SteamRecord?> getSteamById(String id) {
+    return (select(steamRecords)..where((s) => s.id.equals(id)))
+        .getSingleOrNull();
+  }
+
+  Future<List<SteamRecord>> getAllSteams() {
+    return (select(steamRecords)
+          ..orderBy([(s) => OrderingTerm.desc(s.timestamp)]))
+        .get();
+  }
+
+  Future<SteamRecord?> getLatestSteam() {
+    return (select(steamRecords)
+          ..orderBy([(s) => OrderingTerm.desc(s.timestamp)])
+          ..limit(1))
+        .getSingleOrNull();
+  }
+
+  /// Latest steam without the measurements blob — for `/latest` metadata
+  /// queries that don't need per-frame data.
+  Future<SteamRecord?> getLatestSteamMeta() async {
+    final cols = steamRecords.$columns
+        .where((c) => c.$name != 'measurements_json')
+        .map((c) => c.$name)
+        .join(', ');
+    final result = await customSelect(
+      "SELECT $cols, '[]' AS measurements_json "
+      'FROM steam_records ORDER BY timestamp DESC LIMIT 1',
+      readsFrom: {steamRecords},
+    ).getSingleOrNull();
+    if (result == null) return null;
+    return steamRecords.map(result.data);
+  }
+
+  Future<void> insertSteam(SteamRecordsCompanion record) {
+    return into(steamRecords).insert(record);
+  }
+
+  Future<void> upsertSteam(SteamRecordsCompanion record) {
+    return into(steamRecords).insertOnConflictUpdate(record);
+  }
+
+  Future<void> updateSteam(SteamRecordsCompanion record) {
+    return (update(steamRecords)..where((s) => s.id.equals(record.id.value)))
+        .write(record);
+  }
+
+  Future<void> deleteSteam(String id) {
+    return (delete(steamRecords)..where((s) => s.id.equals(id))).go();
+  }
+}

--- a/lib/src/services/database/daos/steam_dao.g.dart
+++ b/lib/src/services/database/daos/steam_dao.g.dart
@@ -1,0 +1,16 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'steam_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$SteamDaoMixin on DatabaseAccessor<AppDatabase> {
+  $SteamRecordsTable get steamRecords => attachedDatabase.steamRecords;
+  SteamDaoManager get managers => SteamDaoManager(this);
+}
+
+class SteamDaoManager {
+  final _$SteamDaoMixin _db;
+  SteamDaoManager(this._db);
+  $$SteamRecordsTableTableManager get steamRecords =>
+      $$SteamRecordsTableTableManager(_db.attachedDatabase, _db.steamRecords);
+}

--- a/lib/src/services/database/database.dart
+++ b/lib/src/services/database/database.dart
@@ -5,11 +5,13 @@ import 'package:reaprime/src/services/database/daos/bean_dao.dart';
 import 'package:reaprime/src/services/database/daos/grinder_dao.dart';
 import 'package:reaprime/src/services/database/daos/profile_dao.dart';
 import 'package:reaprime/src/services/database/daos/shot_dao.dart';
+import 'package:reaprime/src/services/database/daos/steam_dao.dart';
 import 'package:reaprime/src/services/database/daos/workflow_dao.dart';
 import 'package:reaprime/src/services/database/tables/bean_tables.dart';
 import 'package:reaprime/src/services/database/tables/grinder_tables.dart';
 import 'package:reaprime/src/services/database/tables/profile_tables.dart';
 import 'package:reaprime/src/services/database/tables/shot_tables.dart';
+import 'package:reaprime/src/services/database/tables/steam_tables.dart';
 import 'package:reaprime/src/services/database/tables/workflow_tables.dart';
 
 part 'database.g.dart';
@@ -20,6 +22,7 @@ part 'database.g.dart';
     BeanBatches,
     Grinders,
     ShotRecords,
+    SteamRecords,
     Workflows,
     ProfileRecords,
   ],
@@ -27,6 +30,7 @@ part 'database.g.dart';
     BeanDao,
     GrinderDao,
     ShotDao,
+    SteamDao,
     WorkflowDao,
     ProfileDao,
   ],
@@ -40,7 +44,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 2;
+  int get schemaVersion => 3;
 
   @override
   MigrationStrategy get migration {
@@ -54,6 +58,10 @@ class AppDatabase extends _$AppDatabase {
         if (from < 2) {
           await _createIndices();
         }
+        if (from < 3) {
+          await m.createTable(steamRecords);
+          await _createSteamIndices();
+        }
       },
       beforeOpen: (details) async {
         await customStatement('PRAGMA foreign_keys = ON');
@@ -65,6 +73,14 @@ class AppDatabase extends _$AppDatabase {
     await customStatement(
       'CREATE INDEX IF NOT EXISTS idx_shot_records_timestamp '
       'ON shot_records (timestamp DESC)',
+    );
+    await _createSteamIndices();
+  }
+
+  Future<void> _createSteamIndices() async {
+    await customStatement(
+      'CREATE INDEX IF NOT EXISTS idx_steam_records_timestamp '
+      'ON steam_records (timestamp DESC)',
     );
   }
 }

--- a/lib/src/services/database/database.g.dart
+++ b/lib/src/services/database/database.g.dart
@@ -4105,6 +4105,405 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
   }
 }
 
+class $SteamRecordsTable extends SteamRecords
+    with TableInfo<$SteamRecordsTable, SteamRecord> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $SteamRecordsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _timestampMeta = const VerificationMeta(
+    'timestamp',
+  );
+  @override
+  late final GeneratedColumn<DateTime> timestamp = GeneratedColumn<DateTime>(
+    'timestamp',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<Map<String, dynamic>, String>
+  workflowJson = GeneratedColumn<String>(
+    'workflow_json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  ).withConverter<Map<String, dynamic>>(
+    $SteamRecordsTable.$converterworkflowJson,
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<Map<String, dynamic>?, String>
+  annotationsJson = GeneratedColumn<String>(
+    'annotations_json',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  ).withConverter<Map<String, dynamic>?>(
+    $SteamRecordsTable.$converterannotationsJson,
+  );
+  static const VerificationMeta _measurementsJsonMeta = const VerificationMeta(
+    'measurementsJson',
+  );
+  @override
+  late final GeneratedColumn<String> measurementsJson = GeneratedColumn<String>(
+    'measurements_json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    timestamp,
+    workflowJson,
+    annotationsJson,
+    measurementsJson,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'steam_records';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<SteamRecord> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('timestamp')) {
+      context.handle(
+        _timestampMeta,
+        timestamp.isAcceptableOrUnknown(data['timestamp']!, _timestampMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_timestampMeta);
+    }
+    if (data.containsKey('measurements_json')) {
+      context.handle(
+        _measurementsJsonMeta,
+        measurementsJson.isAcceptableOrUnknown(
+          data['measurements_json']!,
+          _measurementsJsonMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_measurementsJsonMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  SteamRecord map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return SteamRecord(
+      id:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}id'],
+          )!,
+      timestamp:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.dateTime,
+            data['${effectivePrefix}timestamp'],
+          )!,
+      workflowJson: $SteamRecordsTable.$converterworkflowJson.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}workflow_json'],
+        )!,
+      ),
+      annotationsJson: $SteamRecordsTable.$converterannotationsJson.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}annotations_json'],
+        ),
+      ),
+      measurementsJson:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}measurements_json'],
+          )!,
+    );
+  }
+
+  @override
+  $SteamRecordsTable createAlias(String alias) {
+    return $SteamRecordsTable(attachedDatabase, alias);
+  }
+
+  static TypeConverter<Map<String, dynamic>, String> $converterworkflowJson =
+      const JsonMapConverter();
+  static TypeConverter<Map<String, dynamic>?, String?>
+  $converterannotationsJson = const NullableJsonMapConverter();
+}
+
+class SteamRecord extends DataClass implements Insertable<SteamRecord> {
+  final String id;
+  final DateTime timestamp;
+  final Map<String, dynamic> workflowJson;
+  final Map<String, dynamic>? annotationsJson;
+  final String measurementsJson;
+  const SteamRecord({
+    required this.id,
+    required this.timestamp,
+    required this.workflowJson,
+    this.annotationsJson,
+    required this.measurementsJson,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['timestamp'] = Variable<DateTime>(timestamp);
+    {
+      map['workflow_json'] = Variable<String>(
+        $SteamRecordsTable.$converterworkflowJson.toSql(workflowJson),
+      );
+    }
+    if (!nullToAbsent || annotationsJson != null) {
+      map['annotations_json'] = Variable<String>(
+        $SteamRecordsTable.$converterannotationsJson.toSql(annotationsJson),
+      );
+    }
+    map['measurements_json'] = Variable<String>(measurementsJson);
+    return map;
+  }
+
+  SteamRecordsCompanion toCompanion(bool nullToAbsent) {
+    return SteamRecordsCompanion(
+      id: Value(id),
+      timestamp: Value(timestamp),
+      workflowJson: Value(workflowJson),
+      annotationsJson:
+          annotationsJson == null && nullToAbsent
+              ? const Value.absent()
+              : Value(annotationsJson),
+      measurementsJson: Value(measurementsJson),
+    );
+  }
+
+  factory SteamRecord.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return SteamRecord(
+      id: serializer.fromJson<String>(json['id']),
+      timestamp: serializer.fromJson<DateTime>(json['timestamp']),
+      workflowJson: serializer.fromJson<Map<String, dynamic>>(
+        json['workflowJson'],
+      ),
+      annotationsJson: serializer.fromJson<Map<String, dynamic>?>(
+        json['annotationsJson'],
+      ),
+      measurementsJson: serializer.fromJson<String>(json['measurementsJson']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'timestamp': serializer.toJson<DateTime>(timestamp),
+      'workflowJson': serializer.toJson<Map<String, dynamic>>(workflowJson),
+      'annotationsJson': serializer.toJson<Map<String, dynamic>?>(
+        annotationsJson,
+      ),
+      'measurementsJson': serializer.toJson<String>(measurementsJson),
+    };
+  }
+
+  SteamRecord copyWith({
+    String? id,
+    DateTime? timestamp,
+    Map<String, dynamic>? workflowJson,
+    Value<Map<String, dynamic>?> annotationsJson = const Value.absent(),
+    String? measurementsJson,
+  }) => SteamRecord(
+    id: id ?? this.id,
+    timestamp: timestamp ?? this.timestamp,
+    workflowJson: workflowJson ?? this.workflowJson,
+    annotationsJson:
+        annotationsJson.present ? annotationsJson.value : this.annotationsJson,
+    measurementsJson: measurementsJson ?? this.measurementsJson,
+  );
+  SteamRecord copyWithCompanion(SteamRecordsCompanion data) {
+    return SteamRecord(
+      id: data.id.present ? data.id.value : this.id,
+      timestamp: data.timestamp.present ? data.timestamp.value : this.timestamp,
+      workflowJson:
+          data.workflowJson.present
+              ? data.workflowJson.value
+              : this.workflowJson,
+      annotationsJson:
+          data.annotationsJson.present
+              ? data.annotationsJson.value
+              : this.annotationsJson,
+      measurementsJson:
+          data.measurementsJson.present
+              ? data.measurementsJson.value
+              : this.measurementsJson,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SteamRecord(')
+          ..write('id: $id, ')
+          ..write('timestamp: $timestamp, ')
+          ..write('workflowJson: $workflowJson, ')
+          ..write('annotationsJson: $annotationsJson, ')
+          ..write('measurementsJson: $measurementsJson')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    timestamp,
+    workflowJson,
+    annotationsJson,
+    measurementsJson,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SteamRecord &&
+          other.id == this.id &&
+          other.timestamp == this.timestamp &&
+          other.workflowJson == this.workflowJson &&
+          other.annotationsJson == this.annotationsJson &&
+          other.measurementsJson == this.measurementsJson);
+}
+
+class SteamRecordsCompanion extends UpdateCompanion<SteamRecord> {
+  final Value<String> id;
+  final Value<DateTime> timestamp;
+  final Value<Map<String, dynamic>> workflowJson;
+  final Value<Map<String, dynamic>?> annotationsJson;
+  final Value<String> measurementsJson;
+  final Value<int> rowid;
+  const SteamRecordsCompanion({
+    this.id = const Value.absent(),
+    this.timestamp = const Value.absent(),
+    this.workflowJson = const Value.absent(),
+    this.annotationsJson = const Value.absent(),
+    this.measurementsJson = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  SteamRecordsCompanion.insert({
+    required String id,
+    required DateTime timestamp,
+    required Map<String, dynamic> workflowJson,
+    this.annotationsJson = const Value.absent(),
+    required String measurementsJson,
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       timestamp = Value(timestamp),
+       workflowJson = Value(workflowJson),
+       measurementsJson = Value(measurementsJson);
+  static Insertable<SteamRecord> custom({
+    Expression<String>? id,
+    Expression<DateTime>? timestamp,
+    Expression<String>? workflowJson,
+    Expression<String>? annotationsJson,
+    Expression<String>? measurementsJson,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (timestamp != null) 'timestamp': timestamp,
+      if (workflowJson != null) 'workflow_json': workflowJson,
+      if (annotationsJson != null) 'annotations_json': annotationsJson,
+      if (measurementsJson != null) 'measurements_json': measurementsJson,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  SteamRecordsCompanion copyWith({
+    Value<String>? id,
+    Value<DateTime>? timestamp,
+    Value<Map<String, dynamic>>? workflowJson,
+    Value<Map<String, dynamic>?>? annotationsJson,
+    Value<String>? measurementsJson,
+    Value<int>? rowid,
+  }) {
+    return SteamRecordsCompanion(
+      id: id ?? this.id,
+      timestamp: timestamp ?? this.timestamp,
+      workflowJson: workflowJson ?? this.workflowJson,
+      annotationsJson: annotationsJson ?? this.annotationsJson,
+      measurementsJson: measurementsJson ?? this.measurementsJson,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (timestamp.present) {
+      map['timestamp'] = Variable<DateTime>(timestamp.value);
+    }
+    if (workflowJson.present) {
+      map['workflow_json'] = Variable<String>(
+        $SteamRecordsTable.$converterworkflowJson.toSql(workflowJson.value),
+      );
+    }
+    if (annotationsJson.present) {
+      map['annotations_json'] = Variable<String>(
+        $SteamRecordsTable.$converterannotationsJson.toSql(
+          annotationsJson.value,
+        ),
+      );
+    }
+    if (measurementsJson.present) {
+      map['measurements_json'] = Variable<String>(measurementsJson.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SteamRecordsCompanion(')
+          ..write('id: $id, ')
+          ..write('timestamp: $timestamp, ')
+          ..write('workflowJson: $workflowJson, ')
+          ..write('annotationsJson: $annotationsJson, ')
+          ..write('measurementsJson: $measurementsJson, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 class $WorkflowsTable extends Workflows
     with TableInfo<$WorkflowsTable, Workflow> {
   @override
@@ -5023,11 +5422,13 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $BeanBatchesTable beanBatches = $BeanBatchesTable(this);
   late final $GrindersTable grinders = $GrindersTable(this);
   late final $ShotRecordsTable shotRecords = $ShotRecordsTable(this);
+  late final $SteamRecordsTable steamRecords = $SteamRecordsTable(this);
   late final $WorkflowsTable workflows = $WorkflowsTable(this);
   late final $ProfileRecordsTable profileRecords = $ProfileRecordsTable(this);
   late final BeanDao beanDao = BeanDao(this as AppDatabase);
   late final GrinderDao grinderDao = GrinderDao(this as AppDatabase);
   late final ShotDao shotDao = ShotDao(this as AppDatabase);
+  late final SteamDao steamDao = SteamDao(this as AppDatabase);
   late final WorkflowDao workflowDao = WorkflowDao(this as AppDatabase);
   late final ProfileDao profileDao = ProfileDao(this as AppDatabase);
   @override
@@ -5039,6 +5440,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     beanBatches,
     grinders,
     shotRecords,
+    steamRecords,
     workflows,
     profileRecords,
   ];
@@ -7114,6 +7516,234 @@ typedef $$ShotRecordsTableProcessedTableManager =
       ShotRecord,
       PrefetchHooks Function()
     >;
+typedef $$SteamRecordsTableCreateCompanionBuilder =
+    SteamRecordsCompanion Function({
+      required String id,
+      required DateTime timestamp,
+      required Map<String, dynamic> workflowJson,
+      Value<Map<String, dynamic>?> annotationsJson,
+      required String measurementsJson,
+      Value<int> rowid,
+    });
+typedef $$SteamRecordsTableUpdateCompanionBuilder =
+    SteamRecordsCompanion Function({
+      Value<String> id,
+      Value<DateTime> timestamp,
+      Value<Map<String, dynamic>> workflowJson,
+      Value<Map<String, dynamic>?> annotationsJson,
+      Value<String> measurementsJson,
+      Value<int> rowid,
+    });
+
+class $$SteamRecordsTableFilterComposer
+    extends Composer<_$AppDatabase, $SteamRecordsTable> {
+  $$SteamRecordsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get timestamp => $composableBuilder(
+    column: $table.timestamp,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<
+    Map<String, dynamic>,
+    Map<String, dynamic>,
+    String
+  >
+  get workflowJson => $composableBuilder(
+    column: $table.workflowJson,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<
+    Map<String, dynamic>?,
+    Map<String, dynamic>,
+    String
+  >
+  get annotationsJson => $composableBuilder(
+    column: $table.annotationsJson,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnFilters<String> get measurementsJson => $composableBuilder(
+    column: $table.measurementsJson,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$SteamRecordsTableOrderingComposer
+    extends Composer<_$AppDatabase, $SteamRecordsTable> {
+  $$SteamRecordsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get timestamp => $composableBuilder(
+    column: $table.timestamp,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get workflowJson => $composableBuilder(
+    column: $table.workflowJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get annotationsJson => $composableBuilder(
+    column: $table.annotationsJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get measurementsJson => $composableBuilder(
+    column: $table.measurementsJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$SteamRecordsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $SteamRecordsTable> {
+  $$SteamRecordsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get timestamp =>
+      $composableBuilder(column: $table.timestamp, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<Map<String, dynamic>, String>
+  get workflowJson => $composableBuilder(
+    column: $table.workflowJson,
+    builder: (column) => column,
+  );
+
+  GeneratedColumnWithTypeConverter<Map<String, dynamic>?, String>
+  get annotationsJson => $composableBuilder(
+    column: $table.annotationsJson,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get measurementsJson => $composableBuilder(
+    column: $table.measurementsJson,
+    builder: (column) => column,
+  );
+}
+
+class $$SteamRecordsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $SteamRecordsTable,
+          SteamRecord,
+          $$SteamRecordsTableFilterComposer,
+          $$SteamRecordsTableOrderingComposer,
+          $$SteamRecordsTableAnnotationComposer,
+          $$SteamRecordsTableCreateCompanionBuilder,
+          $$SteamRecordsTableUpdateCompanionBuilder,
+          (
+            SteamRecord,
+            BaseReferences<_$AppDatabase, $SteamRecordsTable, SteamRecord>,
+          ),
+          SteamRecord,
+          PrefetchHooks Function()
+        > {
+  $$SteamRecordsTableTableManager(_$AppDatabase db, $SteamRecordsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer:
+              () => $$SteamRecordsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer:
+              () => $$SteamRecordsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer:
+              () =>
+                  $$SteamRecordsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<DateTime> timestamp = const Value.absent(),
+                Value<Map<String, dynamic>> workflowJson = const Value.absent(),
+                Value<Map<String, dynamic>?> annotationsJson =
+                    const Value.absent(),
+                Value<String> measurementsJson = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => SteamRecordsCompanion(
+                id: id,
+                timestamp: timestamp,
+                workflowJson: workflowJson,
+                annotationsJson: annotationsJson,
+                measurementsJson: measurementsJson,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required DateTime timestamp,
+                required Map<String, dynamic> workflowJson,
+                Value<Map<String, dynamic>?> annotationsJson =
+                    const Value.absent(),
+                required String measurementsJson,
+                Value<int> rowid = const Value.absent(),
+              }) => SteamRecordsCompanion.insert(
+                id: id,
+                timestamp: timestamp,
+                workflowJson: workflowJson,
+                annotationsJson: annotationsJson,
+                measurementsJson: measurementsJson,
+                rowid: rowid,
+              ),
+          withReferenceMapper:
+              (p0) =>
+                  p0
+                      .map(
+                        (e) => (
+                          e.readTable(table),
+                          BaseReferences(db, table, e),
+                        ),
+                      )
+                      .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$SteamRecordsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $SteamRecordsTable,
+      SteamRecord,
+      $$SteamRecordsTableFilterComposer,
+      $$SteamRecordsTableOrderingComposer,
+      $$SteamRecordsTableAnnotationComposer,
+      $$SteamRecordsTableCreateCompanionBuilder,
+      $$SteamRecordsTableUpdateCompanionBuilder,
+      (
+        SteamRecord,
+        BaseReferences<_$AppDatabase, $SteamRecordsTable, SteamRecord>,
+      ),
+      SteamRecord,
+      PrefetchHooks Function()
+    >;
 typedef $$WorkflowsTableCreateCompanionBuilder =
     WorkflowsCompanion Function({
       required String id,
@@ -7625,6 +8255,8 @@ class $AppDatabaseManager {
       $$GrindersTableTableManager(_db, _db.grinders);
   $$ShotRecordsTableTableManager get shotRecords =>
       $$ShotRecordsTableTableManager(_db, _db.shotRecords);
+  $$SteamRecordsTableTableManager get steamRecords =>
+      $$SteamRecordsTableTableManager(_db, _db.steamRecords);
   $$WorkflowsTableTableManager get workflows =>
       $$WorkflowsTableTableManager(_db, _db.workflows);
   $$ProfileRecordsTableTableManager get profileRecords =>

--- a/lib/src/services/database/mappers/steam_mapper.dart
+++ b/lib/src/services/database/mappers/steam_mapper.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+import 'package:reaprime/src/models/data/shot_annotations.dart';
+import 'package:reaprime/src/models/data/steam_record.dart' as domain;
+import 'package:reaprime/src/models/data/steam_snapshot.dart';
+import 'package:reaprime/src/models/data/workflow.dart' as domain_workflow;
+import 'package:reaprime/src/services/database/database.dart' as db;
+
+/// Maps between domain SteamRecord and Drift SteamRecords rows.
+class SteamMapper {
+  static domain.SteamRecord fromRow(db.SteamRecord row) {
+    final workflow = domain_workflow.Workflow.fromJson(row.workflowJson);
+
+    ShotAnnotations? annotations;
+    if (row.annotationsJson != null) {
+      annotations = ShotAnnotations.fromJson(row.annotationsJson!);
+    }
+
+    final measurements = (jsonDecode(row.measurementsJson) as List)
+        .map((e) => SteamSnapshot.fromJson(e as Map<String, dynamic>))
+        .toList();
+
+    return domain.SteamRecord(
+      id: row.id,
+      timestamp: row.timestamp,
+      measurements: measurements,
+      workflow: workflow,
+      annotations: annotations,
+    );
+  }
+
+  static db.SteamRecordsCompanion toCompanion(domain.SteamRecord record) {
+    return db.SteamRecordsCompanion(
+      id: Value(record.id),
+      timestamp: Value(record.timestamp),
+      workflowJson: Value(record.workflow.toJson()),
+      annotationsJson: Value(record.annotations?.toJson()),
+      measurementsJson: Value(
+        jsonEncode(record.measurements.map((m) => m.toJson()).toList()),
+      ),
+    );
+  }
+}

--- a/lib/src/services/database/tables/steam_tables.dart
+++ b/lib/src/services/database/tables/steam_tables.dart
@@ -1,0 +1,20 @@
+import 'package:drift/drift.dart';
+import 'package:reaprime/src/services/database/converters/json_converters.dart';
+
+/// Steam records — analogue of ShotRecords. Single table with the
+/// workflow + annotations + measurements stored as JSON blobs. Steam
+/// records do not currently need denormalized columns for filtering;
+/// add them when the use-case appears.
+class SteamRecords extends Table {
+  TextColumn get id => text()();
+  DateTimeColumn get timestamp => dateTime()();
+
+  TextColumn get workflowJson => text().map(const JsonMapConverter())();
+  TextColumn get annotationsJson =>
+      text().map(const NullableJsonMapConverter()).nullable()();
+
+  TextColumn get measurementsJson => text()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/lib/src/services/storage/drift_storage_service.dart
+++ b/lib/src/services/storage/drift_storage_service.dart
@@ -1,7 +1,9 @@
 import 'package:reaprime/src/models/data/shot_record.dart' as domain;
+import 'package:reaprime/src/models/data/steam_record.dart' as domain_steam;
 import 'package:reaprime/src/models/data/workflow.dart' as domain_wf;
 import 'package:reaprime/src/services/database/database.dart';
 import 'package:reaprime/src/services/database/mappers/shot_mapper.dart';
+import 'package:reaprime/src/services/database/mappers/steam_mapper.dart';
 import 'package:reaprime/src/services/database/mappers/workflow_mapper.dart';
 import 'package:reaprime/src/services/storage/storage_service.dart';
 
@@ -114,5 +116,51 @@ class DriftStorageService implements StorageService {
   Future<domain.ShotRecord?> getLatestShotMeta() async {
     final row = await _db.shotDao.getLatestShotMeta();
     return row == null ? null : ShotMapper.fromRow(row);
+  }
+
+  // Steam records ------------------------------------------------------------
+
+  @override
+  Future<void> storeSteam(domain_steam.SteamRecord record) {
+    return _db.steamDao.insertSteam(SteamMapper.toCompanion(record));
+  }
+
+  @override
+  Future<void> updateSteam(domain_steam.SteamRecord record) {
+    return _db.steamDao.updateSteam(SteamMapper.toCompanion(record));
+  }
+
+  @override
+  Future<void> deleteSteam(String id) {
+    return _db.steamDao.deleteSteam(id);
+  }
+
+  @override
+  Future<List<String>> getSteamIds() {
+    return _db.steamDao.getAllSteamIds();
+  }
+
+  @override
+  Future<List<domain_steam.SteamRecord>> getAllSteams() async {
+    final rows = await _db.steamDao.getAllSteams();
+    return rows.map(SteamMapper.fromRow).toList();
+  }
+
+  @override
+  Future<domain_steam.SteamRecord?> getSteam(String id) async {
+    final row = await _db.steamDao.getSteamById(id);
+    return row == null ? null : SteamMapper.fromRow(row);
+  }
+
+  @override
+  Future<domain_steam.SteamRecord?> getLatestSteam() async {
+    final row = await _db.steamDao.getLatestSteam();
+    return row == null ? null : SteamMapper.fromRow(row);
+  }
+
+  @override
+  Future<domain_steam.SteamRecord?> getLatestSteamMeta() async {
+    final row = await _db.steamDao.getLatestSteamMeta();
+    return row == null ? null : SteamMapper.fromRow(row);
   }
 }

--- a/lib/src/services/storage/storage_service.dart
+++ b/lib/src/services/storage/storage_service.dart
@@ -1,4 +1,5 @@
 import 'package:reaprime/src/models/data/shot_record.dart';
+import 'package:reaprime/src/models/data/steam_record.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 
 abstract class StorageService {
@@ -43,4 +44,14 @@ abstract class StorageService {
 
   /// Get the most recent shot metadata (excludes measurements).
   Future<ShotRecord?> getLatestShotMeta();
+
+  // Steam records ------------------------------------------------------------
+  Future<void> storeSteam(SteamRecord record);
+  Future<void> updateSteam(SteamRecord record);
+  Future<void> deleteSteam(String id);
+  Future<List<String>> getSteamIds();
+  Future<List<SteamRecord>> getAllSteams();
+  Future<SteamRecord?> getSteam(String id);
+  Future<SteamRecord?> getLatestSteam();
+  Future<SteamRecord?> getLatestSteamMeta();
 }

--- a/lib/src/services/webserver/data_export/steam_export_section.dart
+++ b/lib/src/services/webserver/data_export/steam_export_section.dart
@@ -1,0 +1,67 @@
+import 'package:reaprime/src/controllers/persistence_controller.dart';
+import 'package:reaprime/src/models/data/steam_record.dart';
+import 'package:reaprime/src/services/webserver/data_export/data_export_section.dart';
+
+class SteamExportSection implements DataExportSection {
+  final PersistenceController _controller;
+
+  SteamExportSection({required PersistenceController controller})
+      : _controller = controller;
+
+  @override
+  String get filename => 'steams.json';
+
+  @override
+  Future<dynamic> export() async {
+    final records = await _controller.storageService.getAllSteams();
+    return records.map((r) => r.toJson()).toList();
+  }
+
+  @override
+  Future<SectionImportResult> import(
+    dynamic data,
+    ConflictStrategy strategy,
+  ) async {
+    if (data is! List) {
+      return const SectionImportResult(
+        errors: ['Expected JSON array of steam records'],
+      );
+    }
+
+    int imported = 0;
+    int skipped = 0;
+    final errors = <String>[];
+
+    for (final item in data) {
+      try {
+        final record = SteamRecord.fromJson(item as Map<String, dynamic>);
+        final existing =
+            await _controller.storageService.getSteam(record.id);
+
+        if (existing != null) {
+          if (strategy == ConflictStrategy.overwrite) {
+            await _controller.storageService.updateSteam(record);
+            imported++;
+          } else {
+            skipped++;
+          }
+        } else {
+          await _controller.storageService.storeSteam(record);
+          imported++;
+        }
+      } catch (e) {
+        errors.add('Failed to import steam record: $e');
+      }
+    }
+
+    if (imported > 0) {
+      _controller.notifySteamsChanged();
+    }
+
+    return SectionImportResult(
+      imported: imported,
+      skipped: skipped,
+      errors: errors,
+    );
+  }
+}

--- a/lib/src/services/webserver/steams_handler.dart
+++ b/lib/src/services/webserver/steams_handler.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/persistence_controller.dart';
+import 'package:reaprime/src/models/data/shot_annotations.dart';
+import 'package:reaprime/src/services/webserver/json_response.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+class SteamsHandler {
+  final PersistenceController _controller;
+  final Logger _log = Logger('SteamsHandler');
+
+  SteamsHandler({required PersistenceController controller})
+      : _controller = controller;
+
+  void addRoutes(RouterPlus app) {
+    app.get('/api/v1/steams', _getSteams);
+    app.get('/api/v1/steams/ids', _getIds);
+    app.get('/api/v1/steams/latest', _getLatest);
+    app.get('/api/v1/steams/<id>', _getSteam);
+    app.put('/api/v1/steams/<id>', _updateSteam);
+    app.delete('/api/v1/steams/<id>', _deleteSteam);
+  }
+
+  Future<Response> _getSteams(Request req) async {
+    try {
+      final records = await _controller.storageService.getAllSteams();
+      // List view drops measurements blobs to keep the response small —
+      // mirrors `/api/v1/shots` behaviour. Clients needing per-frame
+      // data request a single record by id.
+      final items = records.map((r) => r.toJsonWithoutMeasurements()).toList();
+      return jsonOk(items);
+    } catch (e, st) {
+      _log.severe('Error getting steams', e, st);
+      return jsonError({'error': e.toString()});
+    }
+  }
+
+  Future<Response> _getIds(Request req) async {
+    try {
+      final ids = await _controller.storageService.getSteamIds();
+      return jsonOk(ids);
+    } catch (e, st) {
+      _log.severe('Error getting steam IDs', e, st);
+      return jsonError({'error': e.toString()});
+    }
+  }
+
+  Future<Response> _getLatest(Request req) async {
+    try {
+      final record = await _controller.storageService.getLatestSteamMeta();
+      return jsonOk(record?.toJsonWithoutMeasurements());
+    } catch (e, st) {
+      _log.severe('Error getting latest steam', e, st);
+      return jsonError({'error': e.toString()});
+    }
+  }
+
+  Future<Response> _getSteam(Request req, String id) async {
+    id = Uri.decodeComponent(id);
+    try {
+      final record = await _controller.storageService.getSteam(id);
+      if (record == null) {
+        return jsonNotFound({'error': 'Steam record not found'});
+      }
+      return jsonOk(record.toJson());
+    } catch (e, st) {
+      _log.severe('Error getting steam $id', e, st);
+      return jsonError({'error': e.toString()});
+    }
+  }
+
+  /// Partial update — only annotations are accepted; the rest of the
+  /// record (measurements, workflow) is immutable.
+  Future<Response> _updateSteam(Request req, String id) async {
+    id = Uri.decodeComponent(id);
+    try {
+      final body = await req.body.asString;
+      final json = jsonDecode(body) as Map<String, dynamic>;
+
+      if (json['id'] != null && json['id'] != id) {
+        return jsonBadRequest(
+            {'error': 'ID in path does not match ID in body'});
+      }
+
+      final existing = await _controller.storageService.getSteam(id);
+      if (existing == null) {
+        return jsonNotFound({'error': 'Steam record not found'});
+      }
+
+      ShotAnnotations? annotations = existing.annotations;
+      if (json['annotations'] != null) {
+        annotations =
+            ShotAnnotations.fromJson(json['annotations'] as Map<String, dynamic>);
+      }
+
+      final updated = existing.copyWith(annotations: annotations);
+      await _controller.updateSteam(updated);
+      return jsonOk(updated.toJson());
+    } catch (e, st) {
+      _log.severe('Error updating steam $id', e, st);
+      return jsonError({'error': e.toString()});
+    }
+  }
+
+  Future<Response> _deleteSteam(Request req, String id) async {
+    id = Uri.decodeComponent(id);
+    try {
+      await _controller.deleteSteam(id);
+      return jsonOk({'success': true, 'id': id});
+    } catch (e, st) {
+      _log.severe('Error deleting steam $id', e, st);
+      return jsonError({'error': e.toString()});
+    }
+  }
+}

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -34,6 +34,7 @@ import 'package:reaprime/src/services/webserver/data_export/grinder_export_secti
 import 'package:reaprime/src/services/webserver/beans_handler.dart';
 import 'package:reaprime/src/services/webserver/grinders_handler.dart';
 import 'package:reaprime/src/services/webserver/shots_handler.dart';
+import 'package:reaprime/src/services/webserver/steams_handler.dart';
 import 'package:reaprime/src/services/webserver/workflow_handler.dart';
 import 'package:reaprime/src/services/storage/bean_storage_service.dart';
 import 'package:reaprime/src/services/storage/grinder_storage_service.dart';
@@ -133,6 +134,9 @@ Future<void> startWebServer(
   final ShotsHandler shotsHandler = ShotsHandler(
     controller: persistenceController,
   );
+  final SteamsHandler steamsHandler = SteamsHandler(
+    controller: persistenceController,
+  );
 
   final PluginsHandler pluginsHandler = PluginsHandler(
     pluginManager: pluginService.pluginManager,
@@ -222,6 +226,7 @@ Future<void> startWebServer(
       sensorsHandler,
       workflowHandler,
       shotsHandler,
+      steamsHandler,
       kvStoreHandler,
       pluginsHandler,
       profileHandler,
@@ -256,6 +261,7 @@ Handler _init(
   SensorsHandler sensorsHandler,
   WorkflowHandler workflowHandler,
   ShotsHandler shotsHandler,
+  SteamsHandler steamsHandler,
   KvStoreHandler kvStoreHandler,
   PluginsHandler pluginsHandler,
   ProfileHandler profileHandler,
@@ -282,6 +288,7 @@ Handler _init(
   sensorsHandler.addRoutes(app);
   workflowHandler.addRoutes(app);
   shotsHandler.addRoutes(app);
+  steamsHandler.addRoutes(app);
   kvStoreHandler.addRoutes(app);
   pluginsHandler.addRoutes(app);
   profileHandler.addRoutes(app);

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -26,6 +26,7 @@ import 'package:reaprime/src/services/webserver/data_export_handler.dart';
 import 'package:reaprime/src/services/webserver/data_sync_handler.dart';
 import 'package:reaprime/src/services/webserver/data_export/profile_export_section.dart';
 import 'package:reaprime/src/services/webserver/data_export/shot_export_section.dart';
+import 'package:reaprime/src/services/webserver/data_export/steam_export_section.dart';
 import 'package:reaprime/src/services/webserver/data_export/workflow_export_section.dart';
 import 'package:reaprime/src/services/webserver/data_export/settings_export_section.dart';
 import 'package:reaprime/src/services/webserver/data_export/kv_store_export_section.dart';
@@ -195,6 +196,7 @@ Future<void> startWebServer(
     sections: [
       ProfileExportSection(controller: profileController),
       ShotExportSection(controller: persistenceController),
+      SteamExportSection(controller: persistenceController),
       WorkflowExportSection(controller: workflowController),
       SettingsExportSection(controller: settingsController),
       KvStoreExportSection(store: kvStoreHandler.store),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1347,10 +1347,10 @@ packages:
     dependency: "direct main"
     description:
       name: shadcn_ui
-      sha256: "6c06f2bcebd8734b9ed0bf3f63ef5c71981573d5664923589b0302f8280e7eaf"
+      sha256: "132d69a43145a9ead0687935b48224a6565d164ab718796fa344a179a69bed70"
       url: "https://pub.dev"
     source: hosted
-    version: "0.53.6"
+    version: "0.54.0"
   share_plus:
     dependency: "direct main"
     description:
@@ -1886,5 +1886,5 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -912,7 +912,7 @@ packages:
     source: hosted
     version: "2.0.0+1"
   lucide_icons_flutter:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: lucide_icons_flutter
       sha256: f9fd5d49b93bf14b89e0ff4818658a74ab16899bdaf7aa745358ee1a34f54eed
@@ -1347,10 +1347,10 @@ packages:
     dependency: "direct main"
     description:
       name: shadcn_ui
-      sha256: "132d69a43145a9ead0687935b48224a6565d164ab718796fa344a179a69bed70"
+      sha256: "6c06f2bcebd8734b9ed0bf3f63ef5c71981573d5664923589b0302f8280e7eaf"
       url: "https://pub.dev"
     source: hosted
-    version: "0.54.0"
+    version: "0.53.6"
   share_plus:
     dependency: "direct main"
     description:
@@ -1886,5 +1886,5 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0"
+  dart: ">=3.10.3 <4.0.0"
+  flutter: ">=3.38.4"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -915,10 +915,10 @@ packages:
     dependency: transitive
     description:
       name: lucide_icons_flutter
-      sha256: df29c1cf4f19f9309f5204d40e0ba95338d9946a8ffdb4d75cf9aaccf449ce41
+      sha256: f9fd5d49b93bf14b89e0ff4818658a74ab16899bdaf7aa745358ee1a34f54eed
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.12"
+    version: "3.1.14+1"
   matcher:
     dependency: transitive
     description:
@@ -1347,10 +1347,10 @@ packages:
     dependency: "direct main"
     description:
       name: shadcn_ui
-      sha256: a7b4b6fd87a44d2925aaeb519fa73f351b8eb6938b9f95e6efe888b9bc6f8434
+      sha256: "132d69a43145a9ead0687935b48224a6565d164ab718796fa344a179a69bed70"
       url: "https://pub.dev"
     source: hosted
-    version: "0.53.5"
+    version: "0.54.0"
   share_plus:
     dependency: "direct main"
     description:
@@ -1886,5 +1886,5 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   screen_brightness: ^2.1.7
   collection: ^1.19.0
   shelf_plus: ^1.11.0
-  shadcn_ui: ^0.53.5
+  shadcn_ui: ^0.54.0
   file_picker: ^11.0.2
   fl_chart: ^1.0.0
   flutter_launcher_icons: ^0.14.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,11 @@ dependencies:
   screen_brightness: ^2.1.7
   collection: ^1.19.0
   shelf_plus: ^1.11.0
+  # NOTE: Do not bump to 0.54.x — it wraps ListTile in a DecoratedBox
+  # with a background color, which trips Flutter's "ListTile background
+  # may be invisible" assertion and breaks ~7 widget tests on CI.
+  # Before any major bump, smoke-test the device-discovery + onboarding
+  # widget tests on Linux Flutter (CI image, not just local macOS).
   shadcn_ui: ^0.53.5
   file_picker: ^11.0.2
   fl_chart: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,12 +31,7 @@ dependencies:
   screen_brightness: ^2.1.7
   collection: ^1.19.0
   shelf_plus: ^1.11.0
-  # NOTE: Do not bump to 0.54.x — it wraps ListTile in a DecoratedBox
-  # with a background color, which trips Flutter's "ListTile background
-  # may be invisible" assertion and breaks ~7 widget tests on CI.
-  # Before any major bump, smoke-test the device-discovery + onboarding
-  # widget tests on Linux Flutter (CI image, not just local macOS).
-  shadcn_ui: ^0.53.5
+  shadcn_ui: ^0.54.0
   file_picker: ^11.0.2
   fl_chart: ^1.0.0
   flutter_launcher_icons: ^0.14.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   screen_brightness: ^2.1.7
   collection: ^1.19.0
   shelf_plus: ^1.11.0
-  shadcn_ui: ^0.54.0
+  shadcn_ui: ^0.53.5
   file_picker: ^11.0.2
   fl_chart: ^1.0.0
   flutter_launcher_icons: ^0.14.3
@@ -104,6 +104,12 @@ dependency_overrides:
     git:
       url: https://github.com/tadelv/libserialport.dart
       ref: fix/reader-isolate-uhandled-throw
+  # shadcn_ui 0.53.5 transitively pins lucide_icons_flutter 3.1.12, which
+  # extends `IconData` — that broke after Flutter's CI SDK made
+  # `IconData` final. Override to a newer lucide that compiles cleanly.
+  # Remove once shadcn_ui ships a release that pins lucide >= 3.1.13 and
+  # the ListTile/DecoratedBox regression introduced in 0.54.0 is fixed.
+  lucide_icons_flutter: ^3.1.14
 
 dev_dependencies:
   flutter_test:

--- a/test/controllers/bengle_probe_bridge_test.dart
+++ b/test/controllers/bengle_probe_bridge_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/bengle_probe_bridge.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/sensor_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+import 'package:rxdart/rxdart.dart';
+
+class _EmptyDiscovery extends DeviceDiscoveryService {
+  @override
+  Stream<List<Device>> get devices => const Stream.empty();
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
+}
+
+class _StubDe1Controller extends De1Controller {
+  _StubDe1Controller()
+      : _subj = BehaviorSubject.seeded(null),
+        super(controller: DeviceController([_EmptyDiscovery()]));
+
+  final BehaviorSubject<De1Interface?> _subj;
+
+  @override
+  Stream<De1Interface?> get de1 => _subj.stream;
+
+  void emit(De1Interface? device) => _subj.add(device);
+}
+
+void main() {
+  group('BengleProbeBridge', () {
+    late SensorController sensors;
+    late _StubDe1Controller de1;
+    late BengleProbeBridge bridge;
+
+    setUp(() async {
+      final deviceController = DeviceController([_EmptyDiscovery()]);
+      await deviceController.initialize();
+      sensors = SensorController(controller: deviceController);
+      de1 = _StubDe1Controller();
+      bridge = BengleProbeBridge(
+          de1Controller: de1, sensorController: sensors);
+    });
+
+    tearDown(() async {
+      await bridge.dispose();
+      sensors.dispose();
+    });
+
+    Future<void> settle() => Future<void>.delayed(Duration.zero);
+
+    test('registers a probe when Bengle connects with probe attached',
+        () async {
+      final bengle = MockBengle();
+      await bengle.onConnect();
+      de1.emit(bengle);
+      await settle();
+      expect(sensors.sensors.keys, contains('${bengle.deviceId}-milkprobe'));
+      await bengle.onDisconnect();
+    });
+
+    test('does not register when probe is not attached', () async {
+      final bengle = MockBengle(probeAttached: false);
+      await bengle.onConnect();
+      de1.emit(bengle);
+      await settle();
+      expect(sensors.sensors, isEmpty);
+      await bengle.onDisconnect();
+    });
+
+    test('unregisters when probe detaches mid-session', () async {
+      final bengle = MockBengle();
+      await bengle.onConnect();
+      de1.emit(bengle);
+      await settle();
+      expect(sensors.sensors, isNotEmpty);
+
+      bengle.setProbeAttached(false);
+      await settle();
+      expect(sensors.sensors, isEmpty);
+      await bengle.onDisconnect();
+    });
+
+    test('unregisters on machine disconnect', () async {
+      final bengle = MockBengle();
+      await bengle.onConnect();
+      de1.emit(bengle);
+      await settle();
+      expect(sensors.sensors, isNotEmpty);
+
+      de1.emit(null);
+      await settle();
+      expect(sensors.sensors, isEmpty);
+      await bengle.onDisconnect();
+    });
+
+    test('does not register for non-Bengle machines', () async {
+      final mockDe1 = MockDe1();
+      await mockDe1.onConnect();
+      de1.emit(mockDe1);
+      await settle();
+      expect(sensors.sensors, isEmpty);
+      await mockDe1.onDisconnect();
+    });
+  });
+}

--- a/test/controllers/bengle_steam_stop_bridge_test.dart
+++ b/test/controllers/bengle_steam_stop_bridge_test.dart
@@ -1,0 +1,203 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/bengle_steam_stop_bridge.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/device/bengle_interface.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/led_strip.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+
+import '../helpers/mock_device_discovery_service.dart';
+import '../helpers/test_de1.dart';
+
+/// Recording stub of BengleInterface — only the steam-stop surface is
+/// exercised; everything else routes through `noSuchMethod`.
+class _RecordingBengle implements BengleInterface {
+  @override
+  String get deviceId => 'rec-bengle';
+  @override
+  String get name => 'Bengle-rec';
+  @override
+  DeviceType get type => DeviceType.machine;
+
+  final List<double> stopAtTempWrites = [];
+  double _target = 0.0;
+
+  @override
+  Future<void> setStopAtTemperatureTarget(double celsius) async {
+    stopAtTempWrites.add(celsius);
+    _target = celsius;
+  }
+
+  @override
+  Future<double> getStopAtTemperatureTarget() async => _target;
+
+  @override
+  Stream<double> get stopAtTemperatureTarget => Stream.value(_target);
+
+  @override
+  Stream<bool> get probeAttached => const Stream.empty();
+
+  @override
+  Stream<double> get probeTemperature => const Stream.empty();
+
+  // Minimal Device + DE1 surface.
+  @override
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.connected);
+  @override
+  Stream<ScaleSnapshot> get weightSnapshot => const Stream.empty();
+  @override
+  Stream<LedStripState> get ledStripState => const Stream.empty();
+  @override
+  Future<void> onConnect() async {}
+  @override
+  Future<void> disconnect() async {}
+
+  /// Stays `false` so [De1Controller._initializeData] never runs.
+  @override
+  Stream<bool> get ready => Stream<bool>.value(false);
+
+  @override
+  Stream<De1ShotSettings> get shotSettings => const Stream.empty();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+const _debounce = Duration(milliseconds: 20);
+
+void main() {
+  late WorkflowController workflow;
+  late DeviceController deviceController;
+  late De1Controller de1Controller;
+
+  setUp(() async {
+    workflow = WorkflowController();
+    deviceController = DeviceController([MockDeviceDiscoveryService()]);
+    await deviceController.initialize();
+    de1Controller = De1Controller(controller: deviceController);
+  });
+
+  Future<void> connectBengle(BengleInterface bengle) =>
+      de1Controller.connectToDe1(bengle);
+
+  Future<void> pumpDebounce() =>
+      Future<void>.delayed(_debounce + const Duration(milliseconds: 30));
+
+  void setStopAtTemp(double value) {
+    final updated = workflow.currentWorkflow.steamSettings
+        .copyWith(stopAtTemperature: value);
+    workflow.updateWorkflow(steamSettings: updated);
+  }
+
+  test('stopAtTemperature change writes to connected Bengle after debounce',
+      () async {
+    final bengle = _RecordingBengle();
+    await connectBengle(bengle);
+
+    final bridge = BengleSteamStopBridge(
+      workflowController: workflow,
+      de1Controller: de1Controller,
+      debounce: _debounce,
+    );
+    await Future<void>.delayed(Duration.zero);
+    bengle.stopAtTempWrites.clear();
+
+    setStopAtTemp(65.0);
+    await pumpDebounce();
+
+    expect(bengle.stopAtTempWrites, [65.0]);
+    await bridge.dispose();
+  });
+
+  test('debounce coalesces rapid edits into a single write', () async {
+    final bengle = _RecordingBengle();
+    await connectBengle(bengle);
+
+    final bridge = BengleSteamStopBridge(
+      workflowController: workflow,
+      de1Controller: de1Controller,
+      debounce: _debounce,
+    );
+    await Future<void>.delayed(Duration.zero);
+    bengle.stopAtTempWrites.clear();
+
+    for (final t in [50.0, 55.0, 60.0, 65.0]) {
+      setStopAtTemp(t);
+      await Future<void>.delayed(const Duration(milliseconds: 2));
+    }
+    await pumpDebounce();
+
+    expect(bengle.stopAtTempWrites, [65.0]);
+    await bridge.dispose();
+  });
+
+  test('no write when connected machine is not Bengle', () async {
+    final de1 = TestDe1();
+    await de1Controller.connectToDe1(de1);
+    de1.emitShotSettings(De1ShotSettings(
+      steamSetting: 0,
+      targetSteamTemp: 150,
+      targetSteamDuration: 30,
+      targetHotWaterTemp: 75,
+      targetHotWaterVolume: 50,
+      targetHotWaterDuration: 30,
+      targetShotVolume: 36,
+      groupTemp: 94.0,
+    ));
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    final bridge = BengleSteamStopBridge(
+      workflowController: workflow,
+      de1Controller: de1Controller,
+      debounce: _debounce,
+    );
+    setStopAtTemp(60.0);
+    await pumpDebounce();
+
+    // TestDe1 has no stop-at-temperature surface; bridge should
+    // short-circuit and not throw.
+    expect(de1.requestedStates, isEmpty);
+    de1.dispose();
+    await bridge.dispose();
+  });
+
+  test('re-applies current target on Bengle (re)connect', () async {
+    setStopAtTemp(58.0);
+
+    final bridge = BengleSteamStopBridge(
+      workflowController: workflow,
+      de1Controller: de1Controller,
+      debounce: _debounce,
+    );
+
+    final bengle = _RecordingBengle();
+    await connectBengle(bengle);
+    await pumpDebounce();
+
+    expect(bengle.stopAtTempWrites, contains(58.0));
+    await bridge.dispose();
+  });
+
+  test('dispose stops further writes', () async {
+    final bengle = _RecordingBengle();
+    await connectBengle(bengle);
+
+    final bridge = BengleSteamStopBridge(
+      workflowController: workflow,
+      de1Controller: de1Controller,
+      debounce: _debounce,
+    );
+    await Future<void>.delayed(Duration.zero);
+    bengle.stopAtTempWrites.clear();
+
+    await bridge.dispose();
+    setStopAtTemp(70.0);
+    await pumpDebounce();
+
+    expect(bengle.stopAtTempWrites, isEmpty);
+  });
+}

--- a/test/controllers/persistence_controller_steam_test.dart
+++ b/test/controllers/persistence_controller_steam_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/persistence_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/shot_record.dart';
+import 'package:reaprime/src/models/data/steam_record.dart';
+import 'package:reaprime/src/models/data/workflow.dart';
+import 'package:reaprime/src/services/storage/storage_service.dart';
+
+class _FakeStorage implements StorageService {
+  final List<SteamRecord> stored = [];
+  final List<SteamRecord> updated = [];
+  final List<String> deleted = [];
+
+  @override
+  Future<void> storeSteam(SteamRecord record) async {
+    stored.add(record);
+  }
+
+  @override
+  Future<void> updateSteam(SteamRecord record) async {
+    updated.add(record);
+  }
+
+  @override
+  Future<void> deleteSteam(String id) async {
+    deleted.add(id);
+  }
+
+  @override
+  Future<List<String>> getSteamIds() async => [];
+  @override
+  Future<List<SteamRecord>> getAllSteams() async => [];
+  @override
+  Future<SteamRecord?> getSteam(String id) async => null;
+  @override
+  Future<SteamRecord?> getLatestSteam() async => null;
+  @override
+  Future<SteamRecord?> getLatestSteamMeta() async => null;
+
+  // Unused shot/workflow surface (defaults).
+  @override
+  Future<void> storeShot(ShotRecord record) async {}
+  @override
+  Future<void> updateShot(ShotRecord record) async {}
+  @override
+  Future<void> deleteShot(String id) async {}
+  @override
+  Future<List<String>> getShotIds() async => [];
+  @override
+  Future<List<ShotRecord>> getAllShots() async => [];
+  @override
+  Future<ShotRecord?> getShot(String id) async => null;
+  @override
+  Future<void> storeCurrentWorkflow(Workflow workflow) async {}
+  @override
+  Future<Workflow?> loadCurrentWorkflow() async => null;
+  @override
+  Future<List<ShotRecord>> getShotsPaginated({
+    int limit = 20,
+    int offset = 0,
+    String? grinderId,
+    String? grinderModel,
+    String? beanBatchId,
+    String? coffeeName,
+    String? coffeeRoaster,
+    String? profileTitle,
+    String? search,
+    bool ascending = false,
+  }) async =>
+      [];
+  @override
+  Future<int> countShots({
+    String? grinderId,
+    String? grinderModel,
+    String? beanBatchId,
+    String? coffeeName,
+    String? coffeeRoaster,
+    String? profileTitle,
+    String? search,
+  }) async =>
+      0;
+  @override
+  Future<ShotRecord?> getLatestShot() async => null;
+  @override
+  Future<ShotRecord?> getLatestShotMeta() async => null;
+}
+
+SteamRecord _record(String id) => SteamRecord(
+      id: id,
+      timestamp: DateTime.utc(2026, 5, 18, 12, 0, 0),
+      measurements: const [],
+      workflow: WorkflowController().currentWorkflow,
+    );
+
+void main() {
+  late _FakeStorage storage;
+  late PersistenceController controller;
+
+  setUp(() {
+    storage = _FakeStorage();
+    controller = PersistenceController(storageService: storage);
+  });
+
+  tearDown(() => controller.dispose());
+
+  test('persistSteam stores via service and emits steamsChanged', () async {
+    final events = <void>[];
+    final sub = controller.steamsChanged.listen(events.add);
+    await controller.persistSteam(_record('s-1'));
+    await Future<void>.delayed(Duration.zero);
+    await sub.cancel();
+    expect(storage.stored, hasLength(1));
+    expect(storage.stored.first.id, equals('s-1'));
+    expect(events, hasLength(1));
+  });
+
+  test('updateSteam delegates and emits steamsChanged', () async {
+    final events = <void>[];
+    final sub = controller.steamsChanged.listen(events.add);
+    await controller.updateSteam(_record('s-2'));
+    await Future<void>.delayed(Duration.zero);
+    await sub.cancel();
+    expect(storage.updated, hasLength(1));
+    expect(events, hasLength(1));
+  });
+
+  test('deleteSteam delegates and emits steamsChanged', () async {
+    final events = <void>[];
+    final sub = controller.steamsChanged.listen(events.add);
+    await controller.deleteSteam('s-3');
+    await Future<void>.delayed(Duration.zero);
+    await sub.cancel();
+    expect(storage.deleted, equals(['s-3']));
+    expect(events, hasLength(1));
+  });
+}

--- a/test/controllers/sensor_controller_test.dart
+++ b/test/controllers/sensor_controller_test.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/sensor_controller.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
+import 'package:reaprime/src/models/device/sensor.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// Discovery service that emits whatever the test feeds it.
+class _TestDiscovery extends DeviceDiscoveryService {
+  final BehaviorSubject<List<Device>> _subj =
+      BehaviorSubject.seeded(const []);
+  @override
+  Stream<List<Device>> get devices => _subj.stream;
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
+  void emit(List<Device> list) => _subj.add(list);
+}
+
+class _StubSensor implements Sensor {
+  _StubSensor(this.deviceId, {this.label = ''});
+  @override
+  final String deviceId;
+  final String label;
+  @override
+  String get name => 'StubSensor';
+  @override
+  DeviceType get type => DeviceType.sensor;
+  @override
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.connected);
+  @override
+  Stream<Map<String, dynamic>> get data => const Stream.empty();
+  @override
+  SensorInfo get info => SensorInfo(
+      name: name, vendor: 'test', dataChannels: const [], commands: const []);
+  @override
+  Future<Map<String, dynamic>> execute(
+          String commandId, Map<String, dynamic>? parameters) async =>
+      const {};
+  @override
+  Future<void> onConnect() async {}
+  @override
+  Future<void> disconnect() async {}
+}
+
+void main() {
+  group('SensorController', () {
+    late _TestDiscovery discovery;
+    late DeviceController deviceController;
+    late SensorController controller;
+
+    setUp(() async {
+      discovery = _TestDiscovery();
+      deviceController = DeviceController([discovery]);
+      await deviceController.initialize();
+      controller = SensorController(controller: deviceController);
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    test('bridge-registered sensor appears alone', () async {
+      final probe = _StubSensor('probe-1', label: 'bridge');
+      await controller.register(probe);
+      expect(controller.sensors, contains('probe-1'));
+      expect(controller.sensors['probe-1'], same(probe));
+    });
+
+    test('DeviceController-sourced sensor appears alone', () async {
+      final sensor = _StubSensor('discovered-1', label: 'discovered');
+      discovery.emit([sensor]);
+      await Future<void>.delayed(Duration.zero);
+      expect(controller.sensors, contains('discovered-1'));
+    });
+
+    test('bridge wins when same deviceId appears from both sources',
+        () async {
+      final discovered = _StubSensor('shared', label: 'discovered');
+      final bridge = _StubSensor('shared', label: 'bridge');
+
+      discovery.emit([discovered]);
+      await Future<void>.delayed(Duration.zero);
+      await controller.register(bridge);
+
+      expect(controller.sensors['shared'], same(bridge),
+          reason: 'bridge-registered instance should win the dedupe');
+    });
+
+    test('unregister removes a bridge-registered sensor', () async {
+      final probe = _StubSensor('probe-2', label: 'bridge');
+      await controller.register(probe);
+      expect(controller.sensors, contains('probe-2'));
+
+      await controller.unregister('probe-2');
+      expect(controller.sensors, isNot(contains('probe-2')));
+    });
+
+    test('unregister does not touch DeviceController-sourced sensors',
+        () async {
+      final discovered = _StubSensor('keep-1');
+      discovery.emit([discovered]);
+      await Future<void>.delayed(Duration.zero);
+
+      await controller.unregister('keep-1');
+      expect(controller.sensors, contains('keep-1'),
+          reason: 'unregister is a no-op on non-bridge entries');
+    });
+  });
+}

--- a/test/controllers/shot_sequencer_bengle_bypass_test.dart
+++ b/test/controllers/shot_sequencer_bengle_bypass_test.dart
@@ -9,6 +9,7 @@ import 'package:reaprime/src/controllers/scale_controller.dart';
 import 'package:reaprime/src/controllers/shot_sequencer.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/data/shot_record.dart';
+import 'package:reaprime/src/models/data/steam_record.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
@@ -59,6 +60,17 @@ class _TestBengle extends TestDe1 implements BengleInterface {
   Future<void> commitLedStrip() async {}
   @override
   Future<void> resetLedStrip() async {}
+
+  @override
+  Future<void> setStopAtTemperatureTarget(double celsius) async {}
+  @override
+  Future<double> getStopAtTemperatureTarget() async => 0.0;
+  @override
+  Stream<double> get stopAtTemperatureTarget => const Stream.empty();
+  @override
+  Stream<bool> get probeAttached => const Stream.empty();
+  @override
+  Stream<double> get probeTemperature => const Stream.empty();
 }
 
 class _FakeDiscoveryService extends DeviceDiscoveryService {
@@ -168,6 +180,23 @@ class _NullStorageService implements StorageService {
   Future<ShotRecord?> getLatestShot() async => null;
   @override
   Future<ShotRecord?> getLatestShotMeta() async => null;
+
+  @override
+  Future<void> storeSteam(SteamRecord record) async {}
+  @override
+  Future<void> updateSteam(SteamRecord record) async {}
+  @override
+  Future<void> deleteSteam(String id) async {}
+  @override
+  Future<List<String>> getSteamIds() async => [];
+  @override
+  Future<List<SteamRecord>> getAllSteams() async => [];
+  @override
+  Future<SteamRecord?> getSteam(String id) async => null;
+  @override
+  Future<SteamRecord?> getLatestSteam() async => null;
+  @override
+  Future<SteamRecord?> getLatestSteamMeta() async => null;
 }
 
 Profile _simpleProfile() => Profile(

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -9,6 +9,7 @@ import 'package:reaprime/src/controllers/scale_controller.dart';
 import 'package:reaprime/src/controllers/shot_sequencer.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/data/shot_record.dart';
+import 'package:reaprime/src/models/data/steam_record.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
@@ -148,6 +149,23 @@ class _NullStorageService implements StorageService {
   Future<ShotRecord?> getLatestShot() async => null;
   @override
   Future<ShotRecord?> getLatestShotMeta() async => null;
+
+  @override
+  Future<void> storeSteam(SteamRecord record) async {}
+  @override
+  Future<void> updateSteam(SteamRecord record) async {}
+  @override
+  Future<void> deleteSteam(String id) async {}
+  @override
+  Future<List<String>> getSteamIds() async => [];
+  @override
+  Future<List<SteamRecord>> getAllSteams() async => [];
+  @override
+  Future<SteamRecord?> getSteam(String id) async => null;
+  @override
+  Future<SteamRecord?> getLatestSteam() async => null;
+  @override
+  Future<SteamRecord?> getLatestSteamMeta() async => null;
 }
 
 /// Creates a minimal Profile with one pressure step and targetWeight of 36g.

--- a/test/controllers/steam_sequencer_test.dart
+++ b/test/controllers/steam_sequencer_test.dart
@@ -1,0 +1,434 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/persistence_controller.dart';
+import 'package:reaprime/src/controllers/sensor_controller.dart';
+import 'package:reaprime/src/controllers/steam_sequencer.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/shot_record.dart';
+import 'package:reaprime/src/models/data/steam_record.dart';
+import 'package:reaprime/src/models/data/workflow.dart';
+import 'package:reaprime/src/models/device/bengle_interface.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
+import 'package:reaprime/src/models/device/sensor.dart';
+import 'package:reaprime/src/services/storage/storage_service.dart';
+import 'package:rxdart/rxdart.dart';
+
+class _EmptyDiscovery extends DeviceDiscoveryService {
+  @override
+  Stream<List<Device>> get devices => const Stream.empty();
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
+}
+
+class _StubDe1Controller extends De1Controller {
+  _StubDe1Controller()
+      : _subj = BehaviorSubject.seeded(null),
+        super(controller: DeviceController([_EmptyDiscovery()]));
+
+  final BehaviorSubject<De1Interface?> _subj;
+
+  @override
+  Stream<De1Interface?> get de1 => _subj.stream;
+
+  void emit(De1Interface? device) => _subj.add(device);
+}
+
+/// Bare machine surface for sequencer unit tests. Lets the test drive
+/// `currentSnapshot` directly via [emit] and records `requestState`
+/// calls.
+class _TestMachine implements De1Interface {
+  _TestMachine({this.id = 'test-machine'});
+
+  final String id;
+  @override
+  String get deviceId => id;
+  @override
+  String get name => 'TestMachine';
+  @override
+  DeviceType get type => DeviceType.machine;
+
+  final BehaviorSubject<MachineSnapshot> _snap = BehaviorSubject();
+  @override
+  Stream<MachineSnapshot> get currentSnapshot => _snap.stream;
+
+  final List<MachineState> requested = [];
+
+  @override
+  Future<void> requestState(MachineState state) async {
+    requested.add(state);
+  }
+
+  void emit(MachineSnapshot s) => _snap.add(s);
+  void dispose() => _snap.close();
+
+  @override
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.connected);
+  @override
+  Future<void> onConnect() async {}
+  @override
+  Future<void> disconnect() async {}
+  @override
+  Stream<bool> get ready => Stream<bool>.value(false);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _BengleTestMachine extends _TestMachine implements BengleInterface {
+  _BengleTestMachine() : super(id: 'bengle-test');
+}
+
+class _TestSensor implements Sensor {
+  _TestSensor() : id = 'test-sensor';
+  final String id;
+  @override
+  String get deviceId => id;
+  @override
+  String get name => 'TestSensor';
+  @override
+  DeviceType get type => DeviceType.sensor;
+  final BehaviorSubject<Map<String, dynamic>> _data = BehaviorSubject();
+  @override
+  Stream<Map<String, dynamic>> get data => _data.stream;
+  @override
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.connected);
+  @override
+  SensorInfo get info => SensorInfo(
+      name: name, vendor: 'test', dataChannels: const [], commands: const []);
+  @override
+  Future<Map<String, dynamic>> execute(String c, Map<String, dynamic>? p) async => const {};
+  @override
+  Future<void> onConnect() async {}
+  @override
+  Future<void> disconnect() async {}
+  void emit(double celsius) =>
+      _data.add({'timestamp': DateTime.now().toIso8601String(), 'temperature': celsius});
+}
+
+class _RecordingStorage implements StorageService {
+  final List<SteamRecord> persisted = [];
+
+  @override
+  Future<void> storeSteam(SteamRecord record) async => persisted.add(record);
+  @override
+  Future<void> updateSteam(SteamRecord record) async {}
+  @override
+  Future<void> deleteSteam(String id) async {}
+  @override
+  Future<List<String>> getSteamIds() async => [];
+  @override
+  Future<List<SteamRecord>> getAllSteams() async => [];
+  @override
+  Future<SteamRecord?> getSteam(String id) async => null;
+  @override
+  Future<SteamRecord?> getLatestSteam() async => null;
+  @override
+  Future<SteamRecord?> getLatestSteamMeta() async => null;
+
+  @override
+  Future<void> storeShot(ShotRecord record) async {}
+  @override
+  Future<void> updateShot(ShotRecord record) async {}
+  @override
+  Future<void> deleteShot(String id) async {}
+  @override
+  Future<List<String>> getShotIds() async => [];
+  @override
+  Future<List<ShotRecord>> getAllShots() async => [];
+  @override
+  Future<ShotRecord?> getShot(String id) async => null;
+  @override
+  Future<void> storeCurrentWorkflow(Workflow workflow) async {}
+  @override
+  Future<Workflow?> loadCurrentWorkflow() async => null;
+  @override
+  Future<List<ShotRecord>> getShotsPaginated({
+    int limit = 20,
+    int offset = 0,
+    String? grinderId,
+    String? grinderModel,
+    String? beanBatchId,
+    String? coffeeName,
+    String? coffeeRoaster,
+    String? profileTitle,
+    String? search,
+    bool ascending = false,
+  }) async =>
+      [];
+  @override
+  Future<int> countShots({
+    String? grinderId,
+    String? grinderModel,
+    String? beanBatchId,
+    String? coffeeName,
+    String? coffeeRoaster,
+    String? profileTitle,
+    String? search,
+  }) async =>
+      0;
+  @override
+  Future<ShotRecord?> getLatestShot() async => null;
+  @override
+  Future<ShotRecord?> getLatestShotMeta() async => null;
+}
+
+MachineSnapshot _snap({
+  required MachineState state,
+  MachineSubstate substate = MachineSubstate.idle,
+  int steamTemperature = 140,
+  DateTime? at,
+}) {
+  return MachineSnapshot(
+    timestamp: at ?? DateTime.now(),
+    state: MachineStateSnapshot(state: state, substate: substate),
+    flow: 0,
+    pressure: 0,
+    targetFlow: 0,
+    targetPressure: 0,
+    mixTemperature: 90,
+    groupTemperature: 90,
+    targetMixTemperature: 93,
+    targetGroupTemperature: 93,
+    profileFrame: 0,
+    steamTemperature: steamTemperature,
+  );
+}
+
+void main() {
+  late _StubDe1Controller de1;
+  late SensorController sensors;
+  late WorkflowController workflow;
+  late PersistenceController persistence;
+  late _RecordingStorage storage;
+  late SteamSequencer sequencer;
+
+  setUp(() async {
+    de1 = _StubDe1Controller();
+    final emptyController = DeviceController([_EmptyDiscovery()]);
+    await emptyController.initialize();
+    sensors = SensorController(controller: emptyController);
+    workflow = WorkflowController();
+    storage = _RecordingStorage();
+    persistence = PersistenceController(storageService: storage);
+    sequencer = SteamSequencer(
+      de1Controller: de1,
+      sensorController: sensors,
+      workflowController: workflow,
+      persistenceController: persistence,
+    );
+  });
+
+  tearDown(() async {
+    await sequencer.dispose();
+    persistence.dispose();
+    sensors.dispose();
+  });
+
+  Future<void> settle() => Future<void>.delayed(Duration.zero);
+
+  group('useFwAutonomousStop predicate truth table', () {
+    test('false on non-Bengle machines regardless of other inputs', () {
+      final m = _TestMachine();
+      expect(
+          sequencer.useFwAutonomousStop(
+              machine: m, probeAttached: true, stopAtTemperature: 60),
+          isFalse);
+      m.dispose();
+    });
+
+    test('false when stop target is 0 (off)', () {
+      final m = _BengleTestMachine();
+      expect(
+          sequencer.useFwAutonomousStop(
+              machine: m, probeAttached: true, stopAtTemperature: 0),
+          isFalse);
+      m.dispose();
+    });
+
+    test('false when probe is not attached', () {
+      final m = _BengleTestMachine();
+      expect(
+          sequencer.useFwAutonomousStop(
+              machine: m, probeAttached: false, stopAtTemperature: 60),
+          isFalse);
+      m.dispose();
+    });
+
+    test('false today because MMR slot is stubbed', () {
+      final m = _BengleTestMachine();
+      // All three "real" preconditions met; predicate still false
+      // because BengleSteamMmr.stopAtTemperatureTarget.address == 0.
+      expect(
+          sequencer.useFwAutonomousStop(
+              machine: m, probeAttached: true, stopAtTemperature: 60),
+          isFalse,
+          reason:
+              'FW slot is still 0x00000000 — predicate must stay false');
+      m.dispose();
+    });
+  });
+
+  group('record lifecycle', () {
+    test('opens on entering steam and finalizes on returning to idle',
+        () async {
+      final m = _TestMachine();
+      de1.emit(m);
+      await settle();
+
+      m.emit(_snap(state: MachineState.idle));
+      await settle();
+      expect(sequencer.isRecording, isFalse);
+
+      m.emit(_snap(state: MachineState.steam));
+      await settle();
+      expect(sequencer.isRecording, isTrue);
+
+      m.emit(_snap(state: MachineState.steam));
+      m.emit(_snap(state: MachineState.idle));
+      await settle();
+
+      expect(sequencer.isRecording, isFalse);
+      expect(storage.persisted, hasLength(1));
+      expect(storage.persisted.first.measurements.length, greaterThan(0));
+      m.dispose();
+    });
+
+    test('finalizes on steam → sleep and on steam → error', () async {
+      for (final exitState in [MachineState.sleeping, MachineState.error]) {
+        storage.persisted.clear();
+        final m = _TestMachine();
+        de1.emit(m);
+        await settle();
+
+        m.emit(_snap(state: MachineState.steam));
+        await settle();
+        m.emit(_snap(state: exitState));
+        await settle();
+
+        expect(storage.persisted, hasLength(1),
+            reason: 'should persist on steam → $exitState');
+        await sequencer.dispose();
+        sequencer = SteamSequencer(
+          de1Controller: de1,
+          sensorController: sensors,
+          workflowController: workflow,
+          persistenceController: persistence,
+        );
+        m.dispose();
+      }
+    });
+
+    test('discards record on machine disconnect mid-steam', () async {
+      final m = _TestMachine();
+      de1.emit(m);
+      await settle();
+
+      m.emit(_snap(state: MachineState.steam));
+      await settle();
+      expect(sequencer.isRecording, isTrue);
+
+      de1.emit(null);
+      await settle();
+
+      expect(sequencer.isRecording, isFalse);
+      expect(storage.persisted, isEmpty,
+          reason: 'mid-steam disconnect must not persist');
+      m.dispose();
+    });
+  });
+
+  group('snapshot collection', () {
+    test('milkTemperature stays null when no sensor registered',
+        () async {
+      final m = _TestMachine();
+      de1.emit(m);
+      await settle();
+      m.emit(_snap(state: MachineState.steam));
+      await settle();
+      m.emit(_snap(state: MachineState.idle));
+      await settle();
+
+      expect(storage.persisted, hasLength(1));
+      expect(
+          storage.persisted.first.measurements
+              .every((m) => m.milkTemperature == null),
+          isTrue);
+      m.dispose();
+    });
+
+    test('milkTemperature picks up first registered sensor', () async {
+      final probe = _TestSensor();
+      await sensors.register(probe);
+
+      final m = _TestMachine();
+      de1.emit(m);
+      await settle();
+      m.emit(_snap(state: MachineState.steam));
+      await settle();
+      probe.emit(55.0);
+      await settle();
+      m.emit(_snap(state: MachineState.steam));
+      await settle();
+      m.emit(_snap(state: MachineState.idle));
+      await settle();
+
+      expect(storage.persisted, hasLength(1));
+      final last = storage.persisted.first.measurements.last;
+      expect(last.milkTemperature, equals(55.0));
+    });
+  });
+
+  group('app-side stop', () {
+    test('no stop fires when no sensor registered', () async {
+      workflow.updateWorkflow(
+        steamSettings: workflow.currentWorkflow.steamSettings
+            .copyWith(stopAtTemperature: 60.0),
+      );
+      final m = _TestMachine();
+      de1.emit(m);
+      await settle();
+      m.emit(_snap(state: MachineState.steam));
+      await settle();
+
+      expect(m.requested, isEmpty);
+      m.dispose();
+    });
+
+    test('requests idle when first sensor crosses target', () async {
+      workflow.updateWorkflow(
+        steamSettings: workflow.currentWorkflow.steamSettings
+            .copyWith(stopAtTemperature: 60.0),
+      );
+      final probe = _TestSensor();
+      await sensors.register(probe);
+
+      final m = _TestMachine();
+      de1.emit(m);
+      await settle();
+
+      m.emit(_snap(state: MachineState.steam));
+      await settle();
+      probe.emit(40.0);
+      m.emit(_snap(state: MachineState.steam));
+      await settle();
+      expect(m.requested, isEmpty);
+
+      probe.emit(65.0);
+      m.emit(_snap(state: MachineState.steam));
+      await settle();
+
+      expect(m.requested, contains(MachineState.idle));
+      m.dispose();
+    });
+  });
+}

--- a/test/data_export/shot_export_section_test.dart
+++ b/test/data_export/shot_export_section_test.dart
@@ -3,6 +3,7 @@ import 'package:reaprime/src/controllers/persistence_controller.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/data/shot_annotations.dart';
 import 'package:reaprime/src/models/data/shot_record.dart';
+import 'package:reaprime/src/models/data/steam_record.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/data/workflow_context.dart';
 import 'package:reaprime/src/services/storage/storage_service.dart';
@@ -95,6 +96,23 @@ class MockStorageService implements StorageService {
 
   @override
   Future<ShotRecord?> getLatestShotMeta() => getLatestShot();
+
+  @override
+  Future<void> storeSteam(SteamRecord record) async {}
+  @override
+  Future<void> updateSteam(SteamRecord record) async {}
+  @override
+  Future<void> deleteSteam(String id) async {}
+  @override
+  Future<List<String>> getSteamIds() async => [];
+  @override
+  Future<List<SteamRecord>> getAllSteams() async => [];
+  @override
+  Future<SteamRecord?> getSteam(String id) async => null;
+  @override
+  Future<SteamRecord?> getLatestSteam() async => null;
+  @override
+  Future<SteamRecord?> getLatestSteamMeta() async => null;
 
   void reset() {
     _shots.clear();

--- a/test/data_export/steam_export_section_test.dart
+++ b/test/data_export/steam_export_section_test.dart
@@ -1,0 +1,177 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/persistence_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/shot_record.dart';
+import 'package:reaprime/src/models/data/steam_record.dart';
+import 'package:reaprime/src/models/data/workflow.dart';
+import 'package:reaprime/src/services/storage/storage_service.dart';
+import 'package:reaprime/src/services/webserver/data_export/data_export_section.dart';
+import 'package:reaprime/src/services/webserver/data_export/steam_export_section.dart';
+
+class _MockStorage implements StorageService {
+  final Map<String, SteamRecord> _steams = {};
+
+  @override
+  Future<void> storeSteam(SteamRecord record) async {
+    _steams[record.id] = record;
+  }
+
+  @override
+  Future<void> updateSteam(SteamRecord record) async {
+    _steams[record.id] = record;
+  }
+
+  @override
+  Future<void> deleteSteam(String id) async {
+    _steams.remove(id);
+  }
+
+  @override
+  Future<List<String>> getSteamIds() async => _steams.keys.toList();
+  @override
+  Future<List<SteamRecord>> getAllSteams() async => _steams.values.toList();
+  @override
+  Future<SteamRecord?> getSteam(String id) async => _steams[id];
+  @override
+  Future<SteamRecord?> getLatestSteam() async =>
+      _steams.values.isEmpty ? null : _steams.values.last;
+  @override
+  Future<SteamRecord?> getLatestSteamMeta() async => getLatestSteam();
+
+  void reset() => _steams.clear();
+
+  // Unused surface --------------------------------------------------
+  @override
+  Future<void> storeShot(ShotRecord record) async {}
+  @override
+  Future<void> updateShot(ShotRecord record) async {}
+  @override
+  Future<void> deleteShot(String id) async {}
+  @override
+  Future<List<String>> getShotIds() async => [];
+  @override
+  Future<List<ShotRecord>> getAllShots() async => [];
+  @override
+  Future<ShotRecord?> getShot(String id) async => null;
+  @override
+  Future<void> storeCurrentWorkflow(Workflow workflow) async {}
+  @override
+  Future<Workflow?> loadCurrentWorkflow() async => null;
+  @override
+  Future<List<ShotRecord>> getShotsPaginated({
+    int limit = 20,
+    int offset = 0,
+    String? grinderId,
+    String? grinderModel,
+    String? beanBatchId,
+    String? coffeeName,
+    String? coffeeRoaster,
+    String? profileTitle,
+    String? search,
+    bool ascending = false,
+  }) async =>
+      [];
+  @override
+  Future<int> countShots({
+    String? grinderId,
+    String? grinderModel,
+    String? beanBatchId,
+    String? coffeeName,
+    String? coffeeRoaster,
+    String? profileTitle,
+    String? search,
+  }) async =>
+      0;
+  @override
+  Future<ShotRecord?> getLatestShot() async => null;
+  @override
+  Future<ShotRecord?> getLatestShotMeta() async => null;
+}
+
+SteamRecord makeSteam(String id) => SteamRecord(
+      id: id,
+      timestamp: DateTime.utc(2026, 5, 18, 12, 0, 0),
+      measurements: const [],
+      workflow: WorkflowController().currentWorkflow,
+    );
+
+void main() {
+  late _MockStorage storage;
+  late PersistenceController controller;
+  late SteamExportSection section;
+
+  setUp(() {
+    storage = _MockStorage();
+    controller = PersistenceController(storageService: storage);
+    section = SteamExportSection(controller: controller);
+  });
+
+  tearDown(() {
+    storage.reset();
+    controller.dispose();
+  });
+
+  test('filename is steams.json', () {
+    expect(section.filename, equals('steams.json'));
+  });
+
+  group('export', () {
+    test('returns empty list when no records exist', () async {
+      final result = await section.export();
+      expect(result, isA<List>());
+      expect(result as List, isEmpty);
+    });
+
+    test('returns persisted records as JSON', () async {
+      await controller.persistSteam(makeSteam('s1'));
+      await controller.persistSteam(makeSteam('s2'));
+      final result = await section.export();
+      expect((result as List).map((m) => (m as Map)['id']),
+          containsAll(['s1', 's2']));
+    });
+  });
+
+  group('import', () {
+    test('rejects non-list payloads', () async {
+      final result =
+          await section.import({'not': 'a list'}, ConflictStrategy.skip);
+      expect(result.errors, isNotEmpty);
+      expect(result.imported, 0);
+    });
+
+    test('inserts new records', () async {
+      final payload = [makeSteam('s1').toJson(), makeSteam('s2').toJson()];
+      final result = await section.import(payload, ConflictStrategy.skip);
+      expect(result.imported, 2);
+      expect(result.skipped, 0);
+      expect(await storage.getSteam('s1'), isNotNull);
+      expect(await storage.getSteam('s2'), isNotNull);
+    });
+
+    test('skip strategy leaves existing records untouched', () async {
+      await controller.persistSteam(makeSteam('s1'));
+      final result = await section
+          .import([makeSteam('s1').toJson()], ConflictStrategy.skip);
+      expect(result.imported, 0);
+      expect(result.skipped, 1);
+    });
+
+    test('overwrite strategy updates existing records', () async {
+      await controller.persistSteam(makeSteam('s1'));
+      final result = await section
+          .import([makeSteam('s1').toJson()], ConflictStrategy.overwrite);
+      expect(result.imported, 1);
+      expect(result.skipped, 0);
+    });
+
+    test('reports failures as errors', () async {
+      final result = await section.import(
+          [
+            {'malformed': true}
+          ],
+          ConflictStrategy.skip);
+      expect(result.errors, hasLength(1));
+      expect(result.imported, 0);
+    });
+  });
+}

--- a/test/database/steam_dao_test.dart
+++ b/test/database/steam_dao_test.dart
@@ -1,0 +1,115 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/database/database.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  Map<String, dynamic> workflowJson() => {
+        'id': 'wf-1',
+        'name': 'Test',
+        'description': '',
+        'profile': {
+          'title': 'Test Profile',
+          'author': 'Test',
+          'notes': '',
+          'beverage_type': 'espresso',
+          'steps': [],
+          'tank_temperature': 0.0,
+          'target_weight': 36.0,
+          'target_volume_count_start': 0,
+          'version': '2',
+        },
+        'steamSettings': {
+          'targetTemperature': 150,
+          'duration': 50,
+          'flow': 0.8,
+          'stopAtTemperature': 65.0,
+        },
+        'hotWaterData': {
+          'targetTemperature': 90,
+          'duration': 15,
+          'volume': 100,
+          'flow': 4.0,
+        },
+        'rinseData': {'targetTemperature': 90, 'duration': 10, 'flow': 6.0},
+      };
+
+  SteamRecordsCompanion makeSteam({
+    String id = 'steam-1',
+    DateTime? timestamp,
+    List<Map<String, dynamic>> measurements = const [],
+  }) {
+    return SteamRecordsCompanion(
+      id: Value(id),
+      timestamp: Value(timestamp ?? DateTime.parse('2026-05-18T12:00:00Z')),
+      workflowJson: Value(workflowJson()),
+      measurementsJson: Value(jsonEncode(measurements)),
+    );
+  }
+
+  group('SteamDao - CRUD', () {
+    test('inserts and retrieves a steam record', () async {
+      await db.steamDao.insertSteam(makeSteam(measurements: [
+        {
+          'machine': {'placeholder': true},
+          'milkTemperature': 50.0,
+        }
+      ]));
+      final row = await db.steamDao.getSteamById('steam-1');
+      expect(row, isNotNull);
+      expect(row!.id, equals('steam-1'));
+      expect(jsonDecode(row.measurementsJson), hasLength(1));
+    });
+
+    test('gets all steam ids', () async {
+      await db.steamDao.insertSteam(makeSteam(id: 's1'));
+      await db.steamDao.insertSteam(makeSteam(id: 's2'));
+      final ids = await db.steamDao.getAllSteamIds();
+      expect(ids, hasLength(2));
+      expect(ids, containsAll(['s1', 's2']));
+    });
+
+    test('latest steam returns most recent', () async {
+      await db.steamDao.insertSteam(makeSteam(
+        id: 'older',
+        timestamp: DateTime.parse('2026-05-18T11:00:00Z'),
+      ));
+      await db.steamDao.insertSteam(makeSteam(
+        id: 'newer',
+        timestamp: DateTime.parse('2026-05-18T13:00:00Z'),
+      ));
+      final latest = await db.steamDao.getLatestSteam();
+      expect(latest?.id, equals('newer'));
+    });
+
+    test('latest steam meta omits measurements blob', () async {
+      await db.steamDao.insertSteam(makeSteam(measurements: [
+        {
+          'machine': {'placeholder': true},
+          'milkTemperature': 50.0,
+        }
+      ]));
+      final meta = await db.steamDao.getLatestSteamMeta();
+      expect(meta, isNotNull);
+      expect(meta!.measurementsJson, equals('[]'));
+    });
+
+    test('deletes a steam record', () async {
+      await db.steamDao.insertSteam(makeSteam());
+      await db.steamDao.deleteSteam('steam-1');
+      expect(await db.steamDao.getSteamById('steam-1'), isNull);
+    });
+  });
+}

--- a/test/import/de1app_importer_test.dart
+++ b/test/import/de1app_importer_test.dart
@@ -8,6 +8,7 @@ import 'package:reaprime/src/models/data/grinder.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/data/profile_record.dart';
 import 'package:reaprime/src/models/data/shot_record.dart';
+import 'package:reaprime/src/models/data/steam_record.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/wake_schedule.dart';
 import 'package:reaprime/src/services/storage/bean_storage_service.dart';
@@ -82,6 +83,23 @@ class FakeStorageService implements StorageService {
   Future<ShotRecord?> getLatestShot() => throw UnimplementedError();
   @override
   Future<ShotRecord?> getLatestShotMeta() => throw UnimplementedError();
+
+  @override
+  Future<void> storeSteam(SteamRecord record) async {}
+  @override
+  Future<void> updateSteam(SteamRecord record) async {}
+  @override
+  Future<void> deleteSteam(String id) async {}
+  @override
+  Future<List<String>> getSteamIds() async => [];
+  @override
+  Future<List<SteamRecord>> getAllSteams() async => [];
+  @override
+  Future<SteamRecord?> getSteam(String id) async => null;
+  @override
+  Future<SteamRecord?> getLatestSteam() async => null;
+  @override
+  Future<SteamRecord?> getLatestSteamMeta() async => null;
 }
 
 class FakeProfileStorageService implements ProfileStorageService {

--- a/test/integration/steam_sequencer_integration_test.dart
+++ b/test/integration/steam_sequencer_integration_test.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/bengle_probe_bridge.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/persistence_controller.dart';
+import 'package:reaprime/src/controllers/sensor_controller.dart';
+import 'package:reaprime/src/controllers/steam_sequencer.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
+import 'package:reaprime/src/services/database/database.dart';
+import 'package:reaprime/src/services/storage/drift_storage_service.dart';
+import 'package:rxdart/rxdart.dart';
+
+class _EmptyDiscovery extends DeviceDiscoveryService {
+  @override
+  Stream<List<Device>> get devices => const Stream.empty();
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
+}
+
+class _StubDe1Controller extends De1Controller {
+  _StubDe1Controller()
+      : _subj = BehaviorSubject.seeded(null),
+        super(controller: DeviceController([_EmptyDiscovery()]));
+
+  final BehaviorSubject<De1Interface?> _subj;
+
+  @override
+  Stream<De1Interface?> get de1 => _subj.stream;
+
+  void emit(De1Interface? device) => _subj.add(device);
+}
+
+void main() {
+  group('SteamSequencer integration', () {
+    late AppDatabase db;
+    late DriftStorageService storage;
+    late PersistenceController persistence;
+    late SensorController sensors;
+    late WorkflowController workflow;
+    late _StubDe1Controller de1;
+    late BengleProbeBridge probeBridge;
+    late SteamSequencer sequencer;
+
+    setUp(() async {
+      db = AppDatabase(NativeDatabase.memory());
+      storage = DriftStorageService(db);
+      persistence = PersistenceController(storageService: storage);
+      final emptyController = DeviceController([_EmptyDiscovery()]);
+      await emptyController.initialize();
+      sensors = SensorController(controller: emptyController);
+      workflow = WorkflowController();
+      de1 = _StubDe1Controller();
+      probeBridge = BengleProbeBridge(
+          de1Controller: de1, sensorController: sensors);
+      sequencer = SteamSequencer(
+        de1Controller: de1,
+        sensorController: sensors,
+        workflowController: workflow,
+        persistenceController: persistence,
+      );
+    });
+
+    tearDown(() async {
+      await sequencer.dispose();
+      await probeBridge.dispose();
+      sensors.dispose();
+      persistence.dispose();
+      await db.close();
+    });
+
+    test('full steaming session persists SteamRecord with probe data',
+        () async {
+      final bengle = MockBengle();
+      await bengle.onConnect();
+      de1.emit(bengle);
+      // Let probe bridge register the milk probe.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(sensors.sensors, isNotEmpty,
+          reason: 'probe bridge should have registered BengleMilkProbe');
+
+      // Drive: idle → steam → idle (autonomous stop wraps it up).
+      await bengle.setStopAtTemperatureTarget(15.0);
+      await bengle.requestState(MachineState.steam);
+      await Future<void>.delayed(const Duration(seconds: 4));
+
+      // Wait for state to return to idle (mock autonomous stop).
+      await bengle.currentSnapshot
+          .firstWhere((s) => s.state.state == MachineState.idle)
+          .timeout(const Duration(seconds: 5));
+      await Future<void>.delayed(Duration.zero);
+
+      final ids = await db.steamDao.getAllSteamIds();
+      expect(ids, hasLength(1));
+
+      final record = await db.steamDao.getLatestSteam();
+      expect(record, isNotNull);
+      // Wrapping into SteamMapper would deserialize; for now just
+      // confirm the JSON blob has measurement entries with a probe
+      // temperature.
+      expect(record!.measurementsJson, contains('milkTemperature'));
+
+      await bengle.onDisconnect();
+    });
+  });
+}

--- a/test/models/device/bengle_steam_stop_test.dart
+++ b/test/models/device/bengle_steam_stop_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+
+import '../../helpers/fake_ble_transport.dart';
+
+/// Pins the real-`Bengle` stop-at-temperature stub contract. FW slot
+/// for `BengleSteamMmr.stopAtTemperatureTarget` is still `0x00000000`,
+/// so writes cache locally and never hit the MMR endpoint. When FW
+/// publishes the real slot, the pin test flips and the rest of the
+/// group needs the assertions inverted.
+void main() {
+  group('Bengle stop-at-temperature wiring (FW slot stubbed)', () {
+    late FakeBleTransport transport;
+    late Bengle bengle;
+
+    setUp(() async {
+      transport = FakeBleTransport();
+      bengle = Bengle(transport: transport);
+      transport.queueOnConnectResponses(v13Model: 128); // Bengle marker
+      await bengle.onConnect();
+    });
+
+    tearDown(() {
+      transport.dispose();
+    });
+
+    test('FW slot address is still TBD', () {
+      expect(BengleSteamMmr.stopAtTemperatureTarget.address, 0x00000000);
+    });
+
+    test('setStopAtTemperatureTarget caches locally and does not write MMR',
+        () async {
+      transport.writes.clear();
+      await bengle.setStopAtTemperatureTarget(65.0);
+
+      final mmrWrites = transport.writes
+          .where((w) => w.characteristicUUID == Endpoint.writeToMMR.uuid)
+          .toList();
+      expect(mmrWrites, isEmpty,
+          reason: 'FW slot is stubbed — no MMR write should hit the wire');
+
+      expect(
+          await bengle.getStopAtTemperatureTarget(), closeTo(65.0, 1e-6));
+    });
+
+    test('setStopAtTemperatureTarget clamps to 0..80', () async {
+      await bengle.setStopAtTemperatureTarget(120.0);
+      expect(await bengle.getStopAtTemperatureTarget(), 80.0);
+
+      await bengle.setStopAtTemperatureTarget(-5.0);
+      expect(await bengle.getStopAtTemperatureTarget(), 0.0);
+    });
+
+    test('stopAtTemperatureTarget stream emits cached value to subscribers',
+        () async {
+      await bengle.setStopAtTemperatureTarget(55.0);
+      final value = await bengle.stopAtTemperatureTarget.first;
+      expect(value, 55.0);
+    });
+
+    test('probeAttached stays false on real Bengle (FW signal TBD)',
+        () async {
+      final value = await bengle.probeAttached.first;
+      expect(value, isFalse);
+    });
+  });
+}

--- a/test/models/device/impl/bengle/bengle_milk_probe_test.dart
+++ b/test/models/device/impl/bengle/bengle_milk_probe_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle_milk_probe.dart';
+import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+
+void main() {
+  group('BengleMilkProbe adapter', () {
+    late MockBengle bengle;
+    late BengleMilkProbe probe;
+
+    setUp(() async {
+      bengle = MockBengle();
+      await bengle.onConnect();
+      probe = BengleMilkProbe(bengle: bengle);
+      await probe.onConnect();
+    });
+
+    tearDown(() async {
+      await probe.disconnect();
+      await bengle.onDisconnect();
+    });
+
+    test('deviceId is derived from machine deviceId', () {
+      expect(probe.deviceId, equals('${bengle.deviceId}-milkprobe'));
+    });
+
+    test('connectionState reflects probeAttached', () async {
+      // MockBengle defaults to attached=true.
+      final initial = await probe.connectionState.first;
+      expect(initial, ConnectionState.connected);
+
+      bengle.setProbeAttached(false);
+      final after = await probe.connectionState
+          .firstWhere((s) => s == ConnectionState.disconnected);
+      expect(after, ConnectionState.disconnected);
+    });
+
+    test('data emits temperature frames while steaming', () async {
+      await bengle.requestState(MachineState.steam);
+      await bengle.setStopAtTemperatureTarget(0.0);
+      final sample = await probe.data
+          .firstWhere((m) => m['temperature'] is num);
+      expect(sample['timestamp'], isA<String>());
+      expect((sample['temperature'] as num).toDouble(), greaterThan(0));
+    });
+
+    test('info exposes temperature channel', () {
+      expect(probe.info.dataChannels.map((c) => c.key), contains('temperature'));
+    });
+  });
+}

--- a/test/models/device/impl/bengle/mock_bengle_steam_probe_test.dart
+++ b/test/models/device/impl/bengle/mock_bengle_steam_probe_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+
+void main() {
+  group('MockBengle milk-probe surface', () {
+    late MockBengle bengle;
+
+    setUp(() async {
+      bengle = MockBengle();
+      await bengle.onConnect();
+    });
+
+    tearDown(() async {
+      await bengle.onDisconnect();
+    });
+
+    test('stopAtTemperatureTarget round-trips set/get', () async {
+      await bengle.setStopAtTemperatureTarget(60.0);
+      expect(await bengle.getStopAtTemperatureTarget(), 60.0);
+      final streamed = await bengle.stopAtTemperatureTarget.first;
+      expect(streamed, 60.0);
+    });
+
+    test('setStopAtTemperatureTarget clamps to 0..80', () async {
+      await bengle.setStopAtTemperatureTarget(120.0);
+      expect(await bengle.getStopAtTemperatureTarget(), 80.0);
+      await bengle.setStopAtTemperatureTarget(-5.0);
+      expect(await bengle.getStopAtTemperatureTarget(), 0.0);
+    });
+
+    test('probeAttached defaults to true', () async {
+      final value = await bengle.probeAttached.first;
+      expect(value, isTrue);
+    });
+
+    test('probeAttached can be flipped via setProbeAttached', () async {
+      bengle.setProbeAttached(false);
+      final value = await bengle.probeAttached.first;
+      expect(value, isFalse);
+    });
+
+    test('probeTemperature emits while machine state is steam', () async {
+      final samples = <double>[];
+      final sub = bengle.probeTemperature.listen(samples.add);
+      await bengle.requestState(MachineState.steam);
+      // Stop-at-temp set higher than rise window so steam doesn't
+      // auto-exit before samples accumulate.
+      await bengle.setStopAtTemperatureTarget(0.0);
+      await Future<void>.delayed(const Duration(seconds: 3));
+      await sub.cancel();
+      expect(samples, isNotEmpty);
+      expect(samples.last, greaterThan(samples.first));
+    });
+
+    test('autonomous stop triggers idle when probe reaches target',
+        () async {
+      await bengle.setStopAtTemperatureTarget(20.0);
+      final stateChanges = <MachineState>[];
+      final sub = bengle.currentSnapshot
+          .map((s) => s.state.state)
+          .distinct()
+          .listen(stateChanges.add);
+      await bengle.requestState(MachineState.steam);
+      // ~5 °C/s rise → target 20°C reached well within 6s.
+      await Future<void>.delayed(const Duration(seconds: 6));
+      await sub.cancel();
+      expect(stateChanges, contains(MachineState.steam));
+      expect(stateChanges, contains(MachineState.idle),
+          reason: 'autonomous stop should request idle when target reached');
+    });
+  });
+}

--- a/test/models/steam_record_test.dart
+++ b/test/models/steam_record_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/shot_annotations.dart';
+import 'package:reaprime/src/models/data/steam_record.dart';
+import 'package:reaprime/src/models/data/steam_snapshot.dart';
+import 'package:reaprime/src/models/data/workflow.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+
+MachineSnapshot _machineSnapshot() => MachineSnapshot(
+      timestamp: DateTime.utc(2026, 5, 18, 12, 0, 0),
+      state: const MachineStateSnapshot(
+        state: MachineState.steam,
+        substate: MachineSubstate.pouring,
+      ),
+      flow: 0,
+      pressure: 0,
+      targetFlow: 0,
+      targetPressure: 0,
+      mixTemperature: 90,
+      groupTemperature: 90,
+      targetMixTemperature: 93,
+      targetGroupTemperature: 93,
+      profileFrame: 0,
+      steamTemperature: 140,
+    );
+
+Workflow _workflow() => WorkflowController().currentWorkflow.copyWith(
+      steamSettings: SteamSettings(
+        targetTemperature: 150,
+        duration: 50,
+        flow: 0.8,
+        stopAtTemperature: 65.0,
+      ),
+    );
+
+void main() {
+  group('SteamRecord', () {
+    test('round-trips with measurements and annotations', () {
+      final original = SteamRecord(
+        id: 'steam-1',
+        timestamp: DateTime.utc(2026, 5, 18, 12, 0, 0),
+        measurements: [
+          SteamSnapshot(machine: _machineSnapshot(), milkTemperature: 50.0),
+          SteamSnapshot(machine: _machineSnapshot(), milkTemperature: 65.0),
+        ],
+        workflow: _workflow(),
+        annotations: ShotAnnotations(espressoNotes: 'silky'),
+      );
+      final json = original.toJson();
+      final restored = SteamRecord.fromJson(json);
+      expect(restored.id, equals('steam-1'));
+      expect(restored.measurements, hasLength(2));
+      expect(restored.measurements.last.milkTemperature, equals(65.0));
+      expect(restored.workflow.steamSettings.stopAtTemperature, equals(65.0));
+      expect(restored.annotations?.espressoNotes, equals('silky'));
+    });
+
+    test('round-trips with empty measurements and no annotations', () {
+      final original = SteamRecord(
+        id: 'steam-2',
+        timestamp: DateTime.utc(2026, 5, 18, 12, 0, 0),
+        measurements: const [],
+        workflow: _workflow(),
+      );
+      final restored = SteamRecord.fromJson(original.toJson());
+      expect(restored.measurements, isEmpty);
+      expect(restored.annotations, isNull);
+    });
+
+    test('toJsonWithoutMeasurements omits measurements key', () {
+      final r = SteamRecord(
+        id: 'steam-3',
+        timestamp: DateTime.utc(2026, 5, 18, 12, 0, 0),
+        measurements: [
+          SteamSnapshot(machine: _machineSnapshot()),
+        ],
+        workflow: _workflow(),
+      );
+      final json = r.toJsonWithoutMeasurements();
+      expect(json.containsKey('measurements'), isFalse);
+      expect(json['id'], equals('steam-3'));
+    });
+  });
+}

--- a/test/models/steam_snapshot_test.dart
+++ b/test/models/steam_snapshot_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/data/steam_snapshot.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+
+MachineSnapshot _machineSnapshot() => MachineSnapshot(
+      timestamp: DateTime.utc(2026, 5, 18, 12, 0, 0),
+      state: const MachineStateSnapshot(
+        state: MachineState.steam,
+        substate: MachineSubstate.pouring,
+      ),
+      flow: 0,
+      pressure: 0,
+      targetFlow: 0,
+      targetPressure: 0,
+      mixTemperature: 90,
+      groupTemperature: 90,
+      targetMixTemperature: 93,
+      targetGroupTemperature: 93,
+      profileFrame: 0,
+      steamTemperature: 140,
+    );
+
+void main() {
+  group('SteamSnapshot', () {
+    test('round-trips with milkTemperature', () {
+      final original = SteamSnapshot(
+        machine: _machineSnapshot(),
+        milkTemperature: 65.5,
+      );
+      final json = original.toJson();
+      final restored = SteamSnapshot.fromJson(json);
+      expect(restored.milkTemperature, equals(65.5));
+      expect(restored.machine.steamTemperature, equals(140));
+      expect(restored.machine.state.state, equals(MachineState.steam));
+    });
+
+    test('round-trips without milkTemperature (null)', () {
+      final original = SteamSnapshot(machine: _machineSnapshot());
+      final json = original.toJson();
+      expect(json['milkTemperature'], isNull);
+      final restored = SteamSnapshot.fromJson(json);
+      expect(restored.milkTemperature, isNull);
+    });
+
+    test('copyWith preserves and overrides milkTemperature', () {
+      final base = SteamSnapshot(
+        machine: _machineSnapshot(),
+        milkTemperature: 50.0,
+      );
+      expect(base.copyWith().milkTemperature, equals(50.0));
+      expect(base.copyWith(milkTemperature: 70.0).milkTemperature,
+          equals(70.0));
+    });
+  });
+}

--- a/test/models/workflow_equality_test.dart
+++ b/test/models/workflow_equality_test.dart
@@ -34,6 +34,58 @@ void main() {
       final b = SteamSettings(targetTemperature: 150, duration: 50, flow: 1.5);
       expect(a, isNot(equals(b)));
     });
+
+    test('differ when stopAtTemperature differs', () {
+      final a = SteamSettings(
+          targetTemperature: 150,
+          duration: 50,
+          flow: 2.1,
+          stopAtTemperature: 65.0);
+      final b = SteamSettings(
+          targetTemperature: 150,
+          duration: 50,
+          flow: 2.1,
+          stopAtTemperature: 70.0);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('stopAtTemperature defaults to 0.0 (off)', () {
+      final s = SteamSettings(targetTemperature: 150, duration: 50, flow: 2.1);
+      expect(s.stopAtTemperature, equals(0.0));
+      expect(SteamSettings.defaults().stopAtTemperature, equals(0.0));
+    });
+
+    test('stopAtTemperature survives fromJson round-trip', () {
+      final original = SteamSettings(
+          targetTemperature: 150,
+          duration: 50,
+          flow: 2.1,
+          stopAtTemperature: 65.0);
+      final roundTrip = SteamSettings.fromJson(original.toJson());
+      expect(roundTrip.stopAtTemperature, equals(65.0));
+      expect(original, equals(roundTrip));
+    });
+
+    test('fromJson tolerates missing stopAtTemperature (legacy clients)', () {
+      final json = <String, dynamic>{
+        'targetTemperature': 150,
+        'duration': 50,
+        'flow': 2.1,
+      };
+      final parsed = SteamSettings.fromJson(json);
+      expect(parsed.stopAtTemperature, equals(0.0));
+    });
+
+    test('copyWith preserves and overrides stopAtTemperature', () {
+      final base = SteamSettings(
+          targetTemperature: 150,
+          duration: 50,
+          flow: 2.1,
+          stopAtTemperature: 65.0);
+      expect(base.copyWith().stopAtTemperature, equals(65.0));
+      expect(base.copyWith(stopAtTemperature: 0.0).stopAtTemperature,
+          equals(0.0));
+    });
   });
 
   group('HotWaterData equality', () {

--- a/test/shot_importer_test.dart
+++ b/test/shot_importer_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/data/shot_record.dart';
+import 'package:reaprime/src/models/data/steam_record.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/services/storage/storage_service.dart';
 import 'package:reaprime/src/util/shot_importer.dart';
@@ -99,6 +100,23 @@ class MockStorageService implements StorageService {
 
   @override
   Future<ShotRecord?> getLatestShotMeta() => getLatestShot();
+
+  @override
+  Future<void> storeSteam(SteamRecord record) async {}
+  @override
+  Future<void> updateSteam(SteamRecord record) async {}
+  @override
+  Future<void> deleteSteam(String id) async {}
+  @override
+  Future<List<String>> getSteamIds() async => [];
+  @override
+  Future<List<SteamRecord>> getAllSteams() async => [];
+  @override
+  Future<SteamRecord?> getSteam(String id) async => null;
+  @override
+  Future<SteamRecord?> getLatestSteam() async => null;
+  @override
+  Future<SteamRecord?> getLatestSteamMeta() async => null;
 }
 
 void main() {

--- a/test/webserver/steams_handler_test.dart
+++ b/test/webserver/steams_handler_test.dart
@@ -1,0 +1,132 @@
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/persistence_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/shot_annotations.dart';
+import 'package:reaprime/src/models/data/steam_record.dart';
+import 'package:reaprime/src/services/database/database.dart' hide SteamRecord;
+import 'package:reaprime/src/services/storage/drift_storage_service.dart';
+import 'package:reaprime/src/services/webserver/steams_handler.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+void main() {
+  late AppDatabase db;
+  late PersistenceController persistence;
+  late Handler handler;
+
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+    persistence = PersistenceController(storageService: DriftStorageService(db));
+    final steamsHandler = SteamsHandler(controller: persistence);
+    final app = Router().plus;
+    steamsHandler.addRoutes(app);
+    handler = app.call;
+  });
+
+  tearDown(() async {
+    persistence.dispose();
+    await db.close();
+  });
+
+  Future<Response> sendGet(String path) async =>
+      handler(Request('GET', Uri.parse('http://localhost$path')));
+
+  Future<Response> sendPut(String path, Map<String, dynamic> body) async =>
+      handler(
+        Request(
+          'PUT',
+          Uri.parse('http://localhost$path'),
+          body: jsonEncode(body),
+          headers: {'content-type': 'application/json'},
+        ),
+      );
+
+  Future<Response> sendDelete(String path) async =>
+      handler(Request('DELETE', Uri.parse('http://localhost$path')));
+
+  SteamRecord makeRecord(String id) => SteamRecord(
+        id: id,
+        timestamp: DateTime.utc(2026, 5, 18, 12, 0, 0),
+        measurements: const [],
+        workflow: WorkflowController().currentWorkflow,
+      );
+
+  group('SteamsHandler', () {
+    test('GET /api/v1/steams returns empty list', () async {
+      final response = await sendGet('/api/v1/steams');
+      expect(response.statusCode, 200);
+      final body = jsonDecode(await response.readAsString()) as List;
+      expect(body, isEmpty);
+    });
+
+    test('GET /api/v1/steams returns persisted records (no measurements)',
+        () async {
+      await persistence.persistSteam(makeRecord('s1'));
+      await persistence.persistSteam(makeRecord('s2'));
+
+      final response = await sendGet('/api/v1/steams');
+      expect(response.statusCode, 200);
+      final body = jsonDecode(await response.readAsString()) as List;
+      expect(body, hasLength(2));
+      for (final entry in body) {
+        expect(entry, isA<Map>());
+        expect((entry as Map).containsKey('measurements'), isFalse);
+      }
+    });
+
+    test('GET /api/v1/steams/ids returns ids', () async {
+      await persistence.persistSteam(makeRecord('s1'));
+      final response = await sendGet('/api/v1/steams/ids');
+      final body = jsonDecode(await response.readAsString()) as List;
+      expect(body, contains('s1'));
+    });
+
+    test('GET /api/v1/steams/latest returns the most recent record',
+        () async {
+      await persistence.persistSteam(makeRecord('s1').copyWith(
+          timestamp: DateTime.utc(2026, 5, 18, 11, 0, 0)));
+      await persistence.persistSteam(makeRecord('s2').copyWith(
+          timestamp: DateTime.utc(2026, 5, 18, 13, 0, 0)));
+
+      final response = await sendGet('/api/v1/steams/latest');
+      final body = jsonDecode(await response.readAsString())
+          as Map<String, dynamic>;
+      expect(body['id'], equals('s2'));
+    });
+
+    test('GET /api/v1/steams/<id> returns the record', () async {
+      await persistence.persistSteam(makeRecord('s1'));
+      final response = await sendGet('/api/v1/steams/s1');
+      expect(response.statusCode, 200);
+      final body = jsonDecode(await response.readAsString())
+          as Map<String, dynamic>;
+      expect(body['id'], equals('s1'));
+    });
+
+    test('GET /api/v1/steams/<id> returns 404 for unknown id', () async {
+      final response = await sendGet('/api/v1/steams/nope');
+      expect(response.statusCode, 404);
+    });
+
+    test('PUT /api/v1/steams/<id> updates annotations', () async {
+      await persistence.persistSteam(makeRecord('s1'));
+      final response = await sendPut('/api/v1/steams/s1', {
+        'annotations': ShotAnnotations(espressoNotes: 'silky').toJson(),
+      });
+      expect(response.statusCode, 200);
+      final body = jsonDecode(await response.readAsString())
+          as Map<String, dynamic>;
+      expect(body['annotations']['espressoNotes'], equals('silky'));
+    });
+
+    test('DELETE /api/v1/steams/<id> removes the record', () async {
+      await persistence.persistSteam(makeRecord('s1'));
+      final response = await sendDelete('/api/v1/steams/s1');
+      expect(response.statusCode, 200);
+      final after = await sendGet('/api/v1/steams/s1');
+      expect(after.statusCode, 404);
+    });
+  });
+}


### PR DESCRIPTION
## What
- New `SteamSettings.stopAtTemperature` field, `SteamRecord` / `SteamSnapshot` models + Drift table (schemaVersion 2→3), REST `/api/v1/steams`, `PersistenceController.steamsChanged`.
- `BengleSteamMmr.stopAtTemperatureTarget` (stub `0x00000000`, pin-tested), `Bengle.setStopAtTemperatureTarget` cache + log-once until FW lands.
- `BengleInterface` gains `stopAtTemperatureTarget` / `probeAttached` / `probeTemperature` streams; `MockBengle` synthesises during steam.
- `BengleMilkProbe` Sensor adapter + `BengleProbeBridge`; `SensorController.register/unregister` with bridge-wins dedupe; `BengleSteamStopBridge` (workflow → MMR reflection).
- `SteamSequencer`: opens record on entry to steam, finalizes on exit, discards on mid-steam disconnect; `useFwAutonomousStop` predicate gated on the MMR address (false today); app-side stop branch reads first registered sensor.

## Why
FW for milk probe + stop-at-temperature isn't ready, but skin developers need the API surface now. This lands the full scaffolding so the day FW publishes the MMR slot and a probe data path, the wiring lights up unchanged: just flip the address and ship a probe device implementation. Probe discovery / transport is intentionally not assumed — it may end up as a new BLE characteristic, not another MMR slot.

## Test plan
- `flutter test`: 1309 pass (model round-trips, DAO, persistence, SensorController register/unregister, both bridges, Bengle stub pin test, MockBengle probe synth + autonomous stop, SteamSequencer unit + integration, SteamsHandler REST).
- Real DE1 smoke on Android tablet: PUT workflow with `stopAtTemperature: 65.0` round-tripped; 8s physical steam captured 78 frames in `/api/v1/steams/latest` with steamTemperature 138–149°C and `milkTemperature: null` (no probe registered, as expected).