### PR TITLE
fix: default profile names

### DIFF
--- a/assets/defaultProfiles/Default1.json
+++ b/assets/defaultProfiles/Default1.json
@@ -1,5 +1,5 @@
 {
-  "title": "Default1",
+  "title": "Default",
   "author": "Decent",
   "notes": "This profile is gentle on the coffee puck and not too demanding on the barista.  Produces a very acceptable espresso in a wide variety of settings.",
   "beverage_type": "espresso",

--- a/assets/defaultProfiles/Gentle_and_sweet1.json
+++ b/assets/defaultProfiles/Gentle_and_sweet1.json
@@ -1,5 +1,5 @@
 {
-  "title": "Gentle and sweet1",
+  "title": "Gentle and sweet",
   "author": "Decent",
   "notes": "This is a very easy espresso to successfully make and is suggested if you are having difficulty making good drinks.  The pressure rises to only 6 bar and then slowly descends to 4 bar.  The resulting espresso should be free of channeling, have low acidity and quite pleasant to drink straight or with milk.",
   "beverage_type": "espresso",


### PR DESCRIPTION
Some of the default bundled profiles had erroneous `1` suffixed names. @allofmeng fixes that.