### PR TITLE
Expose tablet IP to WebUI

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3581,6 +3581,9 @@ paths:
                     type: boolean
                   fullVersion:
                     type: string
+                  localIp:
+                    type: string
+                    description: Gateway Wi-Fi/LAN IP (empty if unavailable), for building phone hand-off URLs.
                 required:
                   - commit
                   - commitShort
@@ -3590,6 +3593,7 @@ paths:
                   - buildNumber
                   - appStore
                   - fullVersion
+                  - localIp
   /api/v1/debug/scale/{command}:
     post:
       summary: Control mock scale (simulate mode only)

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -248,7 +248,7 @@ Sync accepts: `target` (URL), `mode` (pull/push/two_way), `onConflict` (skip/ove
 
 | Method | Path | Description | Handler |
 |--------|------|-------------|---------|
-| GET | `/api/v1/info` | Build metadata (version, commit, branch) | `info_handler.dart` |
+| GET | `/api/v1/info` | Build metadata (version, commit, branch) + gateway LAN IP (`localIp`) | `info_handler.dart` |
 | POST | `/api/v1/feedback` | Submit feedback (creates GitHub issue) | `feedback_handler.dart` |
 | GET | `/api/v1/logs` | Recent log entries | `logs_handler.dart` |
 | GET | `/api/v1/webview-logs` | WebView console log forwarding | `webview_logs_handler.dart` |

--- a/lib/src/services/webserver/info_handler.dart
+++ b/lib/src/services/webserver/info_handler.dart
@@ -1,4 +1,5 @@
 import 'package:logging/logging.dart';
+import 'package:network_info_plus/network_info_plus.dart';
 import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/services/webserver/json_response.dart';
 import 'package:shelf_plus/shelf_plus.dart';
@@ -21,7 +22,20 @@ class InfoHandler {
       'buildNumber': BuildInfo.buildNumber,
       'appStore': BuildInfo.appStore,
       'fullVersion': BuildInfo.fullVersion,
+      'localIp': await _localIp(),
     };
     return jsonOk(info);
+  }
+
+  /// The gateway's Wi-Fi/LAN IP, for WebUI skins building phone hand-off URLs
+  /// (a skin webview runs on localhost and can't discover the LAN IP itself).
+  /// Empty string when unavailable (e.g. on Ethernet, or in tests).
+  Future<String> _localIp() async {
+    try {
+      return await NetworkInfo().getWifiIP() ?? '';
+    } catch (e, st) {
+      _log.fine('Could not read local IP', e, st);
+      return '';
+    }
   }
 }

--- a/test/info_handler_test.dart
+++ b/test/info_handler_test.dart
@@ -38,6 +38,7 @@ void main() {
       expect(body['buildNumber'], BuildInfo.buildNumber);
       expect(body['appStore'], BuildInfo.appStore);
       expect(body['fullVersion'], BuildInfo.fullVersion);
+      expect(body['localIp'], isA<String>());
 
       // Verify no unexpected keys
       final expectedKeys = {
@@ -49,6 +50,7 @@ void main() {
         'buildNumber',
         'appStore',
         'fullVersion',
+        'localIp',
       };
       expect((body as Map).keys.toSet(), expectedKeys);
     });


### PR DESCRIPTION
WebUI skins (e.g. Beanie's AI label scanner) need the gateway's LAN IP to build a phone-reachable hand-off URL — a skin webview runs on localhost and can't discover its own LAN address. Expose it on /api/v1/info as `localIp` (from NetworkInfo().getWifiIP(), the same source as the quick-settings QR), guarded so it returns "" when unavailable (Ethernet, tests) rather than throwing.

- info_handler.dart: add `localIp` via a try/caught _localIp() helper.
- rest_v1.yml + doc/Api.md: document the new field.
- info_handler_test.dart: assert localIp is present in the response.
