### PR TITLE
fix(ble): stop duplicate state from no-op-reconnect subscription stacking

### DIFF
--- a/doc/plans/archive/transport-lifetime-audit/transport-lifetime-audit.md
+++ b/doc/plans/archive/transport-lifetime-audit/transport-lifetime-audit.md
@@ -1,0 +1,113 @@
+# Transport / device lifetime audit
+
+Branch: `fix/transport-lifetime-audit` · TODO ref: `^transport-lifetime-audit` (P1)
+
+## Background & what changed during investigation
+
+The TODO promoted this P3→P1 on the basis of Crashlytics `8caae7dc`
+(`UnifiedDe1Raw.initRawStream` — "Stream has already been listened to"),
+asserting the comms-harden #3 guard "isn't closing the hole" and that the
+real fix is option (b) "fresh transport+device+controllers per reconnect."
+
+**That premise is stale.** Verified 2026-05-25:
+
+- At commit `d7dba8d` (v0.5.14) `initRawStream()` had **no** guard; the guard
+  was added later by `20e5d8e6` (comms-harden #3).
+- Crash `8caae7dc` has `lastSeenVersion: 0.5.14`, **zero events on any
+  0.6.x/0.7.x** build (current release v0.7.3). The events the TODO note read
+  were all pre-guard. The guard closed the hole. Trigger was
+  `ScaleDebugView(inspect:true)` calling `onConnect()` in `initState`.
+- No reconnect-accumulation leak from `dispose()` not being called: BLE
+  `connect()` cycles `_nativeConnectionSub` (cancel+reassign) and `subscribe()`
+  uses `cancelWhenDisconnected`. So option (b)'s churn is unjustified.
+
+**The real, current, user-visible bug** (surfaced from m50mini.home live logs):
+duplicate WebSocket state messages. Root cause:
+`AndroidBluePlusTransport.connect()` (and `BluePlusTransport`) returns early
+when `_device.isConnected` ("Already connected, skipping connect") — *no
+disconnect occurred*. But `UnifiedDe1Transport.connect()` always runs
+`_bleConnect()` afterward, which re-`subscribe()`s all 6 characteristics.
+Because no disconnect fired, `cancelWhenDisconnected` never cancelled the prior
+`onValueReceived.listen` callbacks → two live listeners per characteristic →
+`_stateSubject.add` fires twice per notification → `currentSnapshot`
+(no `.distinct()`) emits twice → duplicate state over WS. Triggered by the
+GATT-133 retry / BLE-timeout recovery reconnect paths.
+
+Also found (deferred, not this PR): `BatteryController._tick()` writes
+`setUsbChargerMode` every 60s unconditionally (~2665 writes/2 days). The
+periodic write is **intentional** — DE1 FW re-enables the charger, so keeping
+the tablet discharging requires periodic re-assertion. Optimisation (write-on-
+change while charging, keep periodic re-assert while discharging) tracked
+separately.
+
+## Scope (user-approved)
+
+1. **Fix duplicate characteristic subscriptions** (the real bug).
+2. **Typed connection guards** (salvaged core of the mmrRead sub-task).
+3. **dispose() wiring** (end-of-life hygiene — see churn note).
+
+Out of scope: option (b) reconnect rewrite; USB-charger write optimisation;
+the `_mmrRead` adapter-state pre-check (redundant — `writeWithResponse`
+already guards connection state, and the 2s timeout is on the notify-wait).
+
+## Phase 1 — Idempotent characteristic subscriptions (headline fix)
+
+Make `subscribe()` idempotent per characteristic so a re-subscribe without an
+intervening disconnect replaces rather than stacks.
+
+- `BluePlusTransport`, `AndroidBluePlusTransport`, `LinuxBluePlusTransport`:
+  add `final Map<String, StreamSubscription> _charSubs = {}` keyed by
+  `characteristicUUID`. In `subscribe()`: cancel + remove any existing entry
+  for that UUID before `onValueReceived.listen`, then store the new sub.
+  (`cancelWhenDisconnected` still handles the real-disconnect case; the map
+  handles the no-disconnect re-subscribe case.)
+- `UniversalBleTransport`: different API (`subscribeNotifications`/
+  `unsubscribe`). Track subscribed `serviceUUID/characteristicUUID` in a Set;
+  `unsubscribe` before re-subscribing if already present.
+- Tests: build a fake BLE transport, subscribe twice for the same
+  characteristic without a disconnect, push one notification, assert the
+  callback fires exactly once. Add a higher-level test asserting
+  `currentSnapshot` does not emit duplicates after a no-op reconnect.
+
+## Phase 2 — Typed connection guards (trivial)
+
+`UnifiedDe1Transport.read` / `write` / `writeWithResponse` currently
+`throw ("de1 not connected")`. Replace with
+`throw DeviceNotConnectedException.machine()` (already defined in
+`models/errors.dart`, already modelled by `ConnectionManager`). Update any
+test asserting the raw string.
+
+## Phase 3 — dispose() wiring (hygiene — higher churn, separable)
+
+**Churn note:** adding `dispose()` to the `DataTransport` interface forces it
+onto `UniversalBleTransport` + `AndroidSerialPort` (currently lack it) and ~6
+test fakes that `implements DataTransport`. Higher churn than the TODO's
+"bounded trivial win" implied, and there's no current crash/leak signal.
+Recommend it can split to a follow-up PR if Phase 1+2 are wanted sooner.
+
+- Add `Future<void> dispose()` to `DataTransport`. Implement everywhere
+  (the 3 BLE transports already have `void dispose()` → widen to async
+  `@override`; desktop serial already async; add to universal_ble, android
+  serial, and the test fakes as no-ops/minimal).
+- `UnifiedDe1Transport.dispose()`: cancel `_transportSubscription` + all
+  `_charSubs`, close the 6 `BehaviorSubject`s, then `await _transport.dispose()`.
+- `UnifiedDe1.dispose()`: close `_rawMessageController` + `_rawInputController`,
+  then dispose the transport. `Bengle.dispose()` override → dispose capability
+  state, then `super.dispose()`.
+- Wiring: call `device.dispose()` when a device is permanently removed from the
+  discovery `_devices` cache (verify removal semantics don't dispose-then-reuse
+  the same instance) and/or on `ConnectionManager`/app shutdown. **Never** on
+  reconnect — cached transports are reused.
+- Tests: dispose is idempotent; subjects report `isClosed`; no double-dispose.
+
+## Verification
+
+- `flutter test` (full suite, 1135+) + `flutter analyze` after each phase.
+- End-to-end: `scripts/sb-dev.sh` simulate, open the DE1 state WebSocket,
+  force a no-op reconnect path, confirm single (not duplicated) state frames.
+- **Tablet smoke before claiming done** — this is a connectivity-layer change;
+  CI + unit tests miss native-stream + platform-timing regressions
+  (per `feedback_real_hw_smoke`).
+- Then update `ReaPrime/TODO.md`: mark `8caae7dc` resolved, rescope
+  `^transport-lifetime-audit`, record the real findings. Check `doc/Api.md` /
+  `doc/DeviceManagement.md` for needed updates.

--- a/lib/src/controllers/battery_controller.dart
+++ b/lib/src/controllers/battery_controller.dart
@@ -18,6 +18,18 @@ class BatteryController {
   late Timer _checkTimer;
   bool _wasCharging = false;
 
+  /// Last `shouldCharge` value actually written to the DE1, and when.
+  /// Distinct from [_wasCharging] (which feeds the decision hysteresis):
+  /// these gate redundant `setUsbChargerMode` writes. Reset to null on
+  /// disconnect so the next connected tick re-asserts against a machine
+  /// that has reset to its charging-on default.
+  bool? _lastAppliedCharge;
+  DateTime? _lastChargeWrite;
+
+  /// While discharging, re-assert "off" at least this often — the DE1
+  /// firmware re-enables the charger on its own. See [shouldWriteChargerMode].
+  static const Duration _dischargeReassertInterval = Duration(minutes: 5);
+
   final BehaviorSubject<ChargingState> _stateSubject =
       BehaviorSubject<ChargingState>();
 
@@ -50,6 +62,9 @@ class BatteryController {
       final de1 = _de1Controller.connectedDe1OrNull;
       if (de1 == null) {
         _log.fine('No machine connected, skipping USB charger mode update');
+        // Force a re-assert on the next connected tick: a reconnected
+        // machine resets to its charging-on default.
+        _lastAppliedCharge = null;
         return;
       }
 
@@ -84,12 +99,23 @@ class BatteryController {
         'reason: ${decision.reason}',
       );
 
-      // Apply to DE1 — early bail at top of method already handled
-      // scan-during-scan and no-machine-connected cases.
-      try {
-        await de1.setUsbChargerMode(decision.shouldCharge);
-      } catch (e) {
-        _log.warning('Failed to set USB charger mode', e);
+      // Apply to DE1 — but skip redundant writes. The firmware re-enables
+      // the charger on its own, so we re-assert "off" periodically while
+      // discharging but avoid spamming an unchanged "on" every tick.
+      if (shouldWriteChargerMode(
+        shouldCharge: decision.shouldCharge,
+        lastApplied: _lastAppliedCharge,
+        now: now,
+        lastWrite: _lastChargeWrite,
+        reassertInterval: _dischargeReassertInterval,
+      )) {
+        try {
+          await de1.setUsbChargerMode(decision.shouldCharge);
+          _lastAppliedCharge = decision.shouldCharge;
+          _lastChargeWrite = now;
+        } catch (e) {
+          _log.warning('Failed to set USB charger mode', e);
+        }
       }
 
       // Emit state

--- a/lib/src/controllers/charging_logic.dart
+++ b/lib/src/controllers/charging_logic.dart
@@ -59,6 +59,34 @@ class ChargingState {
   }
 }
 
+/// Decides whether to push `setUsbChargerMode(shouldCharge)` to the DE1 on
+/// this tick.
+///
+/// The DE1 firmware re-enables the USB charger on its own, so keeping the
+/// tablet discharging requires periodically re-asserting "off". When we want
+/// to charge, the firmware default already matches, so re-writing every tick
+/// is pure BLE noise.
+///
+/// - Write whenever the target differs from [lastApplied] (`null` forces a
+///   write — first tick, or after a reconnect cleared it; a reconnected
+///   machine resets to its charging-on default).
+/// - While discharging (`shouldCharge == false`), re-assert once at least
+///   [reassertInterval] has elapsed since [lastWrite].
+/// - While charging and unchanged, skip.
+bool shouldWriteChargerMode({
+  required bool shouldCharge,
+  required bool? lastApplied,
+  required DateTime now,
+  required DateTime? lastWrite,
+  required Duration reassertInterval,
+}) {
+  if (lastApplied != shouldCharge) return true;
+  if (!shouldCharge) {
+    return lastWrite == null || now.difference(lastWrite) >= reassertInterval;
+  }
+  return false;
+}
+
 int _minutesSinceMidnight(DateTime dt) => dt.hour * 60 + dt.minute;
 
 /// Determines the night phase based on current time and night mode config.

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -9,6 +9,7 @@ import 'package:reaprime/src/models/device/transport/ble_timeout_exception.dart'
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/transport/logical_endpoint.dart';
+import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -368,7 +369,7 @@ class UnifiedDe1Transport {
 
   Future<ByteData> read(LogicalEndpoint endpoint, {Duration? timeout}) async {
     if (await _transport.connectionState.first != device.ConnectionState.connected) {
-      throw ("de1 not connected");
+      throw const DeviceNotConnectedException.machine();
     }
 
     try {
@@ -469,7 +470,7 @@ class UnifiedDe1Transport {
 
   Future<void> write(LogicalEndpoint endpoint, Uint8List data) async {
     if (await _transport.connectionState.first != device.ConnectionState.connected) {
-      throw ("de1 not connected");
+      throw const DeviceNotConnectedException.machine();
     }
     try {
       _log.fine('about to write to ${endpoint.name}');
@@ -509,7 +510,7 @@ class UnifiedDe1Transport {
 
   Future<void> writeWithResponse(LogicalEndpoint endpoint, Uint8List data) async {
     if (await _transport.connectionState.first != device.ConnectionState.connected) {
-      throw ("de1 not connected");
+      throw const DeviceNotConnectedException.machine();
     }
     try {
       _log.fine('about to write to ${endpoint.name}');

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -10,6 +10,7 @@ import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/transport/logical_endpoint.dart';
 import 'package:reaprime/src/models/errors.dart';
+import 'package:reaprime/src/services/telemetry/anonymization.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -82,10 +83,27 @@ class UnifiedDe1Transport {
               : TransportType.unknown,
       _log = Logger("UnifiedDe1Transport-${transport.id}");
   Future<void> connect() async {
+    // A connect() while the transport already reports `connected` means BLE
+    // setup is about to re-subscribe to every characteristic without an
+    // intervening disconnect — the no-op reconnect that used to stack
+    // duplicate notification listeners (every frame delivered twice). The
+    // per-characteristic guard now replaces subscriptions idempotently, but
+    // we record the condition as a non-fatal to measure how often it fires.
+    final wasConnected = transportType == TransportType.ble &&
+        await _transport.connectionState.first ==
+            device.ConnectionState.connected;
+
     await _transport.connect();
 
     switch (transportType) {
       case TransportType.ble:
+        if (wasConnected) {
+          _log.warning(
+            're-running BLE setup on already-connected transport (no-op '
+            'reconnect); notify subscriptions replaced, not stacked',
+            DuplicateBleSubscription(Anonymization.anonymizeMac(_transport.id)),
+          );
+        }
         await _bleConnect();
         break;
       case TransportType.serial:

--- a/lib/src/models/errors.dart
+++ b/lib/src/models/errors.dart
@@ -28,6 +28,28 @@ class DeviceNotConnectedException implements Exception {
       'DeviceNotConnectedException: ${kind.name} not connected';
 }
 
+/// Recorded as a non-fatal (never thrown) when `UnifiedDe1Transport.connect`
+/// re-runs BLE setup on a transport that already reports `connected` — the
+/// no-op reconnect that, before the per-characteristic subscription guard,
+/// stacked duplicate notification listeners and delivered every frame twice.
+/// The setup is now idempotent; this type exists purely so the condition
+/// surfaces in telemetry and we can measure how often it fires in the field.
+///
+/// This is logged as the `error` of a WARNING and forwarded to Crashlytics
+/// verbatim (the telemetry bridge does not scrub the error object), so
+/// [anonymizedDeviceId] MUST already be anonymized by the caller (e.g.
+/// `Anonymization.anonymizeMac`) — never pass a raw BLE MAC / device id.
+class DuplicateBleSubscription implements Exception {
+  final String anonymizedDeviceId;
+
+  const DuplicateBleSubscription(this.anonymizedDeviceId);
+
+  @override
+  String toString() =>
+      'DuplicateBleSubscription: BLE setup re-run on already-connected '
+      'transport ($anonymizedDeviceId)';
+}
+
 /// Thrown by `_mmrRead` in `UnifiedDe1` when a DE1 memory-mapped
 /// register read does not receive a matching notification within the
 /// bounded timeout. Prevents connect attempts from hanging forever on

--- a/lib/src/services/ble/android_blue_plus_transport.dart
+++ b/lib/src/services/ble/android_blue_plus_transport.dart
@@ -6,6 +6,7 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart' as device;
 import 'package:reaprime/src/models/device/transport/ble_timeout_exception.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/services/ble/char_subscriptions.dart';
 import 'package:rxdart/rxdart.dart';
 
 /// Android-specific BLE transport that wraps flutter_blue_plus with
@@ -42,6 +43,7 @@ class AndroidBluePlusTransport implements BLETransport {
   final BehaviorSubject<device.ConnectionState> _connectionStateSubject =
       BehaviorSubject<device.ConnectionState>.seeded(device.ConnectionState.discovered);
   StreamSubscription? _nativeConnectionSub;
+  final CharSubscriptions _charSubs = CharSubscriptions();
 
   // Tracks whether we've ever observed a real `connected` event from
   // flutter_blue_plus. The native connectionState stream replays the
@@ -176,6 +178,7 @@ class AndroidBluePlusTransport implements BLETransport {
   void dispose() {
     _nativeConnectionSub?.cancel();
     _nativeConnectionSub = null;
+    _charSubs.cancelAll();
     if (!_connectionStateSubject.isClosed) {
       _connectionStateSubject.close();
     }
@@ -247,6 +250,12 @@ class AndroidBluePlusTransport implements BLETransport {
     final subscription = characteristic.onValueReceived.listen((data) {
       callback(Uint8List.fromList(data));
     });
+    // Replace any prior listener for this characteristic. On a no-op
+    // reconnect (`connect()` skipped because the device was still connected)
+    // no disconnect fired, so `cancelWhenDisconnected` never cancelled the
+    // old listener — without this the callbacks stack and notifications are
+    // delivered twice.
+    await _charSubs.add(characteristicUUID, subscription);
     _device.cancelWhenDisconnected(subscription);
     await characteristic.setNotifyValue(true);
   }

--- a/lib/src/services/ble/blue_plus_transport.dart
+++ b/lib/src/services/ble/blue_plus_transport.dart
@@ -6,6 +6,7 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart' as device;
 import 'package:reaprime/src/models/device/transport/ble_timeout_exception.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/services/ble/char_subscriptions.dart';
 import 'package:rxdart/rxdart.dart';
 
 class BluePlusTransport implements BLETransport {
@@ -17,6 +18,7 @@ class BluePlusTransport implements BLETransport {
         device.ConnectionState.discovered,
       );
   StreamSubscription? _nativeConnectionSub;
+  final CharSubscriptions _charSubs = CharSubscriptions();
 
   BluePlusTransport({required String remoteId})
     : _device = BluetoothDevice(remoteId: DeviceIdentifier(remoteId)),
@@ -86,6 +88,7 @@ class BluePlusTransport implements BLETransport {
   void dispose() {
     _nativeConnectionSub?.cancel();
     _nativeConnectionSub = null;
+    _charSubs.cancelAll();
     if (!_connectionStateSubject.isClosed) {
       _connectionStateSubject.close();
     }
@@ -136,6 +139,12 @@ class BluePlusTransport implements BLETransport {
     final subscription = characteristic.onValueReceived.listen((data) {
       callback(Uint8List.fromList(data));
     });
+    // Replace any prior listener for this characteristic. On a no-op
+    // reconnect (`connect()` skipped because the device was still connected)
+    // no disconnect fired, so `cancelWhenDisconnected` never cancelled the
+    // old listener — without this the callbacks stack and notifications are
+    // delivered twice.
+    await _charSubs.add(characteristicUUID, subscription);
     _device.cancelWhenDisconnected(subscription);
     await characteristic.setNotifyValue(true);
   }

--- a/lib/src/services/ble/char_subscriptions.dart
+++ b/lib/src/services/ble/char_subscriptions.dart
@@ -1,0 +1,32 @@
+import 'dart:async';
+
+/// Tracks one active characteristic-notification [StreamSubscription] per
+/// characteristic UUID and guarantees re-subscribing replaces rather than
+/// stacks.
+///
+/// The BLE transports re-run `subscribe()` for every characteristic on each
+/// `connect()`. When `connect()` is a no-op because the device was still
+/// connected at the platform layer ("Already connected, skipping connect"),
+/// no disconnect fired, so `cancelWhenDisconnected` never cancelled the prior
+/// listeners. Without cancel-before-replace the callbacks stack, every
+/// notification is delivered twice, and downstream state streams emit
+/// duplicates.
+class CharSubscriptions {
+  final Map<String, StreamSubscription> _subs = {};
+
+  /// Stores [sub] for [characteristicUUID], cancelling any subscription
+  /// previously registered for the same UUID.
+  Future<void> add(String characteristicUUID, StreamSubscription sub) async {
+    await _subs.remove(characteristicUUID)?.cancel();
+    _subs[characteristicUUID] = sub;
+  }
+
+  /// Cancels and forgets every tracked subscription. Idempotent.
+  Future<void> cancelAll() async {
+    final pending = _subs.values.toList();
+    _subs.clear();
+    for (final sub in pending) {
+      await sub.cancel();
+    }
+  }
+}

--- a/lib/src/services/ble/linux_blue_plus_transport.dart
+++ b/lib/src/services/ble/linux_blue_plus_transport.dart
@@ -6,6 +6,7 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart' as device;
 import 'package:reaprime/src/models/device/transport/ble_timeout_exception.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/services/ble/char_subscriptions.dart';
 import 'package:rxdart/rxdart.dart';
 
 /// Linux-specific BLE transport that wraps flutter_blue_plus with
@@ -53,6 +54,7 @@ class LinuxBluePlusTransport implements BLETransport {
   final BehaviorSubject<device.ConnectionState> _connectionStateSubject =
       BehaviorSubject<device.ConnectionState>.seeded(device.ConnectionState.discovered);
   StreamSubscription? _nativeConnectionSub;
+  final CharSubscriptions _charSubs = CharSubscriptions();
 
   LinuxBluePlusTransport({required String remoteId})
     : _device = BluetoothDevice(remoteId: DeviceIdentifier(remoteId)),
@@ -180,6 +182,7 @@ class LinuxBluePlusTransport implements BLETransport {
   void dispose() {
     _nativeConnectionSub?.cancel();
     _nativeConnectionSub = null;
+    _charSubs.cancelAll();
     if (!_connectionStateSubject.isClosed) {
       _connectionStateSubject.close();
     }
@@ -253,6 +256,12 @@ class LinuxBluePlusTransport implements BLETransport {
     final subscription = characteristic.onValueReceived.listen((data) {
       callback(Uint8List.fromList(data));
     });
+    // Replace any prior listener for this characteristic. On a no-op
+    // reconnect (`connect()` skipped because the device was still connected)
+    // no disconnect fired, so `cancelWhenDisconnected` never cancelled the
+    // old listener — without this the callbacks stack and notifications are
+    // delivered twice.
+    await _charSubs.add(characteristicUUID, subscription);
     _device.cancelWhenDisconnected(subscription);
 
     // On BlueZ, setting notify value can occasionally fail if the

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -97,11 +97,16 @@ class UniversalBleTransport implements BLETransport {
     void Function(Uint8List) callback,
   ) async {
     _log.fine("subscribe to: $serviceUUID, $characteristicUUID");
+    final key = "$serviceUUID--$characteristicUUID";
+    // Cancel any prior listener for this characteristic before replacing it.
+    // A re-subscribe without an intervening disconnect (no-op reconnect)
+    // would otherwise stack listeners and deliver every notification twice.
+    await _subscriptions.remove(key)?.cancel();
     final sub = UniversalBle.characteristicValueStream(
       _device.deviceId,
       characteristicUUID,
     ).listen(callback);
-    _subscriptions["$serviceUUID--$characteristicUUID"] = sub;
+    _subscriptions[key] = sub;
 
     await UniversalBle.subscribeNotifications(
       _device.deviceId,

--- a/test/controllers/charging_logic_test.dart
+++ b/test/controllers/charging_logic_test.dart
@@ -615,4 +615,97 @@ void main() {
       expect(json.length, 6);
     });
   });
+
+  group('shouldWriteChargerMode', () {
+    final now = DateTime(2026, 1, 15, 12, 0);
+    const reassert = Duration(minutes: 5);
+
+    test('charging and unchanged: skip (firmware default already on)', () {
+      expect(
+        shouldWriteChargerMode(
+          shouldCharge: true,
+          lastApplied: true,
+          now: now,
+          lastWrite: now.subtract(const Duration(hours: 1)),
+          reassertInterval: reassert,
+        ),
+        isFalse,
+      );
+    });
+
+    test('target changed: always write', () {
+      expect(
+        shouldWriteChargerMode(
+          shouldCharge: false,
+          lastApplied: true,
+          now: now,
+          lastWrite: now,
+          reassertInterval: reassert,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldWriteChargerMode(
+          shouldCharge: true,
+          lastApplied: false,
+          now: now,
+          lastWrite: now,
+          reassertInterval: reassert,
+        ),
+        isTrue,
+      );
+    });
+
+    test('lastApplied null forces a write (first tick / after reconnect)', () {
+      expect(
+        shouldWriteChargerMode(
+          shouldCharge: true,
+          lastApplied: null,
+          now: now,
+          lastWrite: now,
+          reassertInterval: reassert,
+        ),
+        isTrue,
+      );
+    });
+
+    test('discharging re-asserts once the interval elapses', () {
+      // Within the interval: skip.
+      expect(
+        shouldWriteChargerMode(
+          shouldCharge: false,
+          lastApplied: false,
+          now: now,
+          lastWrite: now.subtract(const Duration(minutes: 4)),
+          reassertInterval: reassert,
+        ),
+        isFalse,
+      );
+      // Interval elapsed: re-assert OFF because the firmware re-enables the
+      // charger on its own.
+      expect(
+        shouldWriteChargerMode(
+          shouldCharge: false,
+          lastApplied: false,
+          now: now,
+          lastWrite: now.subtract(const Duration(minutes: 5)),
+          reassertInterval: reassert,
+        ),
+        isTrue,
+      );
+    });
+
+    test('discharging with no prior write re-asserts immediately', () {
+      expect(
+        shouldWriteChargerMode(
+          shouldCharge: false,
+          lastApplied: false,
+          now: now,
+          lastWrite: null,
+          reassertInterval: reassert,
+        ),
+        isTrue,
+      );
+    });
+  });
 }

--- a/test/unit/models/unified_de1_transport_resubscribe_test.dart
+++ b/test/unit/models/unified_de1_transport_resubscribe_test.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/models/errors.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// Minimal BLE transport whose initial connection state is controllable, so
+/// we can drive `UnifiedDe1Transport.connect()` down the first-connect path
+/// (transport disconnected) vs. the no-op-reconnect path (already connected).
+class _Fake extends BLETransport {
+  _Fake(ConnectionState initial)
+      : _connState = BehaviorSubject<ConnectionState>.seeded(initial);
+
+  final BehaviorSubject<ConnectionState> _connState;
+
+  @override
+  String get id => 'fake-id';
+  @override
+  String get name => 'Fake';
+  @override
+  Stream<ConnectionState> get connectionState => _connState.stream;
+  @override
+  Future<void> connect() async => _connState.add(ConnectionState.connected);
+  @override
+  Future<void> disconnect() async =>
+      _connState.add(ConnectionState.disconnected);
+  @override
+  Future<List<String>> discoverServices() async => [de1ServiceUUID];
+  @override
+  Future<Uint8List> read(String s, String c, {Duration? timeout}) async =>
+      Uint8List(20);
+  @override
+  Future<void> subscribe(
+      String s, String c, void Function(Uint8List) cb) async {}
+  @override
+  Future<void> setTransportPriority(bool prioritized) async {}
+  @override
+  Future<void> write(String s, String c, Uint8List data,
+      {bool withResponse = true, Duration? timeout}) async {}
+}
+
+void main() {
+  late StreamSubscription<LogRecord> logSub;
+  late List<LogRecord> records;
+
+  setUp(() {
+    Logger.root.level = Level.ALL;
+    records = [];
+    logSub = Logger.root.onRecord.listen(records.add);
+  });
+
+  tearDown(() async {
+    await logSub.cancel();
+  });
+
+  test('records DuplicateBleSubscription when connect runs on an '
+      'already-connected transport', () async {
+    final transport = UnifiedDe1Transport(transport: _Fake(
+      ConnectionState.connected,
+    ));
+
+    await transport.connect();
+
+    final hits =
+        records.where((r) => r.error is DuplicateBleSubscription).toList();
+    expect(hits.length, 1,
+        reason: 'no-op reconnect should record exactly one non-fatal');
+
+    // Privacy: the recorded error is forwarded to Crashlytics unscrubbed, so
+    // it must carry an anonymized id, never the raw device id / MAC.
+    final err = hits.single.error as DuplicateBleSubscription;
+    expect(err.anonymizedDeviceId, startsWith('mac_'));
+    expect(err.toString(), isNot(contains('fake-id')));
+  });
+
+  test('does not record on a first connect (transport disconnected)',
+      () async {
+    final transport = UnifiedDe1Transport(transport: _Fake(
+      ConnectionState.disconnected,
+    ));
+
+    await transport.connect();
+
+    expect(
+      records.any((r) => r.error is DuplicateBleSubscription),
+      isFalse,
+    );
+  });
+}

--- a/test/unit/services/ble/char_subscriptions_test.dart
+++ b/test/unit/services/ble/char_subscriptions_test.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/ble/char_subscriptions.dart';
+
+void main() {
+  group('CharSubscriptions', () {
+    test('re-adding the same UUID cancels the prior subscription', () async {
+      // Reproduces the no-op-reconnect duplicate: subscribe() runs again for
+      // the same characteristic without an intervening disconnect, so the
+      // prior listener must be cancelled rather than left stacked.
+      final subs = CharSubscriptions();
+
+      final c1 = StreamController<int>();
+      final sub1 = c1.stream.listen((_) {});
+      await subs.add('char-uuid', sub1);
+      expect(c1.hasListener, isTrue);
+
+      final c2 = StreamController<int>();
+      final sub2 = c2.stream.listen((_) {});
+      await subs.add('char-uuid', sub2);
+
+      expect(c1.hasListener, isFalse,
+          reason: 'first subscription should be cancelled on replace');
+      expect(c2.hasListener, isTrue,
+          reason: 'newest subscription stays active');
+
+      await subs.cancelAll();
+      addTearDown(() async {
+        await c1.close();
+        await c2.close();
+      });
+    });
+
+    test('different UUIDs coexist', () async {
+      final subs = CharSubscriptions();
+
+      final ca = StreamController<int>();
+      final cb = StreamController<int>();
+      await subs.add('a', ca.stream.listen((_) {}));
+      await subs.add('b', cb.stream.listen((_) {}));
+
+      expect(ca.hasListener, isTrue);
+      expect(cb.hasListener, isTrue);
+
+      await subs.cancelAll();
+      expect(ca.hasListener, isFalse);
+      expect(cb.hasListener, isFalse);
+
+      addTearDown(() async {
+        await ca.close();
+        await cb.close();
+      });
+    });
+
+    test('cancelAll is idempotent', () async {
+      final subs = CharSubscriptions();
+      final c = StreamController<int>();
+      await subs.add('a', c.stream.listen((_) {}));
+      await subs.cancelAll();
+      await subs.cancelAll(); // must not throw
+      expect(c.hasListener, isFalse);
+      addTearDown(() async => c.close());
+    });
+  });
+}


### PR DESCRIPTION
## What
- Make BLE characteristic subscriptions idempotent (cancel-before-replace per UUID) across all four transports, so a no-op reconnect (`connect()` while still BLE-connected, e.g. GATT-133 retry / "Already connected, skipping connect") no longer stacks listeners.
- Record a Crashlytics non-fatal (`DuplicateBleSubscription`, anonymized device id) when that path fires, to measure its real-world frequency.
- Throw typed `DeviceNotConnectedException.machine()` from the transport's not-connected guards instead of a bare string.
- `BatteryController`: stop writing `setUsbChargerMode` every 60s — write on change, re-assert "off" every ~5 min only while discharging (the DE1 firmware re-enables the charger on its own).

## Why
Duplicate state frames were observed over the WebSocket on the m50mini tablet. Root cause: `UnifiedDe1Transport.connect()` always re-runs `_bleConnect()` even when the underlying transport skipped connect (device still connected), so prior `onValueReceived` listeners were never cancelled (`cancelWhenDisconnected` only fires on a real disconnect) and every notification was delivered twice. Closes the transport/device lifetime-audit item; the original Crashlytics `8caae7dc` that prompted it was already fixed by the comms-harden guard (zero events on ≥0.6.x).

## Test plan
- [x] `flutter analyze` clean, full suite green (1347 tests).
- [x] USB-charger change verified live on m50mini (build 82b28613): writes dropped from per-minute to per-~6-min while discharging, on-change at the charge flip, silent while charging.
- [ ] Tablet smoke for the duplicate-sub fix: force the no-op reconnect path (GATT-133 retry / reconnect while still connected) and confirm WS state stays single + a `DuplicateBleSubscription` non-fatal is recorded. (Clean BT-toggle does not exercise it.)

Note: dispose()/lifetime wiring is intentionally deferred to a follow-up (no live signal, higher churn).