### PR TITLE
Decent account: native-only gating + read-only auth proxy

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3699,6 +3699,46 @@ paths:
                     type: boolean
                     description: True if a Decent account is linked
 
+  /api/v1/account/proxy/{path}:
+    get:
+      summary: Auth-enriching proxy to the Decent backend
+      description: >
+        Forwards a GET to `https://decentespresso.com/{path}` with the linked
+        account's credentials attached server-side as Basic auth, and relays the
+        upstream status code and body verbatim. Clients never see the
+        credentials. Phase 1 is read-only and restricted to the `support/api/`
+        path prefix.
+
+
+        Requires `Authorization: Bearer <token>` scoped `account:proxy` — a skin
+        token (injected into served skin pages) or a user-managed API-client
+        token. Unauthenticated/unknown tokens get 401; known but unscoped get
+        403; a path outside the allowed prefix gets 403; no linked account gets
+        401.
+      tags: [Account]
+      parameters:
+        - name: path
+          in: path
+          required: true
+          description: Decent backend path (e.g. `support/api/sn`)
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Upstream response relayed verbatim (status and body as-is)
+        "401":
+          description: Missing/invalid token, or no Decent account linked
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Token not scoped for account:proxy, or path not allowed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
 components:
   schemas:
     Error:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3676,6 +3676,29 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /api/v1/account/decent:
