### PR TITLE
Improve first connect: early-stop on preferred machine, recover late scale

### DIFF
--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -275,6 +275,17 @@ When `connect()` is called:
    - No preferred, multiple → show picker (`machinePicker`)
 4. **Scale phase** — apply preferred scale policy (same logic as machine)
 
+**Early stop.** With a preferred machine set, the scan stops as soon as
+its targets connect rather than running the full timeout: when a preferred
+scale is also configured, only once *both* connect; when no preferred scale
+is configured, as soon as the machine connects. In the no-preferred-scale
+case a scale that advertises just after that stop would be missed, so a
+deferred (fire-and-forget) scale-only rescan is armed ~3s later — the
+machine is already usable and the scale connects in the background if one
+shows up. The delay mirrors the post-wake reconnect (lets the DE1 BLE link
+stabilise). The rescan is armed only when the scan was actually cut short,
+so a full scan that ran to completion never triggers one.
+
 ### Key Methods
 
 - `connect()` — Full scan + connect flow (machine + scale)

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -335,7 +335,7 @@ class ConnectionManager {
         scaleOnly ? null : settingsController.preferredMachineId;
     final preferredScaleId = settingsController.preferredScaleId;
     final earlyStopEnabled =
-        !scaleOnly && preferredMachineId != null && preferredScaleId != null;
+        !scaleOnly && preferredMachineId != null;
 
     final scanStartTime = DateTime.now();
 
@@ -434,11 +434,30 @@ class ConnectionManager {
     );
   }
 
