### PR TITLE
Fix voltage values for 220v machines

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -4189,8 +4189,9 @@ components:
         heaterVoltage:
           description: |
             Mains heater voltage hint. Accepts `120` (110V region) or `230` (220V region).
-            Values above 1000 are treated as already-set markers (firmware adds 1000 once committed)
-            and are clamped back into the same set. Other values map to "unset" and are ignored.
+            Measured regional readings such as `110` or `220` and values above 1000
+            (firmware committed markers) are normalized to the matching canonical region.
+            Other values map to "unset" and are ignored.
           type: integer
           nullable: true
           enum: [120, 230]
@@ -4218,8 +4219,8 @@ components:
         heaterVoltage:
           description: |
             Mains heater voltage hint. `120` = 110V region, `230` = 220V region.
-            Firmware adds 1000 to indicate the value has been committed (e.g. `1230`);
-            on read this is normalized back to the bare value.
+            Measured regional readings such as `110` or `220`, and firmware committed
+            markers such as `1120` or `1230`, are normalized to the canonical region.
           type: integer
           enum: [120, 230, -1]
         refillKitSetting:
@@ -5521,4 +5522,3 @@ components:
           type: integer
           description: Offset used
           example: 0
-

--- a/lib/src/models/device/de1_interface.dart
+++ b/lib/src/models/device/de1_interface.dart
@@ -123,10 +123,9 @@ enum De1HeaterVoltage {
   factory De1HeaterVoltage.fromInt(int voltage) {
     // account for v + 1000 when voltage has been already set
     voltage = voltage > 1000 ? voltage - 1000 : voltage;
-    return De1HeaterVoltage.values.firstWhere(
-      (e) => e.voltage == voltage,
-      orElse: () => .unset,
-    );
+    if (voltage >= 90 && voltage <= 150) return .v110;
+    if (voltage >= 180 && voltage <= 260) return .v220;
+    return .unset;
   }
 }
 

--- a/test/models/device/de1_heater_voltage_test.dart
+++ b/test/models/device/de1_heater_voltage_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+
+void main() {
+  group('De1HeaterVoltage.fromInt', () {
+    test('normalizes measured regional voltages to canonical settings', () {
+      expect(De1HeaterVoltage.fromInt(110), De1HeaterVoltage.v110);
+      expect(De1HeaterVoltage.fromInt(120), De1HeaterVoltage.v110);
+      expect(De1HeaterVoltage.fromInt(220), De1HeaterVoltage.v220);
+      expect(De1HeaterVoltage.fromInt(230), De1HeaterVoltage.v220);
+    });
+
+    test('normalizes committed voltage markers before classifying', () {
+      expect(De1HeaterVoltage.fromInt(1110), De1HeaterVoltage.v110);
+      expect(De1HeaterVoltage.fromInt(1120), De1HeaterVoltage.v110);
+      expect(De1HeaterVoltage.fromInt(1220), De1HeaterVoltage.v220);
+      expect(De1HeaterVoltage.fromInt(1230), De1HeaterVoltage.v220);
+    });
+
+    test('leaves unknown values unset', () {
+      expect(De1HeaterVoltage.fromInt(0), De1HeaterVoltage.unset);
+      expect(De1HeaterVoltage.fromInt(170), De1HeaterVoltage.unset);
+    });
+  });
+}


### PR DESCRIPTION
When the voltage is 220v it returns -1 instead of 220/230
```
/api/v1/machine/info
"extra": { "voltage": 220 }

/api/v1/machine/settings/advanced
"heaterVoltage": -1
```