+    get:
+      summary: Decent account link status
+      description: >
+        Reports whether a Decent Espresso account is currently linked.
+        Linking and unlinking are performed only through the app's native UI,
+        not over the network, so no login/logout routes are exposed here. The
+        linked email is deliberately omitted — it is PII and this endpoint is
+        unauthenticated.
+      tags: [Account]
+      responses:
+        "200":
+          description: Current link status
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [loggedIn]
+                properties:
+                  loggedIn:
+                    type: boolean
+                    description: True if a Decent account is linked
+
 components:
   schemas:
     Error:

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -244,6 +244,14 @@ Settings fields include: `gatewayMode`, `themeMode`, `logLevel`, `weightFlowMult
 
 Sync accepts: `target` (URL), `mode` (pull/push/two_way), `onConflict` (skip/overwrite), `sections` (array: profiles, shots, workflow, settings, store, beans, grinders).
 
+### Account
+
+| Method | Path | Description | Handler |
+|--------|------|-------------|---------|
+| GET | `/api/v1/account/decent` | Decent account link status: `{loggedIn}` | `account_handler.dart` |
+
+Linking/unlinking a Decent account is **native-only** — there are no network login/logout routes. The webserver is unauthenticated with `Access-Control-Allow-Origin: *`, so exposing credential operations would let any LAN client or browser origin store attacker credentials or unlink the account. The status response omits the linked email (PII). Clients that need to *use* the account will go through the planned auth-enriching proxy (`/api/v1/account/proxy/...`), which never exposes raw credentials — see `doc/plans/account-proxy-design.md`.
+
 ### Other
 
 | Method | Path | Description | Handler |

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -249,8 +249,11 @@ Sync accepts: `target` (URL), `mode` (pull/push/two_way), `onConflict` (skip/ove
 | Method | Path | Description | Handler |
 |--------|------|-------------|---------|
 | GET | `/api/v1/account/decent` | Decent account link status: `{loggedIn}` | `account_handler.dart` |
+| GET | `/api/v1/account/proxy/<path>` | Auth-enriching proxy to `decentespresso.com/<path>` | `account_proxy_handler.dart` |
 
-Linking/unlinking a Decent account is **native-only** — there are no network login/logout routes. The webserver is unauthenticated with `Access-Control-Allow-Origin: *`, so exposing credential operations would let any LAN client or browser origin store attacker credentials or unlink the account. The status response omits the linked email (PII). Clients that need to *use* the account will go through the planned auth-enriching proxy (`/api/v1/account/proxy/...`), which never exposes raw credentials — see `doc/plans/account-proxy-design.md`.
+Linking/unlinking a Decent account is **native-only** — there are no network login/logout routes. The webserver is unauthenticated with `Access-Control-Allow-Origin: *`, so exposing credential operations would let any LAN client or browser origin store attacker credentials or unlink the account. The status response omits the linked email (PII).
+
+The **proxy** lets clients *use* the account without ever seeing the credentials: it attaches the linked account's Basic auth server-side, forwards to `decentespresso.com`, and relays the upstream status + body verbatim. It requires `Authorization: Bearer <token>` scoped `account:proxy` (a skin token injected into served skin pages, or a user-managed API-client token) and is enforced only on this path — the rest of the API keeps its LAN-trust model. Phase 1 is read-only (`GET`) and restricted to the `support/api/` prefix. Responses: 401 (missing/invalid token or no linked account), 403 (token unscoped or path not allowed). See `doc/plans/account-proxy-design.md`.
 
 ### Other
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -409,6 +409,7 @@ void main() async {
       beanStorage: beanStorage,
       grinderStorage: grinderStorage,
       connectionManager: connectionManager,
+      decentAccountService: decentAccountService,
     );
   } catch (e, st) {
     log.severe('failed to start web server', e, st);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -381,6 +381,8 @@ void main() async {
     credentialStore: decentCredentialStore,
   );
   final proxyTokenService = ProxyTokenService();
+  // Serve the skin token into :3000 HTML so skins can call the account proxy.
+  webUIService.skinProxyToken = proxyTokenService.skinToken;
 
   BatteryController? batteryController;
   if (Platform.isAndroid || Platform.isIOS) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,6 +44,8 @@ import 'package:reaprime/src/services/storage/drift_storage_service.dart';
 import 'package:reaprime/src/services/storage/grinder_storage_service.dart';
 import 'package:reaprime/src/services/storage/profile_storage_service.dart';
 import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:reaprime/src/services/account/decent_proxy_service.dart';
+import 'package:reaprime/src/services/account/proxy_token_service.dart';
 import 'package:reaprime/src/services/account/credential_store_factory.dart';
 import 'package:http/http.dart' as http;
 import 'package:reaprime/src/services/storage/hive_store_service.dart';
@@ -367,10 +369,18 @@ void main() async {
   final WebUIService webUIService = WebUIService();
   final WebUIStorage webUIStorage = WebUIStorage(settingsController);
 
+  final decentCredentialStore = await createCredentialStore();
   final decentAccountService = DecentAccountService(
     httpClient: http.Client(),
-    credentialStore: await createCredentialStore(),
+    credentialStore: decentCredentialStore,
   );
+  // Same credential store as the account service: the proxy reads the
+  // credentials that account login wrote, and never exposes them to callers.
+  final decentProxyService = DecentProxyService(
+    httpClient: http.Client(),
+    credentialStore: decentCredentialStore,
+  );
+  final proxyTokenService = ProxyTokenService();
 
   BatteryController? batteryController;
   if (Platform.isAndroid || Platform.isIOS) {
@@ -410,6 +420,8 @@ void main() async {
       grinderStorage: grinderStorage,
       connectionManager: connectionManager,
       decentAccountService: decentAccountService,
+      decentProxyService: decentProxyService,
+      proxyTokenService: proxyTokenService,
     );
   } catch (e, st) {
     log.severe('failed to start web server', e, st);

--- a/lib/src/services/account/decent_proxy_service.dart
+++ b/lib/src/services/account/decent_proxy_service.dart
@@ -56,6 +56,10 @@ class DecentProxyService {
   final Logger _log = Logger('DecentProxy');
 
   /// Response headers never relayed to callers (auth/session/transport).
+  ///
+  /// `content-length`/`content-encoding` are dropped because the http client
+  /// already decoded the body into [DecentProxyResponse.body]; relaying the
+  /// upstream values would describe the encoded bytes and corrupt the response.
   static const _strippedResponseHeaders = {
     'set-cookie',
     'www-authenticate',
@@ -64,6 +68,8 @@ class DecentProxyService {
     'transfer-encoding',
     'keep-alive',
     'proxy-authenticate',
+    'content-length',
+    'content-encoding',
   };
 
   DecentProxyService({

--- a/lib/src/services/account/decent_proxy_service.dart
+++ b/lib/src/services/account/decent_proxy_service.dart
@@ -1,0 +1,145 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart'
+    show CredentialStore;
+
+/// Thrown when a proxied call is attempted but no Decent account is linked.
+/// Front doors map this to HTTP 401.
+class DecentAccountNotLinkedException implements Exception {
+  @override
+  String toString() => 'DecentAccountNotLinkedException: no account linked';
+}
+
+/// Thrown when a caller requests a path outside the allowed proxy surface.
+/// Front doors map this to HTTP 403.
+class DecentProxyForbiddenPathException implements Exception {
+  final String path;
+  DecentProxyForbiddenPathException(this.path);
+  @override
+  String toString() =>
+      'DecentProxyForbiddenPathException: path not allowed: $path';
+}
+
+/// An upstream response, ready to be relayed to the caller as-is.
+class DecentProxyResponse {
+  final int statusCode;
+  final Map<String, String> headers;
+  final String body;
+
+  DecentProxyResponse({
+    required this.statusCode,
+    required this.headers,
+    required this.body,
+  });
+}
+
+/// Auth-enriching reverse proxy for the Decent backend.
+///
+/// This is the **single owner of credential use** for network clients: it reads
+/// the stored Decent credentials, attaches them as Basic auth, forwards the
+/// request to `decentespresso.com`, and relays the upstream status + body back.
+/// Callers never see the credentials or the `Authorization` header. Every call
+/// must carry a [callerId] (skin / plugin id / api-client) so use is auditable.
+///
+/// Phase 1 is read-only (`GET`) and restricted to the `support/api/` prefix.
+/// See `doc/plans/account-proxy-design.md`.
+class DecentProxyService {
+  final http.Client _httpClient;
+  final CredentialStore _store;
+  final String baseUrl;
+
+  /// Path prefixes the proxy is allowed to forward to (no leading slash).
+  final Set<String> allowedPrefixes;
+
+  final Logger _log = Logger('DecentProxy');
+
+  /// Response headers never relayed to callers (auth/session/transport).
+  static const _strippedResponseHeaders = {
+    'set-cookie',
+    'www-authenticate',
+    'authorization',
+    'connection',
+    'transfer-encoding',
+    'keep-alive',
+    'proxy-authenticate',
+  };
+
+  DecentProxyService({
+    required http.Client httpClient,
+    required CredentialStore credentialStore,
+    this.baseUrl = 'https://decentespresso.com',
+    this.allowedPrefixes = const {'support/api/'},
+  }) : _httpClient = httpClient,
+       _store = credentialStore;
+
+  /// Forwards a GET to `<baseUrl>/<path>` with the stored Decent credentials
+  /// attached as Basic auth, returning the upstream response verbatim (minus
+  /// sensitive headers).
+  ///
+  /// Throws [DecentProxyForbiddenPathException] if [path] is outside
+  /// [allowedPrefixes], or [DecentAccountNotLinkedException] if no account is
+  /// linked.
+  Future<DecentProxyResponse> proxyGet({
+    required String callerId,
+    required String path,
+    Map<String, String>? query,
+  }) async {
+    final normalizedPath = _normalizePath(path);
+    if (!_isAllowed(normalizedPath)) {
+      _log.warning('caller=$callerId GET /$normalizedPath -> forbidden path');
+      throw DecentProxyForbiddenPathException(normalizedPath);
+    }
+
+    final email = await _store.read(key: 'email');
+    final password = await _store.read(key: 'password');
+    if (email == null || password == null) {
+      throw DecentAccountNotLinkedException();
+    }
+
+    final uri = Uri.parse('$baseUrl/$normalizedPath').replace(
+      queryParameters: (query == null || query.isEmpty) ? null : query,
+    );
+
+    final basic = base64Encode(
+      utf8.encode('${email.trim()}:${password.trim()}'),
+    );
+    final response = await _httpClient.get(
+      uri,
+      headers: {'authorization': 'Basic $basic'},
+    );
+
+    _log.info(
+      'caller=$callerId GET /$normalizedPath -> ${response.statusCode}',
+    );
+
+    return DecentProxyResponse(
+      statusCode: response.statusCode,
+      headers: _relayHeaders(response.headers),
+      body: response.body,
+    );
+  }
+
+  String _normalizePath(String path) {
+    var p = path.trim();
+    while (p.startsWith('/')) {
+      p = p.substring(1);
+    }
+    return p;
+  }
+
+  bool _isAllowed(String normalizedPath) {
+    return allowedPrefixes.any((prefix) => normalizedPath.startsWith(prefix));
+  }
+
+  Map<String, String> _relayHeaders(Map<String, String> upstream) {
+    final out = <String, String>{};
+    upstream.forEach((key, value) {
+      if (!_strippedResponseHeaders.contains(key.toLowerCase())) {
+        out[key] = value;
+      }
+    });
+    return out;
+  }
+}

--- a/lib/src/services/account/proxy_token_service.dart
+++ b/lib/src/services/account/proxy_token_service.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+import 'dart:math';
+
+/// An authenticated proxy caller: who they are (for audit) and what they may do.
+class ProxyCaller {
+  /// Stable identity used in audit logs, e.g. `skin`, `api:my-laptop`.
+  final String id;
+  final Set<String> scopes;
+
+  const ProxyCaller({required this.id, required this.scopes});
+}
+
+/// Issues and validates bearer tokens for the account proxy.
+///
+/// Two token classes (see `doc/plans/account-proxy-design.md`):
+///
+/// - **Skin token** — one random token per process, generated at startup and
+///   injected into every `:3000` skin response. Lifetime = process; a restart
+///   mints a new one and the old dies. Not persisted.
+/// - **API-client token** — user-created, named, persisted, revocable. Loaded
+///   into the registry via [registerToken].
+class ProxyTokenService {
+  static const String scopeAccountProxy = 'account:proxy';
+
+  final Map<String, ProxyCaller> _tokens = {};
+  late final String _skinToken;
+
+  /// [skinToken] is injectable for tests; production omits it to get a fresh
+  /// cryptographically-random token.
+  ProxyTokenService({String? skinToken}) {
+    _skinToken = skinToken ?? _generateToken();
+    _tokens[_skinToken] = const ProxyCaller(
+      id: 'skin',
+      scopes: {scopeAccountProxy},
+    );
+  }
+
+  /// The current process's skin token. Injected into served skin HTML on :3000.
+  String get skinToken => _skinToken;
+
+  /// Registers a user-managed API-client token.
+  void registerToken(String token, ProxyCaller caller) {
+    _tokens[token] = caller;
+  }
+
+  /// Revokes a previously-registered token. The skin token cannot be revoked
+  /// this way — it lives for the process lifetime.
+  void revokeToken(String token) {
+    if (token == _skinToken) return;
+    _tokens.remove(token);
+  }
+
+  /// Returns the caller for [token], or null if the token is unknown.
+  ProxyCaller? validate(String token) => _tokens[token];
+
+  static String _generateToken() {
+    final rng = Random.secure();
+    final bytes = List<int>.generate(32, (_) => rng.nextInt(256));
+    return base64Url.encode(bytes);
+  }
+}

--- a/lib/src/services/webserver/account_handler.dart
+++ b/lib/src/services/webserver/account_handler.dart
@@ -1,0 +1,68 @@
+part of '../webserver_service.dart';
+
+class AccountHandler {
+  final DecentAccountService _accountService;
+  final Logger _log = Logger('AccountHandler');
+
+  AccountHandler({required DecentAccountService accountService})
+    : _accountService = accountService;
+
+  void addRoutes(RouterPlus app) {
+    app.get('/api/v1/account/decent', _handleStatus);
+    app.post('/api/v1/account/decent/login', _handleLogin);
+    app.delete('/api/v1/account/decent', _handleLogout);
+  }
+
+  Future<Response> _handleStatus(Request request) async {
+    return jsonOk(await _statusJson());
+  }
+
+  Future<Response> _handleLogin(Request request) async {
+    final payload = await request.readAsString();
+    final Map<String, dynamic> json;
+    try {
+      final decoded = jsonDecode(payload);
+      if (decoded is! Map<String, dynamic>) {
+        return jsonBadRequest({'error': 'Expected a JSON object'});
+      }
+      json = decoded;
+    } on FormatException {
+      return jsonBadRequest({'error': 'Invalid JSON'});
+    }
+
+    final email = json['email'];
+    final password = json['password'];
+    if (email is! String || email.trim().isEmpty) {
+      return jsonBadRequest({'error': 'email is required'});
+    }
+    if (password is! String || password.isEmpty) {
+      return jsonBadRequest({'error': 'password is required'});
+    }
+
+    try {
+      final ok = await _accountService.login(email, password);
+      if (!ok) {
+        return jsonUnauthorized({
+          'error': 'Invalid Decent account email or password',
+        });
+      }
+      return jsonOk(await _statusJson());
+    } catch (e, st) {
+      _log.warning('Decent account login failed', e, st);
+      return jsonError({'error': 'Failed to link Decent account'});
+    }
+  }
+
+  Future<Response> _handleLogout(Request request) async {
+    await _accountService.logout();
+    return jsonOk(await _statusJson());
+  }
+
+  Future<Map<String, dynamic>> _statusJson() async {
+    final loggedIn = await _accountService.isLoggedIn();
+    return {
+      'loggedIn': loggedIn,
+      'email': loggedIn ? await _accountService.getEmail() : null,
+    };
+  }
+}

--- a/lib/src/services/webserver/account_handler.dart
+++ b/lib/src/services/webserver/account_handler.dart
@@ -1,68 +1,30 @@
 part of '../webserver_service.dart';
 
+/// Read-only account status for network clients.
+///
+/// Credential operations (link/unlink a Decent account) are intentionally NOT
+/// exposed over the network — they happen only through the app's native UI,
+/// which calls [DecentAccountService] in-process. The bridge webserver has no
+/// caller authentication and serves `Access-Control-Allow-Origin: *`, so a
+/// network-exposed login/logout would let any LAN client or browser origin
+/// store attacker credentials, unlink the account, or read the linked email.
+///
+/// Clients that need to *use* the account (call Decent backend endpoints) will
+/// go through the auth-enriching proxy (`/api/v1/account/proxy/...`, see
+/// `doc/plans/account-proxy-design.md`), which never exposes raw credentials.
 class AccountHandler {
   final DecentAccountService _accountService;
-  final Logger _log = Logger('AccountHandler');
 
   AccountHandler({required DecentAccountService accountService})
     : _accountService = accountService;
 
   void addRoutes(RouterPlus app) {
     app.get('/api/v1/account/decent', _handleStatus);
-    app.post('/api/v1/account/decent/login', _handleLogin);
-    app.delete('/api/v1/account/decent', _handleLogout);
   }
 
+  /// Reports whether a Decent account is linked. Deliberately does not return
+  /// the linked email — that is PII and the endpoint is unauthenticated.
   Future<Response> _handleStatus(Request request) async {
-    return jsonOk(await _statusJson());
-  }
-
-  Future<Response> _handleLogin(Request request) async {
-    final payload = await request.readAsString();
-    final Map<String, dynamic> json;
-    try {
-      final decoded = jsonDecode(payload);
-      if (decoded is! Map<String, dynamic>) {
-        return jsonBadRequest({'error': 'Expected a JSON object'});
-      }
-      json = decoded;
-    } on FormatException {
-      return jsonBadRequest({'error': 'Invalid JSON'});
-    }
-
-    final email = json['email'];
-    final password = json['password'];
-    if (email is! String || email.trim().isEmpty) {
-      return jsonBadRequest({'error': 'email is required'});
-    }
-    if (password is! String || password.isEmpty) {
-      return jsonBadRequest({'error': 'password is required'});
-    }
-
-    try {
-      final ok = await _accountService.login(email, password);
-      if (!ok) {
-        return jsonUnauthorized({
-          'error': 'Invalid Decent account email or password',
-        });
-      }
-      return jsonOk(await _statusJson());
-    } catch (e, st) {
-      _log.warning('Decent account login failed', e, st);
-      return jsonError({'error': 'Failed to link Decent account'});
-    }
-  }
-
-  Future<Response> _handleLogout(Request request) async {
-    await _accountService.logout();
-    return jsonOk(await _statusJson());
-  }
-
-  Future<Map<String, dynamic>> _statusJson() async {
-    final loggedIn = await _accountService.isLoggedIn();
-    return {
-      'loggedIn': loggedIn,
-      'email': loggedIn ? await _accountService.getEmail() : null,
-    };
+    return jsonOk({'loggedIn': await _accountService.isLoggedIn()});
   }
 }

--- a/lib/src/services/webserver/account_proxy_handler.dart
+++ b/lib/src/services/webserver/account_proxy_handler.dart
@@ -1,0 +1,40 @@
+part of '../webserver_service.dart';
+
+/// HTTP front door for the Decent account proxy.
+///
+/// Forwards `GET /api/v1/account/proxy/<decent-path>` through
+/// [DecentProxyService], which attaches the stored credentials and relays the
+/// upstream response. Caller identity comes from [proxyAuthMiddleware] (via
+/// [proxyCallerOf]); this handler assumes the middleware has already rejected
+/// unauthenticated requests under this prefix.
+class AccountProxyHandler {
+  final DecentProxyService _proxy;
+
+  AccountProxyHandler({required DecentProxyService proxy}) : _proxy = proxy;
+
+  void addRoutes(RouterPlus app) {
+    app.get('/api/v1/account/proxy/<rest|.*>', _handleGet);
+  }
+
+  Future<Response> _handleGet(Request request) async {
+    final rest = request.params['rest'] ?? '';
+    final callerId = proxyCallerOf(request)?.id ?? 'unknown';
+
+    try {
+      final result = await _proxy.proxyGet(
+        callerId: callerId,
+        path: rest,
+        query: request.requestedUri.queryParameters,
+      );
+      return Response(
+        result.statusCode,
+        body: result.body,
+        headers: result.headers,
+      );
+    } on DecentAccountNotLinkedException {
+      return jsonUnauthorized({'error': 'Decent account not linked'});
+    } on DecentProxyForbiddenPathException {
+      return jsonForbidden({'error': 'Path not allowed'});
+    }
+  }
+}

--- a/lib/src/services/webserver/json_response.dart
+++ b/lib/src/services/webserver/json_response.dart
@@ -61,6 +61,12 @@ Response jsonForbidden(Object? data) => Response(
       headers: _jsonHeaders,
     );
 
+Response jsonUnauthorized(Object? data) => Response(
+      401,
+      body: jsonEncode(data),
+      headers: _jsonHeaders,
+    );
+
 Response jsonNotFound(Object? data) => Response.notFound(
       jsonEncode(data),
       headers: _jsonHeaders,
@@ -94,4 +100,3 @@ Response jsonServiceUnavailable(Object? data) => Response(
       body: jsonEncode(data),
       headers: _jsonHeaders,
     );
-

--- a/lib/src/services/webserver/proxy_auth_middleware.dart
+++ b/lib/src/services/webserver/proxy_auth_middleware.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+
+import 'package:shelf/shelf.dart';
+
+import 'package:reaprime/src/services/account/proxy_token_service.dart';
+
+const _proxyCallerContextKey = 'decentProxyCaller';
+
+/// The authenticated caller tagged onto a request by [proxyAuthMiddleware], or
+/// null if the request did not pass through proxy auth.
+ProxyCaller? proxyCallerOf(Request request) =>
+    request.context[_proxyCallerContextKey] as ProxyCaller?;
+
+/// Scoped bearer-token auth, applied **only** to requests under [pathPrefix].
+///
+/// Everything outside the prefix passes through untouched (the rest of the
+/// bridge API keeps its LAN-trust model). Inside the prefix, a request must
+/// present `Authorization: Bearer <token>` for a known token holding
+/// [requiredScope]; otherwise it is rejected with 401 (missing/unknown) or 403
+/// (known but unscoped). On success the request is tagged with its [ProxyCaller]
+/// (read via [proxyCallerOf]) for audit. CORS preflight (`OPTIONS`) is allowed
+/// through unauthenticated.
+Middleware proxyAuthMiddleware(
+  ProxyTokenService tokens, {
+  String pathPrefix = '/api/v1/account/proxy/',
+  String requiredScope = ProxyTokenService.scopeAccountProxy,
+}) {
+  return (Handler inner) {
+    return (Request request) {
+      if (!request.requestedUri.path.startsWith(pathPrefix)) {
+        return inner(request);
+      }
+      // Let CORS preflight through — it carries no Authorization by design.
+      if (request.method == 'OPTIONS') {
+        return inner(request);
+      }
+
+      final token = _bearerToken(request.headers['authorization']);
+      if (token == null) {
+        return _json(401, 'Missing or malformed bearer token');
+      }
+      final caller = tokens.validate(token);
+      if (caller == null) {
+        return _json(401, 'Invalid token');
+      }
+      if (!caller.scopes.contains(requiredScope)) {
+        return _json(403, 'Token is not scoped for $requiredScope');
+      }
+
+      return inner(
+        request.change(context: {_proxyCallerContextKey: caller}),
+      );
+    };
+  };
+}
+
+String? _bearerToken(String? authorization) {
+  if (authorization == null) return null;
+  const prefix = 'Bearer ';
+  if (!authorization.startsWith(prefix)) return null;
+  final token = authorization.substring(prefix.length).trim();
+  return token.isEmpty ? null : token;
+}
+
+Response _json(int status, String error) => Response(
+  status,
+  body: jsonEncode({'error': error}),
+  headers: {'content-type': 'application/json'},
+);

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -62,6 +62,9 @@ import 'package:reaprime/src/models/device/de1_rawmessage.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
 import 'package:reaprime/src/services/feedback_service.dart';
 import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:reaprime/src/services/account/decent_proxy_service.dart';
+import 'package:reaprime/src/services/account/proxy_token_service.dart';
+import 'package:reaprime/src/services/webserver/proxy_auth_middleware.dart';
 import 'package:reaprime/src/controllers/battery_controller.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';
 import 'package:reaprime/src/controllers/display_controller.dart';
@@ -92,6 +95,7 @@ part 'webserver/webview_logs_handler.dart';
 part 'webserver/presence_handler.dart';
 part 'webserver/display_handler.dart';
 part 'webserver/account_handler.dart';
+part 'webserver/account_proxy_handler.dart';
 
 final log = Logger("Webservice");
 
@@ -116,6 +120,8 @@ Future<void> startWebServer(
   GrinderStorageService? grinderStorage,
   required ConnectionManager connectionManager,
   DecentAccountService? decentAccountService,
+  DecentProxyService? decentProxyService,
+  ProxyTokenService? proxyTokenService,
 }) async {
   log.info("starting webserver");
   final de1Handler = De1Handler(
@@ -172,6 +178,10 @@ Future<void> startWebServer(
   final accountHandler = decentAccountService == null
       ? null
       : AccountHandler(accountService: decentAccountService);
+
+  final accountProxyHandler = decentProxyService == null
+      ? null
+      : AccountProxyHandler(proxy: decentProxyService);
 
   final webViewLogsHandler = WebViewLogsHandler(
     webViewLogService: webViewLogService,
@@ -250,6 +260,8 @@ Future<void> startWebServer(
       presenceHandler,
       displayHandler,
       accountHandler,
+      accountProxyHandler,
+      proxyTokenService,
       dataExportHandler,
       dataSyncHandler,
       beansHandler,
@@ -286,6 +298,8 @@ Handler _init(
   PresenceHandler? presenceHandler,
   DisplayHandler? displayHandler,
   AccountHandler? accountHandler,
+  AccountProxyHandler? accountProxyHandler,
+  ProxyTokenService? proxyTokenService,
   DataExportHandler dataExportHandler,
   DataSyncHandler dataSyncHandler,
   BeansHandler? beansHandler,
@@ -320,6 +334,9 @@ Handler _init(
   if (accountHandler != null) {
     accountHandler.addRoutes(app);
   }
+  if (accountProxyHandler != null) {
+    accountProxyHandler.addRoutes(app);
+  }
   dataExportHandler.addRoutes(app);
   dataSyncHandler.addRoutes(app);
   if (beansHandler != null) {
@@ -352,6 +369,14 @@ Handler _init(
                 'Accept, Accept-Encoding, Authorization, Content-Type, DNT, Origin, User-Agent, If-None-Match',
           },
         ),
+      )
+      .addMiddleware(
+        // Scoped bearer auth — enforced only under /api/v1/account/proxy/*,
+        // the rest of the API keeps its LAN-trust model. No-op when the proxy
+        // is not configured.
+        proxyTokenService == null
+            ? (Handler h) => h
+            : proxyAuthMiddleware(proxyTokenService),
       )
       .addHandler(app.call);
 

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -61,6 +61,7 @@ import 'package:shelf_cors_headers/shelf_cors_headers.dart';
 import 'package:reaprime/src/models/device/de1_rawmessage.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
 import 'package:reaprime/src/services/feedback_service.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
 import 'package:reaprime/src/controllers/battery_controller.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';
 import 'package:reaprime/src/controllers/display_controller.dart';
@@ -90,6 +91,7 @@ part 'webserver/logs_handler.dart';
 part 'webserver/webview_logs_handler.dart';
 part 'webserver/presence_handler.dart';
 part 'webserver/display_handler.dart';
+part 'webserver/account_handler.dart';
 
 final log = Logger("Webservice");
 
@@ -113,10 +115,11 @@ Future<void> startWebServer(
   BeanStorageService? beanStorage,
   GrinderStorageService? grinderStorage,
   required ConnectionManager connectionManager,
+  DecentAccountService? decentAccountService,
 }) async {
   log.info("starting webserver");
   final de1Handler = De1Handler(
-    controller: de1Controller, 
+    controller: de1Controller,
     settingsController: settingsController,
     scaleController: scaleController,
   );
@@ -166,6 +169,9 @@ Future<void> startWebServer(
   );
 
   final logsHandler = LogsHandler(logFilePath: logFilePath);
+  final accountHandler = decentAccountService == null
+      ? null
+      : AccountHandler(accountService: decentAccountService);
 
   final webViewLogsHandler = WebViewLogsHandler(
     webViewLogService: webViewLogService,
@@ -243,6 +249,7 @@ Future<void> startWebServer(
       webViewLogsHandler,
       presenceHandler,
       displayHandler,
+      accountHandler,
       dataExportHandler,
       dataSyncHandler,
       beansHandler,
@@ -278,6 +285,7 @@ Handler _init(
   WebViewLogsHandler webViewLogsHandler,
   PresenceHandler? presenceHandler,
   DisplayHandler? displayHandler,
+  AccountHandler? accountHandler,
   DataExportHandler dataExportHandler,
   DataSyncHandler dataSyncHandler,
   BeansHandler? beansHandler,
@@ -308,6 +316,9 @@ Handler _init(
   }
   if (displayHandler != null) {
     displayHandler.addRoutes(app);
+  }
+  if (accountHandler != null) {
+    accountHandler.addRoutes(app);
   }
   dataExportHandler.addRoutes(app);
   dataSyncHandler.addRoutes(app);

--- a/lib/src/webui_support/webui_service.dart
+++ b/lib/src/webui_support/webui_service.dart
@@ -1,10 +1,27 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:network_info_plus/network_info_plus.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
-import 'package:shelf_cors_headers/shelf_cors_headers.dart';
+
+/// Injects the account-proxy skin token into served HTML so skin JS can read it
+/// from `window.__REA_PROXY_TOKEN__` and send it as `Authorization: Bearer` to
+/// the proxy on :8080. Inserted before `</head>`, else `</body>`, else
+/// prepended. Returns [html] unchanged if [token] is null/empty.
+String injectProxyTokenScript(String html, String? token) {
+  if (token == null || token.isEmpty) return html;
+  final script =
+      '<script>window.__REA_PROXY_TOKEN__=${jsonEncode(token)};</script>';
+  for (final marker in const ['</head>', '</body>']) {
+    final i = html.indexOf(marker);
+    if (i != -1) {
+      return '${html.substring(0, i)}$script${html.substring(i)}';
+    }
+  }
+  return '$script$html';
+}
 
 class WebUIService {
   final _log = Logger("WebUIService");
@@ -12,6 +29,10 @@ class WebUIService {
   int port = 3000;
   String _path = "";
   String? _localIP;
+
+  /// Current account-proxy skin token, set from `ProxyTokenService.skinToken`.
+  /// Injected into served HTML so skins can call the proxy. Null = no injection.
+  String? skinProxyToken;
 
 
   // WebUI server methods
@@ -80,14 +101,37 @@ class WebUIService {
       };
     }
 
+    Future<Response> Function(Request request) proxyTokenInjector(
+      Handler innerHandler,
+    ) {
+      return (Request request) async {
+        final response = await innerHandler(request);
+        final contentType = response.headers['content-type'] ?? '';
+        if (!contentType.contains('text/html')) {
+          return response;
+        }
+        final body = await response.readAsString();
+        final injected = injectProxyTokenScript(body, skinProxyToken);
+        // Drop content-length: the body length changed and shelf recomputes it.
+        final headers = Map<String, String>.from(response.headers)
+          ..remove('content-length');
+        return response.change(body: injected, headers: headers);
+      };
+    }
+
     //   final handler = (Request request) async {
     //   return Response.ok('<html><body><h1>Hello WebView</h1></body></html>',
     //     headers: {'Content-Type': 'text/html'});
     // };
+    // NOTE: no CORS middleware here on purpose. The skin token is injected into
+    // served HTML, so the :3000 host must NOT send Access-Control-Allow-Origin:
+    // * — otherwise a malicious site could fetch the skin cross-origin and
+    // scrape the token. Skins read their own assets same-origin (no CORS needed)
+    // and call the :8080 API cross-origin (governed by :8080's CORS).
     final handler = const Pipeline()
         .addMiddleware(logRequests())
-        .addMiddleware(corsHeaders())
         .addMiddleware(expirationModifier)
+        .addMiddleware(proxyTokenInjector)
         .addHandler(webUI.call);
 
     try {

--- a/test/services/account/decent_proxy_service_test.dart
+++ b/test/services/account/decent_proxy_service_test.dart
@@ -1,0 +1,209 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:reaprime/src/services/account/decent_proxy_service.dart';
+
+class FakeCredentialStore implements CredentialStore {
+  final Map<String, String> _values = {};
+
+  @override
+  Future<String?> read({required String key}) async => _values[key];
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    _values.remove(key);
+  }
+}
+
+void main() {
+  late FakeCredentialStore store;
+
+  setUp(() {
+    store = FakeCredentialStore();
+  });
+
+  Future<void> linkAccount() async {
+    await store.write(key: 'email', value: 'user@example.com');
+    await store.write(key: 'password', value: 'cryptpw_abc123');
+  }
+
+  DecentProxyService buildService(
+    http_testing.MockClientHandler handler, {
+    String baseUrl = 'https://decentespresso.com',
+  }) {
+    return DecentProxyService(
+      httpClient: http_testing.MockClient(handler),
+      credentialStore: store,
+      baseUrl: baseUrl,
+    );
+  }
+
+  test('throws when no account is linked', () async {
+    final service = buildService((request) async {
+      fail('must not call upstream when not linked: ${request.url}');
+    });
+
+    expect(
+      () => service.proxyGet(callerId: 'skin', path: 'support/api/sn'),
+      throwsA(isA<DecentAccountNotLinkedException>()),
+    );
+  });
+
+  test('attaches Basic auth and relays the upstream body + status', () async {
+    await linkAccount();
+    late http.Request captured;
+    final service = buildService((request) async {
+      captured = request;
+      return http.Response('SN001\nSN002', 200);
+    });
+
+    final result = await service.proxyGet(
+      callerId: 'skin',
+      path: 'support/api/sn',
+    );
+
+    expect(result.statusCode, 200);
+    expect(result.body, 'SN001\nSN002');
+
+    // Credentials are attached server-side as Basic auth.
+    final expected =
+        'Basic ${base64Encode(utf8.encode('user@example.com:cryptpw_abc123'))}';
+    expect(captured.headers['authorization'], expected);
+    expect(
+      captured.url.toString(),
+      'https://decentespresso.com/support/api/sn',
+    );
+  });
+
+  test('never leaks credentials into the returned response', () async {
+    await linkAccount();
+    final service = buildService((request) async {
+      return http.Response('ok', 200);
+    });
+
+    final result = await service.proxyGet(
+      callerId: 'skin',
+      path: 'support/api/sn',
+    );
+
+    final serialized = '${result.body} ${jsonEncode(result.headers)}';
+    expect(serialized.contains('cryptpw_abc123'), isFalse);
+    expect(serialized.toLowerCase().contains('authorization'), isFalse);
+  });
+
+  test('relays upstream error status verbatim', () async {
+    await linkAccount();
+    final service = buildService((request) async {
+      return http.Response('upstream boom', 503);
+    });
+
+    final result = await service.proxyGet(
+      callerId: 'api:tok',
+      path: 'support/api/sn',
+    );
+
+    expect(result.statusCode, 503);
+    expect(result.body, 'upstream boom');
+  });
+
+  test('strips sensitive response headers but keeps content-type', () async {
+    await linkAccount();
+    final service = buildService((request) async {
+      return http.Response(
+        '{}',
+        200,
+        headers: {
+          'content-type': 'application/json',
+          'set-cookie': 'session=secret',
+          'www-authenticate': 'Basic realm="x"',
+        },
+      );
+    });
+
+    final result = await service.proxyGet(
+      callerId: 'skin',
+      path: 'support/api/sn',
+    );
+
+    expect(result.headers['content-type'], 'application/json');
+    expect(result.headers.containsKey('set-cookie'), isFalse);
+    expect(result.headers.containsKey('www-authenticate'), isFalse);
+  });
+
+  test('rejects a path outside the allowed prefix', () async {
+    await linkAccount();
+    final service = buildService((request) async {
+      fail('must not call upstream for a forbidden path: ${request.url}');
+    });
+
+    expect(
+      () => service.proxyGet(callerId: 'skin', path: 'admin/delete-all'),
+      throwsA(isA<DecentProxyForbiddenPathException>()),
+    );
+  });
+
+  test('normalizes a leading slash in the path', () async {
+    await linkAccount();
+    late http.Request captured;
+    final service = buildService((request) async {
+      captured = request;
+      return http.Response('ok', 200);
+    });
+
+    await service.proxyGet(callerId: 'skin', path: '/support/api/sn');
+
+    expect(
+      captured.url.toString(),
+      'https://decentespresso.com/support/api/sn',
+    );
+  });
+
+  test('forwards query parameters', () async {
+    await linkAccount();
+    late http.Request captured;
+    final service = buildService((request) async {
+      captured = request;
+      return http.Response('ok', 200);
+    });
+
+    await service.proxyGet(
+      callerId: 'skin',
+      path: 'support/api/email',
+      query: {'subject': 'hi there', 'body': 'b'},
+    );
+
+    expect(captured.url.queryParameters['subject'], 'hi there');
+    expect(captured.url.queryParameters['body'], 'b');
+  });
+
+  test('emits an audit log line carrying the caller identity', () async {
+    await linkAccount();
+    final records = <LogRecord>[];
+    final sub = Logger('DecentProxy').onRecord.listen(records.add);
+    addTearDown(sub.cancel);
+
+    final service = buildService((request) async {
+      return http.Response('ok', 200);
+    });
+
+    await service.proxyGet(callerId: 'plugin:dye2', path: 'support/api/sn');
+
+    expect(
+      records.any(
+        (r) =>
+            r.message.contains('plugin:dye2') &&
+            r.message.contains('support/api/sn'),
+      ),
+      isTrue,
+    );
+  });
+}

--- a/test/services/account/decent_proxy_service_test.dart
+++ b/test/services/account/decent_proxy_service_test.dart
@@ -125,6 +125,7 @@ void main() {
           'content-type': 'application/json',
           'set-cookie': 'session=secret',
           'www-authenticate': 'Basic realm="x"',
+          'content-encoding': 'gzip',
         },
       );
     });
@@ -137,6 +138,9 @@ void main() {
     expect(result.headers['content-type'], 'application/json');
     expect(result.headers.containsKey('set-cookie'), isFalse);
     expect(result.headers.containsKey('www-authenticate'), isFalse);
+    // Body is already decoded — relaying transfer/length headers would corrupt it.
+    expect(result.headers.containsKey('content-encoding'), isFalse);
+    expect(result.headers.containsKey('content-length'), isFalse);
   });
 
   test('rejects a path outside the allowed prefix', () async {

--- a/test/services/account/proxy_token_service_test.dart
+++ b/test/services/account/proxy_token_service_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/account/proxy_token_service.dart';
+
+void main() {
+  test('mints a non-empty skin token that validates as the skin caller', () {
+    final service = ProxyTokenService();
+
+    expect(service.skinToken, isNotEmpty);
+    final caller = service.validate(service.skinToken);
+    expect(caller, isNotNull);
+    expect(caller!.id, 'skin');
+    expect(caller.scopes, contains(ProxyTokenService.scopeAccountProxy));
+  });
+
+  test('two instances mint different skin tokens', () {
+    expect(ProxyTokenService().skinToken,
+        isNot(ProxyTokenService().skinToken));
+  });
+
+  test('unknown tokens do not validate', () {
+    final service = ProxyTokenService();
+    expect(service.validate('nope'), isNull);
+  });
+
+  test('registers and revokes API-client tokens', () {
+    final service = ProxyTokenService();
+    service.registerToken(
+      'tok-123',
+      const ProxyCaller(
+        id: 'api:laptop',
+        scopes: {ProxyTokenService.scopeAccountProxy},
+      ),
+    );
+
+    expect(service.validate('tok-123')!.id, 'api:laptop');
+
+    service.revokeToken('tok-123');
+    expect(service.validate('tok-123'), isNull);
+  });
+
+  test('the skin token cannot be revoked', () {
+    final service = ProxyTokenService();
+    service.revokeToken(service.skinToken);
+    expect(service.validate(service.skinToken), isNotNull);
+  });
+}

--- a/test/webserver/account_handler_test.dart
+++ b/test/webserver/account_handler_test.dart
@@ -27,16 +27,14 @@ class FakeCredentialStore implements CredentialStore {
 void main() {
   late FakeCredentialStore store;
   late Handler handler;
-  late int loginStatus;
-  late String loginBody;
 
   setUp(() {
     store = FakeCredentialStore();
-    loginStatus = 200;
-    loginBody = 'cryptpw_abc123';
     final service = DecentAccountService(
+      // No request should ever reach the network: status is store-only and
+      // credential ops are not exposed over HTTP.
       httpClient: http_testing.MockClient((request) async {
-        return http.Response(loginBody, loginStatus);
+        fail('AccountHandler must not make network requests: ${request.url}');
       }),
       credentialStore: store,
     );
@@ -69,44 +67,35 @@ void main() {
     expect(response.statusCode, 200);
     final body = jsonDecode(await response.readAsString());
     expect(body['loggedIn'], false);
-    expect(body['email'], isNull);
   });
 
-  test('login links the account and returns linked status', () async {
-    final response = await sendPost('/api/v1/account/decent/login', {
-      'email': 'user@example.com',
-      'password': 'secret',
-    });
+  test('status reports a linked account without leaking the email', () async {
+    await store.write(key: 'email', value: 'user@example.com');
+    await store.write(key: 'password', value: 'cryptpw_abc123');
+
+    final response = await sendGet('/api/v1/account/decent');
     expect(response.statusCode, 200);
-    final body = jsonDecode(await response.readAsString());
+    final body = jsonDecode(await response.readAsString()) as Map;
     expect(body['loggedIn'], true);
-    expect(body['email'], 'user@example.com');
+    // Email is PII and the endpoint is unauthenticated — never include it.
+    expect(body.containsKey('email'), isFalse);
   });
 
-  test('login failure returns 401 and does not store credentials', () async {
-    loginBody = '0';
+  test('login is not exposed over HTTP', () async {
     final response = await sendPost('/api/v1/account/decent/login', {
-      'email': 'user@example.com',
-      'password': 'wrong',
-    });
-    expect(response.statusCode, 401);
-    final body = jsonDecode(await response.readAsString());
-    expect(body['error'], contains('Invalid Decent account'));
-
-    final status = await sendGet('/api/v1/account/decent');
-    final statusBody = jsonDecode(await status.readAsString());
-    expect(statusBody['loggedIn'], false);
-  });
-
-  test('logout removes the linked account', () async {
-    await sendPost('/api/v1/account/decent/login', {
       'email': 'user@example.com',
       'password': 'secret',
     });
+    expect(response.statusCode, 404);
+    expect(await store.read(key: 'email'), isNull);
+  });
+
+  test('logout is not exposed over HTTP', () async {
+    await store.write(key: 'email', value: 'user@example.com');
+
     final response = await sendDelete('/api/v1/account/decent');
-    expect(response.statusCode, 200);
-    final body = jsonDecode(await response.readAsString());
-    expect(body['loggedIn'], false);
-    expect(body['email'], isNull);
+    expect(response.statusCode, 404);
+    // Account remains linked — unlinking is native-only.
+    expect(await store.read(key: 'email'), 'user@example.com');
   });
 }

--- a/test/webserver/account_handler_test.dart
+++ b/test/webserver/account_handler_test.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+class FakeCredentialStore implements CredentialStore {
+  final Map<String, String> _values = {};
+
+  @override
+  Future<String?> read({required String key}) async => _values[key];
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    _values.remove(key);
+  }
+}
+
+void main() {
+  late FakeCredentialStore store;
+  late Handler handler;
+  late int loginStatus;
+  late String loginBody;
+
+  setUp(() {
+    store = FakeCredentialStore();
+    loginStatus = 200;
+    loginBody = 'cryptpw_abc123';
+    final service = DecentAccountService(
+      httpClient: http_testing.MockClient((request) async {
+        return http.Response(loginBody, loginStatus);
+      }),
+      credentialStore: store,
+    );
+    final app = Router().plus;
+    AccountHandler(accountService: service).addRoutes(app);
+    handler = app.call;
+  });
+
+  Future<Response> sendGet(String path) async {
+    return handler(Request('GET', Uri.parse('http://localhost$path')));
+  }
+
+  Future<Response> sendPost(String path, Map<String, dynamic> body) async {
+    return handler(
+      Request(
+        'POST',
+        Uri.parse('http://localhost$path'),
+        body: jsonEncode(body),
+        headers: {'content-type': 'application/json'},
+      ),
+    );
+  }
+
+  Future<Response> sendDelete(String path) async {
+    return handler(Request('DELETE', Uri.parse('http://localhost$path')));
+  }
+
+  test('status reports an unlinked Decent account by default', () async {
+    final response = await sendGet('/api/v1/account/decent');
+    expect(response.statusCode, 200);
+    final body = jsonDecode(await response.readAsString());
+    expect(body['loggedIn'], false);
+    expect(body['email'], isNull);
+  });
+
+  test('login links the account and returns linked status', () async {
+    final response = await sendPost('/api/v1/account/decent/login', {
+      'email': 'user@example.com',
+      'password': 'secret',
+    });
+    expect(response.statusCode, 200);
+    final body = jsonDecode(await response.readAsString());
+    expect(body['loggedIn'], true);
+    expect(body['email'], 'user@example.com');
+  });
+
+  test('login failure returns 401 and does not store credentials', () async {
+    loginBody = '0';
+    final response = await sendPost('/api/v1/account/decent/login', {
+      'email': 'user@example.com',
+      'password': 'wrong',
+    });
+    expect(response.statusCode, 401);
+    final body = jsonDecode(await response.readAsString());
+    expect(body['error'], contains('Invalid Decent account'));
+
+    final status = await sendGet('/api/v1/account/decent');
+    final statusBody = jsonDecode(await status.readAsString());
+    expect(statusBody['loggedIn'], false);
+  });
+
+  test('logout removes the linked account', () async {
+    await sendPost('/api/v1/account/decent/login', {
+      'email': 'user@example.com',
+      'password': 'secret',
+    });
+    final response = await sendDelete('/api/v1/account/decent');
+    expect(response.statusCode, 200);
+    final body = jsonDecode(await response.readAsString());
+    expect(body['loggedIn'], false);
+    expect(body['email'], isNull);
+  });
+}

--- a/test/webserver/account_handler_test.dart
+++ b/test/webserver/account_handler_test.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:http/http.dart' as http;
 import 'package:http/testing.dart' as http_testing;
 import 'package:reaprime/src/services/account/decent_account_service.dart';
 import 'package:reaprime/src/services/webserver_service.dart';

--- a/test/webserver/account_proxy_handler_test.dart
+++ b/test/webserver/account_proxy_handler_test.dart
@@ -1,0 +1,111 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:reaprime/src/services/account/decent_proxy_service.dart';
+import 'package:reaprime/src/services/account/proxy_token_service.dart';
+import 'package:reaprime/src/services/webserver/proxy_auth_middleware.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+class FakeCredentialStore implements CredentialStore {
+  final Map<String, String> _values = {};
+  @override
+  Future<String?> read({required String key}) async => _values[key];
+  @override
+  Future<void> write({required String key, required String value}) async =>
+      _values[key] = value;
+  @override
+  Future<void> delete({required String key}) async => _values.remove(key);
+}
+
+void main() {
+  late FakeCredentialStore store;
+  late ProxyTokenService tokens;
+  late Handler handler;
+  late http.Request? upstream;
+
+  setUp(() {
+    store = FakeCredentialStore();
+    tokens = ProxyTokenService(skinToken: 'skin-token');
+    upstream = null;
+
+    final proxy = DecentProxyService(
+      httpClient: http_testing.MockClient((request) async {
+        upstream = request;
+        return http.Response('SN001\nSN002', 200);
+      }),
+      credentialStore: store,
+    );
+
+    final app = Router().plus;
+    AccountProxyHandler(proxy: proxy).addRoutes(app);
+    handler = const Pipeline()
+        .addMiddleware(proxyAuthMiddleware(tokens))
+        .addHandler(app.call);
+  });
+
+  Future<void> linkAccount() async {
+    await store.write(key: 'email', value: 'user@example.com');
+    await store.write(key: 'password', value: 'cryptpw_abc123');
+  }
+
+  Future<Response> get(String path, {String? token}) async {
+    return handler(Request(
+      'GET',
+      Uri.parse('http://localhost$path'),
+      headers: token == null ? {} : {'authorization': 'Bearer $token'},
+    ));
+  }
+
+  test('unauthenticated proxy request is rejected (401)', () async {
+    final response = await get('/api/v1/account/proxy/support/api/sn');
+    expect(response.statusCode, 401);
+    expect(upstream, isNull);
+  });
+
+  test('authenticated but unlinked returns 401', () async {
+    final response =
+        await get('/api/v1/account/proxy/support/api/sn', token: 'skin-token');
+    expect(response.statusCode, 401);
+    final body = jsonDecode(await response.readAsString());
+    expect(body['error'], contains('not linked'));
+    expect(upstream, isNull);
+  });
+
+  test('authenticated + linked forwards with Basic auth and relays body',
+      () async {
+    await linkAccount();
+    final response =
+        await get('/api/v1/account/proxy/support/api/sn', token: 'skin-token');
+
+    expect(response.statusCode, 200);
+    expect(await response.readAsString(), 'SN001\nSN002');
+
+    final expected =
+        'Basic ${base64Encode(utf8.encode('user@example.com:cryptpw_abc123'))}';
+    expect(upstream!.headers['authorization'], expected);
+    expect(upstream!.url.toString(),
+        'https://decentespresso.com/support/api/sn');
+  });
+
+  test('a path outside the allowed prefix returns 403', () async {
+    await linkAccount();
+    final response =
+        await get('/api/v1/account/proxy/admin/wipe', token: 'skin-token');
+    expect(response.statusCode, 403);
+    expect(upstream, isNull);
+  });
+
+  test('forwards query parameters to upstream', () async {
+    await linkAccount();
+    await get(
+      '/api/v1/account/proxy/support/api/email?subject=hi&body=b',
+      token: 'skin-token',
+    );
+    expect(upstream!.url.queryParameters['subject'], 'hi');
+    expect(upstream!.url.queryParameters['body'], 'b');
+  });
+}

--- a/test/webserver/proxy_auth_middleware_test.dart
+++ b/test/webserver/proxy_auth_middleware_test.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/account/proxy_token_service.dart';
+import 'package:reaprime/src/services/webserver/proxy_auth_middleware.dart';
+import 'package:shelf/shelf.dart';
+
+void main() {
+  late ProxyTokenService tokens;
+  late Handler handler;
+  late Request? seenByInner;
+
+  setUp(() {
+    tokens = ProxyTokenService(skinToken: 'skin-token');
+    seenByInner = null;
+    Response inner(Request request) {
+      seenByInner = request;
+      return Response.ok('inner');
+    }
+
+    handler = const Pipeline()
+        .addMiddleware(proxyAuthMiddleware(tokens))
+        .addHandler(inner);
+  });
+
+  Request get(String path, {Map<String, String> headers = const {}}) =>
+      Request('GET', Uri.parse('http://localhost$path'), headers: headers);
+
+  test('passes non-proxy paths through without auth', () async {
+    final response = await handler(get('/api/v1/shots'));
+    expect(response.statusCode, 200);
+    expect(seenByInner, isNotNull);
+    expect(proxyCallerOf(seenByInner!), isNull);
+  });
+
+  test('rejects a proxy request with no Authorization (401)', () async {
+    final response = await handler(get('/api/v1/account/proxy/support/api/sn'));
+    expect(response.statusCode, 401);
+    expect(seenByInner, isNull);
+  });
+
+  test('rejects a proxy request with an unknown token (401)', () async {
+    final response = await handler(get(
+      '/api/v1/account/proxy/support/api/sn',
+      headers: {'authorization': 'Bearer wrong'},
+    ));
+    expect(response.statusCode, 401);
+  });
+
+  test('rejects a known token that lacks the required scope (403)', () async {
+    tokens.registerToken(
+      'scopeless',
+      const ProxyCaller(id: 'api:weak', scopes: {}),
+    );
+    final response = await handler(get(
+      '/api/v1/account/proxy/support/api/sn',
+      headers: {'authorization': 'Bearer scopeless'},
+    ));
+    expect(response.statusCode, 403);
+    final body = jsonDecode(await response.readAsString());
+    expect(body['error'], contains('account:proxy'));
+  });
+
+  test('admits the skin token and tags the caller', () async {
+    final response = await handler(get(
+      '/api/v1/account/proxy/support/api/sn',
+      headers: {'authorization': 'Bearer skin-token'},
+    ));
+    expect(response.statusCode, 200);
+    expect(seenByInner, isNotNull);
+    final caller = proxyCallerOf(seenByInner!);
+    expect(caller, isNotNull);
+    expect(caller!.id, 'skin');
+  });
+
+  test('lets CORS preflight through unauthenticated', () async {
+    final response = await handler(
+      Request('OPTIONS', Uri.parse('http://localhost/api/v1/account/proxy/x')),
+    );
+    expect(response.statusCode, 200);
+    expect(seenByInner, isNotNull);
+  });
+}

--- a/test/webui_support/webui_token_injection_test.dart
+++ b/test/webui_support/webui_token_injection_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/webui_support/webui_service.dart';
+
+void main() {
+  const token = 'abc.123';
+  const script = '<script>window.__REA_PROXY_TOKEN__="abc.123";</script>';
+
+  test('injects before </head> when present', () {
+    final out = injectProxyTokenScript(
+      '<html><head><title>x</title></head><body>hi</body></html>',
+      token,
+    );
+    expect(out, contains('$script</head>'));
+    expect(out.indexOf(script), lessThan(out.indexOf('<body>')));
+  });
+
+  test('injects before </body> when there is no head', () {
+    final out = injectProxyTokenScript('<body>hi</body>', token);
+    expect(out, '<body>hi$script</body>');
+  });
+
+  test('prepends when neither head nor body is present', () {
+    final out = injectProxyTokenScript('just text', token);
+    expect(out, '${script}just text');
+  });
+
+  test('returns html unchanged when token is null or empty', () {
+    const html = '<html><head></head></html>';
+    expect(injectProxyTokenScript(html, null), html);
+    expect(injectProxyTokenScript(html, ''), html);
+  });
+
+  test('json-encodes the token (escapes quotes)', () {
+    final out = injectProxyTokenScript('<head></head>', 'a"b');
+    expect(out, contains(r'window.__REA_PROXY_TOKEN__="a\"b";'));
+  });
+}


### PR DESCRIPTION
**Supersedes #290** (includes its commit for attribution — close #290 in favor of this).

## What
- **Gate credential ops to native-only.** Remove the HTTP `POST /login` and `DELETE` routes; linking/unlinking happens only through the app's UI (which calls `DecentAccountService` in-process). `GET /api/v1/account/decent` stays as a `{loggedIn}` status check, with the linked email dropped.
- **Add a read-only auth-enriching proxy:** `GET /api/v1/account/proxy/<path>` attaches the linked account's Basic auth server-side, forwards to `decentespresso.com`, and relays the upstream status + body verbatim. Credentials are never exposed to callers. Bearer-scoped (`account:proxy`), enforced only on that path; the rest of the API keeps its LAN-trust model. Skins get a token auto-injected into `:3000` HTML, and `:3000`'s CORS is locked so the token can't be scraped cross-origin.

## Why
#290 exposed account credential operations on the bridge's unauthenticated, `Access-Control-Allow-Origin: *` LAN API — any LAN client or browser origin could store attacker credentials (CSRF account-swap), unlink the account, or read the linked email. This closes that hole and gives clients a credential-safe way to *use* the account.

## Scope / follow-ups (intentionally not here)
Read-only proxy, usable by skins today. Still to come: API-client token management UI, the plugin `proxy.decent_api` path, Phase-2 writes, and the consent prompt.