### PR TITLE
feat: serial-number ownership check + feature flag

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -197,6 +197,7 @@ class _MyAppState extends State<MyApp> {
       persistenceController: widget.persistenceController,
       settingsController: widget.settingsController,
       connectionManager: widget.connectionManager,
+      accountService: widget.decentAccountService,
       navigatorKey: NavigationService.navigatorKey,
     );
   }

--- a/lib/src/controllers/de1_state_manager.dart
+++ b/lib/src/controllers/de1_state_manager.dart
@@ -15,6 +15,7 @@ import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/realtime_shot_feature/realtime_shot_feature.dart';
 import 'package:reaprime/src/realtime_steam_feature/realtime_steam_feature.dart';
 import 'package:reaprime/src/home_feature/home_feature.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
 import 'package:reaprime/src/settings/gateway_mode.dart';
 import 'package:reaprime/src/settings/scale_power_mode.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
@@ -35,6 +36,7 @@ class De1StateManager with WidgetsBindingObserver {
   final PersistenceController _persistenceController;
   final SettingsController _settingsController;
   final ConnectionManager _connectionManager;
+  final DecentAccountService? _accountService;
   final GlobalKey<NavigatorState> _navigatorKey;
 
   StreamSubscription<Machine?>? _de1Subscription;
@@ -72,6 +74,7 @@ class De1StateManager with WidgetsBindingObserver {
     required PersistenceController persistenceController,
     required SettingsController settingsController,
     required ConnectionManager connectionManager,
+    DecentAccountService? accountService,
     required GlobalKey<NavigatorState> navigatorKey,
   }) : _de1Controller = de1Controller,
        _scaleController = scaleController,
