### PR TITLE
fix(telemetry): crashlytics queue

### DIFF
--- a/lib/src/controllers/battery_controller.dart
+++ b/lib/src/controllers/battery_controller.dart
@@ -41,6 +41,18 @@ class BatteryController {
 
   Future<void> _tick() async {
     try {
+      // Bail early if no machine connected — skip settings reads and
+      // charging decision computation.
+      if (_deviceController.isScanning) {
+        _log.fine('Skipping USB charger mode update during BLE scan');
+        return;
+      }
+      final de1 = _de1Controller.connectedDe1OrNull;
+      if (de1 == null) {
+        _log.fine('No machine connected, skipping USB charger mode update');
+        return;
+      }
+
       final batteryPercent = await _battery.batteryLevel;
       final now = DateTime.now();
 
@@ -72,23 +84,12 @@ class BatteryController {
         'reason: ${decision.reason}',
       );
 
-      // Apply to DE1 — skip during BLE scan to avoid congesting the adapter,
-      // and skip when no machine is connected. Pre-checking avoids throwing
-      // DeviceNotConnectedException on every tick when the user has no
-      // machine, which used to log at WARNING and reach Crashlytics.
-      if (_deviceController.isScanning) {
-        _log.fine('Skipping USB charger mode update during BLE scan');
-      } else {
-        final de1 = _de1Controller.connectedDe1OrNull;
-        if (de1 == null) {
-          _log.fine('No machine connected, skipping USB charger mode update');
-        } else {
-          try {
-            await de1.setUsbChargerMode(decision.shouldCharge);
-          } catch (e) {
-            _log.warning('Failed to set USB charger mode', e);
-          }
-        }
+      // Apply to DE1 — early bail at top of method already handled
+      // scan-during-scan and no-machine-connected cases.
+      try {
+        await de1.setUsbChargerMode(decision.shouldCharge);
+      } catch (e) {
+        _log.warning('Failed to set USB charger mode', e);
       }
 
       // Emit state

--- a/lib/src/models/device/impl/acaia/acaia_scale.dart
+++ b/lib/src/models/device/impl/acaia/acaia_scale.dart
@@ -152,6 +152,7 @@ class AcaiaScale implements Scale {
   @override
   disconnect() async {
     _cancelTimers();
+    _connectionStateController.add(ConnectionState.disconnected);
     await _transport.disconnect();
   }
 

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -25,7 +25,19 @@ class UnifiedDe1Transport {
   // serial branch never runs.
   StreamSubscription<String>? _transportSubscription;
 
-  Stream<device.ConnectionState> get connectionState => _transport.connectionState;
+  // True while `_handleBleTimeout` is doing a deliberate disconnect→reconnect
+  // to recover from a BLE timeout. The disconnect it issues must stay
+  // invisible to upstream (De1Controller would otherwise null the machine on
+  // `disconnected` and tear down a connection that's about to come right
+  // back). Suppressing here — rather than at the transport — covers every
+  // platform: the desktop/iOS `BluePlusTransport` emits `disconnected`
+  // synchronously, and Android's native sub emits it async from the platform.
+  bool _recovering = false;
+
+  Stream<device.ConnectionState> get connectionState =>
+      _transport.connectionState.where(
+        (s) => !(_recovering && s == device.ConnectionState.disconnected),
+      );
 
   String get id => _transport.id;
 
@@ -543,6 +555,7 @@ class UnifiedDe1Transport {
   /// Returns true if reconnect succeeded, false if it failed.
   Future<bool> _handleBleTimeout(Object error, StackTrace st) async {
     _log.warning('BLE write timed out, attempting reconnect');
+    _recovering = true;
     try {
       await _transport.disconnect();
       await _transport.connect();
@@ -554,6 +567,9 @@ class UnifiedDe1Transport {
         'BLE reconnect failed, disconnecting',
         reconnectError,
       );
+      // Recovery failed — this is a genuine disconnect. Clear the guard
+      // before tearing down so the `disconnected` reaches upstream.
+      _recovering = false;
       try {
         // Don't await — BLE stack may be unresponsive
         _transport.disconnect();
@@ -561,6 +577,8 @@ class UnifiedDe1Transport {
         _log.fine('transport.disconnect() during BLE recovery failed', e, st);
       }
       return false;
+    } finally {
+      _recovering = false;
     }
   }
 

--- a/lib/src/services/ble/blue_plus_transport.dart
+++ b/lib/src/services/ble/blue_plus_transport.dart
@@ -57,6 +57,14 @@ class BluePlusTransport implements BLETransport {
 
   @override
   Future<void> disconnect() async {
+    // Emit disconnected immediately — do NOT rely on the platform to
+    // fire a connectionState change. On some platforms / error paths
+    // (reconnect-after-timeout failure) the platform never signals the
+    // state transition, leaving consumers (DisconnectSupervisor,
+    // ConnectionManager) unaware the transport is dead. Duplicate
+    // emissions from the native sub are harmless (BehaviorSubject).
+    _connectionStateSubject.add(device.ConnectionState.disconnected);
+
     // Keep `_nativeConnectionSub` alive here — it's the channel that
     // forwards the eventual `disconnected` state from the platform
     // stream to `_connectionStateSubject`, which higher-level code
@@ -68,7 +76,6 @@ class BluePlusTransport implements BLETransport {
       await _device.disconnect(queue: false, timeout: 5);
     } catch (e) {
       _log.warning("Error during disconnect: $e");
-      _connectionStateSubject.add(device.ConnectionState.disconnected);
     }
   }
 

--- a/lib/src/settings/settings_controller.dart
+++ b/lib/src/settings/settings_controller.dart
@@ -21,44 +21,44 @@ class SettingsController with ChangeNotifier {
 
   // Make ThemeMode a private variable so it is not updated directly without
   // also persisting the changes with the SettingsService.
-  late ThemeMode _themeMode;
+  ThemeMode _themeMode = ThemeMode.system;
 
-  late GatewayMode _gatewayMode;
+  GatewayMode _gatewayMode = GatewayMode.disabled;
 
-  late String _logLevel;
+  String _logLevel = 'INFO';
 
-  late Set<SimulatedDevicesTypes> _simulatedDevices;
+  Set<SimulatedDevicesTypes> _simulatedDevices = {};
 
-  late double _weightFlowMultiplier;
+  double _weightFlowMultiplier = 1.0;
 
-  late double _volumeFlowMultiplier;
+  double _volumeFlowMultiplier = 0.3;
 
-  late ScalePowerMode _scalePowerMode;
+  ScalePowerMode _scalePowerMode = ScalePowerMode.disconnect;
 
   String? _preferredMachineId;
 
   String? _preferredScaleId;
 
-  late String _defaultSkinId;
+  String _defaultSkinId = 'streamline.js';
 
-  late bool _automaticUpdateCheck;
+  bool _automaticUpdateCheck = true;
 
-  late bool _telemetryConsent;
+  bool _telemetryConsent = false;
 
-  late bool _telemetryPromptShown;
+  bool _telemetryPromptShown = false;
 
-  late bool _telemetryConsentDialogShown;
+  bool _telemetryConsentDialogShown = false;
 
-  late ChargingMode _chargingMode;
-  late bool _nightModeEnabled;
-  late int _nightModeSleepTime;
-  late int _nightModeMorningTime;
+  ChargingMode _chargingMode = ChargingMode.disabled;
+  bool _nightModeEnabled = false;
+  int _nightModeSleepTime = 1320;
+  int _nightModeMorningTime = 420;
 
-  late bool _userPresenceEnabled;
-  late int _sleepTimeoutMinutes;
-  late String _wakeSchedules;
-  late bool _lowBatteryBrightnessLimit;
-  late bool _onboardingCompleted;
+  bool _userPresenceEnabled = true;
+  int _sleepTimeoutMinutes = 30;
+  String _wakeSchedules = '[]';
+  bool _lowBatteryBrightnessLimit = false;
+  bool _onboardingCompleted = false;
 
   TelemetryService? _telemetryService;
 

--- a/test/unit/models/unified_de1_transport_recovery_test.dart
+++ b/test/unit/models/unified_de1_transport_recovery_test.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart';
+import 'package:reaprime/src/models/device/transport/ble_timeout_exception.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// Fake BLE transport that models the post-#243 behaviour: `disconnect()`
+/// emits `ConnectionState.disconnected` onto the connection-state stream
+/// (as `BluePlusTransport` does synchronously and `AndroidBluePlusTransport`
+/// does via its native sub). The first `write()` times out to trigger
+/// `UnifiedDe1Transport._handleBleTimeout`; reconnect success/failure is
+/// controlled by [reconnectSucceeds].
+class _RecoveryFakeTransport extends BLETransport {
+  _RecoveryFakeTransport({required this.reconnectSucceeds});
+
+  final bool reconnectSucceeds;
+
+  final _connState =
+      BehaviorSubject<ConnectionState>.seeded(ConnectionState.connected);
+
+  int writeCount = 0;
+  int connectCount = 0;
+  int disconnectCount = 0;
+
+  @override
+  String get id => 'recovery-fake';
+
+  @override
+  String get name => 'RecoveryFake';
+
+  @override
+  Stream<ConnectionState> get connectionState => _connState.stream;
+
+  @override
+  Future<void> connect() async {
+    connectCount++;
+    if (!reconnectSucceeds) {
+      throw StateError('reconnect failed');
+    }
+    _connState.add(ConnectionState.connected);
+  }
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCount++;
+    _connState.add(ConnectionState.disconnected);
+  }
+
+  @override
+  Future<List<String>> discoverServices() async => [de1ServiceUUID];
+
+  @override
+  Future<Uint8List> read(String s, String c, {Duration? timeout}) async =>
+      Uint8List(20);
+
+  @override
+  Future<void> subscribe(
+      String s, String c, void Function(Uint8List) cb) async {}
+
+  @override
+  Future<void> setTransportPriority(bool prioritized) async {}
+
+  @override
+  Future<void> write(String s, String c, Uint8List data,
+      {bool withResponse = true, Duration? timeout}) async {
+    writeCount++;
+    // First write times out -> triggers recovery. The retry succeeds.
+    if (writeCount == 1) {
+      throw BleTimeoutException('write');
+    }
+  }
+
+  void dispose() => _connState.close();
+}
+
+void main() {
+  group('UnifiedDe1Transport timeout recovery', () {
+    test(
+        'successful reconnect after timeout does not surface disconnected '
+        'to upstream', () async {
+      final fake = _RecoveryFakeTransport(reconnectSucceeds: true);
+      addTearDown(fake.dispose);
+      final unified = UnifiedDe1Transport(transport: fake);
+
+      final seen = <ConnectionState>[];
+      final sub = unified.connectionState.listen(seen.add);
+      addTearDown(sub.cancel);
+
+      await unified.write(Endpoint.requestedState, Uint8List.fromList([0x02]));
+      await Future<void>.delayed(Duration.zero);
+
+      // Recovery happened (disconnect + reconnect under the hood) and the
+      // write was retried successfully.
+      expect(fake.disconnectCount, 1);
+      expect(fake.connectCount, 1);
+      expect(fake.writeCount, 2);
+
+      // The deliberate recovery disconnect must stay invisible — otherwise
+      // De1Controller would null the machine and tear down a connection
+      // that's about to come right back.
+      expect(seen, isNot(contains(ConnectionState.disconnected)));
+    });
+
+    test('failed reconnect after timeout surfaces disconnected to upstream',
+        () async {
+      final fake = _RecoveryFakeTransport(reconnectSucceeds: false);
+      addTearDown(fake.dispose);
+      final unified = UnifiedDe1Transport(transport: fake);
+
+      final seen = <ConnectionState>[];
+      final sub = unified.connectionState.listen(seen.add);
+      addTearDown(sub.cancel);
+
+      // Recovery fails -> the original timeout propagates.
+      await expectLater(
+        unified.write(Endpoint.requestedState, Uint8List.fromList([0x02])),
+        throwsA(isA<BleTimeoutException>()),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      // The genuine disconnect (recovery gave up) reaches upstream.
+      expect(seen, contains(ConnectionState.disconnected));
+    });
+  });
+}


### PR DESCRIPTION
Applies fixes for the following crashlytics ids:
d84d8f29, 21b6c4a7
f53bf874, 05a656d0

exit early on battery tick, add safe defaults to settings controller and set state to `disconnected` unconditionally when disconnecting `AcaiaScale` or `BluePlusTransport`.