### PR TITLE
skins: bundle OverDose as a supported skin

### DIFF
--- a/skin_sources.json
+++ b/skin_sources.json
@@ -16,5 +16,9 @@
   {
     "type": "github_release",
     "repo": "tadelv/passione"
+  },
+  {
+    "type": "github_release",
+    "repo": "rotium/OverDose"
   }
 ]


### PR DESCRIPTION

  ## What

  Adds `rotium/OverDose` to `skin_sources.json` so the build-time bundler ships
  it as a supported (bundled) skin, selectable by users from the WebUI.

  ## Why

  OverDose is a recipe-driven SolidJS skin for the DE1. Bundling it gives users
  zero-touch install + automatic updates on every gateway build, instead of
  manually installing it from a GitHub release.

  ## Testing

  Built and ran on Linux against the simulated machine/scale. Confirmed
  `GET /api/v1/webui/skins` lists OverDose (`id: overdose`, `isBundled: true`),
  set it as default, and verified it serves correctly on `:3000`.

  Skin repo: https://github.com/rotium/OverDose
