### PR TITLE
fix: send userPresent on wake by reducing throttle to 5s + deferred flush

### DIFF
--- a/lib/src/controllers/presence_controller.dart
+++ b/lib/src/controllers/presence_controller.dart
@@ -11,7 +11,9 @@ import 'package:reaprime/src/settings/settings_controller.dart';
 ///
 /// Three concerns:
 /// 1. **Heartbeat** — event-driven user presence signal, forwarded to DE1 with
-///    30-second throttling.
+///    5-second throttling. Calls during sleep are deferred and flushed
+///    immediately on wake transition, ensuring the DE1 sees a fresh
+///    `userPresent` before the refill-kit decision is made.
 /// 2. **Sleep timeout** — auto-sleep after configurable timeout with no
 ///    heartbeat.
 /// 3. **Scheduled wake** — periodically checks schedules and wakes sleeping
@@ -34,8 +36,18 @@ class PresenceController {
   StreamSubscription<MachineSnapshot>? _snapshotSubscription;
 
   /// Throttle: minimum interval between sendUserPresent() calls.
-  static const Duration _presenceThrottle = Duration(seconds: 30);
+  /// Reduced from 30s to 5s to avoid a cold `userPresent` write blocking
+  /// the wake-time signal. Further safety: calls during sleep are deferred
+  /// and flushed on wake (see [_pendingUserPresent]).
+  static const Duration _presenceThrottle = Duration(seconds: 5);
   DateTime? _lastPresenceSent;
+
+  /// True when a heartbeat arrived while the machine was asleep, meaning a
+  /// `sendUserPresent()` was skipped. Flushed on the next wake transition.
+  /// Cleared after 60s of no wake to avoid a stale flag triggering a write
+  /// on a much-later wake that doesn't need it.
+  bool _pendingUserPresent = false;
+  Timer? _pendingUserPresentTimer;
 
   /// Sleep timeout timer.
   Timer? _sleepTimer;
@@ -58,9 +70,9 @@ class PresenceController {
     required De1Controller de1Controller,
     required SettingsController settingsController,
     DateTime Function()? clock,
-  })  : _de1Controller = de1Controller,
-        _settingsController = settingsController,
-        _clock = clock ?? (() => DateTime.now());
+  }) : _de1Controller = de1Controller,
+       _settingsController = settingsController,
+       _clock = clock ?? (() => DateTime.now());
 
   /// Subscribe to DE1 connection stream, start schedule checker timer,
   /// listen to settings changes.
@@ -80,6 +92,9 @@ class PresenceController {
     _sleepTimer = null;
     _scheduleTimer?.cancel();
     _scheduleTimer = null;
+    _pendingUserPresent = false;
+    _pendingUserPresentTimer?.cancel();
+    _pendingUserPresentTimer = null;
     _keepAwakeUntil = null;
     _settingsController.removeListener(_onSettingsChanged);
   }
