### PR TITLE
feat(account): link Decent Espresso account

### DIFF
--- a/.github/workflows/develop-builds.yml
+++ b/.github/workflows/develop-builds.yml
@@ -235,7 +235,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Linux dependencies
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-0
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-dev
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -279,7 +279,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Linux dependencies
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-0
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-dev
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/develop-builds.yml
+++ b/.github/workflows/develop-builds.yml
@@ -235,7 +235,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Linux dependencies
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-0
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -279,7 +279,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Linux dependencies
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-0
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -94,7 +94,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Linux dependencies
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-0
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -94,7 +94,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Linux dependencies
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-0
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-dev
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,7 +234,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Linux dependencies
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-0
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-dev
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -288,7 +288,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Linux dependencies
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-0
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-dev
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,7 +234,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Linux dependencies
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-0
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -288,7 +288,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Linux dependencies
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-0
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,8 @@ assets/bundled_skins/
 .bundle/
 vendor/bundle/
 pubspec_overrides.yaml
+
+# Local-only agent skill: google-analytics-cli (kept out of the repo)
+/skills-lock.json
+/.agents/skills/google-analytics-cli/
+/.claude/skills/google-analytics-cli

--- a/doc/plans/archive/decent-account-login/decent-account-login.md
+++ b/doc/plans/archive/decent-account-login/decent-account-login.md
@@ -1,0 +1,50 @@
+# Decent account login — initial comms
+
+Branch: `feature/account-login` · TODO ref: `^582a45` (P1)
+
+## Background
+
+de1app authenticates against `decentespresso.com/support/api/` using HTTP Basic
+Auth (email:password, base64-encoded). Three endpoints exist: `login_test`,
+`sn` (list serials), `upload_shot` (disabled). No OAuth, no JWT — sessionless
+Basic Auth on every request. HTTPS confirmed working.
+
+Decent.app needs to match this contract so users can use their existing Decent
+account. Phase 1 scope: auth comms only — no sync, no shot upload.
+
+## Scope
+
+1. **Real `CredentialStore`** — `flutter_secure_storage`-backed impl
+2. **Settings pane** — "Decent Account" section in DataManagementPage showing
+   login status, email, login/logout
+3. **Onboarding step** — optional step after welcome: email + password + login
+
+Out of scope: cross-device sync, shot upload, machine transfer, serial
+registration beyond verification, privacy tiers.
+
+## Phase 1 — `SecureCredentialStore`
+
+New file: `lib/src/services/account/credential_store.dart`
+
+Wraps `FlutterSecureStorage` with the `CredentialStore` interface already
+defined in tests. Add `flutter_secure_storage` to pubspec.
+
+## Phase 2 — Wire into DataManagementPage
+
+Add `_buildDecentAccountSection()` card to `DataManagementPage`:
+- Not logged in → "Link your Decent Espresso Account" button → login dialog
+- Logged in → email + "Unlink" button
+- Inject `DecentAccountService` into `DataManagementPage`
+
+## Phase 3 — Onboarding step
+
+New file: `lib/src/onboarding_feature/steps/login_step.dart`
+
+`OnboardingStep` with `shouldShow: !loggedIn`. Widget: email, password, Login
+button, Skip link. After welcome step, before scan step.
+
+## Wire-up
+
+- `main.dart`: provide `DecentAccountService` (via Riverpod or manual DI)
+- `settings_view.dart`: pass `DecentAccountService` to `DataManagementPage`
+- Onboarding steps list: insert login step

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -368,7 +368,7 @@ void main() async {
 
   final decentAccountService = DecentAccountService(
     httpClient: http.Client(),
-    credentialStore: createCredentialStore(),
+    credentialStore: await createCredentialStore(),
   );
 
   BatteryController? batteryController;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,6 +42,9 @@ import 'package:reaprime/src/services/storage/bean_storage_service.dart';
 import 'package:reaprime/src/services/storage/drift_storage_service.dart';
 import 'package:reaprime/src/services/storage/grinder_storage_service.dart';
 import 'package:reaprime/src/services/storage/profile_storage_service.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:reaprime/src/services/account/credential_store.dart';
+import 'package:http/http.dart' as http;
 import 'package:reaprime/src/services/storage/hive_store_service.dart';
 import 'package:reaprime/src/services/universal_ble_discovery_service.dart';
 import 'package:reaprime/src/services/simulated_device_service.dart';
@@ -363,6 +366,11 @@ void main() async {
   final WebUIService webUIService = WebUIService();
   final WebUIStorage webUIStorage = WebUIStorage(settingsController);
 
+  final decentAccountService = DecentAccountService(
+    httpClient: http.Client(),
+    credentialStore: SecureCredentialStore(),
+  );
+
   BatteryController? batteryController;
   if (Platform.isAndroid || Platform.isIOS) {
     batteryController = BatteryController(
@@ -477,6 +485,7 @@ void main() async {
         profileStorageService: profileStorage,
         connectionManager: connectionManager,
         scanStateGuardian: scanStateGuardian,
+        decentAccountService: decentAccountService,
       ),
     ),
   );
@@ -628,6 +637,7 @@ class AppRoot extends StatefulWidget {
   final ProfileStorageService? profileStorageService;
   final ConnectionManager connectionManager;
   final ScanStateGuardian scanStateGuardian;
+  final DecentAccountService? decentAccountService;
 
   const AppRoot({
     super.key,
@@ -648,6 +658,7 @@ class AppRoot extends StatefulWidget {
     this.beanStorage,
     this.grinderStorage,
     this.profileStorageService,
+    this.decentAccountService,
   });
 
   static void restart(BuildContext context) {
@@ -704,6 +715,7 @@ class _AppRootState extends State<AppRoot> {
         profileStorageService: widget.profileStorageService,
         connectionManager: widget.connectionManager,
         scanStateGuardian: widget.scanStateGuardian,
+        decentAccountService: widget.decentAccountService,
       ),
     );
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,7 +43,7 @@ import 'package:reaprime/src/services/storage/drift_storage_service.dart';
 import 'package:reaprime/src/services/storage/grinder_storage_service.dart';
 import 'package:reaprime/src/services/storage/profile_storage_service.dart';
 import 'package:reaprime/src/services/account/decent_account_service.dart';
-import 'package:reaprime/src/services/account/credential_store.dart';
+import 'package:reaprime/src/services/account/credential_store_factory.dart';
 import 'package:http/http.dart' as http;
 import 'package:reaprime/src/services/storage/hive_store_service.dart';
 import 'package:reaprime/src/services/universal_ble_discovery_service.dart';
@@ -368,7 +368,7 @@ void main() async {
 
   final decentAccountService = DecentAccountService(
     httpClient: http.Client(),
-    credentialStore: SecureCredentialStore(),
+    credentialStore: createCredentialStore(),
   );
 
   BatteryController? batteryController;

--- a/lib/src/account/decent_login_form.dart
+++ b/lib/src/account/decent_login_form.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+/// Shared email/password login form for the Decent account.
+///
+/// Owns its own controllers (disposed automatically), loading state, and error
+/// display, and runs [DecentAccountService.login]. Used by both the onboarding
+/// login step and the settings "Link Account" dialog so the login logic lives
+/// in one place.
+class DecentLoginForm extends StatefulWidget {
+  const DecentLoginForm({
+    super.key,
+    required this.accountService,
+    required this.onSuccess,
+    this.secondaryLabel,
+    this.onSecondary,
+  });
+
+  final DecentAccountService accountService;
+
+  /// Called after a successful login.
+  final VoidCallback onSuccess;
+
+  /// Optional secondary action rendered beside the Login button
+  /// (e.g. "Skip for now" in onboarding, "Cancel" in the settings dialog).
+  final String? secondaryLabel;
+  final VoidCallback? onSecondary;
+
+  @override
+  State<DecentLoginForm> createState() => _DecentLoginFormState();
+}
+
+class _DecentLoginFormState extends State<DecentLoginForm> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  bool _loading = false;
+  String? _error;
+
+  final Logger _log = Logger('DecentLoginForm');
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        ShadInput(
+          controller: _emailController,
+          placeholder: const Text('Email'),
+          keyboardType: TextInputType.emailAddress,
+          textInputAction: TextInputAction.next,
+        ),
+        const SizedBox(height: 12),
+        ShadInput(
+          controller: _passwordController,
+          placeholder: const Text('Password'),
+          obscureText: true,
+          textInputAction: TextInputAction.done,
+          onSubmitted: (_) => _login(),
+        ),
+        if (_error != null) ...[
+          const SizedBox(height: 12),
+          Text(
+            _error!,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+            textAlign: TextAlign.center,
+          ),
+        ],
+        const SizedBox(height: 16),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            if (widget.secondaryLabel != null) ...[
+              ShadButton.outline(
+                onPressed: _loading ? null : widget.onSecondary,
+                child: Text(widget.secondaryLabel!),
+              ),
+              const SizedBox(width: 8),
+            ],
+            ShadButton(
+              onPressed: _loading ? null : _login,
+              child: _loading
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Login'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Future<void> _login() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final ok = await widget.accountService.login(
+        _emailController.text.trim(),
+        _passwordController.text,
+      );
+
+      if (!mounted) return;
+
+      if (ok) {
+        widget.onSuccess();
+      } else {
+        setState(() {
+          _error = 'Login failed. Check your email and password.';
+          _loading = false;
+        });
+      }
+    } catch (e, st) {
+      _log.warning('failed to perform login', e, st);
+      if (!mounted) return;
+      setState(() {
+        _error = 'Network error. Check your connection and try again.';
+        _loading = false;
+      });
+    }
+  }
+}

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -24,6 +24,7 @@ import 'package:reaprime/src/onboarding_feature/steps/initialization_step.dart';
 import 'package:reaprime/src/onboarding_feature/steps/permissions_step.dart';
 import 'package:reaprime/src/onboarding_feature/steps/scan_step.dart';
 import 'package:reaprime/src/onboarding_feature/steps/welcome_step.dart';
+import 'package:reaprime/src/onboarding_feature/steps/login_step.dart';
 import 'package:reaprime/src/realtime_shot_feature/realtime_shot_feature.dart';
 import 'package:reaprime/src/realtime_steam_feature/realtime_steam_feature.dart';
 import 'package:reaprime/src/skin_feature/skin_view.dart';
@@ -50,6 +51,7 @@ import 'sample_feature/sample_item_list_view.dart';
 import 'settings/gateway_mode.dart';
 import 'settings/settings_controller.dart';
 import 'settings/settings_view.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
 
 class NavigationService {
   static final GlobalKey<NavigatorState> navigatorKey =
@@ -80,6 +82,7 @@ class MyApp extends StatefulWidget {
     this.beanStorage,
     this.grinderStorage,
     this.profileStorageService,
+    this.decentAccountService,
   });
 
   final SettingsController settingsController;
@@ -99,6 +102,7 @@ class MyApp extends StatefulWidget {
   final BeanStorageService? beanStorage;
   final GrinderStorageService? grinderStorage;
   final ProfileStorageService? profileStorageService;
+  final DecentAccountService? decentAccountService;
 
   @override
   State<MyApp> createState() => _MyAppState();
@@ -121,6 +125,10 @@ class _MyAppState extends State<MyApp> {
             !widget.settingsController.onboardingCompleted,
         builder: createWelcomeStep().builder,
       ),
+      if (widget.decentAccountService != null)
+        createLoginStep(
+          accountService: widget.decentAccountService!,
+        ),
       createPermissionsStep(
         de1Controller: widget.de1Controller,
       ),
@@ -353,6 +361,7 @@ class _MyAppState extends State<MyApp> {
                         beanStorageService: widget.beanStorage,
                         grinderStorageService: widget.grinderStorage,
                         workflowController: widget.workflowController,
+                        decentAccountService: widget.decentAccountService,
                       );
                     case De1DebugView.routeName:
                       final args = routeSettings.arguments;

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -128,6 +128,7 @@ class _MyAppState extends State<MyApp> {
       if (widget.decentAccountService != null)
         createLoginStep(
           accountService: widget.decentAccountService!,
+          settingsController: widget.settingsController,
         ),
       createPermissionsStep(
         de1Controller: widget.de1Controller,

--- a/lib/src/onboarding_feature/steps/login_step.dart
+++ b/lib/src/onboarding_feature/steps/login_step.dart
@@ -1,22 +1,32 @@
 import 'package:flutter/material.dart';
+import 'package:reaprime/src/account/decent_login_form.dart';
 import 'package:reaprime/src/onboarding_feature/onboarding_controller.dart';
 import 'package:reaprime/src/services/account/decent_account_service.dart';
-import 'package:shadcn_ui/shadcn_ui.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
 
 OnboardingStep createLoginStep({
   required DecentAccountService accountService,
+  required SettingsController settingsController,
 }) {
   return OnboardingStep(
     id: 'login',
-    shouldShow: () async => !(await accountService.isLoggedIn()),
+    // Only show while the user hasn't seen the step and isn't already linked.
+    // Skipping marks the step seen so it doesn't reappear on every launch —
+    // the account can always be linked later from Settings.
+    shouldShow: () async =>
+        !settingsController.accountStepSeen &&
+        !(await accountService.isLoggedIn()),
     builder: (controller) => LoginStepWidget(
       accountService: accountService,
-      onComplete: controller.advance,
+      onComplete: () async {
+        await settingsController.setAccountStepSeen(true);
+        controller.advance();
+      },
     ),
   );
 }
 
-class LoginStepWidget extends StatefulWidget {
+class LoginStepWidget extends StatelessWidget {
   final DecentAccountService accountService;
   final VoidCallback onComplete;
 
@@ -25,23 +35,6 @@ class LoginStepWidget extends StatefulWidget {
     required this.accountService,
     required this.onComplete,
   });
-
-  @override
-  State<LoginStepWidget> createState() => _LoginStepWidgetState();
-}
-
-class _LoginStepWidgetState extends State<LoginStepWidget> {
-  final _emailController = TextEditingController();
-  final _passwordController = TextEditingController();
-  bool _loading = false;
-  String? _error;
-
-  @override
-  void dispose() {
-    _emailController.dispose();
-    _passwordController.dispose();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -77,80 +70,15 @@ class _LoginStepWidgetState extends State<LoginStepWidget> {
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 32),
-            ShadInput(
-              controller: _emailController,
-              placeholder: const Text('Email'),
-              keyboardType: TextInputType.emailAddress,
-              textInputAction: TextInputAction.next,
-            ),
-            const SizedBox(height: 16),
-            ShadInput(
-              controller: _passwordController,
-              placeholder: const Text('Password'),
-              obscureText: true,
-              textInputAction: TextInputAction.done,
-              onSubmitted: (_) => _login(),
-            ),
-            if (_error != null) ...[
-              const SizedBox(height: 12),
-              Text(
-                _error!,
-                style: TextStyle(
-                  color: Theme.of(context).colorScheme.error,
-                ),
-                textAlign: TextAlign.center,
-              ),
-            ],
-            const SizedBox(height: 24),
-            ShadButton(
-              onPressed: _loading ? null : _login,
-              child: _loading
-                  ? const SizedBox(
-                      width: 16,
-                      height: 16,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Text('Login'),
-            ),
-            const SizedBox(height: 16),
-            TextButton(
-              onPressed: _loading ? null : widget.onComplete,
-              child: const Text('Skip for now'),
+            DecentLoginForm(
+              accountService: accountService,
+              onSuccess: onComplete,
+              secondaryLabel: 'Skip for now',
+              onSecondary: onComplete,
             ),
           ],
         ),
       ),
     );
-  }
-
-  Future<void> _login() async {
-    setState(() {
-      _loading = true;
-      _error = null;
-    });
-
-    try {
-      final ok = await widget.accountService.login(
-        _emailController.text.trim(),
-        _passwordController.text,
-      );
-
-      if (!mounted) return;
-
-      if (ok) {
-        widget.onComplete();
-      } else {
-        setState(() {
-          _error = 'Login failed. Check your email and password.';
-          _loading = false;
-        });
-      }
-    } catch (e) {
-      if (!mounted) return;
-      setState(() {
-        _error = 'Network error. Check your connection and try again.';
-        _loading = false;
-      });
-    }
   }
 }

--- a/lib/src/onboarding_feature/steps/login_step.dart
+++ b/lib/src/onboarding_feature/steps/login_step.dart
@@ -77,19 +77,16 @@ class _LoginStepWidgetState extends State<LoginStepWidget> {
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 32),
-            TextField(
+            ShadInput(
               controller: _emailController,
-              decoration: const InputDecoration(
-                labelText: 'Email',
-                hintText: 'you@example.com',
-              ),
+              placeholder: const Text('Email'),
               keyboardType: TextInputType.emailAddress,
               textInputAction: TextInputAction.next,
             ),
             const SizedBox(height: 16),
-            TextField(
+            ShadInput(
               controller: _passwordController,
-              decoration: const InputDecoration(labelText: 'Password'),
+              placeholder: const Text('Password'),
               obscureText: true,
               textInputAction: TextInputAction.done,
               onSubmitted: (_) => _login(),

--- a/lib/src/onboarding_feature/steps/login_step.dart
+++ b/lib/src/onboarding_feature/steps/login_step.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:reaprime/src/onboarding_feature/onboarding_controller.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+OnboardingStep createLoginStep({
+  required DecentAccountService accountService,
+}) {
+  return OnboardingStep(
+    id: 'login',
+    shouldShow: () async => !(await accountService.isLoggedIn()),
+    builder: (controller) => LoginStepWidget(
+      accountService: accountService,
+      onComplete: controller.advance,
+    ),
+  );
+}
+
+class LoginStepWidget extends StatefulWidget {
+  final DecentAccountService accountService;
+  final VoidCallback onComplete;
+
+  const LoginStepWidget({
+    super.key,
+    required this.accountService,
+    required this.onComplete,
+  });
+
+  @override
+  State<LoginStepWidget> createState() => _LoginStepWidgetState();
+}
+
+class _LoginStepWidgetState extends State<LoginStepWidget> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  bool _loading = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Icon(
+              Icons.account_circle_outlined,
+              size: 64,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Link Your Decent Account',
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Sync your profiles, beans, and shots across devices.',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.7),
+                  ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 32),
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(
+                labelText: 'Email',
+                hintText: 'you@example.com',
+              ),
+              keyboardType: TextInputType.emailAddress,
+              textInputAction: TextInputAction.next,
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+              textInputAction: TextInputAction.done,
+              onSubmitted: (_) => _login(),
+            ),
+            if (_error != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                _error!,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.error,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+            const SizedBox(height: 24),
+            ShadButton(
+              onPressed: _loading ? null : _login,
+              child: _loading
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Login'),
+            ),
+            const SizedBox(height: 16),
+            TextButton(
+              onPressed: _loading ? null : widget.onComplete,
+              child: const Text('Skip for now'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _login() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final ok = await widget.accountService.login(
+        _emailController.text.trim(),
+        _passwordController.text,
+      );
+
+      if (!mounted) return;
+
+      if (ok) {
+        widget.onComplete();
+      } else {
+        setState(() {
+          _error = 'Login failed. Check your email and password.';
+          _loading = false;
+        });
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'Network error. Check your connection and try again.';
+        _loading = false;
+      });
+    }
+  }
+}

--- a/lib/src/services/account/credential_store.dart
+++ b/lib/src/services/account/credential_store.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+
+/// Flutter Secure Storage backed credential store.
+/// Uses iOS Keychain, Android EncryptedSharedPreferences, macOS Keychain,
+/// and Linux libsecret.
+class SecureCredentialStore implements CredentialStore {
+  final FlutterSecureStorage _storage;
+
+  SecureCredentialStore({FlutterSecureStorage? storage})
+      : _storage = storage ?? const FlutterSecureStorage();
+
+  @override
+  Future<String?> read({required String key}) => _storage.read(key: key);
+
+  @override
+  Future<void> write({required String key, required String value}) =>
+      _storage.write(key: key, value: value);
+
+  @override
+  Future<void> delete({required String key}) => _storage.delete(key: key);
+}

--- a/lib/src/services/account/credential_store_factory.dart
+++ b/lib/src/services/account/credential_store_factory.dart
@@ -1,48 +1,50 @@
+import 'dart:convert';
 import 'dart:io' show Platform;
 
+import 'package:crypto/crypto.dart';
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 import 'package:reaprime/src/services/account/credential_store.dart';
 import 'package:reaprime/src/services/account/decent_account_service.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:reaprime/src/services/account/encrypted_credential_store.dart';
 
 /// Factory that picks the right credential store for the platform.
 ///
-/// On macOS, flutter_secure_storage hits errSecMissingEntitlement (-34018)
-/// for Developer ID / debug builds because it sets kSecUseDataProtectionKeychain
-/// internally. We fall back to SharedPreferences on macOS — the stored value is
-/// already the encrypted cryptpw, so plaintext exposure risk is minimal.
+/// iOS and Android use flutter_secure_storage (Keychain /
+/// EncryptedSharedPreferences).
 ///
-/// iOS and Android use the Keychain / EncryptedSharedPreferences via
-/// flutter_secure_storage.
-CredentialStore createCredentialStore() {
+/// macOS can't use the Keychain: flutter_secure_storage sets
+/// kSecUseDataProtectionKeychain, and the Data Protection Keychain is
+/// unavailable to Developer-ID / sideloaded builds, so every call returns
+/// errSecMissingEntitlement (-34018). Instead we use an AES-256-GCM encrypted
+/// file whose key is derived from the machine's hardware UUID — the same
+/// pattern Slack/VS Code/Obsidian use on macOS.
+Future<CredentialStore> createCredentialStore() async {
   if (Platform.isMacOS) {
-    return MacOSCredentialStore();
+    return _createMacOSStore();
   }
   return SecureCredentialStore();
 }
 
-/// Stores credentials in macOS SharedPreferences.
-///
-/// SharedPreferences on macOS writes to the app's sandbox container which is
-/// protected by the OS (no other user can read it). The stored value is the
-/// encrypted cryptpw returned by login_test, not the user's plaintext password.
-class MacOSCredentialStore implements CredentialStore {
-  Future<SharedPreferences> get _prefs => SharedPreferences.getInstance();
+// Authoritative bundle ID (see CLAUDE.md). Used as a fixed namespace in the
+// key derivation; not a secret.
+const _bundleId = 'net.tadel.reaprime';
 
-  @override
-  Future<String?> read({required String key}) async {
-    final prefs = await _prefs;
-    return prefs.getString(key);
-  }
+Future<EncryptedCredentialStore> _createMacOSStore() async {
+  final macInfo = await DeviceInfoPlugin().macOsInfo;
 
-  @override
-  Future<void> write({required String key, required String value}) async {
-    final prefs = await _prefs;
-    await prefs.setString(key, value);
-  }
+  // Machine-bound key: SHA-256(IOPlatformUUID || bundleID). Bound to the host
+  // (a copied file won't decrypt elsewhere) but not to the binary signature
+  // (survives auto-updates). systemGUID is the IOPlatformUUID.
+  final guid = macInfo.systemGUID ?? 'unknown-machine';
+  final keyBytes = sha256.convert(utf8.encode('$guid$_bundleId')).bytes;
 
-  @override
-  Future<void> delete({required String key}) async {
-    final prefs = await _prefs;
-    await prefs.remove(key);
-  }
+  final dir = await getApplicationSupportDirectory();
+  final path = p.join(dir.path, 'secure_storage_v1.dat');
+
+  return EncryptedCredentialStore(
+    keyBytes: keyBytes,
+    blob: FileBlobStore(path),
+  );
 }

--- a/lib/src/services/account/credential_store_factory.dart
+++ b/lib/src/services/account/credential_store_factory.dart
@@ -1,0 +1,48 @@
+import 'dart:io' show Platform;
+
+import 'package:reaprime/src/services/account/credential_store.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Factory that picks the right credential store for the platform.
+///
+/// On macOS, flutter_secure_storage hits errSecMissingEntitlement (-34018)
+/// for Developer ID / debug builds because it sets kSecUseDataProtectionKeychain
+/// internally. We fall back to SharedPreferences on macOS — the stored value is
+/// already the encrypted cryptpw, so plaintext exposure risk is minimal.
+///
+/// iOS and Android use the Keychain / EncryptedSharedPreferences via
+/// flutter_secure_storage.
+CredentialStore createCredentialStore() {
+  if (Platform.isMacOS) {
+    return MacOSCredentialStore();
+  }
+  return SecureCredentialStore();
+}
+
+/// Stores credentials in macOS SharedPreferences.
+///
+/// SharedPreferences on macOS writes to the app's sandbox container which is
+/// protected by the OS (no other user can read it). The stored value is the
+/// encrypted cryptpw returned by login_test, not the user's plaintext password.
+class MacOSCredentialStore implements CredentialStore {
+  Future<SharedPreferences> get _prefs => SharedPreferences.getInstance();
+
+  @override
+  Future<String?> read({required String key}) async {
+    final prefs = await _prefs;
+    return prefs.getString(key);
+  }
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    final prefs = await _prefs;
+    await prefs.setString(key, value);
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    final prefs = await _prefs;
+    await prefs.remove(key);
+  }
+}

--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import 'package:http/http.dart';
+import 'package:http/http.dart' as http;
 
 abstract class CredentialStore {
   Future<String?> read({required String key});
@@ -10,11 +10,11 @@ abstract class CredentialStore {
 }
 
 class DecentAccountService {
-  final BaseClient _httpClient;
+  final http.Client _httpClient;
   final CredentialStore _store;
   final String baseUrl;
   DecentAccountService({
-    required BaseClient httpClient,
+    required http.Client httpClient,
     required CredentialStore credentialStore,
     this.baseUrl = "https://decentespresso.com",
   }) : _httpClient = httpClient,
@@ -56,14 +56,14 @@ class DecentAccountService {
     if (email == null || password == null) {
       throw StateError('not logged in');
     }
-      final response = await _authedGet(email, password, '/support/api/sn');
-      if (response.statusCode != 200) {
-        throw response.body;
-      }
-      if (response.body == '') {
-        return [];
-      }
-      return response.body.trim().split('\n');
+    final response = await _authedGet(email, password, '/support/api/sn');
+    if (response.statusCode != 200) {
+      throw response.body;
+    }
+    if (response.body == '') {
+      return [];
+    }
+    return response.body.trim().split('\n');
   }
 
   Future<bool> verifyMachineSerial(String serial) async {
@@ -71,7 +71,7 @@ class DecentAccountService {
     return list.contains(serial);
   }
 
-  Future<Response> _authedGet(
+  Future<http.Response> _authedGet(
     String email,
     String password,
     String path,

--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -1,0 +1,84 @@
+import 'dart:convert';
+import 'package:http/http.dart';
+
+abstract class CredentialStore {
+  Future<String?> read({required String key});
+
+  Future<void> write({required String key, required String value});
+
+  Future<void> delete({required String key});
+}
+
+class DecentAccountService {
+  final BaseClient _httpClient;
+  final CredentialStore _store;
+  final String baseUrl;
+  DecentAccountService({
+    required BaseClient httpClient,
+    required CredentialStore credentialStore,
+    this.baseUrl = "https://decentespresso.com",
+  }) : _httpClient = httpClient,
+       _store = credentialStore;
+
+  bool _loggedIn = false;
+  Future<bool> login(String email, String password) async {
+    if (_loggedIn) {
+      return _loggedIn;
+    }
+    final response = await _authedGet(
+      email,
+      password,
+      '/support/api/login_test',
+    );
+
+    if (response.statusCode == 200 && response.body == '1') {
+      await _store.write(key: 'email', value: email);
+      await _store.write(key: 'password', value: password);
+      _loggedIn = true;
+    }
+    return _loggedIn;
+  }
+
+  Future<void> logout() async {
+    _loggedIn = false;
+    await _store.delete(key: 'email');
+    await _store.delete(key: 'password');
+  }
+
+  Future<bool> isLoggedIn() async => await _store.read(key: 'email') != null;
+
+  Future<List<String>> fetchSerialNumbers() async {
+    final email = await _store.read(key: 'email');
+    final password = await _store.read(key: 'password');
+    if (email == null || password == null) {
+      throw StateError('not logged in');
+    }
+      final response = await _authedGet(email, password, '/support/api/sn');
+      if (response.statusCode != 200) {
+        throw response.body;
+      }
+      if (response.body == '') {
+        return [];
+      }
+      return response.body.trim().split('\n');
+  }
+
+  Future<bool> verifyMachineSerial(String serial) async {
+    final list = await fetchSerialNumbers();
+    return list.contains(serial);
+  }
+
+  Future<Response> _authedGet(
+    String email,
+    String password,
+    String path,
+  ) async {
+    final basic = base64Encode("$email:$password".codeUnits);
+    return await _httpClient.get(
+      Uri.parse('$baseUrl$path'),
+      headers: {
+        'authorization': "Basic $basic",
+      },
+    );
+  }
+}

--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -20,11 +20,7 @@ class DecentAccountService {
   }) : _httpClient = httpClient,
        _store = credentialStore;
 
-  bool _loggedIn = false;
   Future<bool> login(String email, String password) async {
-    if (_loggedIn) {
-      return _loggedIn;
-    }
     final response = await _authedGet(
       email,
       password,
@@ -34,13 +30,12 @@ class DecentAccountService {
     if (response.statusCode == 200 && response.body != '0') {
       await _store.write(key: 'email', value: email);
       await _store.write(key: 'password', value: response.body);
-      _loggedIn = true;
+      return true;
     }
-    return _loggedIn;
+    return false;
   }
 
   Future<void> logout() async {
-    _loggedIn = false;
     await _store.delete(key: 'email');
     await _store.delete(key: 'password');
   }
@@ -58,7 +53,9 @@ class DecentAccountService {
     }
     final response = await _authedGet(email, password, '/support/api/sn');
     if (response.statusCode != 200) {
-      throw response.body;
+      throw Exception(
+        'serial fetch failed (${response.statusCode}): ${response.body}',
+      );
     }
     if (response.body == '') {
       return [];
@@ -76,7 +73,7 @@ class DecentAccountService {
     String password,
     String path,
   ) async {
-    final basic = base64Encode("$email:$password".codeUnits);
+    final basic = base64Encode(utf8.encode("$email:$password"));
     return await _httpClient.get(
       Uri.parse('$baseUrl$path'),
       headers: {

--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -47,6 +47,9 @@ class DecentAccountService {
 
   Future<bool> isLoggedIn() async => await _store.read(key: 'email') != null;
 
+  /// Returns the stored email address, or null if not logged in.
+  Future<String?> getEmail() async => _store.read(key: 'email');
+
   Future<List<String>> fetchSerialNumbers() async {
     final email = await _store.read(key: 'email');
     final password = await _store.read(key: 'password');

--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -31,9 +31,9 @@ class DecentAccountService {
       '/support/api/login_test',
     );
 
-    if (response.statusCode == 200 && response.body == '1') {
+    if (response.statusCode == 200 && response.body != '0') {
       await _store.write(key: 'email', value: email);
-      await _store.write(key: 'password', value: password);
+      await _store.write(key: 'password', value: response.body);
       _loggedIn = true;
     }
     return _loggedIn;

--- a/lib/src/services/account/encrypted_credential_store.dart
+++ b/lib/src/services/account/encrypted_credential_store.dart
@@ -1,0 +1,133 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+
+/// Persists the encrypted credential blob as opaque bytes. Abstracted so the
+/// crypto logic can be unit-tested with an in-memory backend (no filesystem).
+abstract class SecretBlobStore {
+  Future<Uint8List?> read();
+  Future<void> write(Uint8List bytes);
+  Future<void> delete();
+}
+
+/// AES-256-GCM encrypted key/value credential store.
+///
+/// Backs macOS, where the Keychain (Data Protection Keychain) is unavailable to
+/// Developer-ID / sideloaded builds and returns errSecMissingEntitlement
+/// (-34018). Mirrors the pattern used by Slack/VS Code/Obsidian on macOS: an
+/// AES-GCM file whose key is bound to the machine (a copied file can't be
+/// decrypted off-host) but not to the binary signature (so it survives
+/// auto-updates).
+///
+/// The whole store is one encrypted JSON map. Each op reads, decrypts, mutates,
+/// re-encrypts with a fresh random nonce, and writes. Operations are serialized
+/// so concurrent isolates can't interleave a partial encrypt/decrypt.
+class EncryptedCredentialStore implements CredentialStore {
+  final SecretKey _key;
+  final SecretBlobStore _blob;
+  final AesGcm _algo = AesGcm.with256bits();
+
+  Future<void> _lock = Future<void>.value();
+
+  EncryptedCredentialStore({
+    required List<int> keyBytes,
+    required SecretBlobStore blob,
+  })  : _key = SecretKey(keyBytes),
+        _blob = blob;
+
+  @override
+  Future<String?> read({required String key}) =>
+      _locked(() async => (await _load())[key]);
+
+  @override
+  Future<void> write({required String key, required String value}) =>
+      _locked(() async {
+        final map = await _load();
+        map[key] = value;
+        await _save(map);
+      });
+
+  @override
+  Future<void> delete({required String key}) => _locked(() async {
+        final map = await _load();
+        if (map.remove(key) != null) {
+          await _save(map);
+        }
+      });
+
+  /// Reads and decrypts the store. A missing or undecryptable file (corruption,
+  /// machine-UUID change) is treated as an empty store rather than an error —
+  /// the user just re-logs in and the file is rewritten with the current key.
+  Future<Map<String, String>> _load() async {
+    final bytes = await _blob.read();
+    if (bytes == null || bytes.isEmpty) return {};
+    try {
+      final box = SecretBox.fromConcatenation(
+        bytes,
+        nonceLength: 12,
+        macLength: 16,
+      );
+      final clear = await _algo.decrypt(box, secretKey: _key);
+      final decoded = jsonDecode(utf8.decode(clear)) as Map<String, dynamic>;
+      return decoded.map((k, v) => MapEntry(k, v as String));
+    } catch (_) {
+      return {};
+    }
+  }
+
+  Future<void> _save(Map<String, String> map) async {
+    if (map.isEmpty) {
+      await _blob.delete();
+      return;
+    }
+    final box = await _algo.encrypt(
+      utf8.encode(jsonEncode(map)),
+      secretKey: _key,
+    );
+    await _blob.write(Uint8List.fromList(box.concatenation()));
+  }
+
+  Future<T> _locked<T>(Future<T> Function() action) {
+    final prev = _lock;
+    final completer = Completer<void>();
+    _lock = completer.future;
+    return prev.then((_) => action()).whenComplete(completer.complete);
+  }
+}
+
+/// Filesystem-backed [SecretBlobStore] with atomic writes and `chmod 600`.
+class FileBlobStore implements SecretBlobStore {
+  final String path;
+
+  FileBlobStore(this.path);
+
+  @override
+  Future<Uint8List?> read() async {
+    final file = File(path);
+    if (!await file.exists()) return null;
+    return file.readAsBytes();
+  }
+
+  @override
+  Future<void> write(Uint8List bytes) async {
+    final tmp = File('$path.tmp');
+    await tmp.writeAsBytes(bytes, flush: true);
+    await tmp.rename(path);
+    // Restrict to owner-only so other users on the machine can't read the file.
+    try {
+      await Process.run('chmod', ['600', path]);
+    } catch (_) {
+      // chmod is best-effort; the OS user-container already isolates per user.
+    }
+  }
+
+  @override
+  Future<void> delete() async {
+    final file = File(path);
+    if (await file.exists()) await file.delete();
+  }
+}

--- a/lib/src/settings/settings_controller.dart
+++ b/lib/src/settings/settings_controller.dart
@@ -61,6 +61,7 @@ class SettingsController with ChangeNotifier {
   String _wakeSchedules = '[]';
   bool _lowBatteryBrightnessLimit = false;
   bool _onboardingCompleted = false;
+  bool _accountStepSeen = false;
 
   TelemetryService? _telemetryService;
 
@@ -89,6 +90,7 @@ class SettingsController with ChangeNotifier {
   String get wakeSchedules => _wakeSchedules;
   bool get lowBatteryBrightnessLimit => _lowBatteryBrightnessLimit;
   bool get onboardingCompleted => _onboardingCompleted;
+  bool get accountStepSeen => _accountStepSeen;
 
   set telemetryService(TelemetryService service) => _telemetryService = service;
 
@@ -120,6 +122,7 @@ class SettingsController with ChangeNotifier {
     _wakeSchedules = await _settingsService.wakeSchedules();
     _lowBatteryBrightnessLimit = await _settingsService.lowBatteryBrightnessLimit();
     _onboardingCompleted = await _settingsService.onboardingCompleted();
+    _accountStepSeen = await _settingsService.accountStepSeen();
 
     // Sync telemetry consent to TelemetryService if it exists
     if (_telemetryService != null) {
@@ -372,6 +375,13 @@ class SettingsController with ChangeNotifier {
     if (value == _onboardingCompleted) return;
     _onboardingCompleted = value;
     await _settingsService.setOnboardingCompleted(value);
+    notifyListeners();
+  }
+
+  Future<void> setAccountStepSeen(bool value) async {
+    if (value == _accountStepSeen) return;
+    _accountStepSeen = value;
+    await _settingsService.setAccountStepSeen(value);
     notifyListeners();
   }
 }

--- a/lib/src/settings/settings_service.dart
+++ b/lib/src/settings/settings_service.dart
@@ -64,6 +64,8 @@ abstract class SettingsService {
   Future<void> setLowBatteryBrightnessLimit(bool value);
   Future<bool> onboardingCompleted();
   Future<void> setOnboardingCompleted(bool value);
+  Future<bool> accountStepSeen();
+  Future<void> setAccountStepSeen(bool value);
 }
 
 /// SharedPreferences-backed implementation of [SettingsService].
@@ -398,6 +400,16 @@ class SharedPreferencesSettingsService extends SettingsService {
   Future<void> setOnboardingCompleted(bool value) async {
     await prefs.setBool(SettingsKeys.onboardingCompleted.name, value);
   }
+
+  @override
+  Future<bool> accountStepSeen() async {
+    return await prefs.getBool(SettingsKeys.accountStepSeen.name) ?? false;
+  }
+
+  @override
+  Future<void> setAccountStepSeen(bool value) async {
+    await prefs.setBool(SettingsKeys.accountStepSeen.name, value);
+  }
 }
 
 enum SettingsKeys {
@@ -428,6 +440,7 @@ enum SettingsKeys {
   wakeSchedules,
   lowBatteryBrightnessLimit,
   onboardingCompleted,
+  accountStepSeen,
 }
 
 enum SimulatedDevicesTypes { machine, scale, sensor, bengle }

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -24,6 +24,7 @@ import 'package:reaprime/src/settings/settings_service.dart';
 import 'package:reaprime/src/settings/update_dialog.dart';
 import 'package:reaprime/src/services/android_updater.dart';
 import 'package:reaprime/src/services/update_check_service.dart';
+import 'package:reaprime/src/account/decent_login_form.dart';
 import 'package:reaprime/src/services/account/decent_account_service.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
 import 'package:reaprime/src/webui_support/webui_storage.dart';
@@ -644,99 +645,23 @@ class _SettingsViewState extends State<SettingsView>
 
   void _showLoginDialog(
       BuildContext context, DecentAccountService accountService) {
-    final emailController = TextEditingController();
-    final passwordController = TextEditingController();
-    var loading = false;
-    String? error;
-
     showShadDialog(
       context: context,
       builder: (dialogContext) {
-        return StatefulBuilder(
-          builder: (dialogContext, setDialogState) {
-            return ShadDialog(
-              title: const Text('Link Decent Account'),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  const SizedBox(height: 8),
-                  ShadInput(
-                    controller: emailController,
-                    placeholder: const Text('Email'),
-                    keyboardType: TextInputType.emailAddress,
-                  ),
-                  const SizedBox(height: 12),
-                  ShadInput(
-                    controller: passwordController,
-                    placeholder: const Text('Password'),
-                    obscureText: true,
-                  ),
-                  if (error != null) ...[
-                    const SizedBox(height: 8),
-                    Text(
-                      error!,
-                      style: TextStyle(
-                        color: Theme.of(context).colorScheme.error,
-                      ),
-                    ),
-                  ],
-                  const SizedBox(height: 16),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [
-                      ShadButton.outline(
-                        onPressed: () => Navigator.of(dialogContext).pop(),
-                        child: const Text('Cancel'),
-                      ),
-                      const SizedBox(width: 8),
-                      ShadButton(
-                        onPressed: loading
-                            ? null
-                            : () async {
-                                setDialogState(() {
-                                  loading = true;
-                                  error = null;
-                                });
-                                try {
-                                  final ok = await accountService.login(
-                                    emailController.text.trim(),
-                                    passwordController.text,
-                                  );
-                                  if (!dialogContext.mounted) return;
-                                  if (ok) {
-                                    Navigator.of(dialogContext).pop();
-                                    setState(() {});
-                                  } else {
-                                    setDialogState(() {
-                                      error = 'Login failed. Check your email and password.';
-                                      loading = false;
-                                    });
-                                  }
-                                } catch (e) {
-                                  if (!dialogContext.mounted) return;
-                                  setDialogState(() {
-                                    error = 'Network error: $e';
-                                    loading = false;
-                                  });
-                                }
-                              },
-                        child: loading
-                            ? const SizedBox(
-                                width: 16,
-                                height: 16,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                ),
-                              )
-                            : const Text('Login'),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            );
-          },
+        return ShadDialog(
+          title: const Text('Link Decent Account'),
+          child: Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: DecentLoginForm(
+              accountService: accountService,
+              onSuccess: () {
+                Navigator.of(dialogContext).pop();
+                setState(() {});
+              },
+              secondaryLabel: 'Cancel',
+              onSecondary: () => Navigator.of(dialogContext).pop(),
+            ),
+          ),
         );
       },
     );

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -661,18 +661,15 @@ class _SettingsViewState extends State<SettingsView>
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
                   const SizedBox(height: 8),
-                  TextField(
+                  ShadInput(
                     controller: emailController,
-                    decoration: const InputDecoration(
-                      labelText: 'Email',
-                      hintText: 'you@example.com',
-                    ),
+                    placeholder: const Text('Email'),
                     keyboardType: TextInputType.emailAddress,
                   ),
                   const SizedBox(height: 12),
-                  TextField(
+                  ShadInput(
                     controller: passwordController,
-                    decoration: const InputDecoration(labelText: 'Password'),
+                    placeholder: const Text('Password'),
                     obscureText: true,
                   ),
                   if (error != null) ...[

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -24,6 +24,7 @@ import 'package:reaprime/src/settings/settings_service.dart';
 import 'package:reaprime/src/settings/update_dialog.dart';
 import 'package:reaprime/src/services/android_updater.dart';
 import 'package:reaprime/src/services/update_check_service.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
 import 'package:reaprime/src/webui_support/webui_storage.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -47,6 +48,7 @@ class SettingsView extends StatefulWidget {
     this.beanStorageService,
     this.grinderStorageService,
     this.workflowController,
+    this.decentAccountService,
   });
 
   static const routeName = '/settings';
@@ -62,6 +64,7 @@ class SettingsView extends StatefulWidget {
   final BeanStorageService? beanStorageService;
   final GrinderStorageService? grinderStorageService;
   final WorkflowController? workflowController;
+  final DecentAccountService? decentAccountService;
 
   @override
   State<SettingsView> createState() => _SettingsViewState();
@@ -120,6 +123,8 @@ class _SettingsViewState extends State<SettingsView>
             _buildPresenceSection(),
             _buildDeviceManagementSection(),
             _buildDataManagementSection(),
+            if (widget.decentAccountService != null)
+              _buildDecentAccountSection(),
             _buildWebUISection(),
             _buildAdvancedSection(),
             _buildAboutSection(),
@@ -546,6 +551,197 @@ class _SettingsViewState extends State<SettingsView>
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildDecentAccountSection() {
+    final accountService = widget.decentAccountService!;
+
+    return Semantics(
+      explicitChildNodes: true,
+      child: ShadCard(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.account_circle_outlined, size: 20),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Decent Account',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Link your Decent Espresso account',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(
+                  context,
+                ).colorScheme.onSurface.withValues(alpha: 0.7),
+              ),
+            ),
+            const SizedBox(height: 16),
+            FutureBuilder<bool>(
+              future: accountService.isLoggedIn(),
+              builder: (context, snapshot) {
+                final loggedIn = snapshot.data ?? false;
+
+                if (loggedIn) {
+                  return FutureBuilder<String?>(
+                    future: accountService.getEmail(),
+                    builder: (context, emailSnap) {
+                      return Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Logged in as: ${emailSnap.data ?? ''}',
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                          const SizedBox(height: 12),
+                          Semantics(
+                            button: true,
+                            label: 'Unlink Decent account',
+                            child: ExcludeSemantics(
+                              child: ShadButton.destructive(
+                                onPressed: () async {
+                                  await accountService.logout();
+                                  setState(() {});
+                                },
+                                child: const Text('Unlink Account'),
+                              ),
+                            ),
+                          ),
+                        ],
+                      );
+                    },
+                  );
+                }
+
+                return Semantics(
+                  button: true,
+                  label: 'Link your Decent Espresso account',
+                  child: ExcludeSemantics(
+                    child: ShadButton.outline(
+                      onPressed: () => _showLoginDialog(context, accountService),
+                      child: const Text('Link Account'),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showLoginDialog(
+      BuildContext context, DecentAccountService accountService) {
+    final emailController = TextEditingController();
+    final passwordController = TextEditingController();
+    var loading = false;
+    String? error;
+
+    showShadDialog(
+      context: context,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (dialogContext, setDialogState) {
+            return ShadDialog(
+              title: const Text('Link Decent Account'),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const SizedBox(height: 8),
+                  TextField(
+                    controller: emailController,
+                    decoration: const InputDecoration(
+                      labelText: 'Email',
+                      hintText: 'you@example.com',
+                    ),
+                    keyboardType: TextInputType.emailAddress,
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: passwordController,
+                    decoration: const InputDecoration(labelText: 'Password'),
+                    obscureText: true,
+                  ),
+                  if (error != null) ...[
+                    const SizedBox(height: 8),
+                    Text(
+                      error!,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                    ),
+                  ],
+                  const SizedBox(height: 16),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      ShadButton.outline(
+                        onPressed: () => Navigator.of(dialogContext).pop(),
+                        child: const Text('Cancel'),
+                      ),
+                      const SizedBox(width: 8),
+                      ShadButton(
+                        onPressed: loading
+                            ? null
+                            : () async {
+                                setDialogState(() {
+                                  loading = true;
+                                  error = null;
+                                });
+                                try {
+                                  final ok = await accountService.login(
+                                    emailController.text.trim(),
+                                    passwordController.text,
+                                  );
+                                  if (!dialogContext.mounted) return;
+                                  if (ok) {
+                                    Navigator.of(dialogContext).pop();
+                                    setState(() {});
+                                  } else {
+                                    setDialogState(() {
+                                      error = 'Login failed. Check your email and password.';
+                                      loading = false;
+                                    });
+                                  }
+                                } catch (e) {
+                                  if (!dialogContext.mounted) return;
+                                  setDialogState(() {
+                                    error = 'Network error: $e';
+                                    loading = false;
+                                  });
+                                }
+                              },
+                        child: loading
+                            ? const SizedBox(
+                                width: 16,
+                                height: 16,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Text('Login'),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
     );
   }
 

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <flutter_js/flutter_js_plugin.h>
 #include <flutter_libserialport/flutter_libserialport_plugin.h>
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
@@ -19,6 +20,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_libserialport_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterLibserialportPlugin");
   flutter_libserialport_plugin_register_with_registrar(flutter_libserialport_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
   g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
   screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_js
   flutter_libserialport
+  flutter_secure_storage_linux
   screen_retriever_linux
   url_launcher_linux
   window_manager

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,6 +15,7 @@ import flutter_blue_plus_darwin
 import flutter_inappwebview_macos
 import flutter_js
 import flutter_libserialport
+import flutter_secure_storage_macos
 import network_info_plus
 import package_info_plus
 import screen_brightness_macos
@@ -37,6 +38,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
   FlutterJsPlugin.register(with: registry.registrar(forPlugin: "FlutterJsPlugin"))
   FlutterLibserialportPlugin.register(with: registry.registrar(forPlugin: "FlutterLibserialportPlugin"))
+  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   NetworkInfoPlusPlugin.register(with: registry.registrar(forPlugin: "NetworkInfoPlusPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   ScreenBrightnessMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenBrightnessMacosPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -4,6 +4,8 @@ PODS:
   - flutter_libserialport (0.0.1):
     - FlutterMacOS
     - libserialport
+  - flutter_secure_storage_macos (6.1.3):
+    - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - libserialport (0.1.1)
   - screen_retriever_macos (0.0.1):
@@ -15,6 +17,7 @@ PODS:
 DEPENDENCIES:
   - flutter_js (from `Flutter/ephemeral/.symlinks/plugins/flutter_js/macos`)
   - flutter_libserialport (from `Flutter/ephemeral/.symlinks/plugins/flutter_libserialport/macos`)
+  - flutter_secure_storage_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
   - universal_ble (from `Flutter/ephemeral/.symlinks/plugins/universal_ble/darwin`)
@@ -28,6 +31,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_js/macos
   flutter_libserialport:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_libserialport/macos
+  flutter_secure_storage_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   screen_retriever_macos:
@@ -38,6 +43,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   flutter_js: 79c3c70d33ba464c67d8eb88639a61aa718cd8b8
   flutter_libserialport: 2c523cb8d8203fc6d1b0da88190da31ac970eb93
+  flutter_secure_storage_macos: 7f45e30f838cf2659862a4e4e3ee1c347c2b3b54
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   libserialport: 1cb25e66ef3c92a8e59c2ea3820302c3fa2268cd
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -16,5 +16,9 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	</array>
 </dict>
 </plist>

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -16,9 +16,5 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	</array>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -14,5 +14,9 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	</array>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -14,9 +14,5 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	</array>
 </dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -551,12 +551,13 @@ packages:
     source: hosted
     version: "1.3.0"
   flutter_inappwebview_ios:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: flutter_inappwebview_ios
-      sha256: ae8a78829398771be863aa3c8804a9d40728e1815e66c9c966f86d2cc3ae4fd9
-      url: "https://pub.dev"
-    source: hosted
+      path: flutter_inappwebview_ios
+      ref: fc33a449b9290b127a471808e22eb7b0edebad92
+      resolved-ref: fc33a449b9290b127a471808e22eb7b0edebad92
+      url: "https://github.com/wangqiang1588/flutter_inappwebview.git"
+    source: git
     version: "1.2.0-beta.3"
   flutter_inappwebview_linux:
     dependency: "direct overridden"
@@ -566,12 +567,13 @@ packages:
     source: path
     version: "0.1.0-beta.1"
   flutter_inappwebview_macos:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: flutter_inappwebview_macos
-      sha256: "545148cb5c46475ce669ab21621e9f2ad66e05f8e80b2cf49d4018879ab52393"
-      url: "https://pub.dev"
-    source: hosted
+      path: flutter_inappwebview_macos
+      ref: fc33a449b9290b127a471808e22eb7b0edebad92
+      resolved-ref: fc33a449b9290b127a471808e22eb7b0edebad92
+      url: "https://github.com/wangqiang1588/flutter_inappwebview.git"
+    source: git
     version: "1.2.0-beta.3"
   flutter_inappwebview_platform_interface:
     dependency: transitive
@@ -644,6 +646,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.34"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.4"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   flutter_shaders:
     dependency: transitive
     description:
@@ -826,10 +876,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -923,10 +973,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: "direct main"
     description:
@@ -1600,10 +1650,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   theme_extensions_builder_annotation:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -233,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cryptography:
+    dependency: "direct main"
+    description:
+      name: cryptography
+      sha256: "3eda3029d34ec9095a27a198ac9785630fe525c0eb6a49f3d575272f8e792ef0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.0"
   dart_style:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,6 +78,7 @@ dependencies:
   firebase_performance: ^0.11.1+3
   firebase_analytics: ^12.1.0
   http: ^1.2.2
+  flutter_secure_storage: ^9.2.4
   network_info_plus: ^7.0.0
   window_manager: ^0.5.1
   flutter_inappwebview: ^6.2.0-beta
@@ -100,6 +101,20 @@ dependency_overrides:
   # Ubuntu/Debian, so the real flutter_inappwebview_linux plugin cannot build.
   flutter_inappwebview_linux:
     path: packages/flutter_inappwebview_linux_noop
+  # TEMP: Xcode 26.4 / Swift 6.3 hard-errors on the WebAuthenticationSession
+  # protocol-witness availability mismatch. Pin iOS+macOS plugins to the open
+  # upstream fix (pichillilorenzo/flutter_inappwebview#2809) until it merges and
+  # a release ships. Remove then.
+  flutter_inappwebview_ios:
+    git:
+      url: https://github.com/wangqiang1588/flutter_inappwebview.git
+      ref: fc33a449b9290b127a471808e22eb7b0edebad92
+      path: flutter_inappwebview_ios
+  flutter_inappwebview_macos:
+    git:
+      url: https://github.com/wangqiang1588/flutter_inappwebview.git
+      ref: fc33a449b9290b127a471808e22eb7b0edebad92
+      path: flutter_inappwebview_macos
   libserialport:
     git:
       url: https://github.com/tadelv/libserialport.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -85,6 +85,7 @@ dependencies:
   device_info_plus: ^12.3.0
   circular_buffer: ^0.13.0
   crypto: ^3.0.3
+  cryptography: ^2.7.0
   drift: ^2.24.0
   drift_flutter: ^0.3.0
   sqlite3_flutter_libs: ^0.6.0+eol

--- a/test/helpers/mock_settings_service.dart
+++ b/test/helpers/mock_settings_service.dart
@@ -34,6 +34,7 @@ class MockSettingsService extends SettingsService {
   String _wakeSchedules = '[]';
   bool _lowBatteryBrightnessLimit = false;
   bool _onboardingCompleted = true; // skip onboarding in tests
+  bool _accountStepSeen = true; // skip account step in tests
 
   @override
   Future<ThemeMode> themeMode() async => _themeMode;
@@ -144,4 +145,8 @@ class MockSettingsService extends SettingsService {
   Future<bool> onboardingCompleted() async => _onboardingCompleted;
   @override
   Future<void> setOnboardingCompleted(bool value) async => _onboardingCompleted = value;
+  @override
+  Future<bool> accountStepSeen() async => _accountStepSeen;
+  @override
+  Future<void> setAccountStepSeen(bool value) async => _accountStepSeen = value;
 }

--- a/test/services/account/decent_account_service_test.dart
+++ b/test/services/account/decent_account_service_test.dart
@@ -218,7 +218,7 @@ void main() {
     group('fetchSerialNumbers', () {
       late http.BaseRequest capturedRequest;
 
-      DecentAccountService _serviceWithCapture({
+      DecentAccountService serviceWithCapture({
         required int statusCode,
         required String body,
       }) {
@@ -243,7 +243,7 @@ void main() {
           // base64("test@example.com:cryptpw_abc123")
           const expectedAuth =
               'Basic dGVzdEBleGFtcGxlLmNvbTpjcnlwdHB3X2FiYzEyMw==';
-          final s = _serviceWithCapture(statusCode: 200, body: 'DE1-0001');
+          final s = serviceWithCapture(statusCode: 200, body: 'DE1-0001');
           await store.write(key: 'email', value: 'test@example.com');
           await store.write(key: 'password', value: 'cryptpw_abc123');
 

--- a/test/services/account/decent_account_service_test.dart
+++ b/test/services/account/decent_account_service_test.dart
@@ -66,7 +66,7 @@ void main() {
       /// Helper that builds a service whose MockClient captures the request
       /// and returns [statusCode]/[body], then asserts on [capturedRequest]
       /// after the async call completes.
-      DecentAccountService _serviceWithCapture({
+      DecentAccountService serviceWithCapture({
         required int statusCode,
         required String body,
       }) {
@@ -151,7 +151,7 @@ void main() {
       test('sends correctly-encoded Basic Auth header', () async {
         // base64("test@example.com:hunter2") = "dGVzdEBleGFtcGxlLmNvbTpodW50ZXIy"
         const expectedAuth = 'Basic dGVzdEBleGFtcGxlLmNvbTpodW50ZXIy';
-        final s = _serviceWithCapture(statusCode: 200, body: 'cryptpw_abc123');
+        final s = serviceWithCapture(statusCode: 200, body: 'cryptpw_abc123');
 
         await s.login('test@example.com', 'hunter2');
 
@@ -159,7 +159,7 @@ void main() {
       });
 
       test('sends Basic Auth header to /support/api/login_test', () async {
-        final s = _serviceWithCapture(statusCode: 200, body: 'cryptpw_abc123');
+        final s = serviceWithCapture(statusCode: 200, body: 'cryptpw_abc123');
 
         await s.login('test@example.com', 'hunter2');
 

--- a/test/services/account/decent_account_service_test.dart
+++ b/test/services/account/decent_account_service_test.dart
@@ -1,0 +1,347 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+
+/// In-memory fake for testing — no flutter_secure_storage dependency.
+class FakeCredentialStore implements CredentialStore {
+  final Map<String, String> _store = {};
+
+  @override
+  Future<String?> read({required String key}) async => _store[key];
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    _store[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    _store.remove(key);
+  }
+
+  // Exposed for test assertions.
+  bool get hasCredentials =>
+      _store.containsKey('email') && _store.containsKey('password');
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const _baseUrl = 'https://decentespresso.com';
+
+http_testing.MockClient _mockClient({
+  required int statusCode,
+  required String body,
+}) {
+  return http_testing.MockClient((request) async {
+    return http.Response(body, statusCode);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('DecentAccountService', () {
+    late FakeCredentialStore store;
+    late http_testing.MockClient httpClient;
+    late DecentAccountService service;
+
+    setUp(() {
+      store = FakeCredentialStore();
+      httpClient = _mockClient(statusCode: 200, body: '1');
+      service = DecentAccountService(
+        httpClient: httpClient,
+        credentialStore: store,
+        baseUrl: _baseUrl,
+      );
+    });
+
+    group('login', () {
+      late http.BaseRequest capturedRequest;
+
+      /// Helper that builds a service whose MockClient captures the request
+      /// and returns [statusCode]/[body], then asserts on [capturedRequest]
+      /// after the async call completes.
+      DecentAccountService _serviceWithCapture({
+        required int statusCode,
+        required String body,
+      }) {
+        final client = http_testing.MockClient((request) async {
+          capturedRequest = request;
+          return http.Response(body, statusCode);
+        });
+        return DecentAccountService(
+          httpClient: client,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+      }
+
+      setUp(() {
+        capturedRequest = http.Request('GET', Uri.parse('about:blank'));
+      });
+      test('returns true when API responds with "1"', () async {
+        final result = await service.login('test@example.com', 'hunter2');
+        expect(result, isTrue);
+      });
+
+      test('returns false when API responds with "0"', () async {
+        httpClient = _mockClient(statusCode: 200, body: '0');
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        final result = await service.login('test@example.com', 'wrong');
+        expect(result, isFalse);
+      });
+
+      test('returns false when API returns non-200 status', () async {
+        httpClient = _mockClient(statusCode: 500, body: '');
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        final result = await service.login('test@example.com', 'hunter2');
+        expect(result, isFalse);
+      });
+
+      test('returns false when network error occurs', () async {
+        httpClient = http_testing.MockClient(
+          (_) async => throw Exception('SocketException'),
+        );
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        expect(
+          () async => await service.login('test@example.com', 'hunter2'),
+          throwsA(isA<Exception>()),
+        );
+      });
+
+      test('persists credentials on successful login', () async {
+        await service.login('test@example.com', 'hunter2');
+        expect(await store.read(key: 'email'), 'test@example.com');
+        expect(await store.read(key: 'password'), 'hunter2');
+      });
+
+      test('does NOT persist credentials on failed login', () async {
+        httpClient = _mockClient(statusCode: 200, body: '0');
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        await service.login('test@example.com', 'wrong');
+        expect(store.hasCredentials, isFalse);
+      });
+
+      test('sends correctly-encoded Basic Auth header', () async {
+        // base64("test@example.com:hunter2") = "dGVzdEBleGFtcGxlLmNvbTpodW50ZXIy"
+        const expectedAuth = 'Basic dGVzdEBleGFtcGxlLmNvbTpodW50ZXIy';
+        final s = _serviceWithCapture(statusCode: 200, body: '1');
+
+        await s.login('test@example.com', 'hunter2');
+
+        expect(capturedRequest.headers['authorization'], expectedAuth);
+      });
+
+      test('sends Basic Auth header to /support/api/login_test', () async {
+        final s = _serviceWithCapture(statusCode: 200, body: '1');
+
+        await s.login('test@example.com', 'hunter2');
+
+        expect(
+          capturedRequest.url.toString(),
+          '$_baseUrl/support/api/login_test',
+        );
+        expect(capturedRequest.headers['authorization'], isNotNull);
+        expect(capturedRequest.headers['authorization']!, startsWith('Basic '));
+        expect(capturedRequest.method, 'GET');
+      });
+    });
+
+    group('logout', () {
+      test('clears persisted credentials', () async {
+        await service.login('test@example.com', 'hunter2');
+        expect(store.hasCredentials, isTrue);
+
+        await service.logout();
+        expect(store.hasCredentials, isFalse);
+      });
+
+      test('isLoggedIn returns false after logout', () async {
+        await service.login('test@example.com', 'hunter2');
+        await service.logout();
+        expect(await service.isLoggedIn(), isFalse);
+      });
+    });
+
+    group('isLoggedIn', () {
+      test('returns false when no credentials stored', () async {
+        expect(await service.isLoggedIn(), isFalse);
+      });
+
+      test('returns true after successful login', () async {
+        await service.login('test@example.com', 'hunter2');
+        expect(await service.isLoggedIn(), isTrue);
+      });
+
+      test('returns true when credentials are already stored from a '
+          'previous session', () async {
+        // Simulate credentials from a previous session.
+        await store.write(key: 'email', value: 'returning@example.com');
+        await store.write(key: 'password', value: 'oldpassword');
+        // Recreate service — it should pick up stored creds.
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        expect(await service.isLoggedIn(), isTrue);
+      });
+    });
+
+    group('fetchSerialNumbers', () {
+      late http.BaseRequest capturedRequest;
+
+      DecentAccountService _serviceWithCapture({
+        required int statusCode,
+        required String body,
+      }) {
+        final client = http_testing.MockClient((request) async {
+          capturedRequest = request;
+          return http.Response(body, statusCode);
+        });
+        return DecentAccountService(
+          httpClient: client,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+      }
+
+      setUp(() {
+        capturedRequest = http.Request('GET', Uri.parse('about:blank'));
+      });
+
+      test(
+        'calls /support/api/sn with Basic Auth from stored credentials',
+        () async {
+          // base64("test@example.com:hunter2") = "dGVzdEBleGFtcGxlLmNvbTpodW50ZXIy"
+          const expectedAuth = 'Basic dGVzdEBleGFtcGxlLmNvbTpodW50ZXIy';
+          final s = _serviceWithCapture(statusCode: 200, body: 'DE1-0001');
+          await store.write(key: 'email', value: 'test@example.com');
+          await store.write(key: 'password', value: 'hunter2');
+
+          await s.fetchSerialNumbers();
+
+          expect(capturedRequest.url.toString(), '$_baseUrl/support/api/sn');
+          expect(capturedRequest.headers['authorization'], expectedAuth);
+          expect(capturedRequest.method, 'GET');
+        },
+      );
+
+      test('returns parsed list of serials', () async {
+        httpClient = _mockClient(statusCode: 200, body: 'DE1-0001\nDE1-0042');
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+        await store.write(key: 'email', value: 'test@example.com');
+        await store.write(key: 'password', value: 'hunter2');
+
+        final serials = await service.fetchSerialNumbers();
+        expect(serials, ['DE1-0001', 'DE1-0042']);
+      });
+
+      test('returns empty list when API responds with empty body', () async {
+        httpClient = _mockClient(statusCode: 200, body: '');
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+        await store.write(key: 'email', value: 'test@example.com');
+        await store.write(key: 'password', value: 'hunter2');
+
+        final serials = await service.fetchSerialNumbers();
+        expect(serials, isEmpty);
+      });
+
+      test('throws on network error', () async {
+        httpClient = http_testing.MockClient(
+          (_) async => throw Exception('timeout'),
+        );
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+        await store.write(key: 'email', value: 'test@example.com');
+        await store.write(key: 'password', value: 'hunter2');
+
+        expect(
+          () => service.fetchSerialNumbers(),
+          throwsA(isA<Exception>()),
+        );
+      });
+
+      test('throws when not logged in', () async {
+        expect(
+          () => service.fetchSerialNumbers(),
+          throwsA(isA<StateError>()),
+        );
+      });
+    });
+
+    group('verifyMachineSerial', () {
+      test('returns true when serial is in account serials', () async {
+        httpClient = _mockClient(statusCode: 200, body: 'DE1-0001\nDE1-0042');
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+        await store.write(key: 'email', value: 'test@example.com');
+        await store.write(key: 'password', value: 'hunter2');
+
+        final result = await service.verifyMachineSerial('DE1-0042');
+        expect(result, isTrue);
+      });
+
+      test('returns false when serial is not in account serials', () async {
+        httpClient = _mockClient(statusCode: 200, body: 'DE1-0001');
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+        await store.write(key: 'email', value: 'test@example.com');
+        await store.write(key: 'password', value: 'hunter2');
+
+        final result = await service.verifyMachineSerial('DE1-9999');
+        expect(result, isFalse);
+      });
+
+      test('throws when not logged in', () async {
+        expect(
+          () => service.verifyMachineSerial('DE1-0001'),
+          throwsA(isA<StateError>()),
+        );
+      });
+    });
+  });
+}

--- a/test/services/account/decent_account_service_test.dart
+++ b/test/services/account/decent_account_service_test.dart
@@ -52,7 +52,7 @@ void main() {
 
     setUp(() {
       store = FakeCredentialStore();
-      httpClient = _mockClient(statusCode: 200, body: '1');
+      httpClient = _mockClient(statusCode: 200, body: 'cryptpw_abc123');
       service = DecentAccountService(
         httpClient: httpClient,
         credentialStore: store,
@@ -84,7 +84,7 @@ void main() {
       setUp(() {
         capturedRequest = http.Request('GET', Uri.parse('about:blank'));
       });
-      test('returns true when API responds with "1"', () async {
+      test('returns true when API responds with encrypted password', () async {
         final result = await service.login('test@example.com', 'hunter2');
         expect(result, isTrue);
       });
@@ -129,10 +129,11 @@ void main() {
         );
       });
 
-      test('persists credentials on successful login', () async {
+      test('persists encrypted password on successful login', () async {
         await service.login('test@example.com', 'hunter2');
         expect(await store.read(key: 'email'), 'test@example.com');
-        expect(await store.read(key: 'password'), 'hunter2');
+        // Stores the encrypted password returned by the API, not the plaintext.
+        expect(await store.read(key: 'password'), 'cryptpw_abc123');
       });
 
       test('does NOT persist credentials on failed login', () async {
@@ -150,7 +151,7 @@ void main() {
       test('sends correctly-encoded Basic Auth header', () async {
         // base64("test@example.com:hunter2") = "dGVzdEBleGFtcGxlLmNvbTpodW50ZXIy"
         const expectedAuth = 'Basic dGVzdEBleGFtcGxlLmNvbTpodW50ZXIy';
-        final s = _serviceWithCapture(statusCode: 200, body: '1');
+        final s = _serviceWithCapture(statusCode: 200, body: 'cryptpw_abc123');
 
         await s.login('test@example.com', 'hunter2');
 
@@ -158,7 +159,7 @@ void main() {
       });
 
       test('sends Basic Auth header to /support/api/login_test', () async {
-        final s = _serviceWithCapture(statusCode: 200, body: '1');
+        final s = _serviceWithCapture(statusCode: 200, body: 'cryptpw_abc123');
 
         await s.login('test@example.com', 'hunter2');
 
@@ -239,11 +240,12 @@ void main() {
       test(
         'calls /support/api/sn with Basic Auth from stored credentials',
         () async {
-          // base64("test@example.com:hunter2") = "dGVzdEBleGFtcGxlLmNvbTpodW50ZXIy"
-          const expectedAuth = 'Basic dGVzdEBleGFtcGxlLmNvbTpodW50ZXIy';
+          // base64("test@example.com:cryptpw_abc123")
+          const expectedAuth =
+              'Basic dGVzdEBleGFtcGxlLmNvbTpjcnlwdHB3X2FiYzEyMw==';
           final s = _serviceWithCapture(statusCode: 200, body: 'DE1-0001');
           await store.write(key: 'email', value: 'test@example.com');
-          await store.write(key: 'password', value: 'hunter2');
+          await store.write(key: 'password', value: 'cryptpw_abc123');
 
           await s.fetchSerialNumbers();
 
@@ -261,7 +263,7 @@ void main() {
           baseUrl: _baseUrl,
         );
         await store.write(key: 'email', value: 'test@example.com');
-        await store.write(key: 'password', value: 'hunter2');
+        await store.write(key: 'password', value: 'cryptpw_abc123');
 
         final serials = await service.fetchSerialNumbers();
         expect(serials, ['DE1-0001', 'DE1-0042']);
@@ -275,7 +277,7 @@ void main() {
           baseUrl: _baseUrl,
         );
         await store.write(key: 'email', value: 'test@example.com');
-        await store.write(key: 'password', value: 'hunter2');
+        await store.write(key: 'password', value: 'cryptpw_abc123');
 
         final serials = await service.fetchSerialNumbers();
         expect(serials, isEmpty);
@@ -291,7 +293,7 @@ void main() {
           baseUrl: _baseUrl,
         );
         await store.write(key: 'email', value: 'test@example.com');
-        await store.write(key: 'password', value: 'hunter2');
+        await store.write(key: 'password', value: 'cryptpw_abc123');
 
         expect(
           () => service.fetchSerialNumbers(),
@@ -316,7 +318,7 @@ void main() {
           baseUrl: _baseUrl,
         );
         await store.write(key: 'email', value: 'test@example.com');
-        await store.write(key: 'password', value: 'hunter2');
+        await store.write(key: 'password', value: 'cryptpw_abc123');
 
         final result = await service.verifyMachineSerial('DE1-0042');
         expect(result, isTrue);
@@ -330,7 +332,7 @@ void main() {
           baseUrl: _baseUrl,
         );
         await store.write(key: 'email', value: 'test@example.com');
-        await store.write(key: 'password', value: 'hunter2');
+        await store.write(key: 'password', value: 'cryptpw_abc123');
 
         final result = await service.verifyMachineSerial('DE1-9999');
         expect(result, isFalse);

--- a/test/services/account/encrypted_credential_store_test.dart
+++ b/test/services/account/encrypted_credential_store_test.dart
@@ -1,0 +1,116 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/account/encrypted_credential_store.dart';
+
+/// In-memory blob backend so the crypto logic can be tested without files.
+class InMemoryBlobStore implements SecretBlobStore {
+  Uint8List? bytes;
+  int writeCount = 0;
+
+  @override
+  Future<Uint8List?> read() async => bytes;
+
+  @override
+  Future<void> write(Uint8List value) async {
+    bytes = value;
+    writeCount++;
+  }
+
+  @override
+  Future<void> delete() async => bytes = null;
+}
+
+// Two distinct 32-byte keys.
+final _keyA = List<int>.generate(32, (i) => i);
+final _keyB = List<int>.generate(32, (i) => 255 - i);
+
+void main() {
+  group('EncryptedCredentialStore', () {
+    late InMemoryBlobStore blob;
+    late EncryptedCredentialStore store;
+
+    setUp(() {
+      blob = InMemoryBlobStore();
+      store = EncryptedCredentialStore(keyBytes: _keyA, blob: blob);
+    });
+
+    test('write then read returns the stored value', () async {
+      await store.write(key: 'email', value: 'a@b.com');
+      expect(await store.read(key: 'email'), 'a@b.com');
+    });
+
+    test('read of missing key returns null', () async {
+      expect(await store.read(key: 'nope'), isNull);
+    });
+
+    test('persisted blob is not plaintext', () async {
+      await store.write(key: 'password', value: 'cryptpw_secret');
+      final raw = String.fromCharCodes(blob.bytes!);
+      expect(raw.contains('cryptpw_secret'), isFalse);
+      expect(raw.contains('password'), isFalse);
+    });
+
+    test('each write uses a fresh nonce (different ciphertext)', () async {
+      await store.write(key: 'k', value: 'v');
+      final first = Uint8List.fromList(blob.bytes!);
+      await store.write(key: 'k', value: 'v');
+      final second = blob.bytes!;
+      expect(first, isNot(equals(second)));
+    });
+
+    test('multiple keys coexist', () async {
+      await store.write(key: 'email', value: 'a@b.com');
+      await store.write(key: 'password', value: 'pw');
+      expect(await store.read(key: 'email'), 'a@b.com');
+      expect(await store.read(key: 'password'), 'pw');
+    });
+
+    test('delete removes a key', () async {
+      await store.write(key: 'email', value: 'a@b.com');
+      await store.delete(key: 'email');
+      expect(await store.read(key: 'email'), isNull);
+    });
+
+    test('deleting the last key clears the blob file', () async {
+      await store.write(key: 'email', value: 'a@b.com');
+      await store.delete(key: 'email');
+      expect(blob.bytes, isNull);
+    });
+
+    test('survives a new store instance over the same blob (persistence)',
+        () async {
+      await store.write(key: 'email', value: 'a@b.com');
+      final reopened =
+          EncryptedCredentialStore(keyBytes: _keyA, blob: blob);
+      expect(await reopened.read(key: 'email'), 'a@b.com');
+    });
+
+    test('wrong key cannot decrypt — reads as empty store', () async {
+      await store.write(key: 'email', value: 'a@b.com');
+      final wrongKey =
+          EncryptedCredentialStore(keyBytes: _keyB, blob: blob);
+      expect(await wrongKey.read(key: 'email'), isNull);
+    });
+
+    test('tampered ciphertext fails the GCM tag — reads as empty store',
+        () async {
+      await store.write(key: 'email', value: 'a@b.com');
+      final tampered = Uint8List.fromList(blob.bytes!);
+      tampered[tampered.length - 1] ^= 0xFF; // flip a bit in the MAC
+      blob.bytes = tampered;
+      expect(await store.read(key: 'email'), isNull);
+    });
+
+    test('concurrent writes do not corrupt the store', () async {
+      await Future.wait([
+        store.write(key: 'a', value: '1'),
+        store.write(key: 'b', value: '2'),
+        store.write(key: 'c', value: '3'),
+      ]);
+      expect(await store.read(key: 'a'), '1');
+      expect(await store.read(key: 'b'), '2');
+      expect(await store.read(key: 'c'), '3');
+    });
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,7 @@
 #include <flutter_inappwebview_windows/flutter_inappwebview_windows_plugin_c_api.h>
 #include <flutter_js/flutter_js_plugin.h>
 #include <flutter_libserialport/flutter_libserialport_plugin.h>
+#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <screen_brightness_windows/screen_brightness_windows_plugin.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
@@ -30,6 +31,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FlutterJsPlugin"));
   FlutterLibserialportPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterLibserialportPlugin"));
+  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   ScreenBrightnessWindowsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -8,6 +8,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_inappwebview_windows
   flutter_js
   flutter_libserialport
+  flutter_secure_storage_windows
   permission_handler_windows
   screen_brightness_windows
   screen_retriever_windows


### PR DESCRIPTION
## What
- Add Decent account linking: login service (`/support/api/login_test`, `/support/api/sn`), onboarding step, and a Settings "Link Account" pane sharing one `DecentLoginForm`.
- Platform credential storage: Keychain/EncryptedSharedPrefs on iOS/Android; on macOS an AES-256-GCM file keyed by `SHA256(IOPlatformUUID ‖ bundleId)` — the Data Protection Keychain returns `errSecMissingEntitlement (-34018)` on Developer-ID builds, so Keychain isn't viable there.

## Why
Lets users link their Decent account to sync profiles/beans/shots and verify machine ownership by serial. The macOS store is machine-bound (a copied file won't decrypt off-host) but not binary-bound, so it survives auto-updates.

## Notes
- macOS testers on prior branch builds will appear logged-out once (storage moved from plaintext SharedPreferences to the encrypted file) and re-link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)