### PR TITLE
Follow-up to the `-Wdeprecated-literal-operator` build fix — it broke the   linux-arm64 (RPi) build.

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -43,13 +43,19 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_14)
   target_compile_options(${TARGET} PRIVATE -Wall -Werror)
   # flutter_secure_storage_linux vendors an old nlohmann/json.hpp using the
-  # pre-C++23 `operator"" _json` UDL syntax. Clang (>= 17) flags it as
+  # pre-C++23 `operator"" _json` UDL syntax. Clang >= 17 flags it as
   # -Wdeprecated-literal-operator, which -Werror turns into a build failure;
   # all plugins compile through this function. Downgrade just that one
-  # diagnostic to a warning. Clang-only — GCC doesn't define this warning, and
-  # passing it there could itself trip -Werror. (Root cause is the plugin's
-  # vendored json; remove this once it updates.)
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # diagnostic to a warning.
+  #
+  # Gate to Clang >= 17: that's the version that introduced the warning (and
+  # thus the failure). On older Clang the option is unknown, and passing an
+  # unknown -Wno-error= is itself an error under -Werror
+  # (-Wunknown-warning-option) — which broke the linux-arm64 CI. GCC doesn't
+  # define the warning either. (Root cause is the plugin's vendored json;
+  # remove this once it updates.)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND
+     CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 17)
     target_compile_options(${TARGET} PRIVATE -Wno-error=deprecated-literal-operator)
   endif()
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")


### PR DESCRIPTION

  The previous guard was `CMAKE_CXX_COMPILER_ID MATCHES "Clang"` only. The
  arm64 CI runs an **older Clang** that doesn't know that warning, and passing
  an unknown `-Wno-error=deprecated-literal-operator` is *itself* an error there
  under `-Werror` (`-Wunknown-warning-option`):

      error: unknown warning option '-Werror=deprecated-literal-operator'; did
      you mean '-Werror=deprecated-copy-dtor'? [-Werror,-Wunknown-warning-option]

  `-Wdeprecated-literal-operator` was introduced in **Clang 17** — which is also
  the only range where the flutter_secure_storage json actually fails — so add a
  `CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 17` condition. Older Clang
  and GCC never receive the flag.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