@@ -79,6 +82,7 @@ class De1StateManager with WidgetsBindingObserver {
        _persistenceController = persistenceController,
        _settingsController = settingsController,
        _connectionManager = connectionManager,
+       _accountService = accountService,
        _navigatorKey = navigatorKey,
        _backgroundStates = _getPlatformBackgroundStates() {
     _initialize();
@@ -188,10 +192,49 @@ class De1StateManager with WidgetsBindingObserver {
     if (machine != null) {
       _logger.info('DE1 connected, starting to listen for state changes');
       _snapshotSubscription = machine.currentSnapshot.listen(_handleSnapshot);
+
+      // Trigger serial-number ownership check against the Decent account.
+      // Mirrors de1app's fetch_decent_de1_serial_numbers_for_current_login
+      // triggered after connecting to a machine.
+      final sn = machine.machineInfo.serialNumber;
+      if (sn != '0' &&
+          sn.isNotEmpty &&
+          !['mock-bengle', 'mock-de1'].contains(sn)) {
+        unawaited(_checkSerialOwnership(sn));
+      }
     } else {
       _logger.info('DE1 disconnected');
       // Clean up any active shot controller
       _cleanupShotSequencer();
+    }
+  }
+
+  /// Verifies that [serial] belongs to the logged-in Decent account.
+  /// If not, emails tech support - matching the
+  /// de1app behavior in `fetch_decent_de1_serial_numbers_for_current_login`.
+  Future<void> _checkSerialOwnership(String serial) async {
+    final account = _accountService;
+    if (account == null) return;
+
+    try {
+      final isLoggedIn = await account.isLoggedIn();
+      if (!isLoggedIn) return;
+
+      final owns = await account.verifyMachineSerial(serial);
+      if (owns) return;
+
+      // Serial not associated with this account — email support.
+      _logger.warning(
+        'Machine serial $serial not in account — emailing support',
+      );
+      try {
+        await account.emailSerialMismatch(serial);
+      } catch (e) {
+        _logger.warning('Failed to email serial mismatch: $e');
+        // Don't block the dialog — user should still see the message.
+      }
+    } catch (e) {
+      _logger.warning('Serial ownership check failed: $e');
     }
   }
 
@@ -308,8 +351,10 @@ class De1StateManager with WidgetsBindingObserver {
       // Immediate scale connect/service-discovery starves the shared
       // Android BLE radio and causes LINK_SUPERVISION_TIMEOUT on the DE1.
       if (!scaleConnected) {
-        _logger.info('Scale disconnected after sleep, deferring scan 3s '
-            'to avoid BLE radio starvation');
+        _logger.info(
+          'Scale disconnected after sleep, deferring scan 3s '
+          'to avoid BLE radio starvation',
+        );
         _deferredScaleScan?.cancel();
         _deferredScaleScan = Timer(const Duration(seconds: 3), () {
           _deferredScaleScan = null;
@@ -513,7 +558,8 @@ class De1StateManager with WidgetsBindingObserver {
       de1controller: _de1Controller,
       persistenceController: _persistenceController,
       targetProfile: _workflowController.currentWorkflow.profile,
-      targetYield: _workflowController.currentWorkflow.context?.targetYield ?? 0,
+      targetYield:
+          _workflowController.currentWorkflow.context?.targetYield ?? 0,
       bypassSAW: _settingsController.gatewayMode == GatewayMode.full,
       blockOnNoScale: _settingsController.blockOnNoScale,
       weightFlowMultiplier: _settingsController.weightFlowMultiplier,
@@ -540,11 +586,14 @@ class De1StateManager with WidgetsBindingObserver {
 
     // A blocking decision (e.g. blockOnNoScale) means no shot ran — tear down
     // without persisting so the next shot can start tracking.
-    _shotDecisionSubscription =
-        _currentShotSequencer!.decisions.listen((decision) {
+    _shotDecisionSubscription = _currentShotSequencer!.decisions.listen((
+      decision,
+    ) {
       if (decision.reason == ShotDecisionReason.noScale) {
-        _logger.info('Shot blocked (${decision.reason.name}), cleaning up '
-            'ShotSequencer without persisting');
+        _logger.info(
+          'Shot blocked (${decision.reason.name}), cleaning up '
+          'ShotSequencer without persisting',
+        );
         _cleanupShotSequencer();
       }
     });

--- a/lib/src/controllers/de1_state_manager.dart
+++ b/lib/src/controllers/de1_state_manager.dart
@@ -213,6 +213,7 @@ class De1StateManager with WidgetsBindingObserver {
   /// If not, emails tech support - matching the
   /// de1app behavior in `fetch_decent_de1_serial_numbers_for_current_login`.
   Future<void> _checkSerialOwnership(String serial) async {
+    if (!DecentAccountService.kEnableSerialVerification) return;
     final account = _accountService;
     if (account == null) return;
 

--- a/lib/src/controllers/de1_state_manager.dart
+++ b/lib/src/controllers/de1_state_manager.dart
@@ -40,6 +40,7 @@ class De1StateManager with WidgetsBindingObserver {
   final GlobalKey<NavigatorState> _navigatorKey;
 
   StreamSubscription<Machine?>? _de1Subscription;
+  final _emailedSerials = <String>{};
   StreamSubscription<MachineSnapshot>? _snapshotSubscription;
   ShotSequencer? _currentShotSequencer;
   StreamSubscription<ShotState>? _shotStateSubscription;
@@ -228,9 +229,13 @@ class De1StateManager with WidgetsBindingObserver {
       _logger.warning(
         'Machine serial $serial not in account — emailing support',
       );
+      if (_emailedSerials.contains(serial)) return;
+      _emailedSerials.add(serial);
       try {
         await account.emailSerialMismatch(serial);
+        _logger.info('Emailed support about unassociated serial $serial');
       } catch (e) {
+        _emailedSerials.remove(serial);
         _logger.warning('Failed to email serial mismatch: $e');
         // Don't block the dialog — user should still see the message.
       }

--- a/lib/src/models/device/impl/bengle/mock_bengle.dart
+++ b/lib/src/models/device/impl/bengle/mock_bengle.dart
@@ -282,7 +282,7 @@ class MockBengle extends MockDe1 implements BengleInterface {
   MachineInfo get machineInfo => MachineInfo(
         version: '1.0',
         model: 'Bengle',
-        serialNumber: '110010101',
+        serialNumber: 'mock-bengle',
         groupHeadControllerPresent: true,
         extra: {'voltage': 220, 'refillKit': false},
       );

--- a/lib/src/models/device/impl/mock_de1/mock_de1.dart
+++ b/lib/src/models/device/impl/mock_de1/mock_de1.dart
@@ -70,7 +70,7 @@ class MockDe1 implements De1Interface {
   MachineInfo get machineInfo => MachineInfo(
     version: "1337",
     model: "3",
-    serialNumber: "0001",
+    serialNumber: "mock-de1",
     groupHeadControllerPresent: false,
     extra: {},
   );

--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -10,6 +10,9 @@ abstract class CredentialStore {
 }
 
 class DecentAccountService {
+  /// Flip to true when /api/sn is live on the server.
+  static const bool kEnableSerialVerification = false;
+
   final http.Client _httpClient;
   final CredentialStore _store;
   final String baseUrl;

--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -57,7 +57,7 @@ class DecentAccountService {
     final response = await _authedGet(email, password, '/support/api/sn');
     if (response.statusCode != 200) {
       throw Exception(
-        'serial fetch failed (${response.statusCode}): ${response.body}',
+        'serial fetch failed (${response.statusCode}): ${response.body.trim()}',
       );
     }
     if (response.body.trim() == '0') {
@@ -111,15 +111,11 @@ class DecentAccountService {
     final basic = base64Encode(
       utf8.encode("${email.trim()}:${password.trim()}"),
     );
-    final url = '$baseUrl$path';
-    print('curl -H "Authorization: Basic $basic" "$url"');
-    final response = await _httpClient.get(
-      Uri.parse(url),
+    return _httpClient.get(
+      Uri.parse('$baseUrl$path'),
       headers: {
         'authorization': "Basic $basic",
       },
     );
-    print('_authedGet $path → ${response.statusCode}: ${response.body}');
-    return response;
   }
 }

--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -29,7 +29,7 @@ class DecentAccountService {
 
     if (response.statusCode == 200 && response.body != '0') {
       await _store.write(key: 'email', value: email);
-      await _store.write(key: 'password', value: response.body);
+      await _store.write(key: 'password', value: response.body.trim());
       return true;
     }
     return false;
@@ -57,7 +57,10 @@ class DecentAccountService {
         'serial fetch failed (${response.statusCode}): ${response.body}',
       );
     }
-    if (response.body == '') {
+    if (response.body.trim() == '0') {
+      throw StateError("Unexpected response: ${response.body.trim()}");
+    }
+    if (response.body.isEmpty) {
       return [];
     }
     return response.body.trim().split('\n');
@@ -68,17 +71,52 @@ class DecentAccountService {
     return list.contains(serial);
   }
 
+  /// Emails Decent tech support about a serial number not being associated
+  /// with the current user's account. Mirrors de1app's
+  /// `fetch_decent_api "email?subject=...&body=..."`.
+  Future<void> emailSerialMismatch(String serial) async {
+    final email = await _store.read(key: 'email');
+    final password = await _store.read(key: 'password');
+    if (email == null || password == null) {
+      throw StateError('not logged in');
+    }
+    final subject = Uri.encodeComponent(
+      'My machine serial number #$serial is not associated with my login',
+    );
+    final body = Uri.encodeComponent(
+      'I linked my de1app to my Decent account, and found that this '
+      'account does not list the machine #$serial I am connected to.',
+    );
+    final response = await _authedGet(
+      email,
+      password,
+      '/support/api/email?subject=$subject&body=$body',
+    );
+    final responseBody = response.body.trim();
+    if (response.statusCode != 200 || responseBody == '0') {
+      throw Exception(
+        'email serial mismatch failed (${response.statusCode}): ${response.body}',
+      );
+    }
+  }
+
   Future<http.Response> _authedGet(
     String email,
     String password,
     String path,
   ) async {
-    final basic = base64Encode(utf8.encode("$email:$password"));
-    return await _httpClient.get(
-      Uri.parse('$baseUrl$path'),
+    final basic = base64Encode(
+      utf8.encode("${email.trim()}:${password.trim()}"),
+    );
+    final url = '$baseUrl$path';
+    print('curl -H "Authorization: Basic $basic" "$url"');
+    final response = await _httpClient.get(
+      Uri.parse(url),
       headers: {
         'authorization': "Basic $basic",
       },
     );
+    print('_authedGet $path → ${response.statusCode}: ${response.body}');
+    return response;
   }
 }


### PR DESCRIPTION
## Summary

Adds serial-number ownership verification against the Decent account after DE1 connects. Mirrors de1app's `fetch_decent_de1_serial_numbers_for_current_login`.

### Changes

**New functionality:**
- `DecentAccountService.verifyMachineSerial()` — checks if a DE1 serial belongs to logged-in account via `/api/sn`
- `DecentAccountService.emailSerialMismatch()` — emails tech support when serial isn't in account
- `De1StateManager._checkSerialOwnership()` — fires on DE1 connect, gated by login state and mock detection
- Mock serial numbers changed to `mock-de1` / `mock-bengle` so mock machines skip the check

**Temporary disable (endpoint not ready):**
- `DecentAccountService.kEnableSerialVerification = false` — compile-time flag gating the entire check
- Flip to `true` when `/api/sn` is live

**Safety measures:**
- Per-serial dedup cache (`_emailedSerials`) prevents re-emailing same serial in-process
- Removed debug `print()` calls that leaked credentials to stdout
- Feature flag at top of `_checkSerialOwnership` — zero network calls when disabled

### Test plan
- Service-layer tests (32/32) cover login, fetchSerialNumbers, verifyMachineSerial
- Integration tests for `_checkSerialOwnership` + `emailSerialMismatch` deferred to follow-up PR (pending API shape finalization)