### PR TITLE
linux: don't let -Werror fail the build on Clang's -Wdeprecated-literal-operator

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -42,6 +42,16 @@ endif()
 function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_14)
   target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  # flutter_secure_storage_linux vendors an old nlohmann/json.hpp using the
+  # pre-C++23 `operator"" _json` UDL syntax. Clang (>= 17) flags it as
+  # -Wdeprecated-literal-operator, which -Werror turns into a build failure;
+  # all plugins compile through this function. Downgrade just that one
+  # diagnostic to a warning. Clang-only — GCC doesn't define this warning, and
+  # passing it there could itself trip -Werror. (Root cause is the plugin's
+  # vendored json; remove this once it updates.)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(${TARGET} PRIVATE -Wno-error=deprecated-literal-operator)
+  endif()
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
   target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
 endfunction()


### PR DESCRIPTION
# Problem
  
  On recent Clang (seen on 22.x), `flutter build linux` fails to compile
  `flutter_secure_storage_linux`: it vendors an old `nlohmann/json.hpp` that uses
  the pre-C++23 `operator"" _json` user-defined-literal syntax, which Clang flags
  as `-Wdeprecated-literal-operator`. Because `APPLY_STANDARD_SETTINGS` builds all
  targets — plugins included — with `-Wall -Werror`, that warning becomes a hard
  error and the Linux build breaks. 
  
  ## Fix
  
  Downgrade only that one diagnostic from error to warning, guarded to Clang
  (GCC doesn't define the warning, and passing it there could itself trip
  `-Werror`). `-Werror` stays in force for everything else.
  
  ## Alternatives considered
  
  - Blanket `-Wno-error` — loses `-Werror`'s safety across the board.
  - Pinning a Clang version — fragile, not portable.
  - Fixing it upstream in `flutter_secure_storage_linux` (the real root cause) —
    worth doing there too, but reaprime shouldn't be blocked on a dependency
    release. This flag can be dropped once the plugin updates its vendored json.
    
  ## Testing
  
  Builds cleanly on Clang 22.1.6 where it previously failed; GCC and older Clang
  are unaffected (the flag is gated to Clang and scoped to the one diagnostic).
  
  🤖 Generated with [Claude Code](https://claude.com/claude-co