### PR TITLE
Bound serial probe writes so foreign USB devices can't hang startup

### DIFF
--- a/lib/src/services/serial/serial_service_desktop.dart
+++ b/lib/src/services/serial/serial_service_desktop.dart
@@ -392,6 +392,10 @@ class SerialServiceDesktop implements DeviceDiscoveryService {
   }
 }
 
+// Per-chunk blocking-write ceiling. Bounds how long a single native write
+// can wait for an unresponsive device to accept bytes.
+const int _serialWriteTimeoutMs = 500;
+
 class _DesktopSerialPort implements SerialTransport {
   final SerialPort _port;
   late Logger _log;
@@ -562,18 +566,28 @@ class _DesktopSerialPort implements SerialTransport {
   Future<void> _write(Uint8List command) async {
     try {
       // Write all bytes, handling short writes by looping.
-      // timeout: 0 = blocking write (waits until bytes are accepted by OS).
+      // Finite timeout (not 0 = block-forever): scan probes non-Decent
+      // USB-serial devices, and a device that never accepts the bytes must
+      // not be able to wedge the isolate. A zero-progress write means the
+      // device isn't draining — stop instead of spinning.
       int offset = 0;
       while (offset < command.length) {
         final chunk =
             offset == 0 ? command : Uint8List.sublistView(command, offset);
-        final written = await _port.write(chunk, timeout: 0);
+        final written =
+            await _port.write(chunk, timeout: _serialWriteTimeoutMs);
         if (written < 0) {
           throw StateError('Serial write failed: ${SerialPort.lastError}');
         }
+        if (written == 0) {
+          throw StateError(
+              'Serial write stalled (0 bytes in ${_serialWriteTimeoutMs}ms)');
+        }
         offset += written;
       }
-      _port.drain();
+      // Bounded stand-in for the native `_port.drain()`, which blocks the
+      // isolate forever on a device that never transmits the buffer.
+      await drainWithTimeout(bytesToWrite: () => _port.bytesToWrite);
       _log.fine("wrote: ${command.map((e) => e.toRadixString(16))}");
       if (Platform.isLinux || Platform.isMacOS) {
         await Future.delayed(Duration(milliseconds: 20), () {

--- a/lib/src/services/serial/utils.dart
+++ b/lib/src/services/serial/utils.dart
@@ -32,6 +32,31 @@ bool isDE1(List<String> data, List<int> bytes) {
   return data.any((e) => e.startsWith("[M]"));
 }
 
+/// Non-blocking replacement for the native `sp_drain`, which has no timeout
+/// and blocks the calling isolate forever when a USB-serial device never
+/// transmits the buffered bytes (observed when scan probes a non-Decent
+/// device, e.g. a Valve VR Radio on a Windows COM port — it froze startup).
+///
+/// Polls [bytesToWrite] until it reports an empty output buffer or [timeout]
+/// elapses, sleeping [pollInterval] between reads. Always returns; never
+/// waits longer than `ceil(timeout / pollInterval)` polls. [sleep] is
+/// injectable for tests.
+Future<void> drainWithTimeout({
+  required int Function() bytesToWrite,
+  Duration timeout = const Duration(milliseconds: 200),
+  Duration pollInterval = const Duration(milliseconds: 5),
+  Future<void> Function(Duration)? sleep,
+}) async {
+  final sleepFn = sleep ?? Future<void>.delayed;
+  final maxPolls = pollInterval.inMicroseconds <= 0
+      ? 0
+      : (timeout.inMicroseconds / pollInterval.inMicroseconds).ceil();
+  for (var i = 0; i < maxPolls; i++) {
+    if (bytesToWrite() <= 0) return;
+    await sleepFn(pollInterval);
+  }
+}
+
 /// Build a stable device ID for HDS from USB metadata.
 /// Returns null if vid or pid are missing (can't form a meaningful ID).
 String? computeUsbStableId({int? vid, int? pid, String? serial}) {

--- a/test/services/serial/drain_with_timeout_test.dart
+++ b/test/services/serial/drain_with_timeout_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/serial/utils.dart';
+
+/// Regression coverage for the Windows scan hang: probing a non-Decent
+/// USB-serial device (e.g. a Valve VR Radio on COM3) blocked the main
+/// isolate forever inside the native `sp_drain`, freezing app startup.
+///
+/// `drainWithTimeout` is the non-blocking replacement — it polls the
+/// output-buffer count and MUST return within its timeout no matter what
+/// the device does. These tests pin that invariant without touching FFI.
+void main() {
+  group('drainWithTimeout', () {
+    test('returns without sleeping when buffer is already empty', () async {
+      var sleeps = 0;
+      await drainWithTimeout(
+        bytesToWrite: () => 0,
+        sleep: (_) async => sleeps++,
+      );
+      expect(sleeps, 0);
+    });
+
+    test('returns once the buffer drains partway through', () async {
+      final readings = <int>[3, 2, 0, 0];
+      var i = 0;
+      var sleeps = 0;
+      await drainWithTimeout(
+        bytesToWrite: () => readings[i++],
+        sleep: (_) async => sleeps++,
+      );
+      // bytesToWrite read at i=0 (3), sleep, i=1 (2), sleep, i=2 (0) -> stop.
+      expect(sleeps, 2);
+    });
+
+    test('is bounded when the buffer never empties (never hangs)', () async {
+      var sleeps = 0;
+      await drainWithTimeout(
+        bytesToWrite: () => 10, // stuck device: always has bytes pending
+        timeout: const Duration(milliseconds: 100),
+        pollInterval: const Duration(milliseconds: 10),
+        sleep: (_) async => sleeps++,
+      );
+      // ceil(100 / 10) = 10 polls, then give up. Crucially: it returns.
+      expect(sleeps, 10);
+    });
+
+    test('completes promptly even with the default real sleep', () async {
+      // Smoke check that the default sleep path also terminates.
+      await drainWithTimeout(
+        bytesToWrite: () => 1,
+        timeout: const Duration(milliseconds: 20),
+        pollInterval: const Duration(milliseconds: 5),
+      ).timeout(const Duration(seconds: 2));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes a Windows startup hang reported by a user whose machine has a non-Decent USB-serial device on a COM port (a **Valve VR Radio** / SteamVR endpoint). The BLE-bail fix shipped earlier was correct — the BLE adapter is absent and the scan bails cleanly. The hang is in the **serial scanner**, not BLE.

### Root cause

Serial discovery probes every USB-serial port for a DE1 by writing `<+M>`/`<+E>`/MMR commands and waiting for a `[M]` reply. The write path used:

- `_port.write(chunk, timeout: 0)` — `timeout: 0` means **block forever** until the device accepts the bytes (`sp_blocking_write(..., 0)`).
- `_port.drain()` — synchronous `sp_drain`, **no timeout**, blocks until the buffer is fully transmitted.

Probing the Valve device (which never drains its buffer) blocked the **main isolate inside native FFI**, freezing app startup. The log ends right at `Collected serial data: ()` because everything after is buffered and lost when the frozen process is killed/relaunched ~19s later.

A key detail: because the block is **synchronous FFI**, a Dart `.timeout()` wrapper can't fire (the event loop is frozen). The fix must be at the call site.

### Fix

- **write**: finite per-chunk timeout (500ms) instead of block-forever, and bail on a zero-progress write so a finite timeout can't just spin.
- **drain**: replace the unbounded native `drain()` with `drainWithTimeout`, which polls the output-buffer count (`bytesToWrite`) and always returns within its deadline.

Worst case for a foreign device is now a bounded ~5s one-time cost during scan instead of an indefinite hang. This covers *all* unresponsive USB-serial devices, not just this Valve one.

## Test plan

- [x] New unit tests for `drainWithTimeout` pin the anti-hang invariant (returns early when buffer empties; bounded when it never does) — 4/4 green
- [x] Serial-related suites green (46/46)
- [x] Full `flutter test` green (1329)
- [x] `flutter analyze` clean
- [ ] **Needs the Windows user to validate** against the real Valve VR device — the FFI write/drain behavior can't be exercised in tests without that hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)