### PR TITLE
fix(telemetry): cut Crashlytics WARNING noise — SEVERE-only forwarding + plugin-load downgrade

### DIFF
--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -373,7 +373,13 @@ class PluginManager {
       js.evaluate('''
       delete globalThis.__plugins__["$id"];
     ''');
-      _log.severe("Failed to load plugin $id", e, st);
+      // WARNING, not SEVERE: a plugin failing to load is almost always a
+      // user-installed third-party plugin with a bad manifest id or a JS
+      // syntax error, not an app defect. The caller (e.g. PluginsSettingsView)
+      // surfaces the failure to the user. Keeping this at SEVERE escalated
+      // every broken user plugin into Crashlytics crash signal (issue
+      // e396ab1d — a catch-all cluster of unrelated plugin-load failures).
+      _log.warning("Failed to load plugin $id", e, st);
       rethrow;
     }
   }

--- a/lib/src/services/telemetry/telemetry_forwarder_filter.dart
+++ b/lib/src/services/telemetry/telemetry_forwarder_filter.dart
@@ -24,13 +24,21 @@ const _httpFetcherLoggers = <String>{
   'AndroidUpdater',
 };
 
-/// Returns `false` for log records that match a known telemetry-noise pattern
-/// — caller should skip forwarding these to Crashlytics.
+/// Returns `false` for log records that should not be forwarded to Crashlytics
+/// — either below the SEVERE forwarding threshold or matching a known
+/// telemetry-noise pattern.
 ///
