### PR TITLE
Auto-scan for a missing preferred scale after machine connect

### DIFF
--- a/lib/src/controllers/connection/disconnect_supervisor.dart
+++ b/lib/src/controllers/connection/disconnect_supervisor.dart
@@ -31,6 +31,10 @@ class DisconnectSupervisor {
   final bool Function() _isConnectingScale;
   final String? Function() _scaleLastConnectedId;
   final String? Function() _preferredScaleId;
+  final void Function()? _onMachineConnected;
+  final void Function()? _onMachineDisconnected;
+  final void Function()? _onScaleConnected;
+  final void Function()? _onScaleDisconnected;
 
   De1Interface? _latestDe1;
   device.ConnectionState _latestScaleState =
@@ -49,6 +53,10 @@ class DisconnectSupervisor {
     required bool Function() isConnectingScale,
     required String? Function() scaleLastConnectedId,
     required String? Function() preferredScaleId,
+    void Function()? onMachineConnected,
+    void Function()? onMachineDisconnected,
+    void Function()? onScaleConnected,
+    void Function()? onScaleDisconnected,
   })  : _machineStream = machineStream,
         _scaleStream = scaleStream,
         _statusPublisher = statusPublisher,
@@ -56,7 +64,11 @@ class DisconnectSupervisor {
         _isConnectingMachine = isConnectingMachine,
         _isConnectingScale = isConnectingScale,
         _scaleLastConnectedId = scaleLastConnectedId,
-        _preferredScaleId = preferredScaleId {
+        _preferredScaleId = preferredScaleId,
+        _onMachineConnected = onMachineConnected,
+        _onMachineDisconnected = onMachineDisconnected,
+        _onScaleConnected = onScaleConnected,
+        _onScaleDisconnected = onScaleDisconnected {
     _start();
   }
 
@@ -89,10 +101,12 @@ class DisconnectSupervisor {
       _latestDe1 = de1;
       if (de1 != null) {
         _lastKnownMachineId = de1.deviceId;
+        _onMachineConnected?.call();
         return;
       }
       if (hadMachine && !_isConnectingMachine()) {
         _log.fine('Machine disconnected');
+        _onMachineDisconnected?.call();
         _statusPublisher.publish(
           _statusPublisher.current.copyWith(phase: ConnectionPhase.idle),
         );
@@ -108,12 +122,20 @@ class DisconnectSupervisor {
           _latestScaleState == device.ConnectionState.connected;
       _latestScaleState = state;
       _log.fine('scale connection update: ${state.name}');
+      if (!wasConnected && state == device.ConnectionState.connected) {
+        _onScaleConnected?.call();
+      }
       if (wasConnected &&
           state == device.ConnectionState.disconnected &&
           !_isConnectingScale()) {
         final id = _scaleLastConnectedId() ?? _preferredScaleId();
         if (id != null) {
-          _handleScaleDisconnect(id);
+          final unexpected = _handleScaleDisconnect(id);
+          if (unexpected) {
+            _onScaleDisconnected?.call();
+          }
+        } else {
+          _onScaleDisconnected?.call();
         }
       }
     });
@@ -135,10 +157,10 @@ class DisconnectSupervisor {
     ));
   }
 
-  void _handleScaleDisconnect(String deviceId) {
+  bool _handleScaleDisconnect(String deviceId) {
     if (_expectations.consume(deviceId)) {
       _log.fine('Scale $deviceId: expected disconnect, suppressing error');
-      return;
+      return false;
     }
     _statusPublisher.emitError(ConnectionError(
       kind: ConnectionErrorKind.scaleDisconnected,
@@ -150,6 +172,7 @@ class DisconnectSupervisor {
           'The scale may have powered off or moved out of range. '
           'Wake the scale and reconnect.',
     ));
+    return true;
   }
 
   /// Drive the same error-emission path the stream listener would

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -17,12 +17,14 @@ import 'package:reaprime/src/controllers/scale_controller.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle_virtual_scale.dart';
+import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_scanner.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/scan_report.dart';
+import 'package:reaprime/src/settings/scale_power_mode.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -101,6 +103,7 @@ class ConnectionManager {
   bool _isConnecting = false;
   bool _isConnectingMachine = false;
   bool _isConnectingScale = false;
+  bool _activeScaleOnlyScan = false;
 
   /// End-to-end timeout for a single `connectMachine` / `connectScale`
   /// call. Phase 1 bounded the MMR-read hang at 2s; this is the
@@ -116,6 +119,9 @@ class ConnectionManager {
   // of the source streams (no parallel flags).
   bool get _machineConnected => _disconnectSupervisor.isMachineConnected;
   bool get _scaleConnected => _disconnectSupervisor.isScaleConnected;
+  bool get _scaleReconnectBlockedByPowerMode =>
+      settingsController.scalePowerMode == ScalePowerMode.disconnect &&
+      _latestMachineState == MachineState.sleeping;
 
   late final DisconnectSupervisor _disconnectSupervisor;
   late final ScanOrchestrator _scanOrchestrator;
@@ -136,6 +142,15 @@ class ConnectionManager {
   /// a scale that advertises a beat later is missed; this recovers it.
   Timer? _deferredScaleScan;
 
+  /// Preferred-scale reconnect retry while a machine is connected but the
+  /// configured scale is missing. BLE advertisements are only observed during
+  /// scans, so this gives a powered-on scale a chance to appear without user
+  /// interaction.
+  Timer? _preferredScaleReconnect;
+
+  MachineState? _latestMachineState;
+  StreamSubscription<MachineSnapshot>? _machineSnapshotSub;
+
   /// Set true by [_checkEarlyStop] when it actually cut the scan short on
   /// machine-connect with no preferred scale. Distinguishes that case
   /// from a full scan that simply completed without a scale — only the
@@ -150,6 +165,9 @@ class ConnectionManager {
   /// stabilise first. Overridable in tests to avoid a real wait.
   @visibleForTesting
   Duration deferredScaleScanDelay = const Duration(seconds: 3);
+
+  @visibleForTesting
+  Duration preferredScaleReconnectDelay = const Duration(seconds: 5);
 
   ConnectionManager({
     required this.deviceScanner,
@@ -166,6 +184,10 @@ class ConnectionManager {
       isConnectingScale: () => _isConnectingScale,
       scaleLastConnectedId: () => scaleController.lastConnectedDeviceId,
       preferredScaleId: () => settingsController.preferredScaleId,
+      onMachineConnected: _handleMachineConnected,
+      onMachineDisconnected: _handleMachineDisconnected,
+      onScaleConnected: _cancelPreferredScaleReconnect,
+      onScaleDisconnected: _maybeSchedulePreferredScaleReconnect,
     );
     _scanOrchestrator = ScanOrchestrator(
       scanner: deviceScanner,
@@ -349,14 +371,28 @@ class ConnectionManager {
   /// the concurrency guard in [connect] sees the in-flight state.
   Future<void> _executeConnect(bool scaleOnly) async {
     _isConnecting = true;
+    if (scaleOnly) {
+      _activeScaleOnlyScan = true;
+    }
     try {
       await _connectImpl(scaleOnly: scaleOnly);
     } finally {
+      if (scaleOnly) {
+        _activeScaleOnlyScan = false;
+      }
       _isConnecting = false;
     }
   }
 
   Future<void> _connectImpl({required bool scaleOnly}) async {
+    _cancelPreferredScaleReconnect();
+    if (scaleOnly && _scaleReconnectBlockedByPowerMode) {
+      _log.fine(
+        'Skipping scale-only scan while machine is sleeping and scale '
+        'power mode is disconnect',
+      );
+      return;
+    }
     if (!scaleOnly) {
       // A fresh full connect supersedes any pending deferred rescan.
       _deferredScaleScan?.cancel();
@@ -422,6 +458,7 @@ class ConnectionManager {
         preferredScaleId: preferredScaleId,
         terminationReason: ScanTerminationReason.completed,
       );
+      _maybeSchedulePreferredScaleReconnect();
       return;
     }
 
@@ -440,6 +477,7 @@ class ConnectionManager {
         scanReport,
       );
       _maybeArmDeferredScaleScan();
+      _maybeSchedulePreferredScaleReconnect();
       _emitScanReport(
         scanReport: scanReport,
         preferredMachineId: preferredMachineId,
@@ -461,6 +499,7 @@ class ConnectionManager {
         await _connectMachineTracked(m, scanReport);
         await _runScalePhase(m, scales, preferredScaleId, scanReport);
         _maybeArmDeferredScaleScan();
+        _maybeSchedulePreferredScaleReconnect();
       case MachinePickerAction():
         _publishStatus(currentStatus.copyWith(
           phase: ConnectionPhase.idle,
@@ -523,6 +562,7 @@ class ConnectionManager {
   void _maybeArmDeferredScaleScan() {
     if (!_earlyStopFired) return;
     if (!_machineConnected || _scaleConnected) return;
+    if (_scaleReconnectBlockedByPowerMode) return;
     _log.fine(
       'Machine connected without a scale after an early stop; '
       'arming deferred scale rescan in ${deferredScaleScanDelay.inSeconds}s',
@@ -531,8 +571,94 @@ class ConnectionManager {
     _deferredScaleScan = Timer(deferredScaleScanDelay, () {
       _deferredScaleScan = null;
       if (_scaleConnected) return; // a scale arrived in the meantime
+      if (!_machineConnected || _scaleReconnectBlockedByPowerMode) return;
       connect(scaleOnly: true); // fire-and-forget
     });
+  }
+
+  void _maybeSchedulePreferredScaleReconnect() {
+    if (_preferredScaleReconnect != null) return;
+    if (!_shouldRetryPreferredScale()) return;
+    _log.fine(
+      'Preferred scale is missing; retrying scale scan in '
+      '${preferredScaleReconnectDelay.inSeconds}s',
+    );
+    _preferredScaleReconnect = Timer(preferredScaleReconnectDelay, () {
+      _preferredScaleReconnect = null;
+      if (!_shouldRetryPreferredScale()) return;
+      connect(scaleOnly: true); // fire-and-forget
+    });
+  }
+
+  bool _shouldRetryPreferredScale() {
+    return _machineConnected &&
+        !_scaleConnected &&
+        settingsController.preferredScaleId != null &&
+        !_scaleReconnectBlockedByPowerMode;
+  }
+
+  void _cancelPreferredScaleReconnect() {
+    _preferredScaleReconnect?.cancel();
+    _preferredScaleReconnect = null;
+  }
+
+  void _handleMachineConnected() {
+    _watchConnectedMachineState();
+    _maybeSchedulePreferredScaleReconnect();
+  }
+
+  void _handleMachineDisconnected() {
+    _stopWatchingConnectedMachineState();
+    _deferredScaleScan?.cancel();
+    _deferredScaleScan = null;
+    _cancelPreferredScaleReconnect();
+    if (_activeScaleOnlyScan) {
+      deviceScanner.stopScan();
+    }
+  }
+
+  void _watchConnectedMachineState() {
+    _stopWatchingConnectedMachineState();
+    final machine = _disconnectSupervisor.latestMachine;
+    if (machine == null) return;
+    final Stream<MachineSnapshot> snapshots;
+    try {
+      snapshots = machine.currentSnapshot;
+    } catch (e, st) {
+      _log.fine('Machine snapshot stream unavailable', e, st);
+      return;
+    }
+    _machineSnapshotSub = snapshots.listen((snapshot) {
+      final state = snapshot.state.state;
+      if (_latestMachineState == state) return;
+      _latestMachineState = state;
+      if (_scaleReconnectBlockedByPowerMode) {
+        _log.fine(
+          'Machine is sleeping and scale power mode is disconnect; '
+          'pausing preferred scale reconnect',
+        );
+        _pauseScaleReconnectForPowerMode();
+      } else {
+        _maybeSchedulePreferredScaleReconnect();
+      }
+    }, onError: (Object e, StackTrace st) {
+      _log.fine('Machine snapshot stream error', e, st);
+    });
+  }
+
+  void _pauseScaleReconnectForPowerMode() {
+    _deferredScaleScan?.cancel();
+    _deferredScaleScan = null;
+    _cancelPreferredScaleReconnect();
+    if (_activeScaleOnlyScan) {
+      deviceScanner.stopScan();
+    }
+  }
+
+  void _stopWatchingConnectedMachineState() {
+    _machineSnapshotSub?.cancel();
+    _machineSnapshotSub = null;
+    _latestMachineState = null;
   }
 
   /// Gate the scale phase on machine type. When the connected machine
@@ -582,6 +708,13 @@ class ConnectionManager {
     String? preferredScaleId,
     ScanReportBuilder scanReport,
   ) async {
+    if (_scaleReconnectBlockedByPowerMode) {
+      _log.fine(
+        'Skipping scale phase while machine is sleeping and scale power '
+        'mode is disconnect',
+      );
+      return;
+    }
     if (_scaleConnected) {
       _log.fine('Scale already connected, skipping scale phase');
       return;
@@ -659,6 +792,13 @@ class ConnectionManager {
   }
 
   Future<void> connectScale(Scale scale) async {
+    if (_scaleReconnectBlockedByPowerMode) {
+      _log.fine(
+        'connectScale: blocked while machine is sleeping and scale power '
+        'mode is disconnect',
+      );
+      return;
+    }
     if (_isConnectingScale) {
       _log.fine('connectScale: already connecting, skipping');
       return;
@@ -678,6 +818,17 @@ class ConnectionManager {
       await scaleController
           .connectToScale(scale)
           .timeout(_connectTimeout);
+      if (_scaleReconnectBlockedByPowerMode) {
+        markExpectingDisconnect(scale.deviceId);
+        _publishStatus(
+          currentStatus.copyWith(
+            phase:
+                _machineConnected ? ConnectionPhase.ready : ConnectionPhase.idle,
+          ),
+        );
+        await scale.disconnect();
+        return;
+      }
       await settingsController.setPreferredScaleId(scale.deviceId);
       // `_latestScaleState` is populated by the scaleController
       // listener; `_scaleConnected` reads from it.
@@ -745,6 +896,13 @@ class ConnectionManager {
     Scale scale,
     ScanReportBuilder scanReport,
   ) async {
+    if (_scaleReconnectBlockedByPowerMode) {
+      _log.fine(
+        'Skipping external scale early-connect while machine is sleeping '
+        'and scale power mode is disconnect',
+      );
+      return;
+    }
     if (_shouldDeferEarlyScaleConnect()) {
       _log.fine(
         'Deferring external scale early-connect until machine resolves',
@@ -843,6 +1001,7 @@ class ConnectionManager {
   }
 
   Future<void> disconnectMachine() async {
+    _handleMachineDisconnected();
     // Pre-null the supervisor's tracked de1 view so its stream listener's
     // `hadMachine` check sees "no machine was connected" by the time
     // it fires on the upcoming null emission — otherwise the supervisor
@@ -857,6 +1016,7 @@ class ConnectionManager {
   }
 
   Future<void> disconnectScale() async {
+    _cancelPreferredScaleReconnect();
     try {
       final scale = scaleController.connectedScale();
       markExpectingDisconnect(scale.deviceId);
@@ -871,6 +1031,8 @@ class ConnectionManager {
 
   Future<void> dispose() async {
     _deferredScaleScan?.cancel();
+    _cancelPreferredScaleReconnect();
+    _stopWatchingConnectedMachineState();
     await de1Controller.dispose();
     scaleController.dispose();
     _disconnectSupervisor.dispose();
@@ -880,4 +1042,3 @@ class ConnectionManager {
     _scanReportSubject.close();
   }
 }
-

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -10,8 +10,10 @@ import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/models/scan_report.dart';
+import 'package:reaprime/src/settings/scale_power_mode.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 
 import '../helpers/mock_de1_controller.dart';
@@ -25,6 +27,9 @@ import '../helpers/test_scale.dart';
 /// Uses noSuchMethod so we don't need to implement every member.
 /// Provides real implementations for fields that DeviceController accesses.
 class _FakeDe1 implements De1Interface {
+  final StreamController<MachineSnapshot> _snapshotController =
+      StreamController<MachineSnapshot>.broadcast();
+
   @override
   final String deviceId;
 
@@ -38,7 +43,14 @@ class _FakeDe1 implements De1Interface {
   Stream<ConnectionState> get connectionState =>
       Stream.value(ConnectionState.connected);
 
+  @override
+  Stream<MachineSnapshot> get currentSnapshot => _snapshotController.stream;
+
   _FakeDe1({this.deviceId = 'fake-de1'}) : name = 'DE1-$deviceId';
+
+  void emitState(MachineState state) {
+    _snapshotController.add(_machineSnapshot(state));
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => null;
@@ -60,10 +72,30 @@ class _FailingFakeDe1 implements De1Interface {
   Stream<ConnectionState> get connectionState =>
       Stream.value(ConnectionState.disconnected);
 
+  @override
+  Stream<MachineSnapshot> get currentSnapshot => const Stream.empty();
+
   _FailingFakeDe1({this.deviceId = 'failing-de1'}) : name = 'DE1-$deviceId';
 
   @override
   dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+MachineSnapshot _machineSnapshot(MachineState state) {
+  return MachineSnapshot(
+    timestamp: DateTime.utc(2026),
+    state: MachineStateSnapshot(state: state, substate: MachineSubstate.idle),
+    flow: 0,
+    pressure: 0,
+    targetFlow: 0,
+    targetPressure: 0,
+    mixTemperature: 0,
+    groupTemperature: 0,
+    targetMixTemperature: 0,
+    targetGroupTemperature: 0,
+    profileFrame: 0,
+    steamTemperature: 0,
+  );
 }
 
 void main() {
@@ -530,6 +562,35 @@ void main() {
               connectionManager.currentStatus.phase, ConnectionPhase.ready);
         });
 
+        test('machine disconnect cancels deferred scale rescan', () async {
+          await settingsController.setPreferredMachineId('pref-de1');
+          connectionManager.deferredScaleScanDelay =
+              const Duration(milliseconds: 10);
+          mockScanner.scanCompleter = Completer<void>();
+
+          final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+          final connectFuture = connectionManager.connect();
+          await mockScanner.scanningStream.firstWhere((s) => s);
+
+          mockScanner.addDevice(fakeDe1);
+          await Future.delayed(Duration.zero);
+          await Future.delayed(Duration.zero);
+          mockScanner.completeScan();
+          await connectFuture;
+
+          final scanningEvents = <bool>[];
+          final sub = mockScanner.scanningStream.listen(scanningEvents.add);
+          await Future<void>.delayed(Duration.zero);
+
+          mockDe1Controller.de1Subject.add(null);
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+          await Future<void>.delayed(Duration.zero);
+
+          expect(scanningEvents, isNot(contains(true)));
+          expect(mockScaleController.connectCalls, isEmpty);
+          await sub.cancel();
+        });
+
         test(
             'only preferred scale set → does not call stopScan',
             () async {
@@ -684,6 +745,29 @@ void main() {
         await connectFuture;
 
         expect(mockScanner.stopScanCallCount, 0);
+      });
+
+      test(
+          'auto-scans for preferred scale when machine is ready and scale is missing',
+          () async {
+        connectionManager.preferredScaleReconnectDelay = Duration.zero;
+        await settingsController.setPreferredScaleId('pref-scale');
+        mockScanner.scanCompleter = Completer<void>();
+
+        mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
+        await mockScanner.scanningStream.firstWhere((s) => s);
+
+        final testScale = TestScale(deviceId: 'pref-scale');
+        mockScanner.addDevice(testScale);
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+
+        expect(mockScaleController.connectCalls, hasLength(1));
+        expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
+        expect(mockScanner.stopScanCallCount, 0);
+
+        mockScanner.completeScan();
+        await Future.delayed(Duration.zero);
       });
 
       test(
@@ -1165,6 +1249,46 @@ void main() {
             ConnectionErrorKind.scaleConnectFailed);
       });
 
+      test('sleep during scale connect settles back to ready', () async {
+        await connectionManager.dispose();
+        final slowScaleController = _SlowMockScaleController();
+        connectionManager = ConnectionManager(
+          deviceScanner: mockScanner,
+          de1Controller: mockDe1Controller,
+          scaleController: slowScaleController,
+          settingsController: settingsController,
+        );
+        await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
+
+        final fakeMachine = _FakeDe1(deviceId: 'D9:11:0B:E6:9F:86');
+        mockDe1Controller.de1Subject.add(fakeMachine);
+        await Future<void>.delayed(Duration.zero);
+        fakeMachine.emitState(MachineState.idle);
+        await Future<void>.delayed(Duration.zero);
+
+        final connectCompleter = Completer<void>();
+        slowScaleController.connectCompleter = connectCompleter;
+        final future =
+            connectionManager.connectScale(TestScale(deviceId: 'pref-scale'));
+        await Future<void>.delayed(Duration.zero);
+        expect(connectionManager.currentStatus.phase,
+            ConnectionPhase.connectingScale);
+
+        fakeMachine.emitState(MachineState.sleeping);
+        await Future<void>.delayed(Duration.zero);
+        connectCompleter.complete();
+        await future;
+        await Future<void>.delayed(Duration.zero);
+
+        expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
+        expect(connectionManager.currentStatus.error, isNull);
+        expect(settingsController.preferredScaleId, isNull);
+
+        slowScaleController.mockEmitConnectionState(ConnectionState.disconnected);
+        await Future<void>.delayed(Duration.zero);
+        expect(connectionManager.currentStatus.error, isNull);
+      });
+
       test('stays at idle on failure when no machine connected', () async {
         mockScaleController.shouldFailConnect = true;
 
@@ -1252,6 +1376,130 @@ void main() {
         await Future<void>.delayed(Duration.zero);
 
         expect(connectionManager.currentStatus.error, isNull);
+      });
+
+      test('expected scale disconnect does not trigger preferred-scale scan',
+          () async {
+        await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
+        final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
+        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
+        mockScaleController.debugSetLastConnectedId('pref-scale');
+        await settingsController.setPreferredScaleId('pref-scale');
+        connectionManager.preferredScaleReconnectDelay = Duration.zero;
+        mockDe1Controller.de1Subject.add(fakeDe1);
+        await Future<void>.delayed(Duration.zero);
+        fakeDe1.emitState(MachineState.sleeping);
+        final scanningEvents = <bool>[];
+        final sub = mockScanner.scanningStream.listen(scanningEvents.add);
+        await Future<void>.delayed(Duration.zero);
+
+        connectionManager.markExpectingDisconnect('pref-scale');
+        mockScaleController.mockEmitConnectionState(ConnectionState.disconnected);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(connectionManager.currentStatus.error, isNull);
+        expect(scanningEvents, isNot(contains(true)),
+            reason: 'power-mode disconnects are deliberate and must not start BLE');
+        expect(mockScaleController.connectCalls, isEmpty);
+        await sub.cancel();
+      });
+
+      test('unexpected preferred scale disconnect keeps scanning and reconnects',
+          () async {
+        await settingsController.setPreferredScaleId('pref-scale');
+        connectionManager.preferredScaleReconnectDelay = Duration.zero;
+        final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
+        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
+        mockScaleController.debugSetLastConnectedId('pref-scale');
+        mockDe1Controller.de1Subject.add(fakeDe1);
+        await Future<void>.delayed(Duration.zero);
+        fakeDe1.emitState(MachineState.idle);
+        await Future<void>.delayed(Duration.zero);
+
+        mockScanner.scanCompleter = Completer<void>();
+        mockScaleController.mockEmitConnectionState(ConnectionState.disconnected);
+        await mockScanner.scanningStream.firstWhere((s) => s);
+
+        mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        mockScanner.completeScan();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(mockScaleController.connectCalls, hasLength(1));
+        expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
+      });
+
+      test('scale power disconnect pauses while sleeping and resumes when awake',
+          () async {
+        await settingsController.setPreferredScaleId('pref-scale');
+        await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
+        connectionManager.preferredScaleReconnectDelay = Duration.zero;
+
+        final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
+        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
+        mockScaleController.debugSetLastConnectedId('pref-scale');
+        mockDe1Controller.de1Subject.add(fakeDe1);
+        await Future<void>.delayed(Duration.zero);
+        fakeDe1.emitState(MachineState.idle);
+        await Future<void>.delayed(Duration.zero);
+
+        final scanningEvents = <bool>[];
+        final sub = mockScanner.scanningStream.listen(scanningEvents.add);
+
+        fakeDe1.emitState(MachineState.sleeping);
+        connectionManager.markExpectingDisconnect('pref-scale');
+        mockScaleController.mockEmitConnectionState(ConnectionState.disconnected);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(scanningEvents, isNot(contains(true)),
+            reason: 'sleeping + ScalePowerMode.disconnect must not scan');
+
+        mockScanner.scanCompleter = Completer<void>();
+        fakeDe1.emitState(MachineState.idle);
+        await mockScanner.scanningStream.firstWhere((s) => s);
+
+        mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        mockScanner.completeScan();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(mockScaleController.connectCalls, hasLength(1));
+        expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
+        await sub.cancel();
+      });
+
+      test('sleeping during an active scale scan stops it and blocks reconnect',
+          () async {
+        await settingsController.setPreferredScaleId('pref-scale');
+        await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
+        connectionManager.preferredScaleReconnectDelay = Duration.zero;
+
+        final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
+        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
+        mockScaleController.debugSetLastConnectedId('pref-scale');
+        mockDe1Controller.de1Subject.add(fakeDe1);
+        await Future<void>.delayed(Duration.zero);
+        fakeDe1.emitState(MachineState.idle);
+        await Future<void>.delayed(Duration.zero);
+
+        mockScanner.scanCompleter = Completer<void>();
+        mockScaleController.mockEmitConnectionState(ConnectionState.disconnected);
+        await mockScanner.scanningStream.firstWhere((s) => s);
+
+        fakeDe1.emitState(MachineState.sleeping);
+        connectionManager.markExpectingDisconnect('pref-scale');
+        mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        mockScanner.completeScan();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(mockScanner.stopScanCallCount, 1);
+        expect(mockScaleController.connectCalls, isEmpty);
       });
 
       test('unexpected scale disconnect emits scaleDisconnected', () async {


### PR DESCRIPTION
## Summary

Fix preferred-scale reconnection so the app keeps looking for a missing preferred scale while the machine is available, without fighting the scale power-management flow.

## Scenario

A preferred scale can be missing even though the machine is connected and ready. This happens when:

- the scale is powered off during initial machine connect
- the scale powers back on after the initial scan already completed
- the scale unexpectedly drops while the machine remains connected

Before this change, the app would often stop scanning after the machine connected, so the preferred scale would not reconnect until the user manually retried.

At the same time, when `ScalePowerMode.disconnect` is enabled, machine sleep intentionally disconnects the scale. That deliberate sleep-state disconnect must not immediately start BLE scanning again, because it reconnects the scale while the machine is supposed to be asleep.

## Fix

The connection manager now tracks machine state while connected and schedules a preferred-scale-only retry when:

- a machine is connected
- no scale is connected
- a preferred scale is configured
- the machine is not sleeping under `ScalePowerMode.disconnect`

The retry is cancelled or blocked when:

- the machine disconnects
- the scale connects
- the machine enters sleep with `ScalePowerMode.disconnect`
- an app-expected scale disconnect occurs

If sleep happens while a scale scan or scale connect is already in progress, the flow stops scanning, treats the scale disconnect as expected, and returns the UI phase to `ready`/`idle` instead of leaving it in `connectingScale`.

## Testing

- Added coverage for preferred-scale auto-scan and reconnect.
- Added coverage that expected power-mode disconnects do not trigger scans.
- Added coverage that active scale scans stop when the machine enters sleep.
- Added coverage for the sleep-during-scale-connect race.
- Ran focused analyzer and connection-manager tests.