-  /// Stop scan early when both preferred devices are connected.
+  /// Stop scan early based on connection state and scale preference.
+  ///
+  /// When no preferred scale is configured, stop as soon as the preferred
+  /// machine connects — the post-scan scale phase handles any discovered
+  /// scales, and an immediate stop avoids wasting 10+ seconds of scan
+  /// timeout. When a preferred scale IS configured, keep the original
+  /// behaviour: stop only when both preferred devices are connected.
   void _checkEarlyStop(bool earlyStopEnabled) {
-    if (earlyStopEnabled && _machineConnected && _scaleConnected) {
-      _log.fine('Both preferred devices connected, stopping scan early');
-      deviceScanner.stopScan();
+    if (!earlyStopEnabled) return;
+    final preferredScaleId = settingsController.preferredScaleId;
+    if (preferredScaleId == null) {
+      // No preferred scale — stop as soon as the machine connects.
+      // Scales discovered so far are still in scanResult.matchedDevices
+      // and will be handled by the post-scan scale phase.
+      if (_machineConnected) {
+        _log.fine('Machine connected (no preferred scale), stopping scan early');
+        deviceScanner.stopScan();
+      }
+    } else {
+      // Preferred scale exists — stop only when both are connected.
+      if (_machineConnected && _scaleConnected) {
+        _log.fine('Both preferred devices connected, stopping scan early');
+        deviceScanner.stopScan();
+      }
     }
   }
 

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -130,6 +130,27 @@ class ConnectionManager {
   /// outer connect()'s finally block (comms-harden #9).
   Completer<void>? _queuedScaleOnly;
 
+  /// Deferred scale-only rescan armed when the preferred machine
+  /// connects but no preferred scale is configured. The initial scan
+  /// stops the instant the machine connects (see [_checkEarlyStop]), so
+  /// a scale that advertises a beat later is missed; this recovers it.
+  Timer? _deferredScaleScan;
+
+  /// Set true by [_checkEarlyStop] when it actually cut the scan short on
+  /// machine-connect with no preferred scale. Distinguishes that case
+  /// from a full scan that simply completed without a scale — only the
+  /// former warrants a deferred rescan. Reset at the start of each full
+  /// connect.
+  bool _earlyStopFired = false;
+
+  /// Delay before the deferred scale rescan fires. Mirrors the post-wake
+  /// reconnect in `De1StateManager`: starting another scan immediately
+  /// after the DE1 connect starves the shared Android BLE radio and
+  /// risks LINK_SUPERVISION_TIMEOUT on the DE1, so we let the link
+  /// stabilise first. Overridable in tests to avoid a real wait.
+  @visibleForTesting
+  Duration deferredScaleScanDelay = const Duration(seconds: 3);
+
   ConnectionManager({
     required this.deviceScanner,
     required this.de1Controller,
@@ -280,9 +301,14 @@ class ConnectionManager {
   /// Skips machine policy entirely — use when the machine is already
   /// connected and only a scale reconnect is needed (e.g., after wake).
   ///
-  /// Early-stop: if both preferred machine and preferred scale are set,
-  /// the scan stops early once both are connected. If only one (or neither)
-  /// preference is set, the full scan runs to discover all available devices.
+  /// Early-stop: if a preferred machine is set, the scan stops early once
+  /// the machine connects (when no preferred scale is configured) or once
+  /// both preferred devices connect (when a preferred scale is set). With
+  /// no preferred machine, the full scan runs to discover all devices.
+  /// When the scan stops on machine-connect with no preferred scale, a
+  /// deferred (fire-and-forget) scale-only rescan is armed to pick up a
+  /// scale that advertised after the early stop — see
+  /// [_maybeArmDeferredScaleScan].
   ///
   /// Concurrency: a `scaleOnly` call that arrives while another `connect`
   /// is already running is queued and replayed after the in-flight call
@@ -331,6 +357,12 @@ class ConnectionManager {
   }
 
   Future<void> _connectImpl({required bool scaleOnly}) async {
+    if (!scaleOnly) {
+      // A fresh full connect supersedes any pending deferred rescan.
+      _deferredScaleScan?.cancel();
+      _deferredScaleScan = null;
+      _earlyStopFired = false;
+    }
     final preferredMachineId =
         scaleOnly ? null : settingsController.preferredMachineId;
     final preferredScaleId = settingsController.preferredScaleId;
@@ -374,6 +406,16 @@ class ConnectionManager {
         preferredScaleId,
         scanReport,
       );
+      // runScan published `scanning`. `connectScale` resolves the phase
+      // to `ready` when a scale connects; when the scale phase was a
+      // no-op (no scale found) settle it from machine state so the UI
+      // doesn't stay stuck on `scanning`.
+      if (currentStatus.phase == ConnectionPhase.scanning) {
+        _publishStatus(currentStatus.copyWith(
+          phase:
+              _machineConnected ? ConnectionPhase.ready : ConnectionPhase.idle,
+        ));
+      }
       _emitScanReport(
         scanReport: scanReport,
         preferredMachineId: null,
@@ -397,6 +439,7 @@ class ConnectionManager {
         preferredScaleId,
         scanReport,
       );
+      _maybeArmDeferredScaleScan();
       _emitScanReport(
         scanReport: scanReport,
         preferredMachineId: preferredMachineId,
@@ -417,6 +460,7 @@ class ConnectionManager {
       case ConnectMachineAction(machine: final m):
         await _connectMachineTracked(m, scanReport);
         await _runScalePhase(m, scales, preferredScaleId, scanReport);
+        _maybeArmDeferredScaleScan();
       case MachinePickerAction():
         _publishStatus(currentStatus.copyWith(
           phase: ConnectionPhase.idle,
@@ -446,10 +490,12 @@ class ConnectionManager {
     final preferredScaleId = settingsController.preferredScaleId;
     if (preferredScaleId == null) {
       // No preferred scale — stop as soon as the machine connects.
-      // Scales discovered so far are still in scanResult.matchedDevices
-      // and will be handled by the post-scan scale phase.
+      // Scales discovered so far are still in scanRun.scales and will be
+      // handled by the post-scan scale phase; a scale that advertises
+      // after this stop is recovered by _maybeArmDeferredScaleScan.
       if (_machineConnected) {
         _log.fine('Machine connected (no preferred scale), stopping scan early');
+        _earlyStopFired = true;
         deviceScanner.stopScan();
       }
     } else {
@@ -459,6 +505,34 @@ class ConnectionManager {
         deviceScanner.stopScan();
       }
     }
+  }
+
+  /// Compensate for [_checkEarlyStop] cutting the scan short. When a
+  /// preferred machine is configured but no preferred scale is, the scan
+  /// stops the instant the machine connects — a scale that advertises a
+  /// beat later would never reach the scale phase. If we land here with
+  /// the machine connected but no scale, arm a deferred scale-only rescan
+  /// to pick it up. Fire-and-forget, mirroring the post-wake reconnect in
+  /// `De1StateManager` — the machine is already `ready` and usable; the
+  /// scale connects in the background if one shows up.
+  ///
+  /// Gated on [_earlyStopFired] — the scan was *actually* cut short on
+  /// machine-connect. A full scan that ran to completion already saw
+  /// every scale that advertised, so it never arms a (pointless) rescan,
+  /// even when a preferred machine is set but resolved post-scan.
+  void _maybeArmDeferredScaleScan() {
+    if (!_earlyStopFired) return;
+    if (!_machineConnected || _scaleConnected) return;
+    _log.fine(
+      'Machine connected without a scale after an early stop; '
+      'arming deferred scale rescan in ${deferredScaleScanDelay.inSeconds}s',
+    );
+    _deferredScaleScan?.cancel();
+    _deferredScaleScan = Timer(deferredScaleScanDelay, () {
+      _deferredScaleScan = null;
+      if (_scaleConnected) return; // a scale arrived in the meantime
+      connect(scaleOnly: true); // fire-and-forget
+    });
   }
 
   /// Gate the scale phase on machine type. When the connected machine
@@ -796,6 +870,7 @@ class ConnectionManager {
   }
 
   Future<void> dispose() async {
+    _deferredScaleScan?.cancel();
     await de1Controller.dispose();
     scaleController.dispose();
     _disconnectSupervisor.dispose();

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -449,6 +449,88 @@ void main() {
         });
 
         test(
+            'only preferred machine, scale advertises after early-stop → '
+            'deferred rescan connects it',
+            () async {
+          await settingsController.setPreferredMachineId('pref-de1');
+          // No preferred scale. Fire the deferred rescan immediately.
+          connectionManager.deferredScaleScanDelay = Duration.zero;
+
+          mockScanner.scanCompleter = Completer<void>();
+
+          final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+
+          final connectFuture = connectionManager.connect();
+          await mockScanner.scanningStream.firstWhere((s) => s);
+
+          // Machine early-connects; scan stops before any scale appears.
+          mockScanner.addDevice(fakeDe1);
+          await Future.delayed(Duration.zero);
+          await Future.delayed(Duration.zero);
+
+          mockScanner.completeScan();
+          await connectFuture;
+
+          // First pass: machine connected (ready), no scale connected,
+          // scan stopped early. Rescan is armed in the background.
+          expect(mockScanner.stopScanCallCount, 1);
+          expect(mockScaleController.connectCalls, isEmpty);
+          expect(
+              connectionManager.currentStatus.phase, ConnectionPhase.ready);
+
+          // Scale shows up only now — after the early stop.
+          mockScanner.addDevice(TestScale(deviceId: 'late-scale'));
+
+          // Let the deferred rescan fire (zero delay) and its scan run.
+          await Future.delayed(const Duration(milliseconds: 1));
+          await Future.delayed(Duration.zero);
+          await Future.delayed(Duration.zero);
+          await Future.delayed(Duration.zero);
+
+          expect(mockScaleController.connectCalls, hasLength(1),
+              reason: 'deferred rescan must connect the late scale');
+          expect(
+              mockScaleController.connectCalls.first.deviceId, 'late-scale');
+          expect(
+              connectionManager.currentStatus.phase, ConnectionPhase.ready);
+        });
+
+        test(
+            'only preferred machine, no scale ever → deferred rescan is a '
+            'no-op, machine stays ready',
+            () async {
+          await settingsController.setPreferredMachineId('pref-de1');
+          connectionManager.deferredScaleScanDelay = Duration.zero;
+
+          mockScanner.scanCompleter = Completer<void>();
+
+          final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+
+          final connectFuture = connectionManager.connect();
+          await mockScanner.scanningStream.firstWhere((s) => s);
+
+          mockScanner.addDevice(fakeDe1);
+          await Future.delayed(Duration.zero);
+          await Future.delayed(Duration.zero);
+
+          mockScanner.completeScan();
+          await connectFuture;
+
+          expect(
+              connectionManager.currentStatus.phase, ConnectionPhase.ready);
+
+          // Deferred rescan fires, finds no scale, leaves machine ready.
+          await Future.delayed(const Duration(milliseconds: 1));
+          await Future.delayed(Duration.zero);
+          await Future.delayed(Duration.zero);
+          await Future.delayed(Duration.zero);
+
+          expect(mockScaleController.connectCalls, isEmpty);
+          expect(
+              connectionManager.currentStatus.phase, ConnectionPhase.ready);
+        });
+
+        test(
             'only preferred scale set → does not call stopScan',
             () async {
           await settingsController.setPreferredScaleId('pref-scale');
@@ -490,6 +572,42 @@ void main() {
           await connectFuture;
 
           expect(mockScanner.stopScanCallCount, 0);
+        });
+
+        test(
+            'full scan completed (no early stop) → no deferred rescan armed',
+            () async {
+          // No preferences → no early-stop. A single machine auto-connects
+          // via post-scan policy; the full scan already saw every scale, so
+          // a scale appearing afterwards must NOT be auto-connected by a
+          // rescan that should never have been armed.
+          connectionManager.deferredScaleScanDelay = Duration.zero;
+
+          mockScanner.scanCompleter = Completer<void>();
+
+          final fakeDe1 = _FakeDe1(deviceId: 'de1');
+
+          final connectFuture = connectionManager.connect();
+          await mockScanner.scanningStream.firstWhere((s) => s);
+
+          mockScanner.addDevice(fakeDe1);
+          await Future.delayed(Duration.zero);
+
+          mockScanner.completeScan();
+          await connectFuture;
+
+          expect(mockScanner.stopScanCallCount, 0);
+          expect(mockScaleController.connectCalls, isEmpty);
+
+          // A scale shows up after the (completed) scan. With no early stop
+          // there is no armed rescan, so it stays unconnected.
+          mockScanner.addDevice(TestScale(deviceId: 'late-scale'));
+          await Future.delayed(const Duration(milliseconds: 1));
+          await Future.delayed(Duration.zero);
+          await Future.delayed(Duration.zero);
+
+          expect(mockScaleController.connectCalls, isEmpty,
+              reason: 'a completed full scan must not arm a deferred rescan');
         });
 
         test(

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -426,10 +426,10 @@ void main() {
         });
 
         test(
-            'only preferred machine set → does not call stopScan',
+            'only preferred machine set → calls stopScan on machine connect',
             () async {
           await settingsController.setPreferredMachineId('pref-de1');
-          // No preferred scale
+          // No preferred scale — scan should stop as soon as machine connects.
 
           mockScanner.scanCompleter = Completer<void>();
 
@@ -445,7 +445,7 @@ void main() {
           mockScanner.completeScan();
           await connectFuture;
 
-          expect(mockScanner.stopScanCallCount, 0);
+          expect(mockScanner.stopScanCallCount, 1);
         });
 
         test(


### PR DESCRIPTION
## What
- Stop the scan as soon as the preferred machine connects when no preferred scale is configured (previously only stopped once *both* preferred devices connected).
- Recover a scale that advertises just after that early stop via a deferred, fire-and-forget scale-only rescan (~3s, machine stays usable meanwhile).
- Fix a latent bug the rescan exposed: the `scaleOnly` path left the phase stuck on `scanning` when no scale was found — now settles to `ready`/`idle`.

## Why
Without a preferred scale, the old logic ran the full scan timeout even after the machine was already connected — ~10s wasted on every connect. Stopping early risked silently dropping a slow-advertising scale until the next sleep/wake cycle; the deferred rescan closes that gap, gated so a completed full scan never triggers a pointless rescan.

## Test plan
- `flutter test test/controllers/connection_manager_test.dart` (69 pass, incl. new cases: late-scale recovered, no-scale no-op, full-scan-no-rescan).
- Local macOS sim smoke with `preferredScaleId` cleared: confirmed the no-preferred-scale early-stop branch fires and the scale still auto-connects, no stuck phase, no errors.