### PR TITLE
Sync local edits to Visualizer and Visualizer edits back to local shots

### DIFF
--- a/assets/plugins/visualizer.reaplugin/manifest.json
+++ b/assets/plugins/visualizer.reaplugin/manifest.json
@@ -107,6 +107,23 @@
       "data": {
         "description": "Last back-sync result, applied count, cursor and any error"
       }
+    },
+    {
+      "id": "forwardSyncStatus",
+      "type": "http",
+      "data": {
+        "description": "Last forward-sync result and any error"
+      }
+    },
+    {
+      "id": "forwardSyncNow",
+      "type": "http",
+      "data": {
+        "shotId": {
+          "type": "string",
+          "description": "Local shot id to sync to Visualizer"
+        }
+      }
     }
   ]
 }

--- a/assets/plugins/visualizer.reaplugin/manifest.json
+++ b/assets/plugins/visualizer.reaplugin/manifest.json
@@ -2,8 +2,8 @@
   "id": "visualizer.reaplugin",
   "author": "Decent Espresso",
   "name": "Visualizer upload",
-  "description": "Uploads the latest shot to Visualizer",
-  "version": "1.2.1",
+  "description": "Uploads shots to Visualizer and syncs your edited shot metadata back",
+  "version": "1.3.4",
   "apiVersion": 1,
   "permissions": [
     "log",
@@ -30,6 +30,16 @@
       "type": "number",
       "description": "Only upload shots that are longer than the threshold (in seconds)",
       "default": 5
+    },
+    "BackSync": {
+      "type": "boolean",
+      "description": "Sync metadata you edit on Visualizer (notes, TDS, EY, enjoyment, bean/grinder) back onto your local shots. Only your own uploaded shots are touched.",
+      "default": false
+    },
+    "BackSyncIntervalSeconds": {
+      "type": "number",
+      "description": "How often to check Visualizer for back-sync changes (in seconds, minimum 60)",
+      "default": 300
     }
   },
   "api": [
@@ -82,6 +92,20 @@
           "type": "string",
           "description": "4-digit share code from visualizer.coffee"
         }
+      }
+    },
+    {
+      "id": "backSyncNow",
+      "type": "http",
+      "data": {
+        "description": "POST to run a Visualizer back-sync immediately"
+      }
+    },
+    {
+      "id": "backSyncStatus",
+      "type": "http",
+      "data": {
+        "description": "Last back-sync result, applied count, cursor and any error"
       }
     }
   ]

--- a/assets/plugins/visualizer.reaplugin/manifest.json
+++ b/assets/plugins/visualizer.reaplugin/manifest.json
@@ -3,7 +3,7 @@
   "author": "Decent Espresso",
   "name": "Visualizer upload",
   "description": "Uploads shots to Visualizer and syncs your edited shot metadata back",
