### PR TITLE
fix(scale): prevent HDS display from turning on while machine is asleep

### DIFF
--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -137,7 +137,9 @@ class DecentScale implements Scale {
         await _sendHeartBeat();
       });
       await _sendHeartBeat();
-      await _sendOledOn();
+      if (!_isSleeping) {
+        await _sendOledOn();
+      }
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
       _log.warning('Failed to initialize scale: $e');
@@ -196,15 +198,11 @@ class DecentScale implements Scale {
   }
 
   Future<void> _sendHeartBeat() async {
-    if (_isSleeping) {
-      // Scale display is off — no heartbeat needed (scale won't auto-sleep
-      // when we already told it to sleep, and it won't send notifications
-      // for the watchdog to observe).
-      return;
-    }
     _log.finest("send hb");
     // Heartbeat ping: tells the scale the app is still alive so it won't
-    // auto-sleep. Does NOT produce a BLE notification response — watchdog
+    // auto-sleep or disconnect. Send even when _isSleeping — without it
+    // HDS firmware times out and disconnects BLE, which wakes the display.
+    // Does NOT produce a BLE notification response — watchdog
     // is fed by weight notifications (0xCE/0xCA) while scale is awake.
     List<int> payload = [0x03, 0x0A, 0x03, 0xFF, 0xFF, 0x00, 0x0A];
     try {


### PR DESCRIPTION
## What

Stops the HDS (Decent Scale) display from turning back on while the machine is in sleep mode when `ScalePowerMode.displayOff` is active.

## Why

When the machine enters sleep, the app calls `sleepDisplay()` which sends an OLED-off command and sets `_isSleeping = true`. The heartbeat loop then stops sending pings (guarded by `_isSleeping`). After ~10 seconds without a heartbeat, the HDS firmware times out, disconnects BLE, and wakes the display as a side effect of the disconnect routine.

## How

Two changes in `DecentScale` (BLE scale only; the serial `HDSSerial` has no heartbeat mechanism):

1. **`_sendHeartBeat()`** — removed the early return when `_isSleeping`. The heartbeat ping payload (`0x03 0x0A 0x03 0xFF 0xFF 0x00 0x0A`) only resets the HDS internal timer and does not affect the display. Sending it during sleep keeps the BLE connection alive and prevents the firmware-side disconnect that wakes the display.

2. **`onConnect()`** — added `if (!_isSleeping)` guard before `_sendOledOn()`. If a BLE reconnect occurs for any other reason while `_isSleeping` is true, the display stays off.

The periodic `_sendOledOn()` at the 5-minute heartbeat log was already guarded by `!_isSleeping` — no change needed there.