### PR TITLE
fix(scale): reconnect on any transition out of sleeping

### DIFF
--- a/lib/src/controllers/de1_state_manager.dart
+++ b/lib/src/controllers/de1_state_manager.dart
@@ -326,9 +326,11 @@ class De1StateManager with WidgetsBindingObserver {
       }
     }
 
-    // Transition from sleeping to idle -> wake scale or trigger reconnect scan
+    // Transition out of sleeping -> wake scale or trigger reconnect scan.
+    // Catches sleeping → idle, sleeping → schedIdle, sleeping → heating,
+    // and any other transitional state the DE1 firmware may emit during wake.
     if (_previousMachineState == MachineState.sleeping &&
-        currentState == MachineState.idle) {
+        currentState != MachineState.sleeping) {
       _logger.info('Machine waking up from sleep');
 
       // Check if scale is connected


### PR DESCRIPTION
## Problem

When the DE1 wakes from sleep, the scale was not automatically reconnecting. The wake handler in `De1StateManager._handleScalePowerManagement` only matched a direct `sleeping → idle` transition, but the DE1 firmware may emit intermediate states (e.g. `schedIdle`, `heating`) during wake:

1. `sleeping → schedIdle` — handler skips because `currentState != idle`
2. `schedIdle → idle` — handler skips because `_previousMachineState != sleeping`

Both transitions missed, so the deferred scale scan never fired.

## Fix

Changed the condition from matching only `sleeping → idle` to matching **any** transition out of sleeping:

```dart
// before
if (_previousMachineState == MachineState.sleeping &&
    currentState == MachineState.idle) {

// after
if (_previousMachineState == MachineState.sleeping &&
    currentState != MachineState.sleeping) {
```

The rest of the handler already gates correctly: if the scale is still connected it just wakes the display; if disconnected it triggers a deferred scale-only scan. No behavioral change for the direct `sleeping → idle` path.