### PR TITLE
perf(boot): defer plugin + remote-skin load off cold-boot critical path

### DIFF
--- a/doc/plans/archive/cold-boot-audit/cold-boot-audit-phase1.md
+++ b/doc/plans/archive/cold-boot-audit/cold-boot-audit-phase1.md
@@ -1,0 +1,207 @@
+# Cold Boot Flow Audit — Phase 1 (safe subset)
+
+## Context
+
+ReaPrime TODO item `^cold-boot-audit` (P1): *"redesign startup sequence for speed and lower CPU load. Scan → connect machine → show webview → wait 1–2s → scan scale → isolate skin download/plugin loader."* Pairs with the `bb1c4163` WebView-before-webserver-ready crash variant.
+
+**Audit finding — what actually blocks cold boot today:**
+
+After `runApp`, the onboarding flow runs steps sequentially. The **initialization step** (`initialization_step.dart` `_initializeServices`) blocks the **scan step** from even starting until *all* of the following finish, in series:
+
+1. `webUIStorage.initialize()` — which includes a **network download of remote skins** (`downloadRemoteSkins()`, `webui_storage.dart:203`) before scanning installed skins.
+2. `webUIService.serveFolderAtPath()` — local, fast.
+3. `pluginLoaderService.initialize()` — **JS/QuickJS VM init + autoload of enabled plugins** (~0.5–2s).
+4. `deviceController.initialize()` — BLE adapter.
+
+Only then does `advance()` fire and the scan step calls `connectionManager.connect()`. So BLE scanning is gated behind a network fetch and a JS VM spin-up that have nothing to do with finding the machine. The navigate-to-skin path then adds a hard `Future.delayed(500ms)` (`app.dart:250`).
+
+**This phase (agreed scope):** isolate the plugin loader + remote skin download off the critical path, start `deviceController.initialize()` ASAP (overlapped with the fast local inits), drop the 500ms nav delay, and add boot-timing instrumentation to measure the win. Firebase init stays early (it captures crashes during the very boot we're optimizing). The deeper "show webview after machine connect, defer scale ~1–2s" rework is intentionally **deferred to a follow-up** — it needs ConnectionManager phase-flow changes + real-hardware soak.
+
+Outcome: scanning begins ~1 network-RTT + ~1 JS-VM-init sooner; remote skins and plugins load in the background while the user is already scanning/connecting.
+
+## Why this is safe
+
+- `serveFolderAtPath` awaits `shelf_io.serve()` (`webui_service.dart:94`) which binds the port *before* `isServing` (`:118`) flips true, and the REST server (8080) is already `await`ed in `main()` before `runApp` (`main.dart:379`). So both servers are bound before navigation — the 500ms delay is pure belt-and-braces and removable. `_navigateAfterOnboarding` already gates on `isServing` (`app.dart:223`).
+- The **default skin is bundled** (`streamline.js`), extracted by `_copyBundledSkins()` + surfaced by `_scanInstalledSkins()` inside `initialize()`. Remote download is *not* needed to serve the webview — only to surface *additional* remote skins, which are only viewed later in Settings.
+- Plugins hook DE1 events after load; loading them ~1–2s late only delays plugin-provided endpoints, not the machine connect or the webview.
+
+## Changes
+
+### 1. `lib/src/webui_support/webui_storage.dart` — split remote download out of `initialize()`
+
+- `initialize()` (`:175`): add optional named param `{bool downloadRemote = true}`. Guard the existing block at `:200-204` with `if (downloadRemote && !_appStoreMode)`. Default `true` preserves behavior for any other caller.
+- Add a public method that the background path calls (download is currently NOT followed by a rescan inside `downloadRemoteSkins()` — `initialize()` relies on the explicit `_scanInstalledSkins()` at `:207`, so we must re-scan after a deferred download):
+
+```dart
+/// Downloads remote bundled skins then rescans so newly installed skins
+/// surface. Safe to call in the background after initialize(downloadRemote: false).
+Future<void> downloadRemoteSkinsAndRescan() async {
+  if (_appStoreMode) return;
+  await downloadRemoteSkins();
+  await _scanInstalledSkins();
+}
+```
+
+### 2. `lib/src/onboarding_feature/steps/initialization_step.dart` — reorder critical path
+
+Rewrite `_initializeServices()` (`:73-119`) so only the machine/webview-critical work is awaited, plugins + remote skins go to the background, and the independent BLE-adapter init overlaps the local storage init:
+
+```dart
+import 'dart:async'; // add — for unawaited
+
+Future<void> _initializeServices() async {
+  BootTiming.mark('init-step start');
+
+  // BLE adapter init is independent of skin storage — start it now, await later.
+  final deviceInit = widget.deviceController.initialize();
+
+  // Fast, local-only: bundled-skin extraction + installed-skin scan.
+  try {
+    await widget.webUIStorage.initialize(downloadRemote: false);
+  } catch (e) {
+    _log.severe('Failed to initialize WebUI storage', e);
+  }
+
+  // Serve the bundled default skin (local, fast) — needed before the webview.
+  final defaultSkin = widget.webUIStorage.defaultSkin;
+  if (defaultSkin != null) {
+    try {
+      await widget.webUIService.serveFolderAtPath(defaultSkin.path);
+    } catch (e) {
+      _log.severe('Failed to start WebUI service', e);
+    }
+  } else {
+    _log.warning('No default skin available, WebUI service not started');
+  }
+
+  await deviceInit; // BLE must be ready before scan step calls connect()
+  BootTiming.mark('storage+device ready, webui serving');
+
+  if (Platform.isAndroid) {
+    await ForegroundTaskService.start();
+    ForegroundTaskService.watchMachineConnection(widget.de1Controller.de1);
+  }
+
+  widget.onboardingController.advance(); // scan starts now
+
+  // Off the critical path — user is already scanning while these run.
+  final plugins = widget.pluginLoaderService;
+  if (plugins != null) {
+    unawaited(plugins.initialize().catchError(
+      (e) => _log.warning('Background plugin init failed: $e')));
+  }
+  unawaited(widget.webUIStorage.downloadRemoteSkinsAndRescan().catchError(
+    (e) => _log.warning('Background remote-skin download failed: $e')));
+}
+```
+
+### 3. `lib/src/app.dart` — drop the artificial nav delay
+
+In `_navigateAfterOnboarding` remove `await Future.delayed(const Duration(milliseconds: 500));` (`:249-250`). `isServing` is already checked at `:223` and the port is bound by the time `serveFolderAtPath` returns.
+
+### 4. Boot-timing instrumentation → logs + Firebase Performance trace
+
+**4a. `TelemetryService.recordTrace` (new interface method)** — `telemetry_service.dart`:
+
+```dart
+/// Record a one-shot performance trace carrying named integer metrics (ms).
+/// No-op when telemetry/Performance is unavailable (consent off, non-Android/iOS).
+Future<void> recordTrace(String name, Map<String, int> metrics);
+```
+
+- `FirebaseCrashlyticsTelemetryService`: implement with Firebase Performance (already imported). Mirror the existing Android/iOS-only guard used for `FirebasePerformance` (`:34-38`) — Perf has no macOS/Linux impl. Collection is already consent-gated via `setPerformanceCollectionEnabled`, so dropped automatically without consent.
+
+```dart
+@override
+Future<void> recordTrace(String name, Map<String, int> metrics) async {
+  if (kIsWeb ||
+      !(defaultTargetPlatform == TargetPlatform.android ||
+        defaultTargetPlatform == TargetPlatform.iOS)) {
+    return;
+  }
+  final trace = FirebasePerformance.instance.newTrace(name);
+  await trace.start();
+  metrics.forEach(trace.setMetric);
+  await trace.stop();
+}
+```
+
+- `NoOpTelemetryService`: no-op `recordTrace`.
+- `test/controllers/device_controller_test.dart` `_RecordingTelemetry` (`:76`): add a no-op `recordTrace` override (it `implements TelemetryService`).
+
+**4b. `lib/src/services/telemetry/boot_timing.dart` (new)** — Stopwatch + ordered marks for log lines (all platforms), plus a one-shot `complete()` that emits the collected milestone durations as a single `cold_boot` Performance trace. We can't run a *live* trace spanning boot (Firebase isn't initialized at `main()` start), so each milestone's elapsed-since-start is recorded as a trace **metric**; `total_ms` is the final elapsed.
+
+```dart
+import 'dart:async';
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/services/telemetry/telemetry_service.dart';
+
+class BootTiming {
+  static final Stopwatch _sw = Stopwatch();
+  static final Logger _log = Logger('BootTiming');
+  static final Map<String, int> _marks = {};
+  static int _lastMs = 0;
+  static bool _completed = false;
+  static TelemetryService? telemetry;
+
+  static void start() {
+    _sw..reset()..start();
+    _lastMs = 0;
+    _marks.clear();
+    _completed = false;
+  }
+
+  static void mark(String label) {
+    if (!_sw.isRunning) return;
+    final now = _sw.elapsedMilliseconds;
+    _log.info('[BOOT] $label: ${now}ms (Δ${now - _lastMs}ms)');
+    _marks[_metricKey(label)] = now;
+    _lastMs = now;
+  }
+
+  static void complete() {
+    if (_completed || !_sw.isRunning) return;
+    _completed = true;
+    final total = _sw.elapsedMilliseconds;
+    _sw.stop();
+    _log.info('[BOOT] complete: total ${total}ms');
+    final metrics = Map<String, int>.from(_marks)..['total_ms'] = total;
+    final t = telemetry;
+    if (t != null) {
+      unawaited(t.recordTrace('cold_boot', metrics)
+          .catchError((e) => _log.warning('boot trace failed: $e')));
+    }
+  }
+
+  // Firebase Performance metric name: <=32 chars, alnum + underscore.
+  static String _metricKey(String label) {
+    var k = label.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_');
+    k = k.replaceAll(RegExp(r'^_+|_+$'), '');
+    if (!k.endsWith('_ms')) k = '${k}_ms';
+    if (k.length > 32) k = k.substring(0, 32);
+    return k;
+  }
+}
+```
+
+Marks use **short labels** (metric names must be ≤32 chars):
+- `main.dart`: `BootTiming.start()` right after the "==== Decent starting ====" log (`:156`); after creating `telemetryService` (`:181`) set `BootTiming.telemetry = telemetryService;`; `mark('firebase_done')` after the Firebase block; `mark('webserver_up')` after `startWebServer` (`:402`); `mark('runapp')` just before `runApp` (`:454`).
+- `initialization_step.dart`: `mark('init_start')`, `mark('init_ready')` (after storage+device+webui), `mark('scan_start')` right before `advance()`.
+- `scan_step.dart`: in the `status.listen` handler (`:137`) `mark('connect_<phase>')` on phase change; the `ready` branch (`:140`) `mark('scan_ready')`.
+- `skin_view.dart`: `mark('webview')` then `BootTiming.complete()` where the URL is loaded.
+
+## Out of scope (follow-up item)
+
+Showing the webview right after **machine** connect with the **scale** connecting in the background (the "show webview → wait 1–2s → scan scale" half). That requires either advancing onboarding on `connectingScale` instead of `ready`, or a two-phase connect reusing `connect(scaleOnly: true)` / the already-discovered scales. Park as a new TODO sub-item under `^cold-boot-audit`.
+
+## Verification
+
+1. `flutter analyze` — zero issues.
+2. `flutter test` — full suite green (currently ~1347). Add/adjust a widget test for the initialization step: inject a `WebUIStorage` whose `downloadRemoteSkinsAndRescan()` and a `PluginLoaderService` whose `initialize()` never complete (or complete slowly), and assert `onboardingController.advance()` still fires — i.e. the critical path does not await them.
+3. End-to-end (`scripts/sb-dev.sh` + `--dart-define=simulate=1`): boot, confirm `[BOOT]` timing lines appear, webview shows the default skin, and the machine connects. Compare timing lines before/after.
+4. **Real-hardware smoke on m50mini** (connectivity-adjacent — `deviceController.initialize()` timing + scan start changed): flash branch, read `http://m50mini.home:8080/api/v1/logs` (use `/usr/bin/grep`), confirm at the nearest `==== Decent starting ====` block: scan starts sooner, machine + scale both connect, no skin/plugin regressions, and that remote skins still appear in Settings after the background download completes.
+
+## Risks
+
+- A skin needing a plugin-provided endpoint on first paint sees it ~1–2s late (acceptable per scope).
+- Background remote-skin download races nothing BLE-related (network vs BLE are independent); new skins surface in Settings a moment later via the rescan.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -65,6 +65,7 @@ import 'src/services/serial/serial_service.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
 import 'package:reaprime/src/services/telemetry/telemetry_service.dart';
