### PR TITLE
docs: fix Android minimum version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ make dual-build
 ### Minimum Requirements
 
 - **Android**: 9.0 (API 28) or later
-- **macOS**: 10.14 or later
+- **macOS**: 13.0 or later
+- **iOS**: 15.0 or later (experimental)
 - **Linux**: Modern distribution with GTK 3.0+
 - **Windows**: Windows 10 or later
   - **Important**: Requires [Microsoft Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-supported-redistributable-version) to be installed

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ make dual-build
 
 ### Minimum Requirements
 
-- **Android**: 8.0 (API 26) or later
+- **Android**: 9.0 (API 28) or later
 - **macOS**: 10.14 or later
 - **Linux**: Modern distribution with GTK 3.0+
 - **Windows**: Windows 10 or later


### PR DESCRIPTION
The Minimum Requirements section of the README says Android 8.0 (API 26) or later, but `android/app/build.gradle.kts` has `minSdk = 28` (Android 9.0). I also noticed `android/gradle.properties` sets `android.ndk.suppressMinSdkVersionError=28`, so the build target has been 9.0 for a while.

This change updates the README to match the actual build config, so people with devices below API 28 don't try to install an app that won't build or run for them.

Closes #308