-  "version": "1.3.5",
+  "version": "1.3.0",
   "apiVersion": 1,
   "permissions": [
     "log",

--- a/assets/plugins/visualizer.reaplugin/manifest.json
+++ b/assets/plugins/visualizer.reaplugin/manifest.json
@@ -3,7 +3,7 @@
   "author": "Decent Espresso",
   "name": "Visualizer upload",
   "description": "Uploads shots to Visualizer and syncs your edited shot metadata back",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "apiVersion": 1,
   "permissions": [
     "log",

--- a/assets/plugins/visualizer.reaplugin/plugin.js
+++ b/assets/plugins/visualizer.reaplugin/plugin.js
@@ -37,6 +37,9 @@ function createPlugin(host) {
     shotMap: {}, // visualizerId -> localShotId, for our own uploads only
     backSyncState: {}, // visualizerId -> { remoteUpdatedAt }
     backSyncRunning: false,
+    localSyncRunning: {},
+    localSyncSuppressUntil: {},
+    localSyncStatus: { lastCheck: null, lastResult: null, lastError: null, lastShotId: null, lastVisualizerId: null },
     backSyncStatus: { lastCheck: null, lastResult: null, lastError: null, lastApplied: 0 },
   };
 
@@ -160,6 +163,8 @@ function createPlugin(host) {
     const firstTimestamp = new Date(reaShot.measurements[firstEspressoIndex].machine.timestamp).getTime();
     const lastMeasurement = reaShot.measurements[reaShot.measurements.length - 1];
     const lastTimestamp = new Date(lastMeasurement.machine.timestamp).getTime();
+    const annotations = reaShot.annotations || {};
+    const context = reaShot.workflow?.context || {};
     let totalWaterDispensed = 0;
 
     const visualizerShot = {
@@ -176,13 +181,17 @@ function createPlugin(host) {
       app: {
         data: {
           settings: {
-            bean_weight: String(reaShot.workflow.context?.targetDoseWeight ?? reaShot.workflow.doseData?.doseIn ?? 0),
-            drink_weight: String(lastMeasurement.scale?.weight ?? 0),
-            target_weight: String(reaShot.workflow.profile.target_weight),
-            grinder_model: reaShot.workflow.context?.grinderModel ?? reaShot.workflow.grinderData?.model,
-            grinder_setting: reaShot.workflow.context?.grinderSetting ?? reaShot.workflow.grinderData?.setting,
-            bean_brand: reaShot.workflow.context?.coffeeRoaster ?? reaShot.workflow.coffeeData?.roaster,
-            bean_type: reaShot.workflow.context?.coffeeName ?? reaShot.workflow.coffeeData?.name,
+            bean_weight: String(annotations.actualDoseWeight ?? context.targetDoseWeight ?? reaShot.workflow.doseData?.doseIn ?? 0),
+            drink_weight: String(annotations.actualYield ?? lastMeasurement.scale?.weight ?? 0),
+            target_weight: String(context.targetYield ?? reaShot.workflow.profile.target_weight),
+            grinder_model: context.grinderModel ?? reaShot.workflow.grinderData?.model,
+            grinder_setting: context.grinderSetting ?? reaShot.workflow.grinderData?.setting,
+            bean_brand: context.coffeeRoaster ?? reaShot.workflow.coffeeData?.roaster,
+            bean_type: context.coffeeName ?? reaShot.workflow.coffeeData?.name,
+            drink_tds: annotations.drinkTds != null ? String(annotations.drinkTds) : undefined,
+            drink_ey: annotations.drinkEy != null ? String(annotations.drinkEy) : undefined,
+            espresso_enjoyment: annotations.enjoyment != null ? String(Math.round(Number(annotations.enjoyment))) : undefined,
+            espresso_notes: annotations.espressoNotes,
           }
         }
       },
@@ -262,14 +271,14 @@ function createPlugin(host) {
       host.storage({
         type: "write",
         key: "lastUploadedShot",
-        namespace: "visualizer.reaplugin",
+        namespace: NS,
         data: fullShot.id
       });
 
       host.storage({
         type: "write",
         key: "lastVisualizerId",
-        namespace: "visualizer.reaplugin",
+        namespace: NS,
         data: result.id
       });
 
@@ -503,6 +512,7 @@ function createPlugin(host) {
     state.shotMap[String(visualizerId)] = localId;
     persistBackSyncState();
     try {
+      suppressLocalSync(localId);
       await fetch(`${LOCAL_API_URL}/shots/${localId}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -520,6 +530,176 @@ function createPlugin(host) {
     });
     if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
     return await res.json();
+  }
+
+  async function visualizerPatch(path, body) {
+    const res = await fetch(`${VISUALIZER_API_URL}${path}`, {
+      method: "PATCH",
+      headers: {
+        "Authorization": getAuthHeader(),
+        "Content-Type": "application/json",
+        "Accept": "application/json"
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`HTTP ${res.status}: ${text || res.statusText}`);
+    }
+    return await res.json();
+  }
+
+  function suppressLocalSync(localId) {
+    if (!localId) return;
+    state.localSyncSuppressUntil[localId] = Date.now() + 10000;
+  }
+
+  function consumeLocalSyncSuppression(localId) {
+    const until = state.localSyncSuppressUntil[localId];
+    if (!until) return false;
+    if (Date.now() <= until) return true;
+    delete state.localSyncSuppressUntil[localId];
+    return false;
+  }
+
+  function visualizerIdForLocalShot(shot) {
+    const localId = shot?.id;
+    if (!localId) return null;
+    const extras = shot.annotations?.extras || {};
+    if (extras.visualizerId != null) return String(extras.visualizerId);
+    if (extras.visualizer?.shot_id != null) return String(extras.visualizer.shot_id);
+    if (state.lastUploadedShot === localId && state.lastVisualizerId != null) {
+      return String(state.lastVisualizerId);
+    }
+    for (const [visualizerId, mappedLocalId] of Object.entries(state.shotMap)) {
+      if (mappedLocalId === localId) return String(visualizerId);
+    }
+    return null;
+  }
+
+  function localShotToVisualizerUpdate(shot, patch) {
+    const annotations = shot.annotations || {};
+    const context = shot.workflow?.context || {};
+    const patchAnnotations = patch?.annotations || {};
+    const patchContext = patch?.workflow?.context || {};
+    const payload = {};
+    const has = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
+    const setNumber = (key, value, transform) => {
+      if (value == null || value === "") return;
+      const number = Number(value);
+      if (!Number.isFinite(number)) return;
+      payload[key] = transform ? transform(number) : String(number);
+    };
+    const setMaybeNumber = (key, value, source, sourceKey, transform) => {
+      if (has(source, sourceKey) && (value == null || value === "")) {
+        payload[key] = null;
+        return;
+      }
+      setNumber(key, value, transform);
+    };
+    const setString = (key, value) => {
+      if (typeof value === "string" && value.trim() !== "") payload[key] = value;
+    };
+    const setMaybeString = (key, value, source, sourceKey) => {
+      if (has(source, sourceKey) && (value == null || value === "")) {
+        payload[key] = null;
+        return;
+      }
+      setString(key, value);
+    };
+
+    setMaybeNumber("espresso_enjoyment", annotations.enjoyment, patchAnnotations, "enjoyment", (n) => Math.round(n));
+    setMaybeNumber("drink_tds", annotations.drinkTds, patchAnnotations, "drinkTds");
+    setMaybeNumber("drink_ey", annotations.drinkEy, patchAnnotations, "drinkEy");
+    setMaybeNumber("bean_weight", annotations.actualDoseWeight ?? context.targetDoseWeight, patchAnnotations, "actualDoseWeight");
+    setMaybeNumber("drink_weight", annotations.actualYield ?? context.targetYield, patchAnnotations, "actualYield");
+    setMaybeString("espresso_notes", annotations.espressoNotes, patchAnnotations, "espressoNotes");
+    setString("profile_title", shot.workflow?.profile?.title || shot.workflow?.name);
+    setMaybeString("barista", context.baristaName, patchContext, "baristaName");
+    setMaybeString("grinder_setting", context.grinderSetting, patchContext, "grinderSetting");
+    setMaybeString("bean_brand", context.coffeeRoaster, patchContext, "coffeeRoaster");
+    setMaybeString("bean_type", context.coffeeName, patchContext, "coffeeName");
+
+    return payload;
+  }
+
+  function recordLocalSyncStatus(shotId, visualizerId, result, error) {
+    state.localSyncStatus = {
+      lastCheck: Date.now(),
+      lastResult: result || null,
+      lastError: error || null,
+      lastShotId: shotId || null,
+      lastVisualizerId: visualizerId || null,
+    };
+  }
+
+  async function pushLocalShotUpdate(shot, patch, opts) {
+    opts = opts || {};
+    if (!shot || !shot.id) {
+      recordLocalSyncStatus(null, null, "skipped: missing shot", null);
+      return { skipped: "missing shot" };
+    }
+    if (!opts.force && consumeLocalSyncSuppression(shot.id)) {
+      recordLocalSyncStatus(shot.id, null, "skipped: suppressed", null);
+      return { skipped: "suppressed" };
+    }
+    if (state.localSyncRunning[shot.id]) {
+      recordLocalSyncStatus(shot.id, null, "skipped: already running", null);
+      return { skipped: "already running" };
+    }
+    if (!state.username || !state.password) {
+      recordLocalSyncStatus(shot.id, null, "skipped: no credentials", null);
+      return { skipped: "no credentials" };
+    }
+
+    const visualizerId = visualizerIdForLocalShot(shot);
+    if (!visualizerId) {
+      log(`Local sync: ${shot.id} has no visualizer mapping`);
+      recordLocalSyncStatus(shot.id, null, "skipped: no mapping", null);
+      return { skipped: "no mapping" };
+    }
+
+    const update = localShotToVisualizerUpdate(shot, patch || {});
+    if (Object.keys(update).length === 0) {
+      recordLocalSyncStatus(shot.id, visualizerId, "skipped: empty update", null);
+      return { skipped: "empty update" };
+    }
+
+    state.localSyncRunning[shot.id] = true;
+    try {
+      const detail = await visualizerPatch(`/shots/${visualizerId}`, { shot: update });
+      const updatedAt = Number(detail?.updated_at) || Number(detail?.meta?.visualizer?.updated_at) || 0;
+      if (updatedAt > 0) {
+        state.backSyncState[visualizerId] = { remoteUpdatedAt: updatedAt };
+        state.backSyncCursor = Math.max(Number(state.backSyncCursor) || 0, updatedAt);
+        persistBackSyncState();
+      }
+      host.emit("shotForwardSynced", { shotId: shot.id, visualizerId, timestamp: Date.now() });
+      log(`Local sync: updated ${shot.id} → ${visualizerId}`);
+      recordLocalSyncStatus(shot.id, visualizerId, "updated", null);
+      return { ok: true, visualizerId };
+    } catch (e) {
+      log(`Local sync failed for ${shot.id}: ${e.message}`);
+      host.emit("shotForwardSyncError", { shotId: shot.id, visualizerId, error: e.message, timestamp: Date.now() });
+      recordLocalSyncStatus(shot.id, visualizerId, "error", e.message);
+      return { error: e.message };
+    } finally {
+      delete state.localSyncRunning[shot.id];
+    }
+  }
+
+  async function syncLocalShotNow(shotId) {
+    const id = shotId || state.lastUploadedShot;
+    if (!id) {
+      recordLocalSyncStatus(null, null, "skipped: no shot id", null);
+      return { skipped: "no shot id" };
+    }
+    const shot = await fetchShot(id);
+    if (!shot) {
+      recordLocalSyncStatus(id, null, "error", "shot not found");
+      return { error: "shot not found" };
+    }
+    return await pushLocalShotUpdate(shot, {}, { force: true });
   }
 
   // /api/me returns 401 on bad creds, 200 when valid. Gate back-sync on it so we
@@ -699,6 +879,7 @@ function createPlugin(host) {
         const update = mapRemoteToLocal(detail);
         let processed = Object.keys(update).length === 0;
         if (Object.keys(update).length > 0) {
+          suppressLocalSync(localId);
           const res = await fetch(`${LOCAL_API_URL}/shots/${localId}`, {
             method: "PUT",
             headers: { "Content-Type": "application/json" },
@@ -966,6 +1147,29 @@ function createPlugin(host) {
         }));
       }
 
+      if (request.endpoint === 'forwardSyncStatus') {
+        return {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            lastCheck: state.localSyncStatus.lastCheck,
+            lastResult: state.localSyncStatus.lastResult,
+            lastError: state.localSyncStatus.lastError,
+            lastShotId: state.localSyncStatus.lastShotId,
+            lastVisualizerId: state.localSyncStatus.lastVisualizerId,
+            running: Object.keys(state.localSyncRunning),
+          })
+        };
+      }
+
+      if (request.endpoint === 'forwardSyncNow') {
+        return syncLocalShotNow(request.body?.shotId).then((result) => ({
+          status: result && result.error ? 400 : 200,
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ok: !(result && result.error), result, status: state.localSyncStatus })
+        }));
+      }
+
       // Default 404 response
       return {
         status: 404,
@@ -1034,6 +1238,14 @@ function createPlugin(host) {
             // off shortly after enabling.
             armBackSync(2000);
           }
+          break;
+
+        case "shotUpdated":
+          pushLocalShotUpdate(event.payload?.shot || { id: event.payload?.id }, event.payload?.patch || {})
+            .catch((e) => {
+              log(`Local sync unexpected failure: ${e.message}`);
+              recordLocalSyncStatus(event.payload?.id, null, "error", e.message);
+            });
           break;
       }
     },

--- a/assets/plugins/visualizer.reaplugin/plugin.js
+++ b/assets/plugins/visualizer.reaplugin/plugin.js
@@ -11,11 +11,14 @@ function createPlugin(host) {
   "use strict";
 
   const SHOT_FETCH_DELAY_MS = 5000;
+  const NS = "visualizer.reaplugin";
+  const LOCAL_API_URL = "http://localhost:8080/api/v1";
   const VISUALIZER_API_URL = "https://visualizer.coffee/api";
   const VISUALIZER_SHARED_API = "https://visualizer.coffee/api/shots/shared?code=";
   const VISUALIZER_PROFILE_API = "https://visualizer.coffee/api/shots/%1/profile?format=json";
 
   let shotFetchTimeoutId = null;
+  let backSyncTimeoutId = null;
   let isUploading = false;
 
   const state = {
@@ -27,6 +30,14 @@ function createPlugin(host) {
     autoUpload: true,
     lengthThreshold: 5,
     lastMachineState: null,
+    // Back-sync: pull metadata edited on Visualizer back onto local shots.
+    backSyncEnabled: false,
+    backSyncIntervalSeconds: 300,
+    backSyncCursor: 0, // newest remote updated_at we've processed
+    shotMap: {}, // visualizerId -> localShotId, for our own uploads only
+    backSyncState: {}, // visualizerId -> { remoteUpdatedAt }
+    backSyncRunning: false,
+    backSyncStatus: { lastCheck: null, lastResult: null, lastError: null, lastApplied: 0 },
   };
 
   function log(msg) {
@@ -262,6 +273,10 @@ function createPlugin(host) {
         data: result.id
       });
 
+      // Record the local↔visualizer mapping so back-sync can later find this
+      // shot, and only ever touches shots we uploaded ourselves.
+      await rememberUpload(fullShot.id, result.id);
+
       log(`Uploaded ${fullShot.id} → ${result.id}`);
 
       host.emit("shotUploaded", {
@@ -287,6 +302,13 @@ function createPlugin(host) {
     } else if (payload.key === "lastVisualizerId") {
       state.lastVisualizerId = payload.value;
       log(`Loaded lastVisualizerId from storage: ${payload.value}`);
+    } else if (payload.key === "shotMap") {
+      state.shotMap = safeParseObject(payload.value) || {};
+      log(`Loaded shot map (${Object.keys(state.shotMap).length} entries)`);
+    } else if (payload.key === "backSyncCursor") {
+      state.backSyncCursor = Number(payload.value) || 0;
+    } else if (payload.key === "backSyncState") {
+      state.backSyncState = safeParseObject(payload.value) || {};
     }
   }
 
@@ -415,6 +437,321 @@ function createPlugin(host) {
     };
   }
 
+  // ---- Back-sync: pull metadata edited on Visualizer back onto local shots ----
+
+  function safeParseObject(value) {
+    if (value == null) return null;
+    if (typeof value === "object") return value;
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" ? parsed : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function persistBackSyncState() {
+    host.storage({ type: "write", key: "shotMap", namespace: NS, data: JSON.stringify(state.shotMap) });
+    host.storage({ type: "write", key: "backSyncCursor", namespace: NS, data: String(state.backSyncCursor) });
+    host.storage({ type: "write", key: "backSyncState", namespace: NS, data: JSON.stringify(state.backSyncState) });
+  }
+
+  function localShotVisualizerId(shot) {
+    const extras = shot?.annotations?.extras || {};
+    if (extras.visualizerId != null) return String(extras.visualizerId);
+    if (extras.visualizer?.shot_id != null) return String(extras.visualizer.shot_id);
+    return null;
+  }
+
+  async function refreshLocalShotMap() {
+    let offset = 0;
+    const limit = 100;
+    let total = null;
+    let added = 0;
+
+    do {
+      const res = await fetch(`${LOCAL_API_URL}/shots?limit=${limit}&offset=${offset}&order=desc`);
+      if (!res.ok) throw new Error(`Local shots lookup failed: HTTP ${res.status}`);
+      const page = await res.json();
+      const items = Array.isArray(page) ? page : (page.items || []);
+      if (total == null) total = Number(page.total) || items.length;
+
+      for (const shot of items) {
+        const visualizerId = localShotVisualizerId(shot);
+        if (!visualizerId || !shot.id) continue;
+        if (state.shotMap[visualizerId] !== shot.id) {
+          state.shotMap[visualizerId] = shot.id;
+          added++;
+        }
+      }
+
+      offset += items.length;
+      if (items.length === 0) break;
+    } while (offset < total);
+
+    if (added > 0) {
+      persistBackSyncState();
+      log(`Back-sync: discovered ${added} local Visualizer mapping(s)`);
+    }
+    return { total: Object.keys(state.shotMap).length, added };
+  }
+
+  // Remember a successful upload: map visualizerId → localShotId, and stamp the
+  // visualizer id onto the local shot so it's durable and visible to clients.
+  async function rememberUpload(localId, visualizerId) {
+    if (!localId || visualizerId == null) return;
+    state.shotMap[String(visualizerId)] = localId;
+    persistBackSyncState();
+    try {
+      await fetch(`${LOCAL_API_URL}/shots/${localId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ annotations: { extras: { visualizerId: String(visualizerId) } } }),
+      });
+    } catch (e) {
+      log(`Could not stamp visualizerId on ${localId}: ${e.message}`);
+    }
+  }
+
+  async function visualizerGet(path) {
+    const res = await fetch(`${VISUALIZER_API_URL}${path}`, {
+      method: "GET",
+      headers: { "Authorization": getAuthHeader(), "Content-Type": "application/json" },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
+    return await res.json();
+  }
+
+  // /api/me returns 401 on bad creds, 200 when valid. Gate back-sync on it so we
+  // never hit /api/shots unauthenticated (which would return the public feed).
+  async function verifyCredentials() {
+    try {
+      const res = await fetch(`${VISUALIZER_API_URL}/me`, {
+        method: "GET",
+        headers: { "Authorization": getAuthHeader() },
+      });
+      if (!res.ok) return null;
+      try { return await res.json(); } catch (e) { return {}; }
+    } catch (e) {
+      log(`Back-sync: /me check failed: ${e.message}`);
+      return null;
+    }
+  }
+
+  // The shot index echoes the authenticated user's id at the top level. If it's
+  // present and isn't us, we are not looking at our own shots — bail rather than
+  // risk writing someone else's edits onto local shots. (Absent => older server
+  // without the field; the own-uploads map downstream is the real backstop, so
+  // don't hard-fail on absence.)
+  function assertOwnShotIndex(resp, myUserId) {
+    if (!resp || Array.isArray(resp)) return;
+    if (resp.user_id != null && myUserId != null && String(resp.user_id) !== String(myUserId)) {
+      throw new Error("shot index user_id mismatch");
+    }
+  }
+
+  // Authenticated → server returns only Current.user.shots, and `updated_after`
+  // (Unix seconds) makes it return only shots changed since our cursor. So we
+  // just page newest-first until a short page; no client-side cursor comparison.
+  // Older servers ignore the unknown param and return everything, but the
+  // per-shot sync state below still prevents re-applying unchanged shots.
+  async function listChangedShots(cursor, myUserId) {
+    const items = [];
+    const maxPages = 20;
+    const after = cursor > 0 ? `&updated_after=${cursor}` : "";
+    for (let page = 1; page <= maxPages; page++) {
+      const resp = await visualizerGet(`/shots?sort=updated_at&items=50&page=${page}${after}`);
+      assertOwnShotIndex(resp, myUserId);
+      const data = Array.isArray(resp) ? resp : (resp && resp.data) || [];
+      if (data.length === 0) break;
+      for (const shot of data) {
+        items.push({ id: String(shot.id), updatedAt: Number(shot.updated_at) || 0 });
+      }
+      if (data.length < 50) break;
+    }
+    return items;
+  }
+
+  // Newest remote updated_at, for the first-run baseline — one item, so enabling
+  // back-sync records a starting point without paging the whole library.
+  async function newestRemoteUpdatedAt(myUserId) {
+    const resp = await visualizerGet(`/shots?sort=updated_at&items=1`);
+    assertOwnShotIndex(resp, myUserId);
+    const data = Array.isArray(resp) ? resp : (resp && resp.data) || [];
+    return data.reduce((max, shot) => Math.max(max, Number(shot.updated_at) || 0), 0);
+  }
+
+  // Build a partial reaprime shot update from a visualizer shot detail. PUT
+  // /api/v1/shots/<id> deep-merges it, so only the changed fields are sent.
+  function mapRemoteToLocal(remote) {
+    const annotations = {};
+    const context = {};
+    const extras = {};
+    const has = (key) => Object.prototype.hasOwnProperty.call(remote || {}, key);
+    const numberField = (key) => {
+      const value = has(key) ? remote[key] : null;
+      if (value == null || value === "") return null;
+      const number = Number(value);
+      return Number.isFinite(number) ? number : undefined;
+    };
+    const stringField = (key) => {
+      const value = has(key) ? remote[key] : null;
+      if (value == null) return null;
+      if (typeof value !== "string") return undefined;
+      return value.trim() === "" ? null : value;
+    };
+    const set = (obj, key, value) => {
+      if (value !== undefined) obj[key] = value;
+    };
+
+    set(annotations, "drinkTds", numberField("drink_tds"));
+    set(annotations, "drinkEy", numberField("drink_ey"));
+    set(annotations, "enjoyment", numberField("espresso_enjoyment"));
+    set(annotations, "espressoNotes", stringField("espresso_notes"));
+    set(annotations, "actualDoseWeight", numberField("bean_weight"));
+    set(annotations, "actualYield", numberField("drink_weight"));
+    set(context, "coffeeRoaster", stringField("bean_brand"));
+    set(context, "coffeeName", stringField("bean_type"));
+    set(context, "grinderModel", stringField("grinder_model"));
+    set(context, "grinderSetting", stringField("grinder_setting"));
+
+    for (const key of ["roast_level", "roast_date", "bean_notes", "private_notes",
+      "tags", "fragrance", "aroma", "flavor", "aftertaste", "acidity",
+      "bitterness", "sweetness", "mouthfeel"]) {
+      set(extras, key, has(key) ? (remote[key] == null || remote[key] === "" ? null : remote[key]) : null);
+    }
+
+    const update = {};
+    if (Object.keys(annotations).length || Object.keys(extras).length) {
+      update.annotations = annotations;
+      if (Object.keys(extras).length) update.annotations.extras = { visualizer: extras };
+    }
+    if (Object.keys(context).length) update.workflow = { context };
+    return update;
+  }
+
+  async function runBackSync(opts) {
+    opts = opts || {};
+    if (state.backSyncRunning) return { skipped: "already running" };
+    if (!state.backSyncEnabled && !opts.force) return { skipped: "disabled" };
+    if (!state.username || !state.password) return { skipped: "no credentials" };
+
+    state.backSyncRunning = true;
+    state.backSyncStatus.lastCheck = Date.now();
+    let applied = 0;
+    try {
+      // 1) Never query shots unless we're a verified, authenticated user.
+      const me = await verifyCredentials();
+      if (me == null) {
+        state.backSyncStatus.lastError = "invalid credentials";
+        log("Back-sync: credentials not valid — not querying shots");
+        return { error: "invalid credentials" };
+      }
+      const myUserId = me.id != null ? me.id : (me.user_id != null ? me.user_id : (me.user && me.user.id));
+
+      const localMap = await refreshLocalShotMap();
+      const forceAll = opts.force === true;
+
+      // 2) First run: set a baseline and apply nothing, so enabling back-sync
+      // doesn't rewrite the entire history. Record the newest remote updated_at
+      // (one item) rather than paging the whole library.
+      if (!forceAll && state.backSyncCursor === 0) {
+        state.backSyncCursor = await newestRemoteUpdatedAt(myUserId);
+        persistBackSyncState();
+        state.backSyncStatus.lastResult = "baseline set";
+        state.backSyncStatus.lastError = null;
+        log(`Back-sync baseline set at ${state.backSyncCursor}`);
+        return { baseline: true };
+      }
+
+      const items = forceAll
+        ? Object.keys(state.shotMap).map((id) => ({ id, updatedAt: 0, force: true }))
+        : await listChangedShots(state.backSyncCursor, myUserId);
+
+      // Process oldest-first so the cursor advances monotonically.
+      const ordered = items.slice().sort((a, b) => a.updatedAt - b.updatedAt);
+      let maxProcessed = state.backSyncCursor;
+      let cursorBlocked = false;
+      for (const item of ordered) {
+        // 3) Only ever touch shots we uploaded ourselves.
+        const localId = state.shotMap[item.id];
+        if (!localId) {
+          if (!cursorBlocked) maxProcessed = Math.max(maxProcessed, item.updatedAt);
+          continue;
+        }
+
+        const prev = state.backSyncState[item.id];
+        if (!item.force && prev && Number(prev.remoteUpdatedAt) >= item.updatedAt) {
+          if (!cursorBlocked) maxProcessed = Math.max(maxProcessed, item.updatedAt);
+          continue;
+        }
+
+        let detail;
+        try {
+          detail = await visualizerGet(`/shots/${item.id}?essentials=1`);
+        } catch (e) {
+          log(`Back-sync: failed to fetch ${item.id}: ${e.message}`);
+          cursorBlocked = true;
+          continue;
+        }
+        const itemUpdatedAt = Number(detail?.updated_at) || item.updatedAt || 0;
+
+        const update = mapRemoteToLocal(detail);
+        let processed = Object.keys(update).length === 0;
+        if (Object.keys(update).length > 0) {
+          const res = await fetch(`${LOCAL_API_URL}/shots/${localId}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(update),
+          });
+          if (res.ok) {
+            applied++;
+            processed = true;
+            host.emit("shotBackSynced", { shotId: localId, visualizerId: item.id, timestamp: Date.now() });
+          } else {
+            log(`Back-sync: PUT ${localId} failed ${res.status}`);
+          }
+        }
+
+        if (processed) {
+          state.backSyncState[item.id] = { remoteUpdatedAt: itemUpdatedAt };
+          if (!cursorBlocked) maxProcessed = Math.max(maxProcessed, itemUpdatedAt);
+        } else {
+          cursorBlocked = true;
+        }
+      }
+
+      state.backSyncCursor = maxProcessed;
+      persistBackSyncState();
+      state.backSyncStatus.lastResult = `applied ${applied}${forceAll ? ` (checked ${items.length}, mapped ${localMap.total})` : ''}`;
+      state.backSyncStatus.lastApplied = applied;
+      state.backSyncStatus.lastError = null;
+      log(`Back-sync applied ${applied} change(s)`);
+      return { applied };
+    } catch (e) {
+      state.backSyncStatus.lastError = e.message;
+      log(`Back-sync error: ${e.message}`);
+      return { error: e.message };
+    } finally {
+      state.backSyncRunning = false;
+    }
+  }
+
+  // Arm a single back-sync run after delayMs, then re-arm at the configured
+  // interval. A no-op (and cancels any pending run) when back-sync is disabled.
+  function armBackSync(delayMs) {
+    if (backSyncTimeoutId !== null) {
+      clearTimeout(backSyncTimeoutId);
+      backSyncTimeoutId = null;
+    }
+    if (!state.backSyncEnabled) return;
+    backSyncTimeoutId = setTimeout(async () => {
+      backSyncTimeoutId = null;
+      try { await runBackSync(); } catch (e) { log(`Back-sync tick error: ${e.message}`); }
+      armBackSync(Math.max(60, Number(state.backSyncIntervalSeconds) || 300) * 1000);
+    }, delayMs);
+  }
+
   // Return the plugin object
   return {
     id: "visualizer.reaplugin",
@@ -425,21 +762,20 @@ function createPlugin(host) {
       state.password = settings.Password;
       state.autoUpload = settings.AutoUpload != undefined ? settings.AutoUpload : true;
       state.lengthThreshold = settings.LengthThreshold != undefined ? settings.LengthThreshold : 5;
+      state.backSyncEnabled = settings.BackSync === true;
+      state.backSyncIntervalSeconds = settings.BackSyncIntervalSeconds != undefined ? settings.BackSyncIntervalSeconds : 300;
 
-      log(`Loaded with username: ${state.username ? 'configured' : 'not configured'}`);
+      log(`Loaded with username: ${state.username ? 'configured' : 'not configured'}, back-sync ${state.backSyncEnabled ? 'on' : 'off'}`);
 
       // Load saved state from storage
-      host.storage({
-        type: "read",
-        key: "lastUploadedShot",
-        namespace: "visualizer.reaplugin"
-      });
+      host.storage({ type: "read", key: "lastUploadedShot", namespace: NS });
+      host.storage({ type: "read", key: "lastVisualizerId", namespace: NS });
+      host.storage({ type: "read", key: "shotMap", namespace: NS });
+      host.storage({ type: "read", key: "backSyncCursor", namespace: NS });
+      host.storage({ type: "read", key: "backSyncState", namespace: NS });
 
-      host.storage({
-        type: "read",
-        key: "lastVisualizerId",
-        namespace: "visualizer.reaplugin"
-      });
+      // First run ~30s after load so storage reads have settled.
+      if (state.backSyncEnabled) armBackSync(30000);
     },
 
     onUnload() {
@@ -448,6 +784,11 @@ function createPlugin(host) {
         clearTimeout(shotFetchTimeoutId);
         shotFetchTimeoutId = null;
       }
+      if (backSyncTimeoutId !== null) {
+        clearTimeout(backSyncTimeoutId);
+        backSyncTimeoutId = null;
+      }
+      persistBackSyncState();
 
       // Save current state to storage
       if (state.lastUploadedShot) {
@@ -507,6 +848,7 @@ function createPlugin(host) {
           }).then((json) => {
             return uploadShot(convertReaToVisualizerFormat(json), null);
           }).then((shotResponse) => {
+            rememberUpload(shotId, shotResponse.id);
             return {
               status: 200,
               headers: { 'Content-Type': 'application/json' },
@@ -599,6 +941,31 @@ function createPlugin(host) {
           });
       }
 
+      if (request.endpoint === 'backSyncStatus') {
+        return {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            enabled: state.backSyncEnabled,
+            intervalSeconds: state.backSyncIntervalSeconds,
+            cursor: state.backSyncCursor,
+            mappedShots: Object.keys(state.shotMap).length,
+            lastCheck: state.backSyncStatus.lastCheck,
+            lastResult: state.backSyncStatus.lastResult,
+            lastError: state.backSyncStatus.lastError,
+            lastApplied: state.backSyncStatus.lastApplied,
+          })
+        };
+      }
+
+      if (request.endpoint === 'backSyncNow') {
+        return runBackSync({ force: true }).then((result) => ({
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ok: true, result })
+        }));
+      }
+
       // Default 404 response
       return {
         status: 404,
@@ -655,6 +1022,17 @@ function createPlugin(host) {
           }
           if (event.payload?.LengthThreshold !== undefined) {
             state.lengthThreshold = event.payload.LengthThreshold;
+          }
+          if (event.payload?.BackSyncIntervalSeconds !== undefined) {
+            state.backSyncIntervalSeconds = event.payload.BackSyncIntervalSeconds;
+            if (state.backSyncEnabled) armBackSync(2000);
+          }
+          if (event.payload?.BackSync !== undefined) {
+            state.backSyncEnabled = event.payload.BackSync === true;
+            log(`BackSync updated: ${state.backSyncEnabled}`);
+            // armBackSync cancels the pending run when disabled, or kicks one
+            // off shortly after enabling.
+            armBackSync(2000);
           }
           break;
       }

--- a/assets/plugins/visualizer.reaplugin/plugin.js
+++ b/assets/plugins/visualizer.reaplugin/plugin.js
@@ -593,48 +593,54 @@ function createPlugin(host) {
     return null;
   }
 
-  function localShotToVisualizerUpdate(shot, patch) {
+  // Build a Visualizer update from a local shot. In edit mode (force=false) a
+  // field is pushed ONLY when the incoming patch touched it, so editing one
+  // field (e.g. enjoyment) never re-sends — and clobbers — Visualizer-side
+  // edits to other fields that haven't been back-synced yet. In force mode
+  // (manual full sync) every mapped field is pushed: local-wins.
+  function localShotToVisualizerUpdate(shot, patch, force) {
     const annotations = shot.annotations || {};
     const context = shot.workflow?.context || {};
     const patchAnnotations = patch?.annotations || {};
     const patchContext = patch?.workflow?.context || {};
     const payload = {};
     const has = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
-    const setNumber = (key, value, transform) => {
+    const touched = (source, sourceKey) => force === true || has(source, sourceKey);
+    const setNumber = (key, value, source, sourceKey, transform) => {
+      if (!touched(source, sourceKey)) return;
+      if (has(source, sourceKey) && (value == null || value === "")) {
+        payload[key] = null;
+        return;
+      }
       if (value == null || value === "") return;
       const number = Number(value);
       if (!Number.isFinite(number)) return;
       payload[key] = transform ? transform(number) : String(number);
     };
-    const setMaybeNumber = (key, value, source, sourceKey, transform) => {
+    const setString = (key, value, source, sourceKey) => {
+      if (!touched(source, sourceKey)) return;
       if (has(source, sourceKey) && (value == null || value === "")) {
         payload[key] = null;
         return;
       }
-      setNumber(key, value, transform);
-    };
-    const setString = (key, value) => {
       if (typeof value === "string" && value.trim() !== "") payload[key] = value;
     };
-    const setMaybeString = (key, value, source, sourceKey) => {
-      if (has(source, sourceKey) && (value == null || value === "")) {
-        payload[key] = null;
-        return;
-      }
-      setString(key, value);
-    };
 
-    setMaybeNumber("espresso_enjoyment", annotations.enjoyment, patchAnnotations, "enjoyment", (n) => Math.round(n));
-    setMaybeNumber("drink_tds", annotations.drinkTds, patchAnnotations, "drinkTds");
-    setMaybeNumber("drink_ey", annotations.drinkEy, patchAnnotations, "drinkEy");
-    setMaybeNumber("bean_weight", annotations.actualDoseWeight ?? context.targetDoseWeight, patchAnnotations, "actualDoseWeight");
-    setMaybeNumber("drink_weight", annotations.actualYield ?? context.targetYield, patchAnnotations, "actualYield");
-    setMaybeString("espresso_notes", annotations.espressoNotes, patchAnnotations, "espressoNotes");
-    setString("profile_title", shot.workflow?.profile?.title || shot.workflow?.name);
-    setMaybeString("barista", context.baristaName, patchContext, "baristaName");
-    setMaybeString("grinder_setting", context.grinderSetting, patchContext, "grinderSetting");
-    setMaybeString("bean_brand", context.coffeeRoaster, patchContext, "coffeeRoaster");
-    setMaybeString("bean_type", context.coffeeName, patchContext, "coffeeName");
+    setNumber("espresso_enjoyment", annotations.enjoyment, patchAnnotations, "enjoyment", (n) => Math.round(n));
+    setNumber("drink_tds", annotations.drinkTds, patchAnnotations, "drinkTds");
+    setNumber("drink_ey", annotations.drinkEy, patchAnnotations, "drinkEy");
+    setNumber("bean_weight", annotations.actualDoseWeight ?? context.targetDoseWeight, patchAnnotations, "actualDoseWeight");
+    setNumber("drink_weight", annotations.actualYield ?? context.targetYield, patchAnnotations, "actualYield");
+    setString("espresso_notes", annotations.espressoNotes, patchAnnotations, "espressoNotes");
+    setString("barista", context.baristaName, patchContext, "baristaName");
+    setString("grinder_setting", context.grinderSetting, patchContext, "grinderSetting");
+    setString("bean_brand", context.coffeeRoaster, patchContext, "coffeeRoaster");
+    setString("bean_type", context.coffeeName, patchContext, "coffeeName");
+    // profile_title has no patch key; only send it in a full (force) sync.
+    if (force === true) {
+      const title = shot.workflow?.profile?.title || shot.workflow?.name;
+      if (typeof title === "string" && title.trim() !== "") payload.profile_title = title;
+    }
 
     return payload;
   }
@@ -675,7 +681,7 @@ function createPlugin(host) {
       return { skipped: "no mapping" };
     }
 
-    const update = localShotToVisualizerUpdate(shot, patch || {});
+    const update = localShotToVisualizerUpdate(shot, patch || {}, opts.force === true);
     if (Object.keys(update).length === 0) {
       recordLocalSyncStatus(shot.id, visualizerId, "skipped: empty update", null);
       return { skipped: "empty update" };
@@ -764,6 +770,9 @@ function createPlugin(host) {
         items.push({ id: String(shot.id), updatedAt: Number(shot.updated_at) || 0 });
       }
       if (data.length < 50) break;
+      if (page === maxPages) {
+        log(`Back-sync: hit ${maxPages}-page cap (${items.length} changed shots); remaining advance next tick`);
+      }
     }
     return items;
   }
@@ -845,8 +854,13 @@ function createPlugin(host) {
       }
       const myUserId = me.id != null ? me.id : (me.user_id != null ? me.user_id : (me.user && me.user.id));
 
-      const localMap = await refreshLocalShotMap();
+      // The map is persisted and kept current on upload via rememberUpload, so
+      // routine ticks rely on it; only a forced run re-pages the whole library
+      // (heavy on large libraries) to rediscover mappings stamped out-of-band.
       const forceAll = opts.force === true;
+      const localMap = forceAll
+        ? await refreshLocalShotMap()
+        : { total: Object.keys(state.shotMap).length, added: 0 };
 
       // 2) First run: set a baseline and apply nothing, so enabling back-sync
       // doesn't rewrite the entire history. Record the newest remote updated_at
@@ -945,14 +959,19 @@ function createPlugin(host) {
     backSyncTimeoutId = setTimeout(async () => {
       backSyncTimeoutId = null;
       try { await runBackSync(); } catch (e) { log(`Back-sync tick error: ${e.message}`); }
-      armBackSync(Math.max(60, Number(state.backSyncIntervalSeconds) || 300) * 1000);
+      const configured = Number(state.backSyncIntervalSeconds) || 300;
+      const intervalSeconds = Math.max(60, configured);
+      if (configured < 60) {
+        log(`Back-sync interval ${configured}s is below the 60s minimum, clamped to 60s`);
+      }
+      armBackSync(intervalSeconds * 1000);
     }, delayMs);
   }
 
   // Return the plugin object
   return {
     id: "visualizer.reaplugin",
-    version: "1.2.0",
+    version: "1.3.0",
 
     onLoad(settings) {
       state.username = settings.Username;
@@ -1156,6 +1175,13 @@ function createPlugin(host) {
       }
 
       if (request.endpoint === 'backSyncNow') {
+        if (request.method !== 'POST') {
+          return {
+            status: 405,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ error: 'Method not allowed' })
+          };
+        }
         return runBackSync({ force: true }).then((result) => ({
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -1179,6 +1205,13 @@ function createPlugin(host) {
       }
 
       if (request.endpoint === 'forwardSyncNow') {
+        if (request.method !== 'POST') {
+          return {
+            status: 405,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ error: 'Method not allowed' })
+          };
+        }
         return syncLocalShotNow(request.body?.shotId).then((result) => ({
           status: result && result.error ? 400 : 200,
           headers: { 'Content-Type': 'application/json' },

--- a/assets/plugins/visualizer.reaplugin/plugin.js
+++ b/assets/plugins/visualizer.reaplugin/plugin.js
@@ -150,18 +150,34 @@ function createPlugin(host) {
     }
   }
 
+  function isEspressoUploadFrame(measurement) {
+    const substate = measurement?.machine?.state?.substate;
+    return substate === 'preinfusion' || substate === 'pouring';
+  }
+
+  function visualizerUploadMeasurements(measurements) {
+    const firstEspressoIndex = measurements.findIndex(isEspressoUploadFrame);
+    if (firstEspressoIndex < 0) {
+      throw new Error("Shot has no espresso frames for Visualizer upload.");
+    }
+
+    let lastEspressoIndex = firstEspressoIndex;
+    for (let i = firstEspressoIndex + 1; i < measurements.length; i++) {
+      if (!isEspressoUploadFrame(measurements[i])) break;
+      lastEspressoIndex = i;
+    }
+
+    return measurements.slice(firstEspressoIndex, lastEspressoIndex + 1);
+  }
+
   function convertReaToVisualizerFormat(reaShot) {
     if (!reaShot || !reaShot.measurements || reaShot.measurements.length === 0) {
       throw new Error("Invalid or empty Decent shot data for conversion.");
     }
 
-    const firstEspressoIndex = reaShot.measurements.findIndex((element) => {
-      return element.machine.state.substate == 'preinfusion' ||
-        element.machine.state.substate == 'pouring';
-    });
-
-    const firstTimestamp = new Date(reaShot.measurements[firstEspressoIndex].machine.timestamp).getTime();
-    const lastMeasurement = reaShot.measurements[reaShot.measurements.length - 1];
+    const uploadMeasurements = visualizerUploadMeasurements(reaShot.measurements);
+    const firstTimestamp = new Date(uploadMeasurements[0].machine.timestamp).getTime();
+    const lastMeasurement = uploadMeasurements[uploadMeasurements.length - 1];
     const lastTimestamp = new Date(lastMeasurement.machine.timestamp).getTime();
     const annotations = reaShot.annotations || {};
     const context = reaShot.workflow?.context || {};
@@ -197,8 +213,8 @@ function createPlugin(host) {
       },
     };
 
-    for (let i = firstEspressoIndex; i < reaShot.measurements.length; i++) {
-      const m = reaShot.measurements[i];
+    for (let i = 0; i < uploadMeasurements.length; i++) {
+      const m = uploadMeasurements[i];
       const machine = m.machine;
       const scale = m.scale;
 
@@ -217,7 +233,7 @@ function createPlugin(host) {
       visualizerShot.state_change.push(machine.state.substate);
 
       if (i > 0) {
-        const prevMachine = reaShot.measurements[i - 1].machine;
+        const prevMachine = uploadMeasurements[i - 1].machine;
         const timeDelta = elapsed - visualizerShot.elapsed[i - 1];
         totalWaterDispensed += prevMachine.flow * timeDelta;
       }

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -162,6 +162,18 @@ Plugins receive events in the `onEvent` method:
   ```
 
 - **`storageWrite`**: Confirmation of storage write
+- **`shotUpdated`**: A stored shot was edited via `PUT /api/v1/shots/<id>` (e.g. metadata changes — notes, enjoyment, bean/grinder). Broadcast to every plugin so they can react to edits (the Visualizer plugin uses it to forward-sync edited metadata).
+
+  ```javascript
+  {
+    name: "shotUpdated",
+    payload: {
+      id: "shot-12345",       // local shot id
+      shot: { /* full shot without measurements */ },
+      patch: { /* the partial update body that was PUT */ }
+    }
+  }
+  ```
 
 ### Events from Plugin → Flutter
 

--- a/lib/src/services/webserver/shots_handler.dart
+++ b/lib/src/services/webserver/shots_handler.dart
@@ -2,16 +2,21 @@ import 'dart:convert';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/persistence_controller.dart';
 import 'package:reaprime/src/models/data/shot_record.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
 import 'package:reaprime/src/services/webserver/json_response.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
 class ShotsHandler {
   final PersistenceController _controller;
+  final PluginManager? _pluginManager;
 
   final Logger _log = Logger("ShotsHandler");
 
-  ShotsHandler({required PersistenceController controller})
-    : _controller = controller;
+  ShotsHandler({
+    required PersistenceController controller,
+    PluginManager? pluginManager,
+  }) : _controller = controller,
+       _pluginManager = pluginManager;
 
   void addRoutes(RouterPlus app) {
     app.get('/api/v1/shots', _getShots);
@@ -42,8 +47,12 @@ class ShotsHandler {
 
     // Legacy: support filtering by ids (handles both ?ids=a&ids=b and ?ids=a,b,c)
     final rawIds = req.url.queryParametersAll['ids'];
-    final ids = rawIds?.expand((id) => id.split(',')).where((id) => id.isNotEmpty).toList();
-    final hasFilters = grinderId != null ||
+    final ids = rawIds
+        ?.expand((id) => id.split(','))
+        .where((id) => id.isNotEmpty)
+        .toList();
+    final hasFilters =
+        grinderId != null ||
         grinderModel != null ||
         beanBatchId != null ||
         coffeeName != null ||
@@ -61,12 +70,15 @@ class ShotsHandler {
 
       final order = params['order'] ?? 'desc';
       if (order != 'asc' && order != 'desc') {
-        return jsonBadRequest(
-            {"error": "Invalid order value. Supported: asc, desc"});
+        return jsonBadRequest({
+          "error": "Invalid order value. Supported: asc, desc",
+        });
       }
-      shots.sort((a, b) => order == 'asc'
-          ? a.timestamp.compareTo(b.timestamp)
-          : b.timestamp.compareTo(a.timestamp));
+      shots.sort(
+        (a, b) => order == 'asc'
+            ? a.timestamp.compareTo(b.timestamp)
+            : b.timestamp.compareTo(a.timestamp),
+      );
 
       return jsonOk(shots.map((e) => e.toJson()).toList());
     }
@@ -159,7 +171,9 @@ class ShotsHandler {
 
       // Validate that the ID in the path matches the ID in the body (if provided)
       if (json['id'] != null && json['id'] != id) {
-        return jsonBadRequest({"error": "ID in path does not match ID in body"});
+        return jsonBadRequest({
+          "error": "ID in path does not match ID in body",
+        });
       }
 
       // Fetch existing shot for partial update support
@@ -174,6 +188,12 @@ class ShotsHandler {
 
       final updatedShot = ShotRecord.fromJson(merged);
       await _controller.updateShot(updatedShot);
+      _log.info("Broadcasting shotUpdated for ${updatedShot.id}");
+      _pluginManager?.broadcastEvent('shotUpdated', {
+        'id': updatedShot.id,
+        'shot': updatedShot.toJsonWithoutMeasurements(),
+        'patch': json,
+      });
 
       return jsonOk(updatedShot.toJson());
     } catch (e, st) {

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -148,6 +148,7 @@ Future<void> startWebServer(
   );
   final ShotsHandler shotsHandler = ShotsHandler(
     controller: persistenceController,
+    pluginManager: pluginService.pluginManager,
   );
   final SteamsHandler steamsHandler = SteamsHandler(
     controller: persistenceController,


### PR DESCRIPTION
Adds opt-in Visualizer back-sync plus manual/status endpoints, persists local-to-Visualizer shot mappings, and broadcasts local shot updates so edited metadata can also be pushed forward. 