-/// Caller is expected to gate on `record.level >= Level.WARNING` first;
-/// records below WARNING never reach Crashlytics today, so this predicate
-/// only describes WARNING+ records.
+/// Only `SEVERE+` records are forwarded. WARNING records are still captured in
+/// the local log buffer (for crash context) by the caller, but on their own
+/// they are field noise — ~100+ benign WARNING events/week — so they never
+/// reach Crashlytics. The caller still gates on `record.level >= Level.WARNING`
+/// for buffer capture; this predicate independently enforces the SEVERE floor
+/// for forwarding.
 bool shouldForwardToTelemetry(LogRecord record) {
+  // Only SEVERE and above are crash signals. WARNING is informational field
+  // noise and is dropped from forwarding regardless of source or content.
+  if (record.level < Level.SEVERE) return false;
+
   // Drop typed transient exceptions regardless of source logger. These
   // are part of the codebase's normal error model — connection drops,
   // bounded MMR-read timeouts — not crash signals.

--- a/test/services/telemetry/telemetry_forwarder_filter_test.dart
+++ b/test/services/telemetry/telemetry_forwarder_filter_test.dart
@@ -18,10 +18,46 @@ LogRecord _record(
 
 void main() {
   group('shouldForwardToTelemetry', () {
-    group('drops noise from WebUIStorage', () {
-      test('"Skin already exists: ..." WARNING is dropped', () {
+    group('SEVERE floor', () {
+      test('WARNING with no noise pattern is dropped', () {
         final record = _record(
           Level.WARNING,
+          'SomeController',
+          'something unusual happened',
+        );
+        expect(shouldForwardToTelemetry(record), isFalse);
+      });
+
+      test('WARNING with a real error is dropped', () {
+        final record = _record(
+          Level.WARNING,
+          'SomeController',
+          'invariant violated',
+          StateError('bad state'),
+        );
+        expect(shouldForwardToTelemetry(record), isFalse);
+      });
+
+      test('INFO is dropped', () {
+        final record = _record(Level.INFO, 'SomeController', 'just fyi');
+        expect(shouldForwardToTelemetry(record), isFalse);
+      });
+
+      test('SEVERE is forwarded', () {
+        final record = _record(Level.SEVERE, 'SomeController', 'boom');
+        expect(shouldForwardToTelemetry(record), isTrue);
+      });
+
+      test('SHOUT is forwarded', () {
+        final record = _record(Level.SHOUT, 'SomeController', 'really boom');
+        expect(shouldForwardToTelemetry(record), isTrue);
+      });
+    });
+
+    group('drops noise from WebUIStorage', () {
+      test('"Skin already exists: ..." is dropped', () {
+        final record = _record(
+          Level.SEVERE,
           'WebUIStorage',
           'Skin already exists: streamline_project-main, overwriting…',
         );
@@ -90,9 +126,9 @@ void main() {
         expect(shouldForwardToTelemetry(record), isTrue);
       });
 
-      test('Unrelated WARNING message is kept', () {
+      test('Unrelated SEVERE message is kept', () {
         final record = _record(
-          Level.WARNING,
+          Level.SEVERE,
           'WebUIStorage',
           'Manifest parse failed: missing required field',
         );
@@ -115,7 +151,7 @@ void main() {
         '"Skin already exists" emitted by a different logger is kept',
         () {
           final record = _record(
-            Level.WARNING,
+            Level.SEVERE,
             'SomeOtherLogger',
             'Skin already exists: foo',
           );
@@ -127,7 +163,7 @@ void main() {
     group('drops typed transient exceptions regardless of logger', () {
       test('DeviceNotConnectedException.machine from any logger is dropped', () {
         final record = _record(
-          Level.WARNING,
+          Level.SEVERE,
           'BatteryController',
           'Failed to set USB charger mode',
           const DeviceNotConnectedException.machine(),
@@ -137,7 +173,7 @@ void main() {
 
       test('DeviceNotConnectedException.scale from any logger is dropped', () {
         final record = _record(
-          Level.WARNING,
+          Level.SEVERE,
           'PresenceController',
           'Failed to send user present',
           const DeviceNotConnectedException.scale(),
@@ -169,7 +205,7 @@ void main() {
     group('extends transient-network-error skip to AndroidUpdater', () {
       test('SocketException from AndroidUpdater is dropped', () {
         final record = _record(
-          Level.WARNING,
+          Level.SEVERE,
           'AndroidUpdater',
           'checkForUpdate failed',
           const SocketException(
@@ -181,7 +217,7 @@ void main() {
 
       test('TimeoutException from AndroidUpdater is dropped', () {
         final record = _record(
-          Level.WARNING,
+          Level.SEVERE,
           'AndroidUpdater',
           'checkForUpdate timed out',
           TimeoutException('http get'),
@@ -207,15 +243,6 @@ void main() {
           'SomeController',
           'invariant violated',
           StateError('bad state'),
-        );
-        expect(shouldForwardToTelemetry(record), isTrue);
-      });
-
-      test('plain WARNING with no error is kept', () {
-        final record = _record(
-          Level.WARNING,
-          'SomeController',
-          'something unusual happened',
         );
         expect(shouldForwardToTelemetry(record), isTrue);
       });


### PR DESCRIPTION
## What
- Add a SEVERE floor to the telemetry forwarder (`shouldForwardToTelemetry`) — only `SEVERE`/`SHOUT` reach Crashlytics. WARNING is still captured in the local log buffer for crash context, just not forwarded.
- Downgrade `PluginManager.loadPlugin` failure log from SEVERE → WARNING.

## Why
WARNING-level logs (transient fetches, expected disconnects, "skin already exists", broken user plugins) were ~100+ events/week, drowning real crash signal in Crashlytics.

The plugin downgrade fixes Crashlytics issue `e396ab1d` — a catch-all cluster of `loadPlugin` JS-eval failures. Triage showed both variants (`Plugin ID mismatch` + `Unexpected identifier 'Loaded'`) come from a user-installed "Advanced Decent Profile" fork, not a bundled plugin or app defect: the app removes the plugin and the caller already surfaces the failure to the user. With the new SEVERE floor, the WARNING-level log no longer reaches Crashlytics.

## Test plan
- `flutter test test/services/telemetry/telemetry_forwarder_filter_test.dart` — 23 pass (new SEVERE-floor group + reworked noise cases)
- Full `flutter test` suite green (1408)
- `flutter analyze` clean