### PR TITLE
fix(transport): finalize dispose chain + fix De1Controller listener leak

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,7 @@ org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m
 android.useAndroidX=true
 android.enableJetifier=true
 android.ndk.suppressMinSdkVersionError=28
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,7 +2,3 @@ org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m
 android.useAndroidX=true
 android.enableJetifier=true
 android.ndk.suppressMinSdkVersionError=28
-# This builtInKotlin flag was added automatically by Flutter migrator
-android.builtInKotlin=false
-# This newDsl flag was added automatically by Flutter migrator
-android.newDsl=false

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -673,6 +673,12 @@ class _AppRootState extends State<AppRoot> {
   final Logger _log = Logger("AppRoot");
   Key _key = UniqueKey();
 
+  @override
+  void dispose() {
+    unawaited(widget.connectionManager.dispose());
+    super.dispose();
+  }
+
   Future<void> restart() async {
     _log.info("recreating App Root");
     // TODO: need better app base logic for recreate activity

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -673,11 +673,12 @@ class _AppRootState extends State<AppRoot> {
   final Logger _log = Logger("AppRoot");
   Key _key = UniqueKey();
 
-  @override
-  void dispose() {
-    unawaited(widget.connectionManager.dispose());
-    super.dispose();
-  }
+  // NOTE: No dispose() override here — _AppRootState is torn down and
+  // recreated on every app restart (WebView crash, reinit), which must
+  // NOT tear down the DE1/scale connection. ConnectionManager.dispose()
+  // is wired but intentionally not called from here. The OS reclaims
+  // BLE handles and serial ports on process death; the subjects are
+  // harmless at exit.
 
   Future<void> restart() async {
     _log.info("recreating App Root");

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -776,7 +776,9 @@ class ConnectionManager {
     // emission and update it.
   }
 
-  void dispose() {
+  Future<void> dispose() async {
+    await de1Controller.dispose();
+    scaleController.dispose();
     _disconnectSupervisor.dispose();
     _adapterSub?.cancel();
     _disconnectExpectations.dispose();

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -350,5 +350,14 @@ class De1Controller {
       ));
     }
   }
+
+  Future<void> dispose() async {
+    await _de1?.dispose();
+    _de1 = null;
+    if (!_de1Controller.isClosed) _de1Controller.close();
+    if (!_steamDataController.isClosed) _steamDataController.close();
+    if (!_hotWaterDataController.isClosed) _hotWaterDataController.close();
+    if (!_rinseStream.isClosed) _rinseStream.close();
+  }
 }
 

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -352,6 +352,16 @@ class De1Controller {
   }
 
   Future<void> dispose() async {
+    // Cancel listeners + pending debounce before tearing down the
+    // machine. _onDisconnect() (which normally does this) is not
+    // guaranteed to fire: _de1.dispose() closes the transport subjects,
+    // which delivers onDone rather than a `disconnected` event.
+    _shotSettingsDebounce?.cancel();
+    _shotSettingsDebounce = null;
+    for (final sub in _subscriptions) {
+      await sub.cancel();
+    }
+    _subscriptions.clear();
     await _de1?.dispose();
     _de1 = null;
     if (!_de1Controller.isClosed) _de1Controller.close();

--- a/lib/src/models/device/de1_interface.dart
+++ b/lib/src/models/device/de1_interface.dart
@@ -5,6 +5,10 @@ import 'package:reaprime/src/models/device/de1_rawmessage.dart';
 import 'package:reaprime/src/models/data/utils.dart';
 
 abstract class De1Interface extends Machine {
+  /// End-of-life cleanup. Release resources held by this machine
+  /// implementation. Default is a no-op.
+  Future<void> dispose() async {}
+
   Stream<bool> get ready;
 
   Stream<De1RawMessage> get rawOutStream;

--- a/lib/src/models/device/device.dart
+++ b/lib/src/models/device/device.dart
@@ -13,11 +13,6 @@ abstract class Device {
   // tear down any connections
   Future<void> disconnect();
 
-  /// End-of-life cleanup. Release native resources, close subjects,
-  /// cancel subscriptions. Safe to call more than once. Re-using this
-  /// device after dispose is not supported. Default is a no-op.
-  Future<void> dispose() async {}
-
   Stream<ConnectionState> get connectionState;
 }
 

--- a/lib/src/models/device/device.dart
+++ b/lib/src/models/device/device.dart
@@ -13,6 +13,11 @@ abstract class Device {
   // tear down any connections
   Future<void> disconnect();
 
+  /// End-of-life cleanup. Release native resources, close subjects,
+  /// cancel subscriptions. Safe to call more than once. Re-using this
+  /// device after dispose is not supported. Default is a no-op.
+  Future<void> dispose() async {}
+
   Stream<ConnectionState> get connectionState;
 }
 

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -92,6 +92,25 @@ class UnifiedDe1 implements De1Interface {
     await _transport.disconnect();
   }
 
+  /// End-of-life cleanup. Disconnects if still connected, closes the
+  /// raw message controller, and disposes the transport (closing all
+  /// subjects and releasing native resources). Safe to call more than
+  /// once.
+  @override
+  Future<void> dispose() async {
+    // Guard: disconnect first so capability mixin onDisconnect() fires
+    // before subjects close.
+    try {
+      await disconnect();
+    } catch (_) {
+      // Transport may already be dead
+    }
+    if (!_rawMessageController.isClosed) {
+      _rawMessageController.close();
+    }
+    await _transport.dispose();
+  }
+
   @override
   Future<int> getFanThreshhold() async {
     return await _readMMRInt(MMRItem.fanThreshold);

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -183,6 +183,25 @@ class UnifiedDe1Transport {
     await _transport.writeCommand("<B>02");
   }
 
+  /// End-of-life cleanup. Closes all subjects, cancels the serial
+  /// subscription, and disposes the underlying transport. Safe to call
+  /// more than once. Re-use after dispose is not supported.
+  Future<void> dispose() async {
+    // Cancel serial subscription if active
+    await _transportSubscription?.cancel();
+    _transportSubscription = null;
+
+    // Close all BehaviorSubjects so downstream listeners see onDone
+    if (!_stateSubject.isClosed) _stateSubject.close();
+    if (!_shotSampleSubject.isClosed) _shotSampleSubject.close();
+    if (!shotSettingsSubject.isClosed) shotSettingsSubject.close();
+    if (!_waterLevelsSubject.isClosed) _waterLevelsSubject.close();
+    if (!_mmrSubject.isClosed) _mmrSubject.close();
+    if (!_fwMapRequestSubject.isClosed) _fwMapRequestSubject.close();
+
+    await _transport.dispose();
+  }
+
   Future<void> disconnect() async {
     _log.warning(
       'disconnect() called by app code',

--- a/lib/src/models/device/impl/mock_de1/mock_de1.dart
+++ b/lib/src/models/device/impl/mock_de1/mock_de1.dart
@@ -126,6 +126,11 @@ class MockDe1 implements De1Interface {
   }
 
   @override
+  Future<void> dispose() async {
+    // No-op: MockDe1 holds no native resources.
+  }
+
+  @override
   DeviceType get type => DeviceType.machine;
 
   DateTime lastIdleSnapshot = DateTime.now();

--- a/lib/src/models/device/transport/data_transport.dart
+++ b/lib/src/models/device/transport/data_transport.dart
@@ -14,5 +14,10 @@ abstract class DataTransport {
 
   /// Disconnect from the transport
   Future<void> disconnect();
+
+  /// End-of-life cleanup. Release native resources, close subjects,
+  /// cancel subscriptions. Safe to call more than once. Re-using this
+  /// transport after dispose is not supported.
+  Future<void> dispose();
 }
 

--- a/lib/src/services/ble/android_blue_plus_transport.dart
+++ b/lib/src/services/ble/android_blue_plus_transport.dart
@@ -175,7 +175,8 @@ class AndroidBluePlusTransport implements BLETransport {
   /// End-of-life cleanup — close the connection-state subject + any
   /// lingering native subscription. Re-use after dispose is not
   /// supported.
-  void dispose() {
+  @override
+  Future<void> dispose() async {
     _nativeConnectionSub?.cancel();
     _nativeConnectionSub = null;
     _charSubs.cancelAll();

--- a/lib/src/services/ble/blue_plus_transport.dart
+++ b/lib/src/services/ble/blue_plus_transport.dart
@@ -85,7 +85,8 @@ class BluePlusTransport implements BLETransport {
   /// downstream listeners see `onDone`. Also cancels any lingering
   /// native subscription. Safe to call more than once; re-using this
   /// transport after dispose is not supported.
-  void dispose() {
+  @override
+  Future<void> dispose() async {
     _nativeConnectionSub?.cancel();
     _nativeConnectionSub = null;
     _charSubs.cancelAll();

--- a/lib/src/services/ble/linux_blue_plus_transport.dart
+++ b/lib/src/services/ble/linux_blue_plus_transport.dart
@@ -179,7 +179,8 @@ class LinuxBluePlusTransport implements BLETransport {
   /// End-of-life cleanup — close the connection-state subject + any
   /// lingering native subscription. Re-use after dispose is not
   /// supported.
-  void dispose() {
+  @override
+  Future<void> dispose() async {
     _nativeConnectionSub?.cancel();
     _nativeConnectionSub = null;
     _charSubs.cancelAll();

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -137,4 +137,17 @@ class UniversalBleTransport implements BLETransport {
   Future<void> setTransportPriority(bool prioritized) async {
     // no implementation (for now)
   }
+
+  @override
+  Future<void> dispose() async {
+    _connectionStateSubscription?.cancel();
+    _connectionStateSubscription = null;
+    for (final sub in _subscriptions.values) {
+      await sub.cancel();
+    }
+    _subscriptions.clear();
+    if (!_connectionStateSubject.isClosed) {
+      _connectionStateSubject.close();
+    }
+  }
 }

--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -441,6 +441,15 @@ class AndroidSerialPort implements SerialTransport {
     await _port.write(command);
     _log.fine("wrote request: ${command.map((e) => e.toRadixString(16))}");
   }
+
+  @override
+  Future<void> dispose() async {
+    await _portSubscription?.cancel();
+    _portSubscription = null;
+    if (!_open.isClosed) _open.close();
+    if (!_rawController.isClosed) _rawController.close();
+    if (!_outputController.isClosed) _outputController.close();
+  }
 }
 
 

--- a/lib/src/services/serial/serial_service_desktop.dart
+++ b/lib/src/services/serial/serial_service_desktop.dart
@@ -418,6 +418,7 @@ class _DesktopSerialPort implements SerialTransport {
   /// End-of-life cleanup. Calls `disconnect()` to stop the reader isolate +
   /// close the tty, then frees the libserialport `sp_port` FFI handle and
   /// closes the exposed stream controllers. Safe to call more than once.
+  @override
   Future<void> dispose() async {
     try {
       await disconnect();

--- a/test/controllers/de1_controller_dispose_test.dart
+++ b/test/controllers/de1_controller_dispose_test.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+
+import '../helpers/mock_device_discovery_service.dart';
+
+/// Regression tests for De1Controller.dispose().
+///
+/// dispose() must cancel the listeners it registered in connectToDe1()
+/// (`ready` + `connectionState`) and the pending shot-settings debounce
+/// timer. It cannot rely on `_onDisconnect()` to do that: _de1.dispose()
+/// closes the transport subjects, which delivers `onDone` to the
+/// connectionState listener rather than a `disconnected` event, so
+/// `_onDisconnect()` never runs.
+void main() {
+  late MockDe1 mockDe1;
+  late DeviceController deviceController;
+  late De1Controller de1Controller;
+
+  setUp(() async {
+    mockDe1 = MockDe1();
+    deviceController = DeviceController([MockDeviceDiscoveryService()]);
+    await deviceController.initialize();
+    de1Controller = De1Controller(controller: deviceController);
+    await de1Controller.connectToDe1(mockDe1);
+
+    // Let init + the 100 ms shot-settings debounce settle so the
+    // listeners are live before we dispose.
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+  });
+
+  test('dispose cancels the connectionState listener (no events after)',
+      () async {
+    await de1Controller.dispose();
+
+    // If the connectionState listener leaked, this disconnected emit
+    // would fire _onDisconnect() → _de1Controller.add() on a now-closed
+    // subject → uncaught StateError. Capture any uncaught async error.
+    Object? uncaught;
+    await runZonedGuarded(() async {
+      // Backdoor on MockDe1 that pushes a `disconnected` event.
+      await mockDe1.setHeaterPhase2Timeout(0);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    }, (error, _) {
+      uncaught = error;
+    });
+
+    expect(uncaught, isNull,
+        reason: 'disconnected event reached a leaked listener after dispose');
+  });
+
+  test('dispose closes the de1 stream', () async {
+    final done = expectLater(de1Controller.de1, emitsThrough(emitsDone));
+    await de1Controller.dispose();
+    await done;
+  });
+
+  test('dispose is safe to call more than once', () async {
+    await de1Controller.dispose();
+    // Second call must not throw (subjects already closed, _de1 null).
+    await expectLater(de1Controller.dispose(), completes);
+  });
+}

--- a/test/controllers/display_controller_test.dart
+++ b/test/controllers/display_controller_test.dart
@@ -192,6 +192,9 @@ class _TestDe1 implements De1Interface {
   Future<void> setHeaterVoltage(De1HeaterVoltage voltage) async {}
   @override
   Future<void> setRefillKitSettings(De1RefillKitSettings settings) async {}
+
+  @override
+  Future<void> dispose() async {}
 }
 
 /// A De1Controller subclass that exposes a settable de1 subject.

--- a/test/controllers/presence_controller_test.dart
+++ b/test/controllers/presence_controller_test.dart
@@ -195,6 +195,9 @@ class _TestDe1 implements De1Interface {
   Future<void> setHeaterVoltage(De1HeaterVoltage voltage) async {}
   @override
   Future<void> setRefillKitSettings(De1RefillKitSettings settings) async {}
+
+  @override
+  Future<void> dispose() async {}
 }
 
 /// A De1Controller subclass that exposes a settable de1 subject.

--- a/test/controllers/steam_sequencer_test.dart
+++ b/test/controllers/steam_sequencer_test.dart
@@ -67,7 +67,9 @@ class _TestMachine implements De1Interface {
   }
 
   void emit(MachineSnapshot s) => _snap.add(s);
-  void dispose() => _snap.close();
+
+  @override
+  Future<void> dispose() async => _snap.close();
 
   @override
   Stream<ConnectionState> get connectionState =>

--- a/test/helpers/fake_ble_transport.dart
+++ b/test/helpers/fake_ble_transport.dart
@@ -224,5 +224,6 @@ class FakeBleTransport extends BLETransport {
     queueMmrResponseInt(MMRItem.refillKitPresent, refillKitPresent);
   }
 
-  void dispose() => _connState.close();
+  @override
+  Future<void> dispose() async => _connState.close();
 }

--- a/test/helpers/fake_connection_manager.dart
+++ b/test/helpers/fake_connection_manager.dart
@@ -76,8 +76,8 @@ class FakeConnectionManager extends ConnectionManager {
   }
 
   @override
-  void dispose() {
+  Future<void> dispose() async {
     _statusOverride.close();
-    super.dispose();
+    await super.dispose();
   }
 }

--- a/test/helpers/test_de1.dart
+++ b/test/helpers/test_de1.dart
@@ -82,7 +82,8 @@ class TestDe1 implements De1Interface {
     _connectionState.add(state);
   }
 
-  void dispose() {
+  @override
+  Future<void> dispose() async {
     snapshotSubject.close();
     _connectionState.close();
     _shotSettingsSubject.close();

--- a/test/models/device/unified_de1_crashlytics_triage_test.dart
+++ b/test/models/device/unified_de1_crashlytics_triage_test.dart
@@ -59,7 +59,8 @@ class _ControllableSerialTransport extends SerialTransport {
     _readCtl.add(chunk);
   }
 
-  void dispose() {
+  @override
+  Future<void> dispose() async {
     _connState.close();
     _readCtl.close();
   }

--- a/test/models/device/unified_de1_mmr_test.dart
+++ b/test/models/device/unified_de1_mmr_test.dart
@@ -57,7 +57,8 @@ class _QuietSerialTransport extends SerialTransport {
   @override
   Future<void> writeCommand(String command) async {}
 
-  void dispose() {
+  @override
+  Future<void> dispose() async {
     _connState.close();
   }
 }

--- a/test/models/device/unified_de1_reconnect_test.dart
+++ b/test/models/device/unified_de1_reconnect_test.dart
@@ -54,7 +54,8 @@ class _QuietSerialTransport extends SerialTransport {
   @override
   Future<void> writeCommand(String command) async {}
 
-  void dispose() {
+  @override
+  Future<void> dispose() async {
     _connState.close();
   }
 }

--- a/test/models/device/unified_de1_set_profile_test.dart
+++ b/test/models/device/unified_de1_set_profile_test.dart
@@ -69,7 +69,8 @@ class _RecordingSerialTransport extends SerialTransport {
     }
   }
 
-  void dispose() {
+  @override
+  Future<void> dispose() async {
     _connState.close();
   }
 }

--- a/test/onboarding/scan_step_test.dart
+++ b/test/onboarding/scan_step_test.dart
@@ -89,9 +89,9 @@ class MockConnectionManager extends ConnectionManager {
   Future<void> connectScale(device_scale.Scale scale) async {}
 
   @override
-  void dispose() {
+  Future<void> dispose() async {
     _statusOverride.close();
-    super.dispose();
+    await super.dispose();
   }
 }
 

--- a/test/unit/devices/hds_serial_disconnect_test.dart
+++ b/test/unit/devices/hds_serial_disconnect_test.dart
@@ -59,7 +59,8 @@ class MockSerialTransport implements SerialTransport {
     _rawController.add(data);
   }
 
-  void dispose() {
+  @override
+  Future<void> dispose() async {
     _connectionSubject.close();
     _rawController.close();
     _readController.close();

--- a/test/unit/models/acaia_scale_test.dart
+++ b/test/unit/models/acaia_scale_test.dart
@@ -67,6 +67,9 @@ class MockAcaiaBleTransport extends BLETransport {
   void simulateNotification(List<int> data) {
     _notificationCallback?.call(Uint8List.fromList(data));
   }
+
+  @override
+  Future<void> dispose() async {}
 }
 
 void main() {

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -87,7 +87,8 @@ class _DisconnectedBleTransport extends BLETransport {
     );
   }
 
-  void dispose() {
+  @override
+  Future<void> dispose() async {
     _connectionState.close();
   }
 }

--- a/test/unit/models/device/transport/logical_endpoint_test.dart
+++ b/test/unit/models/device/transport/logical_endpoint_test.dart
@@ -58,7 +58,8 @@ class _StubSerialTransport extends SerialTransport {
   @override
   Future<void> writeHexCommand(Uint8List command) async {}
 
-  void dispose() => _connState.close();
+  @override
+  Future<void> dispose() async => _connState.close();
 }
 
 void main() {

--- a/test/unit/models/unified_de1_transport_dispose_test.dart
+++ b/test/unit/models/unified_de1_transport_dispose_test.dart
@@ -1,0 +1,93 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+
+/// Fake BLE transport that tracks whether dispose was called.
+class _Fake extends BLETransport {
+  _Fake()
+      : _connState = BehaviorSubject<ConnectionState>.seeded(
+          ConnectionState.disconnected,
+        );
+
+  final BehaviorSubject<ConnectionState> _connState;
+  bool disposeCalled = false;
+
+  @override String get id => 'fake-dispose';
+  @override String get name => 'FakeDispose';
+  @override Stream<ConnectionState> get connectionState => _connState.stream;
+  @override Future<void> connect() async {}
+  @override Future<void> disconnect() async {}
+  @override Future<List<String>> discoverServices() async => [de1ServiceUUID];
+  @override
+  Future<Uint8List> read(String s, String c, {Duration? timeout}) async =>
+      Uint8List(20);
+  @override
+  Future<void> subscribe(String s, String c, void Function(Uint8List) cb) async {}
+  @override Future<void> setTransportPriority(bool prioritized) async {}
+  @override
+  Future<void> write(String s, String c, Uint8List data,
+      {bool withResponse = true, Duration? timeout}) async {}
+  @override
+  Future<void> dispose() async {
+    disposeCalled = true;
+    if (!_connState.isClosed) _connState.close();
+  }
+}
+
+// ignore: prefer_function_declarations_over_variables
+void main() {
+  test('dispose closes all subjects and calls underlying transport dispose',
+      () async {
+    final fake = _Fake();
+    final transport = UnifiedDe1Transport(transport: fake);
+
+    // Access subjects via public getters to confirm they're open
+    expect(transport.state, isA<Stream>());
+    expect(transport.shotSample, isA<Stream>());
+    expect(transport.waterLevels, isA<Stream>());
+    expect(transport.shotSettings, isA<Stream>());
+    expect(transport.mmr, isA<Stream>());
+    expect(transport.fwMapRequest, isA<Stream>());
+
+    await transport.dispose();
+
+    // Underlying transport should have been disposed
+    expect(fake.disposeCalled, isTrue);
+
+    // After dispose, subjects are closed. A closed BehaviorSubject
+    // stream emits its last value then done, so drain and verify
+    // completion (not the value itself, which is a seeded zero buffer).
+    for (final stream in [
+      transport.state,
+      transport.shotSample,
+      transport.waterLevels,
+      transport.shotSettings,
+      transport.mmr,
+      transport.fwMapRequest,
+    ]) {
+      final events = await stream.toList();
+      // Each subject was seeded with a ByteData buffer at construction.
+      // After close, toList() returns the buffered value and then
+      // completes — we just verify it completed (no timeout / hang).
+      expect(events.isNotEmpty, isTrue);
+    }
+  });
+
+  test('dispose is safe to call more than once', () async {
+    final fake = _Fake();
+    final transport = UnifiedDe1Transport(transport: fake);
+
+    await transport.dispose();
+    expect(fake.disposeCalled, isTrue);
+
+    // Second call should not throw
+    fake.disposeCalled = false;
+    await transport.dispose();
+    expect(fake.disposeCalled, isTrue);
+  });
+}

--- a/test/unit/models/unified_de1_transport_recovery_test.dart
+++ b/test/unit/models/unified_de1_transport_recovery_test.dart
@@ -75,7 +75,8 @@ class _RecoveryFakeTransport extends BLETransport {
     }
   }
 
-  void dispose() => _connState.close();
+  @override
+  Future<void> dispose() async => _connState.close();
 }
 
 void main() {

--- a/test/unit/models/unified_de1_transport_resubscribe_test.dart
+++ b/test/unit/models/unified_de1_transport_resubscribe_test.dart
@@ -43,6 +43,8 @@ class _Fake extends BLETransport {
   @override
   Future<void> write(String s, String c, Uint8List data,
       {bool withResponse = true, Duration? timeout}) async {}
+  @override
+  Future<void> dispose() async {}
 }
 
 void main() {

--- a/test/unit/services/device_matcher_test.dart
+++ b/test/unit/services/device_matcher_test.dart
@@ -55,6 +55,9 @@ class _MockBLETransport extends BLETransport {
 
   @override
   Future<void> setTransportPriority(bool prioritized) async {}
+
+  @override
+  Future<void> dispose() async {}
 }
 
 void main() {

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -122,7 +122,8 @@ class SpyDe1 implements De1Interface {
     ),
   );
 
-  void dispose() {
+  @override
+  Future<void> dispose() async {
     _shotSettings.close();
     _connectionState.close();
     _snapshot.close();


### PR DESCRIPTION
## What
- Add `dispose()` to the `DataTransport` interface and all concrete transports (BLE, serial), `UnifiedDe1Transport`, `UnifiedDe1`, and `De1Controller`; wire it through the controller chain.
- Fix `De1Controller.dispose()` leaking the `ready`/`connectionState` listeners and the shot-settings debounce timer.

## Why
Finalizes the transport `dispose` work. `De1Controller.dispose()` closed its subjects but relied on `_onDisconnect()` for listener/timer cleanup — which it bypassed, and which never fires at dispose time (closing the transport subjects delivers `onDone`, not a `disconnected` event). Left subscriptions leaked and a timer that could fire post-dispose.

`ConnectionManager.dispose()` is wired but intentionally not called from `_AppRootState` (it's torn down/recreated on app restart, which must not drop the DE1/scale connection) — see comment in `main.dart`. The OS reclaims BLE/serial on process death; the chain matters once a real caller exists.

## Test plan
- New `test/controllers/de1_controller_dispose_test.dart` — listener-cancellation case is a proven regression guard (fails without the fix, passes with it).
- `test/unit/models/unified_de1_transport_dispose_test.dart` — subjects close + idempotent dispose.
- `flutter analyze` clean; `flutter test test/controllers/` green (262 tests).