### PR TITLE
feat(update): add Download action to update notification

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ import 'package:reaprime/src/controllers/workflow_device_sync.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+import 'package:reaprime/src/services/android_updater.dart';
 import 'package:reaprime/src/services/blue_plus_discovery_service.dart';
 import 'package:reaprime/src/services/ble/linux_ble_discovery_service.dart';
 import 'package:reaprime/src/services/database/database.dart' hide Workflow;
@@ -574,15 +575,35 @@ class AppLifecycleObserver with WidgetsBindingObserver {
 
     final controller = messenger.showSnackBar(
       SnackBar(
-        content: Text('Update available: ${updateInfo.version}'),
-        action: SnackBarAction(
-          label: 'View',
-          onPressed: () {
-            _showUpdateDialog(context, updateInfo);
-          },
+        content: Row(
+          children: [
+            Expanded(
+              child: Text('Update: ${updateInfo.version}'),
+            ),
+            SnackBarAction(
+              label: 'View',
+              onPressed: () {
+                _showUpdateDialog(context, updateInfo);
+              },
+            ),
+            SnackBarAction(
+              label: 'Download',
+              onPressed: () {
+                if (Platform.isAndroid) {
+                  _showAndroidDownloadDialog(context, updateInfo);
+                } else {
+                  final releaseUrl =
+                      updateCheckService?.getReleaseUrl();
+                  if (releaseUrl != null) {
+                    launchUrl(Uri.parse(releaseUrl));
+                  }
+                }
+              },
+            ),
+          ],
         ),
         showCloseIcon: true,
-        duration: const Duration(days: 1), // Persistent snackbar
+        duration: const Duration(days: 1),
         behavior: SnackBarBehavior.floating,
       ),
     );
@@ -597,19 +618,74 @@ class AppLifecycleObserver with WidgetsBindingObserver {
 
   void _showUpdateDialog(BuildContext context, dynamic updateInfo) async {
     if (Platform.isAndroid) {
-      // On Android, navigate to settings where user can download and install
-      Navigator.of(context).pushNamed('/settings');
+      _showAndroidDownloadDialog(context, updateInfo as UpdateInfo);
     } else {
-      // On other platforms, open the release page in browser
+      final info = updateInfo as UpdateInfo;
       final releaseUrl = updateCheckService?.getReleaseUrl();
-      if (releaseUrl != null) {
-        try {
-          await launchUrl(Uri.parse(releaseUrl));
-        } catch (e) {
-          _log.warning('Failed to open release URL', e);
-        }
-      }
+      showDialog(
+        context: context,
+        builder:
+            (ctx) => AlertDialog(
+              title: Text('Update ${info.version}'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Version ${info.version} is available'),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Current version: ${BuildInfo.version}',
+                  ),
+                  if (info.releaseNotes.isNotEmpty) ...[
+                    const SizedBox(height: 16),
+                    const Text(
+                      'Release Notes:',
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 8),
+                    Container(
+                      constraints:
+                          const BoxConstraints(maxHeight: 200),
+                      child: SingleChildScrollView(
+                        child: Text(info.releaseNotes),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(ctx).pop(),
+                  child: const Text('Later'),
+                ),
+                if (releaseUrl != null)
+                  ElevatedButton(
+                    onPressed: () {
+                      Navigator.of(ctx).pop();
+                      launchUrl(Uri.parse(releaseUrl));
+                    },
+                    child: const Text('Download'),
+                  ),
+              ],
+            ),
+      );
     }
+  }
+
+  /// Show a download+install dialog that starts downloading immediately.
+  void _showAndroidDownloadDialog(
+    BuildContext context,
+    UpdateInfo updateInfo,
+  ) {
+    final updater = AndroidUpdater(owner: 'tadelv', repo: 'reaprime');
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => _AndroidQuickUpdateDialog(
+        updateInfo: updateInfo,
+        updater: updater,
+      ),
+    );
   }
 
   void dispose() {
@@ -789,5 +865,119 @@ class _AppRootState extends State<AppRoot> {
         ],
       ),
     ];
+  }
+}
+
+/// Minimal update dialog that starts downloading immediately.
+/// Used from the persistent SnackBar "Download" action on Android.
+class _AndroidQuickUpdateDialog extends StatefulWidget {
+  final UpdateInfo updateInfo;
+  final AndroidUpdater updater;
+
+  const _AndroidQuickUpdateDialog({
+    required this.updateInfo,
+    required this.updater,
+  });
+
+  @override
+  State<_AndroidQuickUpdateDialog> createState() =>
+      _AndroidQuickUpdateDialogState();
+}
+
+class _AndroidQuickUpdateDialogState
+    extends State<_AndroidQuickUpdateDialog> {
+  bool _isDownloading = true;
+  bool _isInstalling = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _startDownload();
+  }
+
+  Future<void> _startDownload() async {
+    try {
+      final path = await widget.updater.downloadUpdate(widget.updateInfo);
+      if (!mounted) return;
+      setState(() {
+        _isDownloading = false;
+        _isInstalling = true;
+      });
+      final success = await widget.updater.installUpdate(path);
+      if (!mounted) return;
+      if (success) {
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Update installation started. Follow the on-screen prompts.',
+            ),
+          ),
+        );
+      } else {
+        setState(() {
+          _isInstalling = false;
+          _error =
+              'Install permission required. Grant permission and try again.';
+        });
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'Failed: $e';
+        _isDownloading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text('Update ${widget.updateInfo.version}'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (_isDownloading) ...[
+            const LinearProgressIndicator(),
+            const SizedBox(height: 12),
+            const Text('Downloading update…'),
+          ],
+          if (_isInstalling) ...[
+            const LinearProgressIndicator(),
+            const SizedBox(height: 12),
+            const Text('Installing update…'),
+          ],
+          if (_error != null) ...[
+            const SizedBox(height: 12),
+            Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: Colors.red.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Text(_error!, style: const TextStyle(color: Colors.red)),
+            ),
+          ],
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: _isDownloading ? null : () => Navigator.of(context).pop(),
+          child: const Text('Close'),
+        ),
+        if (_error != null)
+          ElevatedButton(
+            onPressed: () {
+              setState(() {
+                _error = null;
+                _isDownloading = true;
+              });
+              _startDownload();
+            },
+            child: const Text('Retry'),
+          ),
+      ],
+    );
   }
 }