+import 'package:reaprime/src/services/telemetry/boot_timing.dart';
 import 'package:reaprime/src/services/telemetry/log_buffer.dart';
 import 'package:reaprime/src/services/telemetry/anonymization.dart';
 import 'package:reaprime/src/services/telemetry/error_report_throttle.dart';
@@ -154,6 +155,7 @@ void main() async {
   await webViewLogService.initialize();
 
   Logger.root.info("==== Decent starting ====");
+  BootTiming.start();
 
   Logger.root.info(
     "build: ${BuildInfo.commitShort}, branch: ${BuildInfo.branch}",
@@ -174,11 +176,13 @@ void main() async {
       log.warning('Firebase initialization failed', e, st);
     }
   }
+  BootTiming.mark('firebase_done');
 
   // Create log buffer, error report throttle, and telemetry service
   final logBuffer = LogBuffer();
   final errorReportThrottle = ErrorReportThrottle();
   final telemetryService = TelemetryService.create(logBuffer: logBuffer);
+  BootTiming.telemetry = telemetryService;
 
   // Initialize telemetry (disables collection by default, sets up error handlers)
   try {
@@ -400,6 +404,7 @@ void main() async {
   } catch (e, st) {
     log.severe('failed to start web server', e, st);
   }
+  BootTiming.mark('webserver_up');
   // Load the user's preferred theme while the splash screen is displayed.
   // This prevents a sudden theme change when the app is first displayed.
   settingsController.addListener(() {
@@ -451,6 +456,7 @@ void main() async {
     ForegroundTaskService.init();
   }
 
+  BootTiming.mark('runapp');
   runApp(
     WithForegroundTask(
       child: AppRoot(

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -246,9 +246,9 @@ class _MyAppState extends State<MyApp> {
       }
     }
 
-    // Wait a brief moment for WebUI to be fully ready
-    await Future.delayed(const Duration(milliseconds: 500));
-
+    // No artificial delay needed: serveFolderAtPath awaits shelf_io.serve()
+    // (port bound before isServing flips true) and the REST server is already
+    // up from main(), so both are ready by the time we navigate.
     _log.info('Navigating to SkinView');
     // Push both routes to stack: HomeScreen first, then SkinView on top
     navigator.pushNamedAndRemoveUntil(

--- a/lib/src/onboarding_feature/steps/initialization_step.dart
+++ b/lib/src/onboarding_feature/steps/initialization_step.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -6,6 +7,7 @@ import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
 import 'package:reaprime/src/services/foreground_service.dart';
+import 'package:reaprime/src/services/telemetry/boot_timing.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
 import 'package:reaprime/src/webui_support/webui_storage.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
@@ -71,16 +73,23 @@ class _InitializationStepViewState extends State<_InitializationStepView> {
   }
 
   Future<void> _initializeServices() async {
-    // Initialize WebUI storage
+    BootTiming.mark('init_start');
+
+    // BLE adapter init is independent of skin storage — start it now and
+    // await it later so it overlaps the (local) storage + serve work.
+    final deviceInit = widget.deviceController.initialize();
+
+    // Fast, local-only: bundled-skin extraction + installed-skin scan. The
+    // remote-skin network download is deferred to the background below.
     _log.info('Initializing WebUI storage...');
     try {
-      await widget.webUIStorage.initialize();
+      await widget.webUIStorage.initialize(downloadRemote: false);
       _log.info('WebUI storage initialized successfully');
     } catch (e) {
       _log.severe('Failed to initialize WebUI storage', e);
     }
 
-    // Start WebUI service with default skin
+    // Serve the bundled default skin (local, fast) — needed before the webview.
     final defaultSkin = widget.webUIStorage.defaultSkin;
     if (defaultSkin != null) {
       _log.info('Starting WebUI service with skin: ${defaultSkin.name}');
@@ -94,17 +103,9 @@ class _InitializationStepViewState extends State<_InitializationStepView> {
       _log.warning('No default skin available, WebUI service not started');
     }
 
-    // Initialize plugins
-    if (widget.pluginLoaderService != null) {
-      try {
-        await widget.pluginLoaderService!.initialize();
-      } catch (e) {
-        _log.warning('Failed to initialize plugins: $e');
-      }
-    }
-
-    // Initialize device controller
-    await widget.deviceController.initialize();
+    // BLE must be ready before the scan step calls connect().
+    await deviceInit;
+    BootTiming.mark('init_ready');
 
     // Start foreground service on Android (permissions already granted
     // by the preceding permissions step or a previous launch).
@@ -115,7 +116,24 @@ class _InitializationStepViewState extends State<_InitializationStepView> {
       );
     }
 
+    BootTiming.mark('scan_start');
     widget.onboardingController.advance();
+
+    // Off the critical path — the user is already scanning while the JS
+    // plugin VM spins up and remote skins download in the background.
+    final plugins = widget.pluginLoaderService;
+    if (plugins != null) {
+      unawaited(
+        plugins.initialize().catchError(
+          (Object e) => _log.warning('Background plugin init failed: $e'),
+        ),
+      );
+    }
+    unawaited(
+      widget.webUIStorage.downloadRemoteSkinsAndRescan().catchError(
+        (Object e) => _log.warning('Background remote-skin download failed: $e'),
+      ),
+    );
   }
 
   @override

--- a/lib/src/onboarding_feature/steps/scan_step.dart
+++ b/lib/src/onboarding_feature/steps/scan_step.dart
@@ -13,6 +13,7 @@ import 'package:reaprime/src/home_feature/widgets/device_selection_widget.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart' as dev;
 import 'package:reaprime/src/models/device/scale.dart' as device_scale;
+import 'package:reaprime/src/services/telemetry/boot_timing.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/settings/settings_service.dart';
 import 'package:reaprime/src/widgets/accessible_button.dart';
@@ -137,9 +138,15 @@ class ScanStepViewState extends State<ScanStepView> {
     _statusSubscription = widget.connectionManager.status.listen((status) {
       if (!mounted) return;
 
+      // Boot-timing: record each phase transition once.
+      if (status.phase != _status.phase) {
+        BootTiming.mark('connect_${status.phase.name}');
+      }
+
       if (status.phase == ConnectionPhase.ready && !_hasNavigated) {
         _hasNavigated = true;
         _cancelTooLongTimer();
+        BootTiming.mark('scan_ready');
         widget.onboardingController.advance();
         return;
       }

--- a/lib/src/services/telemetry/boot_timing.dart
+++ b/lib/src/services/telemetry/boot_timing.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/services/telemetry/telemetry_service.dart';
+
+/// Lightweight cold-boot timing instrumentation.
+///
+/// [start] is called once at the top of `main()`. [mark] records a milestone
+/// (logged on every platform, so it shows up in the on-device log + the
+/// m50mini `/api/v1/logs` dump). [complete] is called once when the first
+/// webview is up and emits all collected milestone durations as a single
+/// `cold_boot` Firebase Performance trace.
+///
+/// A live trace can't span the whole boot — Firebase isn't initialized at
+/// `main()` start — so each milestone's elapsed-since-start is recorded as a
+/// trace *metric*, with `total_ms` as the final elapsed.
+class BootTiming {
+  static final Stopwatch _sw = Stopwatch();
+  static final Logger _log = Logger('BootTiming');
+  static final Map<String, int> _marks = {};
+  static int _lastMs = 0;
+  static bool _completed = false;
+
+  /// Telemetry sink for the `cold_boot` trace. Wired in `main()` once the
+  /// telemetry service exists. Left null in tests / unsupported platforms.
+  static TelemetryService? telemetry;
+
+  static void start() {
+    _sw
+      ..reset()
+      ..start();
+    _lastMs = 0;
+    _marks.clear();
+    _completed = false;
+  }
+
+  static void mark(String label) {
+    if (!_sw.isRunning) return;
+    final now = _sw.elapsedMilliseconds;
+    _log.info('[BOOT] $label: ${now}ms (Δ${now - _lastMs}ms)');
+    _marks[_metricKey(label)] = now;
+    _lastMs = now;
+  }
+
+  /// One-shot — emits the `cold_boot` Performance trace. Safe to call more
+  /// than once (only the first call records).
+  static void complete() {
+    if (_completed || !_sw.isRunning) return;
+    _completed = true;
+    final total = _sw.elapsedMilliseconds;
+    _sw.stop();
+    _log.info('[BOOT] complete: total ${total}ms');
+    final metrics = Map<String, int>.from(_marks)..['total_ms'] = total;
+    final t = telemetry;
+    if (t != null) {
+      unawaited(
+        t.recordTrace('cold_boot', metrics).catchError(
+          (Object e) => _log.warning('boot trace failed: $e'),
+        ),
+      );
+    }
+  }
+
+  /// Firebase Performance metric name: <=32 chars, alnum + underscore.
+  static String _metricKey(String label) {
+    var k = label.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_');
+    k = k.replaceAll(RegExp(r'^_+|_+$'), '');
+    if (!k.endsWith('_ms')) k = '${k}_ms';
+    if (k.length > 32) k = k.substring(0, 32);
+    return k;
+  }
+}

--- a/lib/src/services/telemetry/firebase_crashlytics_telemetry_service.dart
+++ b/lib/src/services/telemetry/firebase_crashlytics_telemetry_service.dart
@@ -95,6 +95,22 @@ class FirebaseCrashlyticsTelemetryService implements TelemetryService {
   }
 
   @override
+  Future<void> recordTrace(String name, Map<String, int> metrics) async {
+    // Firebase Performance has no macOS/Linux implementation — same guard as
+    // initialize(). Collection is consent-gated, so traces are dropped client
+    // side until the user consents.
+    if (kIsWeb ||
+        !(defaultTargetPlatform == TargetPlatform.android ||
+            defaultTargetPlatform == TargetPlatform.iOS)) {
+      return;
+    }
+    final trace = FirebasePerformance.instance.newTrace(name);
+    await trace.start();
+    metrics.forEach(trace.setMetric);
+    await trace.stop();
+  }
+
+  @override
   Future<void> setConsentEnabled(bool enabled) async {
     await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(enabled);
     await FirebaseAnalytics.instance.setAnalyticsCollectionEnabled(enabled);

--- a/lib/src/services/telemetry/noop_telemetry_service.dart
+++ b/lib/src/services/telemetry/noop_telemetry_service.dart
@@ -33,6 +33,11 @@ class NoOpTelemetryService implements TelemetryService {
   }
 
   @override
+  Future<void> recordTrace(String name, Map<String, int> metrics) async {
+    // No-op
+  }
+
+  @override
   Future<void> setConsentEnabled(bool enabled) async {
     // No-op
   }

--- a/lib/src/services/telemetry/telemetry_service.dart
+++ b/lib/src/services/telemetry/telemetry_service.dart
@@ -39,6 +39,12 @@ abstract class TelemetryService {
   /// Useful for tracking app state, user configuration, or session info.
   Future<void> setCustomKey(String key, Object value);
 
+  /// Record a one-shot performance trace carrying named integer metrics (ms).
+  ///
+  /// Used for boot/startup timing. No-op when Performance Monitoring is
+  /// unavailable (consent off, non-Android/iOS, or NoOp backend).
+  Future<void> recordTrace(String name, Map<String, int> metrics);
+
   /// Enable or disable telemetry collection
   ///
   /// When disabled, no data should be sent to remote servers.

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/home_feature/widgets/quick_settings_widget.dart';
+import 'package:reaprime/src/services/telemetry/boot_timing.dart';
 import 'package:reaprime/src/services/webview_compatibility_checker.dart';
 import 'package:reaprime/src/services/webview_log_service.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
@@ -548,6 +549,9 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
           },
           onLoadStart: (controller, url) {
             _log.info('Page started loading: $url');
+            // Webview is up — final cold-boot milestone (idempotent).
+            BootTiming.mark('webview');
+            BootTiming.complete();
             setState(() {
               _isLoading = true;
               _errorMessage = null;

--- a/lib/src/webui_support/webui_storage.dart
+++ b/lib/src/webui_support/webui_storage.dart
@@ -172,7 +172,12 @@ class WebUIStorage {
   /// - Copies bundled skins from assets
   /// - Downloads remote bundled skins
   /// - Scans for installed skins
-  Future<void> initialize() async {
+  ///
+  /// When [downloadRemote] is false, the remote-skin network download is
+  /// skipped so the (local, bundled) default skin is ready fast — callers on
+  /// the cold-boot critical path pass false and run
+  /// [downloadRemoteSkinsAndRescan] in the background afterwards.
+  Future<void> initialize({bool downloadRemote = true}) async {
     if (_initialized) {
       _log.fine('WebUIStorage already initialized');
       return;
@@ -198,8 +203,10 @@ class WebUIStorage {
     await _copyBundledSkins();
 
     // Download and install remote bundled skins (includes version checking)
-    // Skip on App Store builds — bundled skins from assets are the only source
-    if (!_appStoreMode) {
+    // Skip on App Store builds — bundled skins from assets are the only source.
+    // Skip when downloadRemote is false (cold-boot critical path) — the caller
+    // runs downloadRemoteSkinsAndRescan() in the background instead.
+    if (downloadRemote && !_appStoreMode) {
       await downloadRemoteSkins();
     }
 
@@ -463,6 +470,16 @@ class WebUIStorage {
         // Continue with other sources even if one fails
       }
     }
+  }
+
+  /// Downloads remote bundled skins then rescans so newly installed skins
+  /// surface. Safe to run in the background after
+  /// `initialize(downloadRemote: false)` — [downloadRemoteSkins] does not
+  /// rescan on its own, so the explicit [_scanInstalledSkins] is required.
+  Future<void> downloadRemoteSkinsAndRescan() async {
+    if (_appStoreMode) return;
+    await downloadRemoteSkins();
+    await _scanInstalledSkins();
   }
 
   /// Update all skins: remote-bundled skins and user-installed skins with source URLs.

--- a/test/controllers/device_controller_test.dart
+++ b/test/controllers/device_controller_test.dart
@@ -95,6 +95,9 @@ class _RecordingTelemetry implements TelemetryService {
   Future<void> setConsentEnabled(bool enabled) async {}
 
   @override
+  Future<void> recordTrace(String name, Map<String, int> metrics) async {}
+
+  @override
   String getLogBuffer() => '';
 }
 

--- a/test/onboarding/initialization_step_test.dart
+++ b/test/onboarding/initialization_step_test.dart
@@ -1,0 +1,119 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/onboarding_feature/onboarding_controller.dart';
+import 'package:reaprime/src/onboarding_feature/steps/initialization_step.dart';
+import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+import 'package:reaprime/src/services/storage/hive_store_service.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/webui_support/webui_service.dart';
+import 'package:reaprime/src/webui_support/webui_storage.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+import '../helpers/mock_de1_controller.dart';
+import '../helpers/mock_settings_service.dart';
+
+/// WebUIStorage fake: fast local init, no default skin (so the serve step is
+/// skipped), and a remote-download that never completes — so the test can
+/// assert the critical path does NOT await it.
+class _FakeWebUIStorage extends WebUIStorage {
+  bool? initDownloadRemote;
+  bool downloadRescanCalled = false;
+
+  _FakeWebUIStorage(super.settings);
+
+  @override
+  Future<void> initialize({bool downloadRemote = true}) async {
+    initDownloadRemote = downloadRemote;
+  }
+
+  @override
+  WebUISkin? get defaultSkin => null;
+
+  @override
+  Future<void> downloadRemoteSkinsAndRescan() {
+    downloadRescanCalled = true;
+    return Completer<void>().future; // never completes
+  }
+}
+
+/// Plugin loader fake whose initialize() never completes — so the test can
+/// assert the critical path kicks it off without awaiting.
+class _FakePluginLoaderService extends PluginLoaderService {
+  bool initCalled = false;
+
+  _FakePluginLoaderService()
+      : super(kvStore: HiveStoreService(defaultNamespace: 'test-plugins'));
+
+  @override
+  Future<void> initialize() {
+    initCalled = true;
+    return Completer<void>().future; // never completes
+  }
+}
+
+class _TrackingOnboardingController extends OnboardingController {
+  int advanceCallCount = 0;
+
+  _TrackingOnboardingController()
+      : super(steps: [
+          OnboardingStep(
+            id: 'initialization',
+            shouldShow: () async => true,
+            builder: (_) => const SizedBox(),
+          ),
+          OnboardingStep(
+            id: 'next',
+            shouldShow: () async => true,
+            builder: (_) => const SizedBox(),
+          ),
+        ]);
+
+  @override
+  void advance() {
+    advanceCallCount++;
+    super.advance();
+  }
+}
+
+void main() {
+  testWidgets(
+    'advances without awaiting plugin init or remote skin download',
+    (tester) async {
+      final settings = SettingsController(MockSettingsService());
+      await settings.loadSettings();
+
+      final storage = _FakeWebUIStorage(settings);
+      final plugins = _FakePluginLoaderService();
+      final onboarding = _TrackingOnboardingController();
+      await onboarding.initialize();
+
+      final step = createInitializationStep(
+        deviceController: DeviceController([]),
+        de1Controller: MockDe1Controller(controller: DeviceController([])),
+        pluginLoaderService: plugins,
+        webUIStorage: storage,
+        webUIService: WebUIService(),
+      );
+
+      await tester.pumpWidget(
+        ShadApp(home: Scaffold(body: step.builder(onboarding))),
+      );
+      // Flush the init future's microtasks.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // Critical path completed and advanced even though the deferred work
+      // (plugin init + remote download) never completes.
+      expect(onboarding.advanceCallCount, 1);
+      // Remote download was NOT awaited on the critical path...
+      expect(storage.initDownloadRemote, isFalse);
+      // ...but was kicked off in the background.
+      expect(storage.downloadRescanCalled, isTrue);
+      // Plugin init kicked off in the background.
+      expect(plugins.initCalled, isTrue);
+    },
+  );
+}


### PR DESCRIPTION
## What
Phase 1 of the cold-boot audit (`^cold-boot-audit`): take the remote-skin network download and the plugin JS-VM autoload off the startup critical path so BLE scanning starts immediately, and add boot-timing instrumentation.

- `WebUIStorage.initialize({downloadRemote})` + `downloadRemoteSkinsAndRescan()` — bundled default skin serves fast; remote download runs in the background after `advance()`.
- Plugin loader `initialize()` moved off the critical path (`unawaited`).
- `deviceController.initialize()` overlaps the local storage init.
- Dropped the blind 500ms delay before pushing `SkinView` (`serveFolderAtPath` already binds the port before `isServing` flips).
- New `BootTiming` helper logs `[BOOT]` phase marks and emits a `cold_boot` Firebase Performance trace via a new `TelemetryService.recordTrace` (Android/iOS, consent-gated).

## Why
The onboarding initialization step blocked the scan step until a network fetch + QuickJS VM spin-up finished — neither is needed to find the machine or serve the bundled skin. Validated on m50mini: scan starts at **1.3s**, boot→webview **6.3s**, DE1 + scale connected.

Phase 2 (show webview after machine, defer scale) and scan early-stop tightening are tracked as follow-ups under `^cold-boot-audit`.