### PR TITLE
fix(scale): decent scale stability

### DIFF
--- a/lib/src/models/device/impl/atomheart/atomheart_scale.dart
+++ b/lib/src/models/device/impl/atomheart/atomheart_scale.dart
@@ -75,7 +75,7 @@ class AtomheartScale implements Scale {
           'Discovered services: $services',
         );
       }
-      _registerNotifications();
+      await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
       disconnectSub?.cancel();
@@ -140,7 +140,7 @@ class AtomheartScale implements Scale {
     await tare();
   }
 
-  void _registerNotifications() async {
+  Future<void> _registerNotifications() async {
     await _transport.subscribe(serviceIdentifier.long, dataCharacteristic.long, _parseNotification);
   }
 

--- a/lib/src/models/device/impl/blackcoffee/blackcoffee_scale.dart
+++ b/lib/src/models/device/impl/blackcoffee/blackcoffee_scale.dart
@@ -69,7 +69,7 @@ class BlackCoffeeScale implements Scale {
           'Discovered services: $services',
         );
       }
-      _registerNotifications();
+      await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
       disconnectSub?.cancel();
@@ -110,7 +110,7 @@ class BlackCoffeeScale implements Scale {
 
   double _lastRawWeight = 0.0;
 
-  void _registerNotifications() async {
+  Future<void> _registerNotifications() async {
     await _transport.subscribe(serviceIdentifier.long, dataCharacteristic.long, _parseNotification);
   }
 

--- a/lib/src/models/device/impl/bookoo/miniscale.dart
+++ b/lib/src/models/device/impl/bookoo/miniscale.dart
@@ -64,7 +64,7 @@ class BookooScale implements Scale {
           'Discovered services: $services',
         );
       }
-      _registerNotifications();
+      await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
       disconnectSub?.cancel();
@@ -105,7 +105,7 @@ class BookooScale implements Scale {
     // This is a no-op
   }
 
-  void _registerNotifications() async {
+  Future<void> _registerNotifications() async {
     await _transport.subscribe(serviceIdentifier.long, dataCharacteristic.long, _parseNotification);
   }
 

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -100,36 +100,44 @@ class DecentScale implements Scale {
           disconnect();
           return;
         }
-        _ticksSinceLastNotification++;
         _heartbeatTotalTicks++;
 
         // Periodic heartbeat log every 5 min (75 ticks at 4s)
         if (_heartbeatTotalTicks % 75 == 0) {
           final uptimeMin = (_heartbeatTotalTicks * 4) ~/ 60;
           _log.fine("heartbeat: ${uptimeMin}m uptime, $_totalNotifications notifications");
+          if (!_isSleeping) {
+            await _sendOledOn();
+          }
         }
 
-        if (_ticksSinceLastNotification >= _watchdogDisconnectTicks) {
-          _log.severe(
-            "No BLE notifications for ${_watchdogDisconnectTicks * 4}s "
-            "(total=$_totalNotifications, uptime=${_heartbeatTotalTicks * 4}s), disconnecting",
-          );
-          disconnect();
-          return;
-        } else if (_ticksSinceLastNotification >= _watchdogWarningTicks &&
-            !_watchdogRetryAttempted) {
-          _watchdogRetryAttempted = true;
-          _log.warning(
-            "No BLE notifications for ${_watchdogWarningTicks * 4}s "
-            "(total=$_totalNotifications), re-subscribing",
-          );
-          _registerNotifications();
+        // Watchdog: only active when scale is awake (weight notifications
+        // flowing). When sleeping, scale sends nothing — skip checks.
+        if (!_isSleeping) {
+          _ticksSinceLastNotification++;
+
+          if (_ticksSinceLastNotification >= _watchdogDisconnectTicks) {
+            _log.severe(
+              "No BLE notifications for ${_watchdogDisconnectTicks * 4}s "
+              "(total=$_totalNotifications, uptime=${_heartbeatTotalTicks * 4}s), disconnecting",
+            );
+            disconnect();
+            return;
+          } else if (_ticksSinceLastNotification >= _watchdogWarningTicks &&
+              !_watchdogRetryAttempted) {
+            _watchdogRetryAttempted = true;
+            _log.warning(
+              "No BLE notifications for ${_watchdogWarningTicks * 4}s "
+              "(total=$_totalNotifications), re-subscribing",
+            );
+            _registerNotifications();
+          }
         }
 
         await _sendHeartBeat();
       });
-      _sendOledOn();
-      _sendHeartBeat();
+      await _sendOledOn();
+      await _sendHeartBeat();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
       _log.warning('Failed to initialize scale: $e');
@@ -188,14 +196,17 @@ class DecentScale implements Scale {
   }
 
   Future<void> _sendHeartBeat() async {
-    _log.finest("send hb");
-    // List<int> payload = [0x03, 0x0A, 0x03, 0xFF, 0xFF, 0x00, 0x0A];
-    // Send OLed off command (will return battery %)
-    List<int> payload = [0x03, 0x0A, 0x03, 0xFF, 0xFF, 0x00, 0x0A];
-    if (!_isSleeping) {
-      // Send OLed on command (will return battery %)
-      payload = [0x03, 0x0A, 0x03, 0xFF, 0xFF, 0x00, 0x0A];
+    if (_isSleeping) {
+      // Scale display is off — no heartbeat needed (scale won't auto-sleep
+      // when we already told it to sleep, and it won't send notifications
+      // for the watchdog to observe).
+      return;
     }
+    _log.finest("send hb");
+    // Heartbeat ping: tells the scale the app is still alive so it won't
+    // auto-sleep. Does NOT produce a BLE notification response — watchdog
+    // is fed by weight notifications (0xCE/0xCA) while scale is awake.
+    List<int> payload = [0x03, 0x0A, 0x03, 0xFF, 0xFF, 0x00, 0x0A];
     try {
       await _device.write(
         serviceIdentifier.long,
@@ -309,6 +320,9 @@ class DecentScale implements Scale {
   @override
   Future<void> wakeDisplay() async {
     _isSleeping = false;
+    // Reset watchdog so scale has time to resume sending weight notifications
+    _ticksSinceLastNotification = 0;
+    _watchdogRetryAttempted = false;
     _log.info('Waking Decent Scale display');
     await _sendOledOn();
   }

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -87,7 +87,7 @@ class DecentScale implements Scale {
           'Discovered services: $services',
         );
       }
-      _registerNotifications();
+      await _registerNotifications();
       _heartbeatTimer?.cancel();
       _ticksSinceLastNotification = 0;
       _watchdogRetryAttempted = false;
@@ -219,7 +219,7 @@ class DecentScale implements Scale {
     }
   }
 
-  void _registerNotifications() async {
+  Future<void> _registerNotifications() async {
     await _device.subscribe(
       serviceIdentifier.long,
       dataCharacteristic.long,

--- a/lib/src/models/device/impl/difluid/difluid_scale.dart
+++ b/lib/src/models/device/impl/difluid/difluid_scale.dart
@@ -77,7 +77,7 @@ class DifluidScale implements Scale {
           'Discovered services: $services',
         );
       }
-      _registerNotifications();
+      await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
       disconnectSub?.cancel();
@@ -119,7 +119,7 @@ class DifluidScale implements Scale {
     // This is a no-op
   }
 
-  void _registerNotifications() async {
+  Future<void> _registerNotifications() async {
     await _transport.subscribe(serviceIdentifier.long, dataCharacteristic.long, _parseNotification);
 
     // Send start weight notifications command

--- a/lib/src/models/device/impl/eureka/eureka_scale.dart
+++ b/lib/src/models/device/impl/eureka/eureka_scale.dart
@@ -75,7 +75,7 @@ class EurekaScale implements Scale {
           'Discovered services: $services',
         );
       }
-      _registerNotifications();
+      await _registerNotifications();
       _readBattery();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
@@ -155,7 +155,7 @@ class EurekaScale implements Scale {
     // This is a no-op
   }
 
-  void _registerNotifications() async {
+  Future<void> _registerNotifications() async {
     await _transport.subscribe(serviceIdentifier.long, dataCharacteristic.long, _parseNotification);
   }
 

--- a/lib/src/models/device/impl/felicita/arc.dart
+++ b/lib/src/models/device/impl/felicita/arc.dart
@@ -69,7 +69,7 @@ class FelicitaArc implements Scale {
           'Discovered services: $services',
         );
       }
-      _registerNotifications();
+      await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
       disconnectSub?.cancel();
@@ -115,7 +115,7 @@ class FelicitaArc implements Scale {
 
   late StreamSubscription<Uint8List>? _notificationsSubscription;
 
-  void _registerNotifications() async {
+  Future<void> _registerNotifications() async {
     await _transport.subscribe(serviceIdentifier.long, dataCharacteristic.long, _parseNotification);
   }
 

--- a/lib/src/models/device/impl/hiroia/hiroia_scale.dart
+++ b/lib/src/models/device/impl/hiroia/hiroia_scale.dart
@@ -69,7 +69,7 @@ class HiroiaScale implements Scale {
           'Discovered services: $services',
         );
       }
-      _registerNotifications();
+      await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
       disconnectSub?.cancel();
@@ -112,7 +112,7 @@ class HiroiaScale implements Scale {
     // This is a no-op
   }
 
-  void _registerNotifications() async {
+  Future<void> _registerNotifications() async {
     await _transport.subscribe(serviceIdentifier.long, dataCharacteristic.long, _parseNotification);
   }
 

--- a/lib/src/models/device/impl/smartchef/smartchef_scale.dart
+++ b/lib/src/models/device/impl/smartchef/smartchef_scale.dart
@@ -68,7 +68,7 @@ class SmartChefScale implements Scale {
           'Discovered services: $services',
         );
       }
-      _registerNotifications();
+      await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
       disconnectSub?.cancel();
@@ -107,7 +107,7 @@ class SmartChefScale implements Scale {
     // This is a no-op
   }
 
-  void _registerNotifications() async {
+  Future<void> _registerNotifications() async {
     await _transport.subscribe(serviceIdentifier.long, dataCharacteristic.long, _parseNotification);
   }
 

--- a/lib/src/models/device/impl/varia/varia_aku_scale.dart
+++ b/lib/src/models/device/impl/varia/varia_aku_scale.dart
@@ -80,7 +80,7 @@ class VariaAkuScale implements Scale {
           'Discovered services: $services',
         );
       }
-      _registerNotifications();
+      await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
       disconnectSub?.cancel();
@@ -119,7 +119,7 @@ class VariaAkuScale implements Scale {
     // Varia AKU doesn't support display wake via BLE
   }
 
-  void _registerNotifications() async {
+  Future<void> _registerNotifications() async {
     await _transport.subscribe(serviceIdentifier.long, dataCharacteristic.long, _parseNotification);
   }
 


### PR DESCRIPTION
After updating to Flutter 3.44 locally, a data race has surfaced in decent scale notification subscription logic. Proper signature and awaiting restores correct functionality. Applied to all `scale` implementations.
Additionally, the HDS oled control & watchdog timer logic has been corrected, to reflect actual state of hardware.