### PR TITLE
Fix scale snapshot battery spec (#249) and bundled-skin clobber (#250)

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3856,20 +3856,6 @@ components:
         details:
           type: string
 
-    ScaleSnapshot:
-      type: object
-      properties:
-        timestamp:
-          type: string
-          format: date-time
-        weight:
-          type: number
-        batteryLevel:
-          type: integer
-        timerValue:
-          type: integer
-          nullable: true
-          description: Timer elapsed time in milliseconds. Null if scale doesn't support timers or timer hasn't been started.
     MachineSnapshot:
       type: object
       properties:
@@ -4825,8 +4811,14 @@ components:
           type: number
         weightFlow:
           type: number
-        batteryLevel:
+        battery:
           type: integer
+          nullable: true
+          description: Scale battery level (0–100). Null if the scale does not report battery.
+        timerValue:
+          type: integer
+          nullable: true
+          description: Timer elapsed time in milliseconds. Null if scale doesn't support timers or timer hasn't been started.
 
     PluginManifest:
       type: object

--- a/lib/src/webui_support/webui_storage.dart
+++ b/lib/src/webui_support/webui_storage.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
@@ -141,6 +142,18 @@ class WebUIStorage {
   WebUIStorage(this._settingsController, {bool? appStoreMode})
       : _appStoreMode = appStoreMode ?? BuildInfo.appStore;
 
+  /// Test seam: point storage at a specific web-ui directory and mark it
+  /// initialized, bypassing the asset/network [initialize] flow so install
+  /// behavior can be exercised against a temp directory.
+  @visibleForTesting
+  void debugInitWithWebUIDir(Directory dir) {
+    _webUIDir = dir;
+    if (!_webUIDir.existsSync()) {
+      _webUIDir.createSync(recursive: true);
+    }
+    _initialized = true;
+  }
+
   /// Hardcoded list of bundled asset paths
   /// These are Flutter assets that ship with the app
   static const List<String> _bundledAssetPaths = [
@@ -271,17 +284,22 @@ class WebUIStorage {
   /// Install a WebUI skin from a local filesystem path
   /// The path can be either a directory or a zip file
   /// Returns the installed skin ID
-  Future<String> installFromPath(String sourcePath) async {
+  Future<String> installFromPath(
+    String sourcePath, {
+    bool overwriteIfExists = true,
+  }) async {
     final source = File(sourcePath);
     final sourceDir = Directory(sourcePath);
 
     String skinId;
     if (source.existsSync() && sourcePath.endsWith('.zip')) {
       // It's a zip file - extract it
-      skinId = await _installFromZip(sourcePath);
+      skinId = await _installFromZip(sourcePath,
+          overwriteIfExists: overwriteIfExists);
     } else if (sourceDir.existsSync()) {
       // It's a directory - copy it
-      skinId = await _installFromDirectory(sourceDir);
+      skinId = await _installFromDirectory(sourceDir,
+          overwriteIfExists: overwriteIfExists);
     } else {
       throw Exception('Source does not exist: $sourcePath');
     }
@@ -954,7 +972,7 @@ class WebUIStorage {
         await tempFile.writeAsBytes(zipData.buffer.asUint8List());
 
         try {
-          await _installFromZip(tempFile.path);
+          await _installFromZip(tempFile.path, overwriteIfExists: false);
           _log.info('Installed bundled skin from asset: $skinId');
         } finally {
           if (tempFile.existsSync()) await tempFile.delete();
@@ -1077,7 +1095,10 @@ class WebUIStorage {
 
   /// Install a WebUI skin from a zip file
   /// Returns the installed skin ID
-  Future<String> _installFromZip(String zipPath) async {
+  Future<String> _installFromZip(
+    String zipPath, {
+    bool overwriteIfExists = true,
+  }) async {
     _log.info('Installing WebUI from zip: $zipPath');
 
     // Create temp extraction directory
@@ -1122,7 +1143,10 @@ class WebUIStorage {
       }
 
       // Install from the extracted directory
-      return await _installFromDirectory(contentDir);
+      return await _installFromDirectory(
+        contentDir,
+        overwriteIfExists: overwriteIfExists,
+      );
     } finally {
       // Clean up temp directory
       if (tempDir.existsSync()) {
@@ -1132,8 +1156,18 @@ class WebUIStorage {
   }
 
   /// Install a WebUI skin from a directory
-  /// Returns the installed skin ID
-  Future<String> _installFromDirectory(Directory sourceDir) async {
+  /// Returns the installed skin ID.
+  ///
+  /// When [overwriteIfExists] is false, an existing non-empty skin directory is
+  /// left untouched and its id returned. Bundled-asset installs use this so they
+  /// never clobber a newer copy installed from a GitHub release (issue #250):
+  /// the skin's install dir is keyed by its manifest `id` (e.g. `streamline.js`),
+  /// not the bundled asset basename (e.g. `streamline_project`), so the caller's
+  /// own existence check cannot see it.
+  Future<String> _installFromDirectory(
+    Directory sourceDir, {
+    bool overwriteIfExists = true,
+  }) async {
     // Try to load skin ID from skin-manifest.json first, then manifest.json,
     // otherwise fall back to directory name
     String skinId;
@@ -1152,6 +1186,14 @@ class WebUIStorage {
 
     // Check if skin already exists
     final destDir = Directory('${_webUIDir.path}/$skinId');
+    if (destDir.existsSync() &&
+        destDir.listSync().isNotEmpty &&
+        !overwriteIfExists) {
+      _log.info(
+        'Skin "$skinId" already installed; skipping to avoid clobbering existing copy',
+      );
+      return skinId;
+    }
     if (destDir.existsSync()) {
       _log.warning('Skin already exists: $skinId, overwriting...');
       await destDir.delete(recursive: true);

--- a/test/webui_storage_install_test.dart
+++ b/test/webui_storage_install_test.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/webui_support/webui_storage.dart';
+
+import 'helpers/mock_settings_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('WebUIStorage install overwrite semantics', () {
+    late Directory tmpRoot;
+    late Directory webUIDir;
+    late WebUIStorage storage;
+
+    setUp(() async {
+      tmpRoot = Directory.systemTemp.createTempSync('webui_storage_test');
+      webUIDir = Directory('${tmpRoot.path}/web-ui');
+
+      final settingsController = SettingsController(MockSettingsService());
+      await settingsController.loadSettings();
+      storage = WebUIStorage(settingsController, appStoreMode: true);
+      storage.debugInitWithWebUIDir(webUIDir);
+    });
+
+    tearDown(() {
+      if (tmpRoot.existsSync()) tmpRoot.deleteSync(recursive: true);
+    });
+
+    // Builds a source skin directory whose skin-manifest.json shares [id] but
+    // carries a distinct [version], mimicking two builds of the same skin.
+    Directory makeSkinSource(String version) {
+      final dir = Directory('${tmpRoot.path}/src_$version');
+      dir.createSync(recursive: true);
+      File('${dir.path}/skin-manifest.json').writeAsStringSync(jsonEncode({
+        'id': 'test.skin',
+        'name': 'Test Skin',
+        'version': version,
+      }));
+      File('${dir.path}/index.html').writeAsStringSync('<html>$version</html>');
+      return dir;
+    }
+
+    String installedVersion() {
+      final manifest =
+          File('${webUIDir.path}/test.skin/skin-manifest.json');
+      final json = jsonDecode(manifest.readAsStringSync())
+          as Map<String, dynamic>;
+      return json['version'] as String;
+    }
+
+    test('overwriteIfExists:false leaves an existing skin untouched', () async {
+      // Newer copy installed first (e.g. from a GitHub release).
+      await storage.installFromPath(makeSkinSource('0.1.33').path);
+      expect(installedVersion(), '0.1.33');
+
+      // Bundled (older) copy must not clobber it — issue #250.
+      await storage.installFromPath(
+        makeSkinSource('0.1.31').path,
+        overwriteIfExists: false,
+      );
+      expect(installedVersion(), '0.1.33');
+    });
+
+    test('overwriteIfExists:true replaces an existing skin', () async {
+      await storage.installFromPath(makeSkinSource('0.1.31').path);
+      expect(installedVersion(), '0.1.31');
+
+      await storage.installFromPath(makeSkinSource('0.1.33').path);
+      expect(installedVersion(), '0.1.33');
+    });
+
+    test('overwriteIfExists:false still installs when absent', () async {
+      await storage.installFromPath(
+        makeSkinSource('0.1.31').path,
+        overwriteIfExists: false,
+      );
+      expect(installedVersion(), '0.1.31');
+    });
+  });
+}


### PR DESCRIPTION
## What
- **#249** — `rest_v1.yml`: `WeightSnapshot.batteryLevel` → `battery` (nullable) + add missing `timerValue`; remove orphan unreferenced `ScaleSnapshot` schema. Doc-only; app code was already correct.
- **#250** — `webui_storage.dart`: bundled-asset skin installs no longer overwrite a newer remote-installed skin.

## Why
- #249: served frame (`ws/v1/scale/snapshot`, `ShotSnapshot.scale`) emits `battery`/`timerValue`; spec documented `batteryLevel` and omitted `timerValue`.
- #250: skin install dir is keyed by manifest `id` (`streamline.js`), but the bundled-asset loop guards on the asset basename (`streamline_project`), so its existence check never matched — every boot re-extracted the build-time bundled copy and clobbered the GitHub-release update. On-disk reverted to the older version while release metadata still advertised the newer tag. Confirmed against device logs in the report.

## Test plan
- [x] `flutter analyze` clean (changed files)
- [x] new `test/webui_storage_install_test.dart` (overwrite vs skip semantics) — 3/3
- [x] full `flutter test` — 1351 pass

Closes #249
Closes #250