@@ -117,6 +132,9 @@ class PresenceController {
     _currentMachineState = null;
     _lastPresenceSent = null;
 
+    _pendingUserPresent = false;
+    _pendingUserPresentTimer?.cancel();
+    _pendingUserPresentTimer = null;
     _keepAwakeUntil = null;
     _de1 = de1;
 
@@ -130,6 +148,22 @@ class PresenceController {
 
   void _onSnapshot(MachineSnapshot snapshot) {
     final newState = snapshot.state.state;
+
+    // Detect wake-from-sleep: send deferred userPresent immediately.
+    if (_currentMachineState == MachineState.sleeping &&
+        (newState == MachineState.idle || newState == MachineState.schedIdle)) {
+      if (_pendingUserPresent) {
+        _pendingUserPresent = false;
+        _pendingUserPresentTimer?.cancel();
+        _pendingUserPresentTimer = null;
+        _lastPresenceSent = null; // clear throttle so the flush fires
+        _de1?.sendUserPresent().catchError((Object e) {
+          _log.warning('Failed to send deferred user present on wake', e);
+        });
+        _lastPresenceSent = _clock();
+      }
+    }
+
     if (newState == MachineState.sleeping &&
         _currentMachineState != MachineState.sleeping &&
         _keepAwakeUntil != null) {
@@ -168,6 +202,24 @@ class PresenceController {
     }
 
     _lastPresenceSent = now;
+
+    // If the machine is asleep, defer the write — the BLE transport may not
+    // deliver it. The deferred flag is flushed in [_onSnapshot] when the
+    // machine transitions back to idle/schedIdle.
+    if (_currentMachineState == MachineState.sleeping) {
+      _pendingUserPresent = true;
+      _pendingUserPresentTimer?.cancel();
+      _pendingUserPresentTimer = Timer(
+        const Duration(seconds: 60),
+        () {
+          _pendingUserPresent = false;
+          _log.fine('Stale deferred userPresent cleared (60s timeout)');
+        },
+      );
+      _log.fine('Deferred sendUserPresent (machine asleep)');
+      return;
+    }
+
     _de1?.sendUserPresent().catchError((Object e) {
       _log.warning('Failed to send user present', e);
     });
@@ -196,7 +248,9 @@ class PresenceController {
     if (_de1 == null) return;
 
     if (_keepAwakeUntil != null && _clock().isBefore(_keepAwakeUntil!)) {
-      _log.info('Sleep timeout suppressed by keep-awake (until $_keepAwakeUntil)');
+      _log.info(
+        'Sleep timeout suppressed by keep-awake (until $_keepAwakeUntil)',
+      );
       _resetSleepTimer();
       return;
     }
@@ -209,7 +263,8 @@ class PresenceController {
     // If machine is in an active state, restart the timer instead of sleeping
     if (_isActiveState(_currentMachineState)) {
       _log.info(
-          'Sleep timeout fired but machine is in active state ($_currentMachineState), restarting timer');
+        'Sleep timeout fired but machine is in active state ($_currentMachineState), restarting timer',
+      );
       _resetSleepTimer();
       return;
     }
@@ -289,14 +344,18 @@ class PresenceController {
 
         if (schedule.matchesTime(now)) {
           _log.info(
-              'Schedule ${schedule.id} matched at ${now.hour}:${now.minute}, waking machine');
+            'Schedule ${schedule.id} matched at ${now.hour}:${now.minute}, waking machine',
+          );
           _firedScheduleIds.add(schedule.id);
           _de1!.requestState(MachineState.schedIdle).catchError((Object e) {
             _log.warning('Failed to request schedIdle', e);
           });
           if (schedule.keepAwakeFor != null) {
-            final newExpiry = now.add(Duration(minutes: schedule.keepAwakeFor!));
-            if (_keepAwakeUntil == null || newExpiry.isAfter(_keepAwakeUntil!)) {
+            final newExpiry = now.add(
+              Duration(minutes: schedule.keepAwakeFor!),
+            );
+            if (_keepAwakeUntil == null ||
+                newExpiry.isAfter(_keepAwakeUntil!)) {
               _keepAwakeUntil = newExpiry;
               _log.info('Keep-awake window set until $_keepAwakeUntil');
             }

--- a/test/controllers/presence_controller_test.dart
+++ b/test/controllers/presence_controller_test.dart
@@ -40,36 +40,38 @@ class _FakeDiscoveryService implements DeviceDiscoveryService {
 class _TestDe1 implements De1Interface {
   final BehaviorSubject<MachineSnapshot> _snapshotSubject =
       BehaviorSubject.seeded(
-    MachineSnapshot(
-      timestamp: DateTime(2026, 1, 15, 8, 0),
-      state: const MachineStateSnapshot(
-        state: MachineState.idle,
-        substate: MachineSubstate.idle,
-      ),
-      flow: 0,
-      pressure: 0,
-      targetFlow: 0,
-      targetPressure: 0,
-      mixTemperature: 90,
-      groupTemperature: 90,
-      targetMixTemperature: 93,
-      targetGroupTemperature: 93,
-      profileFrame: 0,
-      steamTemperature: 0,
-    ),
-  );
+        MachineSnapshot(
+          timestamp: DateTime(2026, 1, 15, 8, 0),
+          state: const MachineStateSnapshot(
+            state: MachineState.idle,
+            substate: MachineSubstate.idle,
+          ),
+          flow: 0,
+          pressure: 0,
+          targetFlow: 0,
+          targetPressure: 0,
+          mixTemperature: 90,
+          groupTemperature: 90,
+          targetMixTemperature: 93,
+          targetGroupTemperature: 93,
+          profileFrame: 0,
+          steamTemperature: 0,
+        ),
+      );
 
   int sendUserPresentCount = 0;
   final List<MachineState> requestedStates = [];
 
   void emitState(MachineState state) {
     final current = _snapshotSubject.value;
-    _snapshotSubject.add(current.copyWith(
-      state: MachineStateSnapshot(
-        state: state,
-        substate: MachineSubstate.idle,
+    _snapshotSubject.add(
+      current.copyWith(
+        state: MachineStateSnapshot(
+          state: state,
+          substate: MachineSubstate.idle,
+        ),
       ),
-    ));
+    );
   }
 
   @override
@@ -104,12 +106,12 @@ class _TestDe1 implements De1Interface {
   Stream<bool> get ready => Stream.value(true);
   @override
   MachineInfo get machineInfo => MachineInfo(
-        version: '1',
-        model: '1',
-        serialNumber: '1',
-        groupHeadControllerPresent: false,
-        extra: {},
-      );
+    version: '1',
+    model: '1',
+    serialNumber: '1',
+    groupHeadControllerPresent: false,
+    extra: {},
+  );
   @override
   Stream<De1ShotSettings> get shotSettings => const Stream.empty();
   @override
@@ -183,8 +185,10 @@ class _TestDe1 implements De1Interface {
   @override
   Future<void> setHeaterIdleTemp(double val) async {}
   @override
-  Future<void> updateFirmware(Uint8List fwImage,
-      {required void Function(double progress) onProgress}) async {}
+  Future<void> updateFirmware(
+    Uint8List fwImage, {
+    required void Function(double progress) onProgress,
+  }) async {}
   @override
   Future<void> cancelFirmwareUpload() async {}
   @override
@@ -202,8 +206,9 @@ class _TestDe1 implements De1Interface {
 
 /// A De1Controller subclass that exposes a settable de1 subject.
 class _TestDe1Controller extends De1Controller {
-  final BehaviorSubject<De1Interface?> _de1Subject =
-      BehaviorSubject.seeded(null);
+  final BehaviorSubject<De1Interface?> _de1Subject = BehaviorSubject.seeded(
+    null,
+  );
 
   _TestDe1Controller({required super.controller});
 
@@ -233,7 +238,7 @@ void main() {
   });
 
   group('heartbeat() throttling', () {
-    test('two calls within 30s = only 1 sendUserPresent() call', () {
+    test('two calls within 5s = only 1 sendUserPresent() call', () {
       fakeAsync((async) {
         final controller = PresenceController(
           de1Controller: de1Controller,
@@ -247,7 +252,7 @@ void main() {
         async.flushMicrotasks();
 
         controller.heartbeat();
-        async.elapse(const Duration(seconds: 10));
+        async.elapse(const Duration(seconds: 3));
         controller.heartbeat();
         async.elapse(const Duration(seconds: 5));
 
@@ -257,7 +262,7 @@ void main() {
       });
     });
 
-    test('second call after 30s is allowed, total = 2 sendUserPresent()', () {
+    test('second call after 5s is allowed, total = 2 sendUserPresent()', () {
       fakeAsync((async) {
         final controller = PresenceController(
           de1Controller: de1Controller,
@@ -281,70 +286,74 @@ void main() {
   });
 
   group('sleep timeout', () {
-    test('heartbeat resets sleep timer - no sleep if heartbeat before timeout',
-        () {
-      fakeAsync((async) {
-        // Set 5-minute timeout for faster test
-        settingsController.setSleepTimeoutMinutes(5);
-        async.flushMicrotasks();
+    test(
+      'heartbeat resets sleep timer - no sleep if heartbeat before timeout',
+      () {
+        fakeAsync((async) {
+          // Set 5-minute timeout for faster test
+          settingsController.setSleepTimeoutMinutes(5);
+          async.flushMicrotasks();
 
-        final controller = PresenceController(
-          de1Controller: de1Controller,
-          settingsController: settingsController,
-          clock: () => clock.now(),
-        );
-        controller.initialize();
-        de1Controller.setDe1(testDe1);
-        async.flushMicrotasks();
+          final controller = PresenceController(
+            de1Controller: de1Controller,
+            settingsController: settingsController,
+            clock: () => clock.now(),
+          );
+          controller.initialize();
+          de1Controller.setDe1(testDe1);
+          async.flushMicrotasks();
 
-        controller.heartbeat();
-        async.flushMicrotasks();
+          controller.heartbeat();
+          async.flushMicrotasks();
 
-        // Advance to just before timeout (4 min 50 sec)
-        async.elapse(const Duration(minutes: 4, seconds: 50));
-        expect(testDe1.requestedStates, isEmpty);
+          // Advance to just before timeout (4 min 50 sec)
+          async.elapse(const Duration(minutes: 4, seconds: 50));
+          expect(testDe1.requestedStates, isEmpty);
 
-        // Heartbeat resets the timer
-        controller.heartbeat();
-        async.flushMicrotasks();
+          // Heartbeat resets the timer
+          controller.heartbeat();
+          async.flushMicrotasks();
 
-        // Advance past original timeout (another 20 sec — total 5 min 10 sec from start)
-        async.elapse(const Duration(seconds: 20));
-        expect(
-          testDe1.requestedStates.contains(MachineState.sleeping),
-          isFalse,
-          reason: 'heartbeat should have reset the timer',
-        );
+          // Advance past original timeout (another 20 sec — total 5 min 10 sec from start)
+          async.elapse(const Duration(seconds: 20));
+          expect(
+            testDe1.requestedStates.contains(MachineState.sleeping),
+            isFalse,
+            reason: 'heartbeat should have reset the timer',
+          );
 
-        controller.dispose();
-      });
-    });
+          controller.dispose();
+        });
+      },
+    );
 
-    test('no heartbeat for configured minutes sends requestState(sleeping)',
-        () {
-      fakeAsync((async) {
-        settingsController.setSleepTimeoutMinutes(5);
-        async.flushMicrotasks();
+    test(
+      'no heartbeat for configured minutes sends requestState(sleeping)',
+      () {
+        fakeAsync((async) {
+          settingsController.setSleepTimeoutMinutes(5);
+          async.flushMicrotasks();
 
-        final controller = PresenceController(
-          de1Controller: de1Controller,
-          settingsController: settingsController,
-          clock: () => clock.now(),
-        );
-        controller.initialize();
-        de1Controller.setDe1(testDe1);
-        async.flushMicrotasks();
+          final controller = PresenceController(
+            de1Controller: de1Controller,
+            settingsController: settingsController,
+            clock: () => clock.now(),
+          );
+          controller.initialize();
+          de1Controller.setDe1(testDe1);
+          async.flushMicrotasks();
 
-        controller.heartbeat();
-        async.flushMicrotasks();
+          controller.heartbeat();
+          async.flushMicrotasks();
 
-        async.elapse(const Duration(minutes: 5, seconds: 1));
+          async.elapse(const Duration(minutes: 5, seconds: 1));
 
-        expect(testDe1.requestedStates, contains(MachineState.sleeping));
+          expect(testDe1.requestedStates, contains(MachineState.sleeping));
 
-        controller.dispose();
-      });
-    });
+          controller.dispose();
+        });
+      },
+    );
 
     test('timeout = 0 means disabled — no sleep even after long time', () {
       fakeAsync((async) {
@@ -427,8 +436,9 @@ void main() {
           daysOfWeek: {},
           enabled: true,
         );
-        settingsController
-            .setWakeSchedules(WakeSchedule.serializeList([schedule]));
+        settingsController.setWakeSchedules(
+          WakeSchedule.serializeList([schedule]),
+        );
         async.flushMicrotasks();
 
         final controller = PresenceController(
@@ -463,8 +473,9 @@ void main() {
           daysOfWeek: {},
           enabled: true,
         );
-        settingsController
-            .setWakeSchedules(WakeSchedule.serializeList([schedule]));
+        settingsController.setWakeSchedules(
+          WakeSchedule.serializeList([schedule]),
+        );
         async.flushMicrotasks();
 
         final controller = PresenceController(
@@ -593,8 +604,9 @@ void main() {
           enabled: true,
           keepAwakeFor: 60,
         );
-        settingsController
-            .setWakeSchedules(WakeSchedule.serializeList([schedule]));
+        settingsController.setWakeSchedules(
+          WakeSchedule.serializeList([schedule]),
+        );
         async.flushMicrotasks();
 
         final controller = PresenceController(
@@ -643,8 +655,9 @@ void main() {
           enabled: true,
           keepAwakeFor: 10,
         );
-        settingsController
-            .setWakeSchedules(WakeSchedule.serializeList([schedule]));
+        settingsController.setWakeSchedules(
+          WakeSchedule.serializeList([schedule]),
+        );
         async.flushMicrotasks();
 
         final controller = PresenceController(
@@ -688,8 +701,9 @@ void main() {
           enabled: true,
           keepAwakeFor: 60,
         );
-        settingsController
-            .setWakeSchedules(WakeSchedule.serializeList([schedule]));
+        settingsController.setWakeSchedules(
+          WakeSchedule.serializeList([schedule]),
+        );
         async.flushMicrotasks();
 
         final controller = PresenceController(
@@ -731,8 +745,9 @@ void main() {
           daysOfWeek: {},
           enabled: true,
         );
-        settingsController
-            .setWakeSchedules(WakeSchedule.serializeList([schedule]));
+        settingsController.setWakeSchedules(
+          WakeSchedule.serializeList([schedule]),
+        );
         async.flushMicrotasks();
 
         final controller = PresenceController(
@@ -779,8 +794,9 @@ void main() {
             keepAwakeFor: 120,
           ),
         ];
-        settingsController
-            .setWakeSchedules(WakeSchedule.serializeList(schedules));
+        settingsController.setWakeSchedules(
+          WakeSchedule.serializeList(schedules),
+        );
         async.flushMicrotasks();
 
         final controller = PresenceController(


### PR DESCRIPTION
## Problem

Three refill-kit tickets report the refill kit never activates after user-initiated wake:

- BC 9945389750 — John: refill kit doesn't fire when tapping screen to wake DE1
- BC 9946256953 — John: refill kit works with tcl app but not DA
- GH #260 — User log dump from Samsung A9, same complaint

Log analysis from m50mini confirmed the root cause across 3 wake-ups:

| Wake-up | userPresent timing | Outcome |
|---------|------------------|---------|
| #1 — 2 Jun 15:26 | Throttled (9s after last heartbeat) | ❌ Blocked |
| #2 — 3 Jun 07:05 | Throttled (14s after last heartbeat) | ❌ Blocked, arrived 25s late |
| #3 — 3 Jun 07:24 | Sent 240ms before wake (throttle expired) | ✅ Accidental success |

## Root Cause

`PresenceController._sendPresenceThrottled()` had a 30-second throttle that blocked the critical `userPresent` MMR write (address `0x803860`) when the user tapped to wake the machine within 30s of the last heartbeat. The DE1 FW likely clears `userPresent` during sleep, so a fresh write at wake transition is required for the refill kit to activate.

## Fix

1. **Reduce throttle from 30s to 5s** — narrows the race window significantly
2. **Defer writes during sleep, flush on wake** — if a heartbeat arrives while machine is asleep, sets `_pendingUserPresent` flag; flushed immediately in `_onSnapshot()` on `sleeping → idle/schedIdle` transition
3. **60s stale timeout** — clears `_pendingUserPresent` if machine doesn't wake within 60s

## Tests

1400/1400 passing, including updated throttle tests (now test 5s boundary instead of 30s).