--- a/lib/src/services/update_check_service.dart
+++ b/lib/src/services/update_check_service.dart
@@ -142,6 +142,19 @@ class UpdateCheckService {
     _availableUpdate = null;
   }
 
+  /// Force an update to appear for testing. Only use in debug builds.
+  void debugForceUpdate() {
+    _log.info('DEBUG: forcing fake update notification');
+    _availableUpdate = UpdateInfo(
+      version: '99.0.0',
+      downloadUrl:
+          'https://github.com/tadelv/reaprime/releases/latest',
+      releaseNotes: 'Fake update for testing the download banner.',
+      isPrerelease: false,
+      tagName: 'v99.0.0',
+    );
+  }
+
   /// Skip the current update version permanently
   Future<void> skipCurrentUpdate() async {
     final version = _availableUpdate?.version;

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/services/foreground_service.dart';
@@ -269,10 +270,9 @@ class _SettingsViewState extends State<SettingsView>
                   onPressed: () {
                     Navigator.of(context).push(
                       MaterialPageRoute(
-                        builder:
-                            (_) => BatteryChargingSettingsPage(
-                              controller: widget.controller,
-                            ),
+                        builder: (_) => BatteryChargingSettingsPage(
+                          controller: widget.controller,
+                        ),
                       ),
                     );
                   },
@@ -353,12 +353,11 @@ class _SettingsViewState extends State<SettingsView>
                   onPressed: () {
                     Navigator.of(context).push(
                       MaterialPageRoute(
-                        builder:
-                            (_) => PresenceSettingsPage(
-                              controller: widget.controller,
-                              keepAwakeUntil:
-                                  widget.presenceController.keepAwakeUntil,
-                            ),
+                        builder: (_) => PresenceSettingsPage(
+                          controller: widget.controller,
+                          keepAwakeUntil:
+                              widget.presenceController.keepAwakeUntil,
+                        ),
                       ),
                     );
                   },
@@ -429,11 +428,10 @@ class _SettingsViewState extends State<SettingsView>
                   onPressed: () {
                     Navigator.of(context).push(
                       MaterialPageRoute(
-                        builder:
-                            (_) => DeviceManagementPage(
-                              settingsController: widget.controller,
-                              deviceController: widget.deviceController,
-                            ),
+                        builder: (_) => DeviceManagementPage(
+                          settingsController: widget.controller,
+                          deviceController: widget.deviceController,
+                        ),
                       ),
                     );
                   },
@@ -530,18 +528,14 @@ class _SettingsViewState extends State<SettingsView>
                   onPressed: () {
                     Navigator.of(context).push(
                       MaterialPageRoute(
-                        builder:
-                            (_) => DataManagementPage(
-                              controller: widget.controller,
-                              persistenceController:
-                                  widget.persistenceController,
-                              profileStorageService:
-                                  widget.profileStorageService,
-                              beanStorageService: widget.beanStorageService,
-                              grinderStorageService:
-                                  widget.grinderStorageService,
-                              workflowController: widget.workflowController,
-                            ),
+                        builder: (_) => DataManagementPage(
+                          controller: widget.controller,
+                          persistenceController: widget.persistenceController,
+                          profileStorageService: widget.profileStorageService,
+                          beanStorageService: widget.beanStorageService,
+                          grinderStorageService: widget.grinderStorageService,
+                          workflowController: widget.workflowController,
+                        ),
                       ),
                     );
                   },
@@ -630,7 +624,8 @@ class _SettingsViewState extends State<SettingsView>
                   label: 'Link your Decent Espresso account',
                   child: ExcludeSemantics(
                     child: ShadButton.outline(
-                      onPressed: () => _showLoginDialog(context, accountService),
+                      onPressed: () =>
+                          _showLoginDialog(context, accountService),
                       child: const Text('Link Account'),
                     ),
                   ),
@@ -644,7 +639,9 @@ class _SettingsViewState extends State<SettingsView>
   }
 
   void _showLoginDialog(
-      BuildContext context, DecentAccountService accountService) {
+    BuildContext context,
+    DecentAccountService accountService,
+  ) {
     showShadDialog(
       context: context,
       builder: (dialogContext) {
@@ -701,8 +698,8 @@ class _SettingsViewState extends State<SettingsView>
             child: ExcludeSemantics(
               child: ShadButton.outline(
                 onPressed: () async {
-                  final result =
-                      await Permission.manageExternalStorage.request();
+                  final result = await Permission.manageExternalStorage
+                      .request();
                   if (result.isPermanentlyDenied) {
                     await openAppSettings();
                   }
@@ -829,7 +826,14 @@ class _SettingsViewState extends State<SettingsView>
             label: "Update available",
             child: ExcludeSemantics(
               child: ShadButton(
-                onPressed: () => _checkForUpdates(context),
+                onPressed: () {
+                  if (Platform.isAndroid) {
+                    _checkForUpdates(context);
+                  } else {
+                    final url = widget.updateCheckService?.getReleaseUrl();
+                    if (url != null) launchUrl(Uri.parse(url));
+                  }
+                },
                 leading: Icon(
                   Icons.system_update,
                   color: Theme.of(context).colorScheme.onPrimaryContainer,
@@ -854,10 +858,9 @@ class _SettingsViewState extends State<SettingsView>
               label: 'Open plugins settings',
               child: ExcludeSemantics(
                 child: ShadButton.outline(
-                  onPressed:
-                      () => Navigator.of(
-                        context,
-                      ).pushNamed(PluginsSettingsView.routeName),
+                  onPressed: () => Navigator.of(
+                    context,
+                  ).pushNamed(PluginsSettingsView.routeName),
                   child: const Text("Plugins"),
                 ),
               ),
@@ -897,7 +900,16 @@ class _SettingsViewState extends State<SettingsView>
       icon: Icons.info_outline,
       description: 'Version and build information',
       children: [
-        _InfoRow('Version', BuildInfo.version),
+        GestureDetector(
+          onLongPress: () {
+            if (!kDebugMode) {
+              return;
+            }
+            widget.updateCheckService?.debugForceUpdate();
+            setState(() {});
+          },
+          child: _InfoRow('Version', BuildInfo.version),
+        ),
         _InfoRow('Build', BuildInfo.buildNumber),
         _InfoRow('Commit', BuildInfo.commitShort),
         _InfoRow('Branch', BuildInfo.branch),
@@ -989,29 +1001,26 @@ class _SettingsViewState extends State<SettingsView>
 
                         final confirmed = await showDialog<bool>(
                           context: context,
-                          builder:
-                              (dialogContext) => AlertDialog(
-                                title: const Text('Remove skin?'),
-                                content: Text(
-                                  'Remove "${skin.name}"? This cannot be undone.',
-                                ),
-                                actions: [
-                                  TextButton(
-                                    onPressed:
-                                        () => Navigator.of(
-                                          dialogContext,
-                                        ).pop(false),
-                                    child: const Text('Cancel'),
-                                  ),
-                                  TextButton(
-                                    onPressed:
-                                        () => Navigator.of(
-                                          dialogContext,
-                                        ).pop(true),
-                                    child: const Text('Remove'),
-                                  ),
-                                ],
+                          builder: (dialogContext) => AlertDialog(
+                            title: const Text('Remove skin?'),
+                            content: Text(
+                              'Remove "${skin.name}"? This cannot be undone.',
+                            ),
+                            actions: [
+                              TextButton(
+                                onPressed: () => Navigator.of(
+                                  dialogContext,
+                                ).pop(false),
+                                child: const Text('Cancel'),
                               ),
+                              TextButton(
+                                onPressed: () => Navigator.of(
+                                  dialogContext,
+                                ).pop(true),
+                                child: const Text('Remove'),
+                              ),
+                            ],
+                          ),
                         );
                         if (confirmed != true) return;
 
@@ -1321,61 +1330,59 @@ class _SettingsViewState extends State<SettingsView>
           final updater = AndroidUpdater(owner: 'tadelv', repo: 'reaprime');
           showDialog(
             context: context,
-            builder:
-                (context) => UpdateDialog(
-                  updateInfo: updateInfo,
-                  currentVersion: BuildInfo.version,
-                  onDownload: (info) => updater.downloadUpdate(info),
-                  onInstall: (path) => updater.installUpdate(path),
-                ),
+            builder: (context) => UpdateDialog(
+              updateInfo: updateInfo,
+              currentVersion: BuildInfo.version,
+              onDownload: (info) => updater.downloadUpdate(info),
+              onInstall: (path) => updater.installUpdate(path),
+            ),
           );
         } else {
           // On other platforms, show dialog and open browser
           final releaseUrl = widget.updateCheckService?.getReleaseUrl();
           showDialog(
             context: context,
-            builder:
-                (context) => AlertDialog(
-                  title: const Text('Update Available'),
-                  content: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text('Version ${updateInfo.version} is available'),
-                      const SizedBox(height: 8),
-                      Text('Current version: ${BuildInfo.version}'),
-                      if (updateInfo.releaseNotes.isNotEmpty) ...[
-                        const SizedBox(height: 16),
-                        const Text(
-                          'Release Notes:',
-                          style: TextStyle(fontWeight: FontWeight.bold),
-                        ),
-                        const SizedBox(height: 8),
-                        Container(
-                          constraints: const BoxConstraints(maxHeight: 200),
-                          child: SingleChildScrollView(
-                            child: Text(updateInfo.releaseNotes),
-                          ),
-                        ),
-                      ],
-                    ],
-                  ),
-                  actions: [
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(),
-                      child: const Text('Later'),
+            builder: (context) => AlertDialog(
+              title: const Text('Update Available'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Version ${updateInfo.version} is available'),
+                  const SizedBox(height: 8),
+                  Text('Current version: ${BuildInfo.version}'),
+                  if (updateInfo.releaseNotes.isNotEmpty) ...[
+                    const SizedBox(height: 16),
+                    const Text(
+                      'Release Notes:',
+                      style: TextStyle(fontWeight: FontWeight.bold),
                     ),
-                    ElevatedButton(
-                      onPressed: () async {
-                        Navigator.of(context).pop();
-                        if (releaseUrl != null) {
-                          await launchUrl(Uri.parse(releaseUrl));
-                        }
-                      },
-                      child: const Text('Download'),
+                    const SizedBox(height: 8),
+                    Container(
+                      constraints: const BoxConstraints(maxHeight: 200),
+                      child: SingleChildScrollView(
+                        child: Text(updateInfo.releaseNotes),
+                      ),
                     ),
                   ],
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Later'),
                 ),
+                ElevatedButton(
+                  onPressed: () async {
+                    Navigator.of(context).pop();
+                    if (releaseUrl != null) {
+                      await launchUrl(Uri.parse(releaseUrl));
+                    }
+                  },
+                  child: const Text('Download'),
+                ),
+              ],
+            ),
           );
         }
       } else {


### PR DESCRIPTION
## What

Adds a "Download" button to the update-available SnackBar, so users can go straight to downloading without navigating through dialogs. Updates the settings page banner to open the release page in one click on desktop.

## How

- **SnackBar** now has two actions: "View" (release notes dialog) and "Download" (skips dialog).
  - Android: "Download" opens a progress dialog that starts APK download+install immediately.
  - Non-Android: "Download" opens the GitHub release page in browser.
- **Settings banner**: non-Android — one click opens browser. Android unchanged.
- **`debugForceUpdate()`** — long-press the Version row in Settings > About to inject a fake update for testing.