### PR TITLE
chore: flip brightness limit on low battery

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -4356,7 +4356,7 @@ components:
         lowBatteryBrightnessLimit:
           type: boolean
           nullable: true
-          description: When enabled and battery drops below 30%, screen brightness is capped at 20. Only effective on platforms with battery monitoring.
+          description: When enabled and battery drops below 30%, screen brightness is capped at 20. Only effective on platforms with battery monitoring. Default value is true.
         simulatedDevices:
           description: List of simulated device types to enable in scan results
           type: array

--- a/lib/src/settings/settings_controller.dart
+++ b/lib/src/settings/settings_controller.dart
@@ -59,7 +59,7 @@ class SettingsController with ChangeNotifier {
   bool _userPresenceEnabled = true;
   int _sleepTimeoutMinutes = 30;
   String _wakeSchedules = '[]';
-  bool _lowBatteryBrightnessLimit = false;
+  bool _lowBatteryBrightnessLimit = true;
   bool _onboardingCompleted = false;
   bool _accountStepSeen = false;
 

--- a/lib/src/settings/settings_service.dart
+++ b/lib/src/settings/settings_service.dart
@@ -383,7 +383,7 @@ class SharedPreferencesSettingsService extends SettingsService {
   @override
   Future<bool> lowBatteryBrightnessLimit() async {
     return await prefs.getBool(SettingsKeys.lowBatteryBrightnessLimit.name) ??
-        false;
+        true;
   }
 
   @override


### PR DESCRIPTION
Limit brightness on low battery by default