### PR TITLE
Native UI redesign: launcher + settings (PR1+PR2)

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,7 @@ org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m
 android.useAndroidX=true
 android.enableJetifier=true
 android.ndk.suppressMinSdkVersionError=28
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/doc/plans/native-ui-redesign-implementation.md
+++ b/doc/plans/native-ui-redesign-implementation.md
@@ -1,0 +1,134 @@
+# Native UI Redesign — Implementation Plan
+
+> **Design doc:** `doc/plans/native-ui-redesign.md`
+> **This file:** step-by-step implementation tasks. Delete after shipping (commit chain is authoritative).
+
+## PR1: Widget Previews + Launcher
+
+### Setup
+- [ ] Add `widget_preview` dependency (or Flutter built-in previews if available)
+- [ ] Create preview infrastructure: `lib/src/previews/` with app-level preview config
+- [ ] Verify previews render in IDE
+
+### Status Bar Component
+- [ ] Create `lib/src/launcher/widgets/status_bar.dart`
+  - Machine: name + state from `De1Controller.connectedDe1Stream` + `De1Controller.machineState`
+  - Scale: name + state from `ScaleController.connectedScaleStream`
+  - Battery: level + charging from `BatteryController` (conditional: mobile only)
+  - Water level: from DE1 snapshot `waterLevelMl` / `waterCapacityMl`
+  - QR icon button (opens QR overlay dialog)
+- [ ] Create widget preview for status bar (with mock data)
+- [ ] QR code overlay dialog — generate `http://{ip}:3000?_={timestamp}` URL, display as QR + copyable text
+
+### Launcher Grid
+- [ ] Create `lib/src/launcher/launcher_view.dart` — the new HomeScreen replacement
+  - Status bar at top
+  - "Return to Skin" hero button (conditional on `WebUIService.isServing` + WebView support)
+  - Skin-unavailable explanation widget (conditional, mutually exclusive with return button)
+  - Browser redirect hero card (conditional on no-WebView OR degraded Android)
+  - Grid of destination cards: Settings, Devices, Data, Skins, Account, Plugins, Advanced
+  - Account and Plugins conditionally visible
+- [ ] Create widget preview for launcher (mock services)
+- [ ] Create `lib/src/launcher/widgets/destination_card.dart` — reusable grid item (icon + label + optional badge)
+- [ ] Create widget preview for destination card
+
+### Wiring
+- [ ] Update `app.dart` route table: replace HomeScreen route with LauncherView
+- [ ] Update navigation from onboarding → launcher (was → HomeScreen)
+- [ ] Update navigation from SkinView → launcher on exit
+- [ ] Verify back-navigation from sub-pages returns to launcher
+- [ ] Run `flutter test` — fix any broken references to HomeScreen
+- [ ] Run `flutter analyze`
+
+## PR2: Settings Flattening + Standalone Sub-Pages
+
+### Extract Sub-Pages
+- [ ] Create `lib/src/data_management/data_management_page.dart` — standalone page
+  - Move export/import logic from `SettingsView` data management section
+  - Add AppBar with back navigation
+  - Restyle to iOS Settings row style
+- [ ] Create `lib/src/device_management/device_management_page.dart` — standalone page
+  - Move from `SettingsView` device management section (already partially standalone as `device_management_page.dart`)
+  - Restyle
+- [ ] Create `lib/src/skin_selector/skin_selector_page.dart` — standalone page
+  - Move WebUI skin selection from `SettingsView`
+  - Restyle
+- [ ] Create `lib/src/account/account_page.dart` — standalone page
+  - Move Decent account section from `SettingsView`
+  - Restyle
+
+### Flatten Settings
+- [ ] Rewrite `settings_view.dart` — flat list with only:
+  - Appearance (theme mode toggle)
+  - Gateway mode (tap to change)
+  - Battery charging mode (mobile only, tap to navigate)
+  - Presence (tap to navigate)
+  - Advanced (debug logging, simulated devices)
+  - About (version info)
+- [ ] Each row: iOS Settings style — label left, current value right, tap action
+- [ ] Remove collapsible sections / accordion pattern
+- [ ] Create widget preview for new SettingsView
+
+### Route Registration
+- [ ] Add routes for new standalone pages in `app.dart`
+- [ ] Wire launcher grid destinations to new routes
+- [ ] Run `flutter test` — fix any broken settings tests
+- [ ] Run `flutter analyze`
+
+## PR3: Onboarding Restyle + Android Warning
+
+### Android Warning Step
+- [ ] Create `lib/src/onboarding_feature/steps/android_warning_step.dart`
+  - Check `Platform.isAndroid` + SDK version via `DeviceInfoPlugin` or platform channel
+  - Dismissible warning message
+  - "Continue" button calls `controller.advance()`
+  - Persist dismissal flag in `SettingsService`
+- [ ] Add step to `OnboardingController` — insert before welcome step, skip if not Android or SDK >= 31 or already dismissed
+
+### Restyle Onboarding Steps
+- [ ] Audit visual consistency: ensure all steps use same card style, typography, spacing as launcher
+- [ ] Update `welcome_step.dart` — match new visual language
+- [ ] Update `login_step.dart` — match new visual language
+- [ ] Update `permissions_step.dart` — match new visual language
+- [ ] Update `initialization_step.dart` — match new visual language
+- [ ] Update `import_step.dart` — match new visual language
+- [ ] Update `scan_step.dart` — match new visual language
+- [ ] Create widget previews for key onboarding steps
+
+### Tests
+- [ ] Unit test: Android warning step shown/hidden based on SDK level
+- [ ] Unit test: dismissal flag persisted and respected
+- [ ] Run `flutter test`
+- [ ] Run `flutter analyze`
+
+## PR4: LandingFeature → Launcher Integration
+
+### Browser Hero Card
+- [ ] Create `lib/src/launcher/widgets/browser_hero_card.dart`
+  - URL display: `http://{ip}:3000?_={timestamp}`
+  - Copy URL button
+  - Open Browser button (via `url_launcher`)
+  - Inline QR code
+- [ ] Create widget preview for hero card
+
+### Conditional Launcher Composition
+- [ ] Add WebView availability detection (platform check + potentially Android SDK check)
+- [ ] Launcher shows browser hero card when: no WebView OR degraded Android
+- [ ] Launcher hides "Return to Skin" when: no WebView available
+- [ ] Launcher shows skin-unavailable explanation when return-to-skin hidden
+
+### Cleanup
+- [ ] Remove or deprecate `landing_feature.dart` (redirect any remaining references to launcher)
+- [ ] Update route table
+- [ ] Run `flutter test`
+- [ ] Run `flutter analyze`
+
+## Cross-PR Checklist
+
+- [ ] All new widgets have previews
+- [ ] Dark mode verified for all new screens
+- [ ] Accessibility: semantic labels on all interactive elements
+- [ ] Tablet layout (primary target) looks good at common resolutions
+- [ ] Phone layout degrades gracefully
+- [ ] Full `flutter test` green before each PR
+- [ ] `flutter analyze` clean before each PR

--- a/doc/plans/native-ui-redesign.md
+++ b/doc/plans/native-ui-redesign.md
@@ -1,0 +1,157 @@
+# Native UI Redesign — Design Document
+
+> **Status:** Design approved via grill session (2026-06-09)
+> **Branch:** `feature/native-ui-redesign`
+> **PR strategy:** Incremental — 4 PRs, each reviewable and mergeable independently
+> **Basecamp:** [9211874487](https://3.basecamp.com/3671212/buckets/42895019/todos/9211874487)
+
+## Problem
+
+The native Flutter UI ("back office") has discoverability issues. Users can't find data management, settings are buried in a long scrollable page, and the HomeScreen duplicates what skins already show. Android 9/10 users hit degraded WebView/BLE performance with no guidance.
+
+## Design Decisions
+
+### Mental Model
+
+Native UI = back office. Skins are the daily driver. The native UI handles:
+- First-time setup (onboarding)
+- Settings and configuration
+- Device management
+- Data management (export/import)
+- Skin selection
+- Account management
+- Diagnostics
+
+It does NOT compete with skins for dashboard, shot execution, or history.
+
+### Launcher (replaces HomeScreen)
+
+The screen users see when exiting the skin. Phone home-screen metaphor: status bar + app grid.
+
+**Status bar (top):**
+- Machine: name + state (idle/heating/ready/sleep)
+- Scale: name + connection state
+- Battery: level + charging (mobile only — Android/iOS)
+- Water level: bar indicator
+- QR icon: tap to show QR overlay with webUI URL
+
+**Grid destinations:**
+1. **Settings** — theme, gateway mode, presence, advanced, about
+2. **Devices** — device management, connection preferences
+3. **Data** — export/import shots, profiles, beans, grinders, logs
+4. **Skins** — skin selector, download
+5. **Account** — Decent login (conditional: only when `DecentAccountService` available)
+6. **Plugins** — plugin management (conditional: only when plugins loaded)
+7. **Advanced** — debug views, log level, simulated devices
+
+**"Return to Skin" button:**
+- Most prominent action — not in the grid, above it or as a hero element
+- Conditionally visible: only when `WebUIService.isServing == true` AND platform supports WebView
+- When hidden: show explanation of why (skin not running, no WebView support, etc.) with actionable options (send feedback, export logs, open skin selector)
+
+**Browser redirect hero card (conditional):**
+- Shown when: no WebView support OR degraded Android (SDK < 31)
+- Contains: URL (`http://{ip}:3000?_={timestamp}`), Copy button, Open Browser button, inline QR code
+- Positioned above the grid
+
+### LandingFeature Absorbed
+
+No separate LandingFeature. The launcher handles both paths:
+- Normal: status bar + return-to-skin + grid
+- Degraded/no-WebView: status bar + browser hero card + grid (no return-to-skin)
+
+The launcher widget is shared; conditional widgets handle the difference.
+
+### Settings (Flattened)
+
+After extracting heavy sub-pages to the launcher grid, Settings becomes a flat list (~5-6 rows):
+- Appearance (theme: System/Light/Dark)
+- Gateway mode (Full/Restricted/None)
+- Battery charging mode (mobile only)
+- Presence (keep-alive settings)
+- Advanced (debug logging, simulated devices)
+- About (version, build info)
+
+Style: iOS Settings — flat rows, current value inline on the right, tap to edit or navigate to sub-page.
+
+### Standalone Sub-Pages
+
+Each launcher destination opens a dedicated page via `Navigator.push`:
+- **Data Management** — already exists, extracted from settings
+- **Device Management** — already exists, extracted from settings
+- **Skin Selector** — already exists in WebUI settings section
+- **Account** — already exists as a settings section
+- **Plugins** — already exists as `PluginsSettingsView`
+
+These pages get restyled to match the new visual language but keep their existing logic.
+
+### Navigation
+
+Stack-based `Navigator.pushNamed` — no change from current pattern. No go_router needed.
+
+Status bar appears on the launcher only. Sub-pages get a standard AppBar with back arrow.
+
+### Android Degraded-Experience Warning
+
+New onboarding step, shown when `SDK < 31` (Android 12):
+- Dismissible warning — not blocking
+- Message: "Your Android version may have reduced performance and WebView issues. The full experience works best on Android 12+."
+- "Continue" button proceeds with onboarding normally
+- Dismissal persisted in `SettingsService` — shown once, ever
+
+### Onboarding Restyle
+
+Keep the existing flow (welcome → login → permissions → init → scan → connect). Add Android warning step before welcome. Restyle all steps to match the new visual language (same card style, typography, spacing as the launcher).
+
+### Visual Language
+
+- **Toolkit:** shadcn_ui (unchanged)
+- **Launcher:** spacious, large tap targets (tablet-first)
+- **Sub-pages:** iOS Settings style — flat rows, clean spacing
+- **Theme:** System/Light/Dark (unchanged)
+- **Icons:** LucideIcons (unchanged)
+
+### Widget Previews
+
+Set up Flutter Widget Previewer before building screens. Every new component gets a preview wrapper for visual iteration without running the full app.
+
+## Scope
+
+### v1 (this effort)
+
+1. Widget preview infrastructure
+2. Launcher (HomeScreen replacement) with status bar + grid + QR
+3. Browser redirect hero card (conditional)
+4. Return-to-skin with conditional visibility + explanation
+5. Settings flattening + standalone sub-pages
+6. Data Management as standalone page
+7. Device Management as standalone page
+8. Skin Selector as standalone page
+9. Account as standalone page
+10. Onboarding restyle + Android warning step
+11. LandingFeature → launcher integration
+
+### Deferred
+
+- Realtime shot/steam screen redesign (skin territory)
+- History screen redesign (skin territory)
+- Plugin management redesign (niche)
+- Diagnostics/debug view redesign (dev-only)
+- go_router migration (not needed)
+
+## PR Breakdown
+
+| PR | Scope | Depends on |
+|----|-------|-----------|
+| PR1 | Widget preview infra + launcher component (status bar + grid) | — |
+| PR2 | Settings flattening + standalone sub-pages | PR1 |
+| PR3 | Onboarding restyle + Android warning step | PR1 |
+| PR4 | LandingFeature → launcher integration + browser hero card + QR | PR1 |
+
+## Rejected Alternatives
+
+- **Native UI as daily-driver competing with skins** — too much scope, skins are already better at this
+- **Drawer/tab navigation** — over-engineered for 6-7 destinations, stack push is simpler
+- **Blocking Android gate** — app still works on Android 9, just degraded; blocking is hostile
+- **Separate LandingFeature** — same launcher widget with conditional content is cleaner
+- **go_router** — stack-based navigation is sufficient for the back office

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -511,6 +511,7 @@ void main() async {
         connectionManager: connectionManager,
         scanStateGuardian: scanStateGuardian,
         decentAccountService: decentAccountService,
+        batteryController: batteryController,
       ),
     ),
   );
@@ -738,6 +739,7 @@ class AppRoot extends StatefulWidget {
   final ConnectionManager connectionManager;
   final ScanStateGuardian scanStateGuardian;
   final DecentAccountService? decentAccountService;
+  final BatteryController? batteryController;
 
   const AppRoot({
     super.key,
@@ -759,6 +761,7 @@ class AppRoot extends StatefulWidget {
     this.grinderStorage,
     this.profileStorageService,
     this.decentAccountService,
+    this.batteryController,
   });
 
   static void restart(BuildContext context) {
@@ -823,6 +826,7 @@ class _AppRootState extends State<AppRoot> {
         connectionManager: widget.connectionManager,
         scanStateGuardian: widget.scanStateGuardian,
         decentAccountService: widget.decentAccountService,
+        batteryController: widget.batteryController,
       ),
     );
 

--- a/lib/src/account/account_page.dart
+++ b/lib/src/account/account_page.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:reaprime/src/account/decent_login_form.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class AccountPage extends StatefulWidget {
+  const AccountPage({
+    super.key,
+    required this.accountService,
+  });
+
+  static const routeName = '/account';
+
+  final DecentAccountService accountService;
+
+  @override
+  State<AccountPage> createState() => _AccountPageState();
+}
+
+class _AccountPageState extends State<AccountPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Decent Account')),
+      body: SafeArea(
+        top: false,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: FutureBuilder<bool>(
+            future: widget.accountService.isLoggedIn(),
+            builder: (context, snapshot) {
+              final loggedIn = snapshot.data ?? false;
+
+              if (loggedIn) {
+                return FutureBuilder<String?>(
+                  future: widget.accountService.getEmail(),
+                  builder: (context, emailSnap) {
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        ShadCard(
+                          child: Padding(
+                            padding: const EdgeInsets.all(16),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Row(
+                                  children: [
+                                    const Icon(Icons.account_circle, size: 40),
+                                    const SizedBox(width: 12),
+                                    Expanded(
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: [
+                                          Text(
+                                            'Logged In',
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .titleMedium,
+                                          ),
+                                          Text(
+                                            emailSnap.data ?? '',
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .bodySmall,
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                const SizedBox(height: 16),
+                                ShadButton.destructive(
+                                  onPressed: () async {
+                                    await widget.accountService.logout();
+                                    setState(() {});
+                                  },
+                                  child: const Text('Unlink Account'),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ],
+                    );
+                  },
+                );
+              }
+
+              return ShadCard(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Link Your Account',
+                        style: Theme.of(context)
+                            .textTheme
+                            .titleMedium
+                            ?.copyWith(fontWeight: FontWeight.bold),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        'Link your Decent Espresso account to verify your machine serial number and access additional features.',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onSurface
+                                  .withValues(alpha: 0.7),
+                            ),
+                      ),
+                      const SizedBox(height: 16),
+                      DecentLoginForm(
+                        accountService: widget.accountService,
+                        onSuccess: () => setState(() {}),
+                        secondaryLabel: 'Cancel',
+                        onSecondary: () => Navigator.of(context).pop(),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -46,7 +46,12 @@ import 'package:reaprime/src/services/storage/grinder_storage_service.dart';
 import 'package:reaprime/src/services/storage/profile_storage_service.dart';
 import 'package:reaprime/src/services/update_check_service.dart';
 import 'package:reaprime/src/services/webview_log_service.dart';
+import 'package:reaprime/src/account/account_page.dart';
+import 'package:reaprime/src/settings/data_management_page.dart';
+import 'package:reaprime/src/settings/device_management_page.dart';
+import 'package:reaprime/src/settings/advanced_page.dart';
 import 'package:reaprime/src/settings/plugins_settings_view.dart';
+import 'package:reaprime/src/skin_selector/skin_selector_page.dart';
 import 'sample_feature/sample_item_details_view.dart';
 
 import 'sample_feature/sample_item_list_view.dart';
@@ -348,17 +353,9 @@ class _MyAppState extends State<MyApp> {
                     case SettingsView.routeName:
                       return SettingsView(
                         controller: widget.settingsController,
-                        persistenceController: widget.persistenceController,
-                        deviceController: widget.deviceController,
-                        presenceController: widget.presenceController,
-                        webUIService: widget.webUIService,
-                        webUIStorage: widget.webUIStorage,
                         updateCheckService: widget.updateCheckService,
-                        profileStorageService: widget.profileStorageService,
-                        beanStorageService: widget.beanStorage,
-                        grinderStorageService: widget.grinderStorage,
-                        workflowController: widget.workflowController,
-                        decentAccountService: widget.decentAccountService,
+                        presenceController: widget.presenceController,
+                        webUIStorage: widget.webUIStorage,
                       );
                     case De1DebugView.routeName:
                       final args = routeSettings.arguments;
@@ -464,6 +461,39 @@ class _MyAppState extends State<MyApp> {
                       return LandingFeature(
                         webUIStorage: widget.webUIStorage,
                         webUIService: widget.webUIService,
+                      );
+                    case DeviceManagementPage.routeName:
+                      return DeviceManagementPage(
+                        settingsController: widget.settingsController,
+                        deviceController: widget.deviceController,
+                      );
+                    case DataManagementPage.routeName:
+                      return DataManagementPage(
+                        controller: widget.settingsController,
+                        persistenceController: widget.persistenceController,
+                        profileStorageService: widget.profileStorageService,
+                        beanStorageService: widget.beanStorage,
+                        grinderStorageService: widget.grinderStorage,
+                        workflowController: widget.workflowController,
+                      );
+                    case SkinSelectorPage.routeName:
+                      return SkinSelectorPage(
+                        settingsController: widget.settingsController,
+                        webUIService: widget.webUIService,
+                        webUIStorage: widget.webUIStorage,
+                      );
+                    case AdvancedPage.routeName:
+                      return AdvancedPage(
+                        controller: widget.settingsController,
+                      );
+                    case AccountPage.routeName:
+                      if (widget.decentAccountService == null) {
+                        return Scaffold(
+                          body: Center(child: Text('Account service not available')),
+                        );
+                      }
+                      return AccountPage(
+                        accountService: widget.decentAccountService!,
                       );
                     case SkinView.routeName:
                       return SkinView(

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -34,7 +34,8 @@ import 'package:shadcn_ui/shadcn_ui.dart' hide Scale;
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
-import 'package:reaprime/src/home_feature/home_feature.dart';
+import 'package:reaprime/src/controllers/battery_controller.dart';
+import 'package:reaprime/src/launcher/launcher_view.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
@@ -83,6 +84,7 @@ class MyApp extends StatefulWidget {
     this.grinderStorage,
     this.profileStorageService,
     this.decentAccountService,
+    this.batteryController,
   });
 
   final SettingsController settingsController;
@@ -103,6 +105,7 @@ class MyApp extends StatefulWidget {
   final GrinderStorageService? grinderStorage;
   final ProfileStorageService? profileStorageService;
   final DecentAccountService? decentAccountService;
+  final BatteryController? batteryController;
 
   @override
   State<MyApp> createState() => _MyAppState();
@@ -164,7 +167,7 @@ class _MyAppState extends State<MyApp> {
         scanStateGuardian: widget.scanStateGuardian,
         onSkipToDashboard: () {
           NavigationService.navigatorKey.currentState?.pushNamedAndRemoveUntil(
-            HomeScreen.routeName,
+            LauncherView.routeName,
             (_) => false,
           );
         },
@@ -260,9 +263,9 @@ class _MyAppState extends State<MyApp> {
     // (port bound before isServing flips true) and the REST server is already
     // up from main(), so both are ready by the time we navigate.
     _log.info('Navigating to SkinView');
-    // Push both routes to stack: HomeScreen first, then SkinView on top
+    // Push both routes to stack: Launcher first, then SkinView on top
     navigator.pushNamedAndRemoveUntil(
-      HomeScreen.routeName,
+      LauncherView.routeName,
       (_) => false,
     );
     navigator.pushNamed(SkinView.routeName);
@@ -288,7 +291,7 @@ class _MyAppState extends State<MyApp> {
     });
     // Foreground service is now started in main.dart for Android
 
-    final themeColor = 'green';
+    final themeColor = 'neutral';
 
     final body = ScaffoldMessenger(
         child: ListenableBuilder(
@@ -445,19 +448,14 @@ class _MyAppState extends State<MyApp> {
                         initialSteamSettings: steamSettings,
                         gatewayMode: widget.settingsController.gatewayMode,
                       );
-                    case HomeScreen.routeName:
-                      return HomeScreen(
-                        de1controller: widget.de1Controller,
-                        workflowController: widget.workflowController,
+                    case LauncherView.routeName:
+                      return LauncherView(
+                        de1Controller: widget.de1Controller,
                         scaleController: widget.scaleController,
-                        deviceController: widget.deviceController,
-                        persistenceController: widget.persistenceController,
-                        settingsController: widget.settingsController,
                         webUIService: widget.webUIService,
-                        webUIStorage: widget.webUIStorage,
-                        beanStorage: widget.beanStorage,
-                        grinderStorage: widget.grinderStorage,
-                        connectionManager: widget.connectionManager,
+                        pluginLoaderService: widget.pluginLoaderService,
+                        batteryController: widget.batteryController,
+                        decentAccountService: widget.decentAccountService,
                       );
                     case HistoryFeature.routeName:
                       final possibleShot = routeSettings.arguments as String;
@@ -498,4 +496,11 @@ class _MyAppState extends State<MyApp> {
     return body;
   }
 }
+
+
+
+
+
+
+
 

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -28,6 +28,7 @@ import 'package:reaprime/src/onboarding_feature/steps/login_step.dart';
 import 'package:reaprime/src/realtime_shot_feature/realtime_shot_feature.dart';
 import 'package:reaprime/src/realtime_steam_feature/realtime_steam_feature.dart';
 import 'package:reaprime/src/skin_feature/skin_view.dart';
+import 'package:reaprime/src/theme/theme.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
 import 'package:reaprime/src/webui_support/webui_storage.dart';
 import 'package:shadcn_ui/shadcn_ui.dart' hide Scale;
@@ -291,8 +292,6 @@ class _MyAppState extends State<MyApp> {
     });
     // Foreground service is now started in main.dart for Android
 
-    final themeColor = 'neutral';
-
     final body = ScaffoldMessenger(
         child: ListenableBuilder(
           listenable: widget.settingsController,
@@ -321,23 +320,16 @@ class _MyAppState extends State<MyApp> {
             //
             // The appTitle is defined in .arb files found in the localization
             // directory.
-            onGenerateTitle: (BuildContext context) => "Streamline",
-
+          onGenerateTitle: (BuildContext context) => "Decent.app",
             // Define a light and dark color theme. Then, read the user's
             // preferred ThemeMode (light, dark, or system default) from the
             // SettingsController to display the correct theme.
             theme: ShadThemeData(
-              colorScheme: ShadColorScheme.fromName(
-                themeColor,
-                brightness: Brightness.light,
-              ),
+              colorScheme: DecentColorScheme.light(),
               brightness: Brightness.light,
             ),
             darkTheme: ShadThemeData(
-              colorScheme: ShadColorScheme.fromName(
-                themeColor,
-                brightness: Brightness.dark,
-              ),
+              colorScheme: DecentColorScheme.dark(),
               brightness: Brightness.dark,
             ),
             themeMode: widget.settingsController.themeMode,

--- a/lib/src/controllers/de1_state_manager.dart
+++ b/lib/src/controllers/de1_state_manager.dart
@@ -16,7 +16,7 @@ import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/realtime_shot_feature/realtime_shot_feature.dart';
 import 'package:reaprime/src/realtime_steam_feature/realtime_steam_feature.dart';
-import 'package:reaprime/src/home_feature/home_feature.dart';
+import 'package:reaprime/src/launcher/launcher_view.dart';
 import 'package:reaprime/src/services/account/decent_account_service.dart';
 import 'package:reaprime/src/settings/gateway_mode.dart';
 import 'package:reaprime/src/settings/scale_power_mode.dart';
@@ -148,7 +148,7 @@ class De1StateManager with WidgetsBindingObserver {
     });
     final route = result; //ModalRoute.of(context);
 
-    return route?.settings.name == HomeScreen.routeName && route!.isCurrent;
+    return route?.settings.name == LauncherView.routeName && route!.isCurrent;
   }
 
   /// Returns true if the current app state is considered "background" for the platform.

--- a/lib/src/device_discovery_feature/device_discovery_view.dart
+++ b/lib/src/device_discovery_feature/device_discovery_view.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';
-import 'package:reaprime/src/home_feature/home_feature.dart';
+import 'package:reaprime/src/launcher/launcher_view.dart';
 import 'package:reaprime/src/home_feature/widgets/device_selection_widget.dart';
 import 'package:reaprime/src/landing_feature/landing_feature.dart';
 import 'package:reaprime/src/shared/connection_error_banner.dart';
@@ -157,7 +157,7 @@ class _DeviceDiscoveryState extends State<DeviceDiscoveryView> {
 
     if (route == SkinView.routeName) {
       // Push both routes to stack: HomeScreen first, then SkinView on top
-      Navigator.popAndPushNamed(context, HomeScreen.routeName);
+      Navigator.popAndPushNamed(context, LauncherView.routeName);
       Navigator.of(context).pushNamed(SkinView.routeName);
     } else {
       // For LandingFeature or any other route, navigate directly
@@ -345,7 +345,7 @@ class _DeviceDiscoveryState extends State<DeviceDiscoveryView> {
               ShadButton.secondary(
                 size: ShadButtonSize.sm,
                 onPressed: () {
-                  Navigator.popAndPushNamed(context, HomeScreen.routeName);
+                  Navigator.popAndPushNamed(context, LauncherView.routeName);
                 },
                 child: Text('Dashboard'),
               ),
@@ -458,7 +458,7 @@ class _DeviceDiscoveryState extends State<DeviceDiscoveryView> {
                           onPressed: () {
                             Navigator.popAndPushNamed(
                               context,
-                              HomeScreen.routeName,
+                              LauncherView.routeName,
                             );
                           },
                           child: Text('Continue to Dashboard'),

--- a/lib/src/landing_feature/landing_feature.dart
+++ b/lib/src/landing_feature/landing_feature.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
-import 'package:reaprime/src/home_feature/home_feature.dart';
+import 'package:reaprime/src/launcher/launcher_view.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
 import 'package:reaprime/src/webui_support/webui_storage.dart';
 import 'package:reaprime/src/widgets/accessible_button.dart';
@@ -140,7 +140,7 @@ class _LandingState extends State<LandingFeature> {
 
   void _navigateToHome() {
     if (mounted) {
-      Navigator.pushReplacementNamed(context, HomeScreen.routeName);
+      Navigator.pushReplacementNamed(context, LauncherView.routeName);
     }
   }
 
@@ -409,4 +409,6 @@ class _LandingState extends State<LandingFeature> {
     return url;
   }
 }
+
+
 

--- a/lib/src/launcher/launcher_view.dart
+++ b/lib/src/launcher/launcher_view.dart
@@ -1,0 +1,223 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:reaprime/src/controllers/battery_controller.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/launcher/widgets/browser_hero_card.dart';
+import 'package:reaprime/src/launcher/widgets/destination_card.dart';
+import 'package:reaprime/src/launcher/widgets/skin_unavailable_card.dart';
+import 'package:reaprime/src/launcher/widgets/status_bar.dart';
+import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:reaprime/src/settings/settings_view.dart';
+import 'package:reaprime/src/skin_feature/skin_view.dart';
+import 'package:reaprime/src/webui_support/webui_service.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class LauncherView extends StatelessWidget {
+  static const routeName = '/home';
+
+  const LauncherView({
+    super.key,
+    required this.de1Controller,
+    required this.scaleController,
+    required this.webUIService,
+    required this.pluginLoaderService,
+    this.batteryController,
+    this.decentAccountService,
+  });
+
+  final De1Controller de1Controller;
+  final ScaleController scaleController;
+  final WebUIService webUIService;
+  final PluginLoaderService pluginLoaderService;
+  final BatteryController? batteryController;
+  final DecentAccountService? decentAccountService;
+
+  bool get _supportsWebView =>
+      Platform.isIOS || Platform.isAndroid || Platform.isMacOS || Platform.isWindows;
+
+  bool get _isDegradedAndroid {
+    if (!Platform.isAndroid) return false;
+    // SDK version check would go here; for now we rely on the
+    // onboarding warning step and keep this as a layout hint.
+    // The launcher shows the browser hero card on platforms without WebView.
+    return false;
+  }
+
+  bool get _showBrowserHero => !_supportsWebView || _isDegradedAndroid;
+
+  bool get _canReturnToSkin => _supportsWebView && webUIService.isServing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: [
+          // Status bar
+          StatusBar(
+            de1Controller: de1Controller,
+            scaleController: scaleController,
+            batteryController: batteryController,
+            webUIService: webUIService,
+          ),
+
+          // Scrollable content
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(24),
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 600),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    spacing: 24,
+                    children: [
+                      // Return to skin — hero button or unavailable explanation
+                      if (_canReturnToSkin)
+                        _ReturnToSkinButton(onTap: () {
+                          Navigator.of(context).pushNamed(SkinView.routeName);
+                        })
+                      else
+                        _buildSkinUnavailable(context),
+
+                      // Browser hero card (no WebView or degraded)
+                      if (_showBrowserHero)
+                        BrowserHeroCard(
+                          deviceIp: webUIService.deviceIp(),
+                        ),
+
+                      // Destination grid
+                      _buildGrid(context),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSkinUnavailable(BuildContext context) {
+    final reason = !_supportsWebView
+        ? SkinUnavailableReason.noWebView
+        : SkinUnavailableReason.notServing;
+
+    return SkinUnavailableCard(
+      reason: reason,
+      onPickSkin: () {
+        // Navigate to settings for now; will be standalone skin selector in PR2
+        Navigator.of(context).pushNamed(SettingsView.routeName);
+      },
+      onSendFeedback: () {
+        // Navigate to settings where feedback is accessible
+        Navigator.of(context).pushNamed(SettingsView.routeName);
+      },
+    );
+  }
+
+  Widget _buildGrid(BuildContext context) {
+    final destinations = <_Destination>[
+      _Destination(
+        icon: LucideIcons.settings,
+        label: 'Settings',
+        route: SettingsView.routeName,
+      ),
+      _Destination(
+        icon: LucideIcons.bluetooth,
+        label: 'Devices',
+        // Device management is inside settings for now; standalone in PR2
+        route: SettingsView.routeName,
+      ),
+      _Destination(
+        icon: LucideIcons.database,
+        label: 'Data',
+        // Data management is inside settings for now; standalone in PR2
+        route: SettingsView.routeName,
+      ),
+      _Destination(
+        icon: LucideIcons.palette,
+        label: 'Skins',
+        // Skin selector is inside settings for now; standalone in PR2
+        route: SettingsView.routeName,
+      ),
+      if (decentAccountService != null)
+        _Destination(
+          icon: LucideIcons.user,
+          label: 'Account',
+          route: SettingsView.routeName,
+        ),
+      if (pluginLoaderService.availablePlugins.isNotEmpty)
+        _Destination(
+          icon: LucideIcons.puzzle,
+          label: 'Plugins',
+          route: '/plugins',
+        ),
+      _Destination(
+        icon: LucideIcons.wrench,
+        label: 'Advanced',
+        route: SettingsView.routeName,
+      ),
+    ];
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final crossAxisCount = constraints.maxWidth > 400 ? 4 : 3;
+        return GridView.count(
+          crossAxisCount: crossAxisCount,
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          mainAxisSpacing: 12,
+          crossAxisSpacing: 12,
+          childAspectRatio: 1.0,
+          children: destinations
+              .map((d) => DestinationCard(
+                    icon: d.icon,
+                    label: d.label,
+                    onTap: () =>
+                        Navigator.of(context).pushNamed(d.route),
+                  ))
+              .toList(),
+        );
+      },
+    );
+  }
+}
+
+class _Destination {
+  final IconData icon;
+  final String label;
+  final String route;
+
+  const _Destination({
+    required this.icon,
+    required this.label,
+    required this.route,
+  });
+}
+
+class _ReturnToSkinButton extends StatelessWidget {
+  const _ReturnToSkinButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+
+    return ShadButton(
+      size: ShadButtonSize.lg,
+      leading: const Icon(LucideIcons.arrowLeft, size: 18),
+      onPressed: onTap,
+      child: Text(
+        'Return to Skin',
+        style: theme.textTheme.p.copyWith(
+          color: theme.colorScheme.primaryForeground,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/launcher/launcher_view.dart
+++ b/lib/src/launcher/launcher_view.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:reaprime/src/account/account_page.dart';
 import 'package:reaprime/src/controllers/battery_controller.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
@@ -10,8 +11,12 @@ import 'package:reaprime/src/launcher/widgets/skin_unavailable_card.dart';
 import 'package:reaprime/src/launcher/widgets/status_bar.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
 import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:reaprime/src/settings/advanced_page.dart';
+import 'package:reaprime/src/settings/data_management_page.dart';
+import 'package:reaprime/src/settings/device_management_page.dart';
 import 'package:reaprime/src/settings/settings_view.dart';
 import 'package:reaprime/src/skin_feature/skin_view.dart';
+import 'package:reaprime/src/skin_selector/skin_selector_page.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
@@ -109,11 +114,9 @@ class LauncherView extends StatelessWidget {
     return SkinUnavailableCard(
       reason: reason,
       onPickSkin: () {
-        // Navigate to settings for now; will be standalone skin selector in PR2
-        Navigator.of(context).pushNamed(SettingsView.routeName);
+        Navigator.of(context).pushNamed(SkinSelectorPage.routeName);
       },
       onSendFeedback: () {
-        // Navigate to settings where feedback is accessible
         Navigator.of(context).pushNamed(SettingsView.routeName);
       },
     );
@@ -129,26 +132,23 @@ class LauncherView extends StatelessWidget {
       _Destination(
         icon: LucideIcons.bluetooth,
         label: 'Devices',
-        // Device management is inside settings for now; standalone in PR2
-        route: SettingsView.routeName,
+        route: DeviceManagementPage.routeName,
       ),
       _Destination(
         icon: LucideIcons.database,
         label: 'Data',
-        // Data management is inside settings for now; standalone in PR2
-        route: SettingsView.routeName,
+        route: DataManagementPage.routeName,
       ),
       _Destination(
         icon: LucideIcons.palette,
         label: 'Skins',
-        // Skin selector is inside settings for now; standalone in PR2
-        route: SettingsView.routeName,
+        route: SkinSelectorPage.routeName,
       ),
       if (decentAccountService != null)
         _Destination(
           icon: LucideIcons.user,
           label: 'Account',
-          route: SettingsView.routeName,
+          route: AccountPage.routeName,
         ),
       if (pluginLoaderService.availablePlugins.isNotEmpty)
         _Destination(
@@ -159,7 +159,7 @@ class LauncherView extends StatelessWidget {
       _Destination(
         icon: LucideIcons.wrench,
         label: 'Advanced',
-        route: SettingsView.routeName,
+        route: AdvancedPage.routeName,
       ),
     ];
 

--- a/lib/src/launcher/widgets/browser_hero_card.dart
+++ b/lib/src/launcher/widgets/browser_hero_card.dart
@@ -55,16 +55,20 @@ class BrowserHeroCard extends StatelessWidget {
             spacing: 16,
             children: [
               // QR code
-              SizedBox(
-                width: 120,
-                height: 120,
-                child: PrettyQrView.data(
-                  data: _url,
-                  decoration: PrettyQrDecoration(
-                    quietZone: PrettyQrQuietZone.standard,
-                    shape: PrettyQrSquaresSymbol(
-                      unifiedFinderPattern: true,
-                      color: theme.colorScheme.foreground,
+              Semantics(
+                label: 'QR code to open WebUI at $_displayUrl',
+                excludeSemantics: true,
+                child: SizedBox(
+                  width: 120,
+                  height: 120,
+                  child: PrettyQrView.data(
+                    data: _url,
+                    decoration: PrettyQrDecoration(
+                      quietZone: PrettyQrQuietZone.standard,
+                      shape: PrettyQrSquaresSymbol(
+                        unifiedFinderPattern: true,
+                        color: theme.colorScheme.foreground,
+                      ),
                     ),
                   ),
                 ),

--- a/lib/src/launcher/widgets/browser_hero_card.dart
+++ b/lib/src/launcher/widgets/browser_hero_card.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widget_previews.dart';
+import 'package:pretty_qr_code/pretty_qr_code.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Hero card shown when the platform has no WebView support or is a degraded
+/// Android version. Displays the webUI URL, QR code, and action buttons so
+/// users can connect from another device's browser.
+class BrowserHeroCard extends StatelessWidget {
+  const BrowserHeroCard({
+    super.key,
+    required this.deviceIp,
+    this.port = 3000,
+  });
+
+  final String deviceIp;
+  final int port;
+
+  String get _url =>
+      'http://$deviceIp:$port/?_=${DateTime.now().millisecondsSinceEpoch}';
+
+  String get _displayUrl => 'http://$deviceIp:$port';
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+
+    return ShadCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 16,
+        children: [
+          Row(
+            spacing: 8,
+            children: [
+              Icon(
+                LucideIcons.globe,
+                size: 20,
+                color: theme.colorScheme.primary,
+              ),
+              Text(
+                'Open in browser',
+                style: theme.textTheme.h4,
+              ),
+            ],
+          ),
+          Text(
+            'For the best experience, open the UI on a phone or laptop browser.',
+            style: theme.textTheme.muted,
+          ),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            spacing: 16,
+            children: [
+              // QR code
+              SizedBox(
+                width: 120,
+                height: 120,
+                child: PrettyQrView.data(
+                  data: _url,
+                  decoration: PrettyQrDecoration(
+                    quietZone: PrettyQrQuietZone.standard,
+                    shape: PrettyQrSquaresSymbol(
+                      unifiedFinderPattern: true,
+                      color: theme.colorScheme.foreground,
+                    ),
+                  ),
+                ),
+              ),
+              // URL + actions
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  spacing: 12,
+                  children: [
+                    SelectableText(
+                      _displayUrl,
+                      style: theme.textTheme.p.copyWith(
+                        fontFamily: 'monospace',
+                      ),
+                    ),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        ShadButton.outline(
+                          size: ShadButtonSize.sm,
+                          leading: const Icon(LucideIcons.copy, size: 14),
+                          child: const Text('Copy URL'),
+                          onPressed: () {
+                            Clipboard.setData(ClipboardData(text: _url));
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('URL copied'),
+                                duration: Duration(seconds: 2),
+                              ),
+                            );
+                          },
+                        ),
+                        ShadButton(
+                          size: ShadButtonSize.sm,
+                          leading: const Icon(
+                              LucideIcons.externalLink, size: 14),
+                          child: const Text('Open Browser'),
+                          onPressed: () {
+                            launchUrl(Uri.parse(_url));
+                          },
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// -- Widget Previews --
+
+@Preview(name: 'Browser Hero Card', group: 'Launcher')
+Widget browserHeroCardPreview() {
+  return ShadApp(
+    home: Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.all(32),
+        child: SizedBox(
+          width: 500,
+          child: BrowserHeroCard(deviceIp: '192.168.1.42'),
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/src/launcher/widgets/destination_card.dart
+++ b/lib/src/launcher/widgets/destination_card.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widget_previews.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class DestinationCard extends StatelessWidget {
+  const DestinationCard({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.badge,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  final String? badge;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+
+    return Semantics(
+      button: true,
+      label: label,
+      child: ShadCard(
+        rowMainAxisAlignment: .center,
+        columnMainAxisAlignment: .spaceBetween,
+        padding: EdgeInsets.zero,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(8),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              // mainAxisSize: MainAxisSize.min,
+              spacing: 12,
+              children: [
+                Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    Icon(
+                      icon,
+                      size: 32,
+                      color: theme.colorScheme.foreground,
+                    ),
+                    if (badge != null)
+                      Positioned(
+                        right: -8,
+                        top: -8,
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 6,
+                            vertical: 2,
+                          ),
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.primary,
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          child: Text(
+                            badge!,
+                            style: theme.textTheme.small.copyWith(
+                              color: theme.colorScheme.primaryForeground,
+                              fontSize: 10,
+                            ),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+                Text(
+                  label,
+                  style: theme.textTheme.small.copyWith(
+                    color: theme.colorScheme.foreground,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// -- Widget Previews --
+
+@Preview(name: 'Destination Card', group: 'Launcher')
+Widget destinationCardPreview() {
+  return ShadApp(
+    home: Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Wrap(
+          spacing: 16,
+          runSpacing: 16,
+          children: [
+            SizedBox(
+              width: 120,
+              child: DestinationCard(
+                icon: LucideIcons.settings,
+                label: 'Settings',
+                onTap: () {},
+              ),
+            ),
+            SizedBox(
+              width: 120,
+              child: DestinationCard(
+                icon: LucideIcons.database,
+                label: 'Data',
+                onTap: () {},
+                badge: '3',
+              ),
+            ),
+            SizedBox(
+              width: 120,
+              child: DestinationCard(
+                icon: LucideIcons.bluetooth,
+                label: 'Devices',
+                onTap: () {},
+              ),
+            ),
+            SizedBox(
+              width: 120,
+              child: DestinationCard(
+                icon: LucideIcons.palette,
+                label: 'Skins',
+                onTap: () {},
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/src/launcher/widgets/destination_card.dart
+++ b/lib/src/launcher/widgets/destination_card.dart
@@ -23,6 +23,7 @@ class DestinationCard extends StatelessWidget {
     return Semantics(
       button: true,
       label: label,
+      excludeSemantics: true,
       child: ShadCard(
         rowMainAxisAlignment: .center,
         columnMainAxisAlignment: .spaceBetween,
@@ -31,53 +32,57 @@ class DestinationCard extends StatelessWidget {
         child: InkWell(
           borderRadius: BorderRadius.circular(8),
           onTap: onTap,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              // mainAxisSize: MainAxisSize.min,
-              spacing: 12,
-              children: [
-                Stack(
-                  clipBehavior: Clip.none,
-                  children: [
-                    Icon(
-                      icon,
-                      size: 32,
-                      color: theme.colorScheme.foreground,
-                    ),
-                    if (badge != null)
-                      Positioned(
-                        right: -8,
-                        top: -8,
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 6,
-                            vertical: 2,
-                          ),
-                          decoration: BoxDecoration(
-                            color: theme.colorScheme.primary,
-                            borderRadius: BorderRadius.circular(10),
-                          ),
-                          child: Text(
-                            badge!,
-                            style: theme.textTheme.small.copyWith(
-                              color: theme.colorScheme.primaryForeground,
-                              fontSize: 10,
+          child: SizedBox.expand(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                vertical: 24,
+                horizontal: 16,
+              ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                spacing: 12,
+                children: [
+                  Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      Icon(
+                        icon,
+                        size: 32,
+                        color: theme.colorScheme.foreground,
+                      ),
+                      if (badge != null)
+                        Positioned(
+                          right: -8,
+                          top: -8,
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 6,
+                              vertical: 2,
+                            ),
+                            decoration: BoxDecoration(
+                              color: theme.colorScheme.primary,
+                              borderRadius: BorderRadius.circular(10),
+                            ),
+                            child: Text(
+                              badge!,
+                              style: theme.textTheme.small.copyWith(
+                                color: theme.colorScheme.primaryForeground,
+                                fontSize: 10,
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                  ],
-                ),
-                Text(
-                  label,
-                  style: theme.textTheme.table.copyWith(
-                    color: theme.colorScheme.foreground,
+                    ],
                   ),
-                  textAlign: TextAlign.center,
-                ),
-              ],
+                  Text(
+                    label,
+                    style: theme.textTheme.table.copyWith(
+                      color: theme.colorScheme.foreground,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
             ),
           ),
         ),
@@ -137,3 +142,6 @@ Widget destinationCardPreview() {
     ),
   );
 }
+
+
+

--- a/lib/src/launcher/widgets/destination_card.dart
+++ b/lib/src/launcher/widgets/destination_card.dart
@@ -27,6 +27,7 @@ class DestinationCard extends StatelessWidget {
         rowMainAxisAlignment: .center,
         columnMainAxisAlignment: .spaceBetween,
         padding: EdgeInsets.zero,
+        backgroundColor: theme.colorScheme.secondary,
         child: InkWell(
           borderRadius: BorderRadius.circular(8),
           onTap: onTap,
@@ -71,7 +72,7 @@ class DestinationCard extends StatelessWidget {
                 ),
                 Text(
                   label,
-                  style: theme.textTheme.small.copyWith(
+                  style: theme.textTheme.table.copyWith(
                     color: theme.colorScheme.foreground,
                   ),
                   textAlign: TextAlign.center,

--- a/lib/src/launcher/widgets/skin_unavailable_card.dart
+++ b/lib/src/launcher/widgets/skin_unavailable_card.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widget_previews.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+/// Shown when the "Return to Skin" button is hidden — explains why and gives
+/// the user actionable options (pick a skin, export logs, send feedback).
+class SkinUnavailableCard extends StatelessWidget {
+  const SkinUnavailableCard({
+    super.key,
+    required this.reason,
+    this.onPickSkin,
+    this.onExportLogs,
+    this.onSendFeedback,
+  });
+
+  final SkinUnavailableReason reason;
+  final VoidCallback? onPickSkin;
+  final VoidCallback? onExportLogs;
+  final VoidCallback? onSendFeedback;
+
+  @override
+  Widget build(BuildContext context) {
+    return ShadAlert(
+      icon: const Icon(LucideIcons.info, size: 16),
+      title: Text(_title),
+      description: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 12,
+        children: [
+          Text(_description),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              if (reason == SkinUnavailableReason.notServing &&
+                  onPickSkin != null)
+                ShadButton.outline(
+                  size: ShadButtonSize.sm,
+                  onPressed: onPickSkin,
+                  child: const Text('Pick a skin'),
+                ),
+              if (onExportLogs != null)
+                ShadButton.outline(
+                  size: ShadButtonSize.sm,
+                  onPressed: onExportLogs,
+                  child: const Text('Export logs'),
+                ),
+              if (onSendFeedback != null)
+                ShadButton.outline(
+                  size: ShadButtonSize.sm,
+                  onPressed: onSendFeedback,
+                  child: const Text('Send feedback'),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  String get _title {
+    switch (reason) {
+      case SkinUnavailableReason.notServing:
+        return 'WebUI is not running';
+      case SkinUnavailableReason.noWebView:
+        return 'WebView not available';
+      case SkinUnavailableReason.skinError:
+        return 'Skin failed to load';
+    }
+  }
+
+  String get _description {
+    switch (reason) {
+      case SkinUnavailableReason.notServing:
+        return 'No skin is currently serving. Pick a skin to get started, '
+            'or use a browser to connect.';
+      case SkinUnavailableReason.noWebView:
+        return 'This platform does not support in-app WebView. '
+            'Use a browser on another device to access the full UI.';
+      case SkinUnavailableReason.skinError:
+        return 'Something went wrong loading the skin. '
+            'Try picking a different skin, or export logs for troubleshooting.';
+    }
+  }
+}
+
+enum SkinUnavailableReason {
+  notServing,
+  noWebView,
+  skinError,
+}
+
+// -- Widget Previews --
+
+@Preview(name: 'Skin Unavailable - Not Serving', group: 'Launcher')
+Widget skinUnavailableNotServingPreview() {
+  return ShadApp(
+    home: Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.all(32),
+        child: SizedBox(
+          width: 500,
+          child: SkinUnavailableCard(
+            reason: SkinUnavailableReason.notServing,
+            onPickSkin: () {},
+            onExportLogs: () {},
+            onSendFeedback: () {},
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+@Preview(name: 'Skin Unavailable - No WebView', group: 'Launcher')
+Widget skinUnavailableNoWebviewPreview() {
+  return ShadApp(
+    home: Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.all(32),
+        child: SizedBox(
+          width: 500,
+          child: SkinUnavailableCard(
+            reason: SkinUnavailableReason.noWebView,
+            onExportLogs: () {},
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/src/launcher/widgets/status_bar.dart
+++ b/lib/src/launcher/widgets/status_bar.dart
@@ -1,0 +1,429 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widget_previews.dart';
+import 'package:reaprime/src/controllers/battery_controller.dart';
+import 'package:reaprime/src/controllers/charging_logic.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart' as device;
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/webui_support/webui_service.dart';
+import 'package:pretty_qr_code/pretty_qr_code.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class StatusBar extends StatelessWidget {
+  const StatusBar({
+    super.key,
+    required this.de1Controller,
+    required this.scaleController,
+    required this.webUIService,
+    this.batteryController,
+    this.onQrTap,
+  });
+
+  final De1Controller de1Controller;
+  final ScaleController scaleController;
+  final BatteryController? batteryController;
+  final WebUIService webUIService;
+  final VoidCallback? onQrTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      decoration: BoxDecoration(
+        color: colorScheme.card,
+        border: Border(
+          bottom: BorderSide(color: colorScheme.border, width: 1),
+        ),
+      ),
+      child: SafeArea(
+        bottom: false,
+        child: Row(
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  spacing: 16,
+                  children: [
+                    _MachineStatus(de1Controller: de1Controller),
+                    _ScaleStatus(scaleController: scaleController),
+                    if (batteryController != null)
+                      _BatteryStatus(
+                        batteryController: batteryController!,
+                      ),
+                    _WaterLevel(de1Controller: de1Controller),
+                  ],
+                ),
+              ),
+            ),
+            _QrButton(
+              webUIService: webUIService,
+              onTap: onQrTap,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({
+    required this.icon,
+    required this.label,
+    this.color,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      spacing: 6,
+      children: [
+        Icon(icon, size: 14, color: color ?? theme.colorScheme.mutedForeground),
+        Text(
+          label,
+          style: theme.textTheme.small.copyWith(
+            color: color ?? theme.colorScheme.foreground,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _MachineStatus extends StatelessWidget {
+  const _MachineStatus({required this.de1Controller});
+
+  final De1Controller de1Controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<De1Interface?>(
+      stream: de1Controller.de1,
+      builder: (context, de1Snap) {
+        final de1 = de1Snap.data;
+        if (de1 == null) {
+          return _StatusChip(
+            icon: LucideIcons.coffee,
+            label: 'No machine',
+            color: ShadTheme.of(context).colorScheme.mutedForeground,
+          );
+        }
+
+        return StreamBuilder<MachineSnapshot>(
+          stream: de1.currentSnapshot,
+          builder: (context, snapshot) {
+            final state = snapshot.data?.state.state;
+            final stateLabel = state != null
+                ? _machineStateLabel(state)
+                : 'connecting';
+            final color = _machineStateColor(context, state);
+
+            return _StatusChip(
+              icon: LucideIcons.coffee,
+              label: '${de1.name} · $stateLabel',
+              color: color,
+            );
+          },
+        );
+      },
+    );
+  }
+
+  static String _machineStateLabel(MachineState state) {
+    return switch (state) {
+      MachineState.idle || MachineState.schedIdle => 'idle',
+      MachineState.heating || MachineState.preheating => 'heating',
+      MachineState.sleeping => 'sleep',
+      MachineState.espresso => 'espresso',
+      MachineState.hotWater => 'hot water',
+      MachineState.flush => 'flush',
+      MachineState.steam => 'steam',
+      MachineState.steamRinse => 'steam rinse',
+      MachineState.needsWater => 'needs water',
+      MachineState.error => 'error',
+      _ => state.name,
+    };
+  }
+
+  static Color _machineStateColor(BuildContext context, MachineState? state) {
+    if (state == null) {
+      return ShadTheme.of(context).colorScheme.mutedForeground;
+    }
+    return switch (state) {
+      MachineState.idle || MachineState.schedIdle => Colors.green,
+      MachineState.heating || MachineState.preheating ||
+      MachineState.booting || MachineState.busy => Colors.orange,
+      MachineState.sleeping => ShadTheme.of(context).colorScheme.mutedForeground,
+      MachineState.needsWater => Colors.orange,
+      MachineState.error => Colors.red,
+      _ => Colors.blue,
+    };
+  }
+}
+
+class _ScaleStatus extends StatelessWidget {
+  const _ScaleStatus({required this.scaleController});
+
+  final ScaleController scaleController;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<device.ConnectionState>(
+      stream: scaleController.connectionState,
+      builder: (context, snapshot) {
+        final state = snapshot.data;
+        final connected = state == device.ConnectionState.connected;
+
+        String label;
+        Color color;
+        if (connected) {
+          try {
+            label = scaleController.connectedScale().name;
+            color = Colors.green;
+          } catch (_) {
+            label = 'Connected';
+            color = Colors.green;
+          }
+        } else if (state == device.ConnectionState.connecting) {
+          label = 'Connecting';
+          color = Colors.orange;
+        } else {
+          label = 'No scale';
+          color = ShadTheme.of(context).colorScheme.mutedForeground;
+        }
+
+        return _StatusChip(
+          icon: LucideIcons.scale,
+          label: label,
+          color: color,
+        );
+      },
+    );
+  }
+}
+
+class _BatteryStatus extends StatelessWidget {
+  const _BatteryStatus({required this.batteryController});
+
+  final BatteryController batteryController;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<ChargingState>(
+      stream: batteryController.chargingState,
+      builder: (context, snapshot) {
+        final state = snapshot.data;
+        if (state == null) return const SizedBox.shrink();
+
+        final percent = state.batteryPercent;
+        final charging = state.usbChargerOn;
+        final icon = charging
+            ? LucideIcons.batteryCharging
+            : percent > 75
+                ? LucideIcons.batteryFull
+                : percent > 25
+                    ? LucideIcons.batteryMedium
+                    : LucideIcons.batteryLow;
+        final color = percent <= 15
+            ? Colors.red
+            : percent <= 25
+                ? Colors.orange
+                : null;
+
+        return _StatusChip(
+          icon: icon,
+          label: '$percent%',
+          color: color,
+        );
+      },
+    );
+  }
+}
+
+class _WaterLevel extends StatelessWidget {
+  const _WaterLevel({required this.de1Controller});
+
+  final De1Controller de1Controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<De1Interface?>(
+      stream: de1Controller.de1,
+      builder: (context, de1Snap) {
+        final de1 = de1Snap.data;
+        if (de1 == null) return const SizedBox.shrink();
+
+        return StreamBuilder<De1WaterLevels>(
+          stream: de1.waterLevels,
+          builder: (context, snapshot) {
+            final levels = snapshot.data;
+            if (levels == null) return const SizedBox.shrink();
+
+            final low = levels.currentLevel <= levels.refillLevel;
+
+            return _StatusChip(
+              icon: LucideIcons.glassWaterDir,
+              label: '${levels.currentLevel.toInt()}%',
+              color: low ? Colors.orange : null,
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _QrButton extends StatelessWidget {
+  const _QrButton({
+    required this.webUIService,
+    this.onTap,
+  });
+
+  final WebUIService webUIService;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: 'Show QR code for WebUI',
+      child: ExcludeSemantics(
+        child: ShadIconButton.ghost(
+          icon: const Icon(LucideIcons.qrCode, size: 18),
+          onPressed: onTap ?? () => _showQrDialog(context),
+        ),
+      ),
+    );
+  }
+
+  void _showQrDialog(BuildContext context) {
+    final deviceIp = webUIService.deviceIp();
+    final url =
+        'http://$deviceIp:3000/?_=${DateTime.now().millisecondsSinceEpoch}';
+
+    showShadDialog(
+      context: context,
+      builder: (context) => ShadDialog(
+        title: const Text('Scan to connect'),
+        description: Text(url),
+        actions: [
+          ShadButton.outline(
+            child: const Text('Close'),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ],
+        child: Center(
+          child: SizedBox(
+            height: 220,
+            child: PrettyQrView.data(
+              data: url,
+              decoration: PrettyQrDecoration(
+                quietZone: PrettyQrQuietZone.standard,
+                shape: PrettyQrSquaresSymbol(
+                  unifiedFinderPattern: true,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// -- Widget Previews --
+
+@Preview(name: 'Status Bar', group: 'Launcher')
+Widget statusBarPreview() {
+  // Preview uses placeholder widgets since controllers need dart:io
+  return MaterialApp(
+    home: Scaffold(
+      body: _StatusBarPreviewStatic(),
+    ),
+  );
+}
+
+/// Static preview that doesn't depend on controllers (which use dart:io).
+class _StatusBarPreviewStatic extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        border: Border(
+          bottom: BorderSide(color: theme.dividerColor, width: 1),
+        ),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Row(
+              spacing: 16,
+              children: [
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  spacing: 6,
+                  children: [
+                    Icon(LucideIcons.coffee, size: 14, color: Colors.green),
+                    Text('DE1 · idle',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: Colors.green,
+                        )),
+                  ],
+                ),
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  spacing: 6,
+                  children: [
+                    Icon(LucideIcons.scale, size: 14, color: Colors.green),
+                    Text('Lunar',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: Colors.green,
+                        )),
+                  ],
+                ),
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  spacing: 6,
+                  children: [
+                    Icon(LucideIcons.batteryMedium, size: 14),
+                    Text('73%', style: theme.textTheme.bodySmall),
+                  ],
+                ),
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  spacing: 6,
+                  children: [
+                    Icon(LucideIcons.droplets, size: 14),
+                    Text('60%', style: theme.textTheme.bodySmall),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            icon: const Icon(LucideIcons.qrCode, size: 18),
+            onPressed: () {},
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/launcher/widgets/status_bar.dart
+++ b/lib/src/launcher/widgets/status_bar.dart
@@ -87,18 +87,22 @@ class _StatusChip extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = ShadTheme.of(context);
 
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      spacing: 6,
-      children: [
-        Icon(icon, size: 14, color: color ?? theme.colorScheme.mutedForeground),
-        Text(
-          label,
-          style: theme.textTheme.small.copyWith(
-            color: color ?? theme.colorScheme.foreground,
+    return Semantics(
+      label: label,
+      excludeSemantics: true,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 6,
+        children: [
+          Icon(icon, size: 14, color: color ?? theme.colorScheme.mutedForeground),
+          Text(
+            label,
+            style: theme.textTheme.small.copyWith(
+              color: color ?? theme.colorScheme.foreground,
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/lib/src/models/device/impl/sensor/debug_port.dart
+++ b/lib/src/models/device/impl/sensor/debug_port.dart
@@ -27,7 +27,7 @@ class DebugPort implements Sensor {
       BehaviorSubject();
 
   @override
-  Stream<Map<String, dynamic>> get data => _streamSubject.asBroadcastStream();
+  Stream<Map<String, dynamic>> get data => _streamSubject.stream;
 
   @override
   String get deviceId => _transport.id;

--- a/lib/src/settings/advanced_page.dart
+++ b/lib/src/settings/advanced_page.dart
@@ -42,15 +42,15 @@ class AdvancedPage extends StatelessWidget {
                       value: controller.logLevel,
                       onChanged: controller.updateLogLevel,
                       items: const [
-                        DropdownMenuItem(value: 'FINE', child: Text('Fine')),
-                        DropdownMenuItem(value: 'INFO', child: Text('Info')),
-                        DropdownMenuItem(
-                          value: 'FINEST',
-                          child: Text('Finest'),
-                        ),
                         DropdownMenuItem(
                           value: 'WARNING',
                           child: Text('Warning'),
+                        ),
+                        DropdownMenuItem(value: 'INFO', child: Text('Info')),
+                        DropdownMenuItem(value: 'FINE', child: Text('Fine')),
+                        DropdownMenuItem(
+                          value: 'FINEST',
+                          child: Text('Finest'),
                         ),
                       ],
                     ),
@@ -149,7 +149,7 @@ class AdvancedPage extends StatelessWidget {
         return ShadDialog(
           title: const Text('Gateway Mode'),
           description: const Text(
-            'Control how external clients interact with the machine',
+            'Control how external skins interact with the machine',
           ),
           actions: [
             TextButton.icon(
@@ -166,16 +166,26 @@ class AdvancedPage extends StatelessWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                ...GatewayMode.values.map((mode) {
+                ...const [
+                  GatewayMode.tracking,
+                  GatewayMode.full,
+                  GatewayMode.disabled,
+                ].map((mode) {
                   String subtitle;
                   switch (mode) {
-                    case GatewayMode.full:
-                      subtitle = 'App has no control';
                     case GatewayMode.tracking:
                       subtitle =
-                          'App will stop shot if target weight is reached';
+                          'External skins control the machine. This app adds '
+                          'weight tracking and stops the shot at your target. '
+                          '(Used by most skins.)';
+                    case GatewayMode.full:
+                      subtitle =
+                          'External skins fully control the machine, including '
+                          'stopping the shot. This app only displays status.';
                     case GatewayMode.disabled:
-                      subtitle = 'App has full control';
+                      subtitle =
+                          'This app controls the machine directly. External '
+                          'skins can\'t. (Legacy.)';
                   }
                   return ListTile(
                     title: Text(

--- a/lib/src/settings/advanced_page.dart
+++ b/lib/src/settings/advanced_page.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import 'package:reaprime/build_info.dart';
+import 'package:reaprime/src/settings/common.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/settings/settings_service.dart';
+import 'package:reaprime/src/services/foreground_service.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+import 'dart:io';
+
+import 'package:reaprime/src/settings/gateway_mode.dart';
+import 'package:reaprime/src/settings/gateway_mode_info_dialog.dart';
+
+class AdvancedPage extends StatelessWidget {
+  const AdvancedPage({
+    super.key,
+    required this.controller,
+  });
+
+  static const routeName = '/advanced';
+
+  final SettingsController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Advanced')),
+      body: ListenableBuilder(
+        listenable: controller,
+        builder: (context, _) {
+          return ListView(
+            children: [
+              // Log Level
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 12,
+                ),
+                child: Row(
+                  children: [
+                    const Expanded(child: Text('Log Level')),
+                    DropdownButton<String>(
+                      value: controller.logLevel,
+                      onChanged: controller.updateLogLevel,
+                      items: const [
+                        DropdownMenuItem(value: 'FINE', child: Text('Fine')),
+                        DropdownMenuItem(value: 'INFO', child: Text('Info')),
+                        DropdownMenuItem(
+                          value: 'FINEST',
+                          child: Text('Finest'),
+                        ),
+                        DropdownMenuItem(
+                          value: 'WARNING',
+                          child: Text('Warning'),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              const SettingsDivider(),
+
+              SettingsTile(
+                icon: Icons.settings_remote_outlined,
+                label: 'Gateway Mode',
+                trailing: Text(_gatewayModeLabel(controller.gatewayMode)),
+                onTap: () => _showGatewayModePicker(context),
+              ),
+              const SettingsDivider(),
+
+              // Simulated devices
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
+                child: Text(
+                  'Simulated Devices',
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+              ),
+              for (final type in SimulatedDevicesTypes.values)
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 4,
+                  ),
+                  child: ShadSwitch(
+                    value: controller.simulatedDevices.contains(type),
+                    onChanged: (v) async {
+                      final current = Set<SimulatedDevicesTypes>.from(
+                        controller.simulatedDevices,
+                      );
+                      if (v) {
+                        current.add(type);
+                      } else {
+                        current.remove(type);
+                      }
+                      await controller.setSimulatedDevices(current);
+                    },
+                    label: Text(
+                      type.name[0].toUpperCase() + type.name.substring(1),
+                    ),
+                  ),
+                ),
+              const SettingsDivider(),
+
+              // Exit
+              if (!BuildInfo.appStore)
+                ListTile(
+                  leading: Icon(
+                    LucideIcons.logOut,
+                    color: Theme.of(context).colorScheme.error,
+                  ),
+                  title: Text(
+                    'Exit Decent',
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                  ),
+                  onTap: () {
+                    if (Platform.isAndroid) {
+                      ForegroundTaskService.stop();
+                    }
+                    exit(0);
+                  },
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  static String _gatewayModeLabel(GatewayMode mode) {
+    switch (mode) {
+      case GatewayMode.full:
+        return 'Full';
+      case GatewayMode.tracking:
+        return 'Tracking';
+      case GatewayMode.disabled:
+        return 'Disabled';
+    }
+  }
+
+  void _showGatewayModePicker(BuildContext context) {
+    showShadDialog(
+      context: context,
+      builder: (dialogContext) {
+        return ShadDialog(
+          title: const Text('Gateway Mode'),
+          description: const Text(
+            'Control how external clients interact with the machine',
+          ),
+          actions: [
+            TextButton.icon(
+              onPressed: () {
+                Navigator.of(dialogContext).pop();
+                showGatewayModeInfoDialog(context);
+              },
+              icon: const Icon(Icons.info_outline, size: 16),
+              label: const Text('Learn more'),
+            ),
+          ],
+          child: Material(
+            type: MaterialType.transparency,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ...GatewayMode.values.map((mode) {
+                  String subtitle;
+                  switch (mode) {
+                    case GatewayMode.full:
+                      subtitle = 'App has no control';
+                    case GatewayMode.tracking:
+                      subtitle =
+                          'App will stop shot if target weight is reached';
+                    case GatewayMode.disabled:
+                      subtitle = 'App has full control';
+                  }
+                  return ListTile(
+                    title: Text(
+                      mode.name[0].toUpperCase() + mode.name.substring(1),
+                    ),
+                    subtitle: Text(
+                      subtitle,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    trailing: controller.gatewayMode == mode
+                        ? const Icon(Icons.check)
+                        : null,
+                    onTap: () {
+                      controller.updateGatewayMode(mode);
+                      Navigator.of(dialogContext).pop();
+                    },
+                  );
+                }),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/src/settings/advanced_page.dart
+++ b/lib/src/settings/advanced_page.dart
@@ -3,6 +3,7 @@ import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/settings/common.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/settings/settings_service.dart';
+import 'package:reaprime/src/sample_feature/sample_item_list_view.dart';
 import 'package:reaprime/src/services/foreground_service.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 import 'dart:io';
@@ -102,6 +103,18 @@ class AdvancedPage extends StatelessWidget {
                     ),
                   ),
                 ),
+              const SettingsDivider(),
+
+              // Debug view
+              ListTile(
+                leading: const Icon(LucideIcons.bug),
+                title: const Text('Debug view'),
+                trailing: const Icon(Icons.chevron_right, size: 20),
+                onTap: () => Navigator.pushNamed(
+                  context,
+                  SampleItemListView.routeName,
+                ),
+              ),
               const SettingsDivider(),
 
               // Exit

--- a/lib/src/settings/battery_charging_settings_page.dart
+++ b/lib/src/settings/battery_charging_settings_page.dart
@@ -84,19 +84,19 @@ class _BatteryChargingSettingsPageState
             items: const [
               DropdownMenuItem(
                 value: ChargingMode.disabled,
-                child: Text('Disabled (always charge)'),
+                child: Text('Always charge'),
               ),
               DropdownMenuItem(
                 value: ChargingMode.longevity,
-                child: Text('Longevity (45-55%)'),
+                child: Text('Maximize battery lifespan (45–55%)'),
               ),
               DropdownMenuItem(
                 value: ChargingMode.balanced,
-                child: Text('Balanced (40-80%)'),
+                child: Text('Balanced (40–80%)'),
               ),
               DropdownMenuItem(
                 value: ChargingMode.highAvailability,
-                child: Text('High Availability (80-95%)'),
+                child: Text('Always ready (80–95%)'),
               ),
             ],
           ),
@@ -126,14 +126,16 @@ class _BatteryChargingSettingsPageState
             onChanged: (v) {
               widget.controller.setNightModeEnabled(v);
             },
-            label: const Text('Night Mode'),
-            sublabel:
-                const Text('Override charging schedule in the evening and night'),
+            label: const Text('Overnight charging'),
+            sublabel: const Text(
+              'Top up before bedtime, then pause charging overnight to reduce '
+              'battery wear.',
+            ),
           ),
           if (widget.controller.nightModeEnabled) ...[
             const SizedBox(height: 16),
             _buildTimePicker(
-              label: 'Sleep time',
+              label: 'Bedtime',
               minutesSinceMidnight: widget.controller.nightModeSleepTime,
               onChanged: (minutes) {
                 widget.controller.setNightModeSleepTime(minutes);
@@ -141,7 +143,7 @@ class _BatteryChargingSettingsPageState
             ),
             const SizedBox(height: 8),
             _buildTimePicker(
-              label: 'Morning time',
+              label: 'Wake-up time',
               minutesSinceMidnight: widget.controller.nightModeMorningTime,
               onChanged: (minutes) {
                 widget.controller.setNightModeMorningTime(minutes);
@@ -173,15 +175,15 @@ class _BatteryChargingSettingsPageState
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Emergency Floor',
+            'Low battery protection',
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
                   fontWeight: FontWeight.bold,
                 ),
           ),
           const SizedBox(height: 8),
           Text(
-            'If battery drops to 15% or below, charging is always enabled '
-            'regardless of other settings.',
+            'If the battery drops to 15% or lower, charging turns on '
+            'automatically — whatever the settings above say.',
             style: Theme.of(context).textTheme.bodyMedium,
           ),
         ],

--- a/lib/src/settings/common.dart
+++ b/lib/src/settings/common.dart
@@ -26,6 +26,27 @@ class SettingsTile extends StatelessWidget {
   }
 }
 
+class SettingsSectionHeader extends StatelessWidget {
+  final String label;
+
+  const SettingsSectionHeader(this.label, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 24, 16, 8),
+      child: Text(
+        label.toUpperCase(),
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.5,
+            ),
+      ),
+    );
+  }
+}
+
 class SettingsDivider extends StatelessWidget {
   const SettingsDivider({super.key});
 

--- a/lib/src/settings/common.dart
+++ b/lib/src/settings/common.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+// MARK: - Settings Tile Widgets
+
+class SettingsTile extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final Widget? trailing;
+  final VoidCallback? onTap;
+
+  const SettingsTile({super.key, 
+    required this.icon,
+    required this.label,
+    this.trailing,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(icon),
+      title: Text(label),
+      trailing: trailing ?? const Icon(Icons.chevron_right, size: 20),
+      onTap: onTap,
+    );
+  }
+}
+
+class SettingsDivider extends StatelessWidget {
+  const SettingsDivider({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Divider(height: 1, indent: 56);
+  }
+}
+
+class InfoRow extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const InfoRow(this.label, this.value, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 72,
+          child: Text(
+            '$label:',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ),
+        Expanded(
+          child: Text(
+            value,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              fontFamily: 'monospace',
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/settings/data_management_page.dart
+++ b/lib/src/settings/data_management_page.dart
@@ -178,7 +178,7 @@ class _DataManagementPageState extends State<DataManagementPage> {
               if (_canImportFromDe1app)
                 ShadButton.outline(
                   onPressed: _importFromDe1app,
-                  child: const Text('Import from Decent app'),
+                  child: const Text('Import from DE1 app'),
                 ),
             ],
           ),
@@ -658,14 +658,14 @@ class _DataManagementPageState extends State<DataManagementPage> {
       if (folderPath == null) {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('No Decent app data found')),
+            const SnackBar(content: Text('No DE1 app data found')),
           );
         }
         return;
       }
     } else {
       folderPath = await FilePicker.getDirectoryPath(
-        dialogTitle: 'Select Decent app folder',
+        dialogTitle: 'Select the DE1 app folder',
       );
     }
     if (folderPath == null) return;
@@ -694,7 +694,7 @@ class _DataManagementPageState extends State<DataManagementPage> {
       if (scanResult.isEmpty) {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('No Decent app data found in this folder')),
+            const SnackBar(content: Text('No DE1 app data found in this folder')),
           );
         }
         return;

--- a/lib/src/settings/data_management_page.dart
+++ b/lib/src/settings/data_management_page.dart
@@ -38,6 +38,8 @@ class DataManagementPage extends StatefulWidget {
     this.workflowController,
   });
 
+  static const routeName = '/data';
+
   final SettingsController controller;
   final PersistenceController persistenceController;
   final ProfileStorageService? profileStorageService;

--- a/lib/src/settings/device_management_page.dart
+++ b/lib/src/settings/device_management_page.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/models/device/device.dart';
-import 'package:reaprime/src/sample_feature/sample_item_list_view.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
@@ -53,7 +52,7 @@ class _DeviceManagementPageState extends State<DeviceManagementPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Device Management')),
+      appBar: AppBar(title: const Text('Devices')),
       body: ListenableBuilder(
         listenable: widget.settingsController,
         builder: (context, _) {
@@ -67,7 +66,7 @@ class _DeviceManagementPageState extends State<DeviceManagementPage> {
                 spacing: 16,
                 children: [
                   _buildSection(
-                    title: 'Preferred Machine',
+                    title: 'Auto-connect Machine',
                     icon: Icons.coffee_outlined,
                     devices: _machines,
                     selectedId: widget.settingsController.preferredMachineId,
@@ -78,7 +77,7 @@ class _DeviceManagementPageState extends State<DeviceManagementPage> {
                     },
                   ),
                   _buildSection(
-                    title: 'Preferred Scale',
+                    title: 'Auto-connect Scale',
                     icon: Icons.scale_outlined,
                     devices: _scales,
                     selectedId: widget.settingsController.preferredScaleId,
@@ -87,13 +86,6 @@ class _DeviceManagementPageState extends State<DeviceManagementPage> {
                       await widget.settingsController.setPreferredScaleId(id);
                       if (mounted) _showSavedSnackbar();
                     },
-                  ),
-                  ShadButton.outline(
-                    onPressed: () => Navigator.pushNamed(
-                      context,
-                      SampleItemListView.routeName,
-                    ),
-                    child: const Text('Debug view'),
                   ),
                 ],
               ),

--- a/lib/src/settings/device_management_page.dart
+++ b/lib/src/settings/device_management_page.dart
@@ -14,6 +14,8 @@ class DeviceManagementPage extends StatefulWidget {
     required this.deviceController,
   });
 
+  static const routeName = '/devices';
+
   final SettingsController settingsController;
   final DeviceController deviceController;
 

--- a/lib/src/settings/gateway_mode_info_dialog.dart
+++ b/lib/src/settings/gateway_mode_info_dialog.dart
@@ -3,7 +3,7 @@ import 'package:shadcn_ui/shadcn_ui.dart';
 
 /// Shows an informational dialog explaining the Gateway Mode settings
 ///
-/// This dialog explains the three gateway modes (Disabled, Full, Tracking)
+/// This dialog explains the three gateway modes (Tracking, Full, Disabled)
 /// and when to use them. It can be reused in both the Settings view and
 /// the Home screen quick settings card.
 ///
@@ -21,7 +21,7 @@ void showGatewayModeInfoDialog(BuildContext context) {
         (context) => ShadDialog(
           title: const Text('Gateway Mode'),
           description: const Text(
-            'Control whether Rea acts as a gateway for external clients',
+            'Control how external skins interact with the machine',
           ),
           actions: [
             ShadButton(
@@ -35,31 +35,31 @@ void showGatewayModeInfoDialog(BuildContext context) {
             spacing: 16,
             children: [
               _GatewayModeOption(
-                title: 'Disabled',
+                title: 'Tracking',
                 description:
-                    'Gateway is completely disabled. Rea has full control over the machine, shot execution, and all parameters. External clients cannot control the machine.',
-                icon: Icons.block,
-                color: Colors.grey,
+                    'External skins control the machine. This app adds weight tracking and stops the shot at your target. (Used by most skins.)',
+                icon: Icons.track_changes,
+                color: Colors.orange,
               ),
               _GatewayModeOption(
                 title: 'Full',
                 description:
-                    'Full gateway mode. Rea has no control - external clients have complete control over the machine, shot execution, profiles, and all parameters. Rea only displays status and graphs.',
+                    'External skins fully control the machine, including stopping the shot. This app only displays status.',
                 icon: Icons.open_in_browser,
                 color: Colors.blue,
               ),
               _GatewayModeOption(
-                title: 'Tracking',
+                title: 'Disabled',
                 description:
-                    'Hybrid mode. Rea will not show graphs but will monitor the shot. When the target weight is reached, Rea will automatically stop the shot. External clients can still control most parameters.',
-                icon: Icons.track_changes,
-                color: Colors.orange,
+                    'This app controls the machine directly. External skins can\'t. (Legacy.)',
+                icon: Icons.block,
+                color: Colors.grey,
               ),
               const SizedBox(height: 8),
               Builder(
                 builder:
                     (context) => Text(
-                      'Use gateway mode when you want to control Rea from external applications like web dashboards, mobile apps, or automation systems.',
+                      'Use gateway mode when you drive the machine from an external skin — a web dashboard, browser, or another tablet.',
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
                         fontStyle: FontStyle.italic,
                       ),

--- a/lib/src/settings/presence_settings_page.dart
+++ b/lib/src/settings/presence_settings_page.dart
@@ -39,7 +39,7 @@ class _PresenceSettingsPageState extends State<PresenceSettingsPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Presence & Sleep')),
+      appBar: AppBar(title: const Text('Sleep & Wake')),
       body: ListenableBuilder(
         listenable: widget.controller,
         builder: (context, _) {
@@ -79,10 +79,9 @@ class _PresenceSettingsPageState extends State<PresenceSettingsPage> {
             onChanged: (v) {
               widget.controller.setUserPresenceEnabled(v);
             },
-            label: const Text('User Presence'),
+            label: const Text('Auto sleep & wake'),
             sublabel: const Text(
-              'Enable presence-based power management. When enabled, the machine '
-              'can automatically sleep after inactivity and wake on a schedule.',
+              'Let the machine sleep when idle and wake on a schedule.',
             ),
           ),
         ],
@@ -97,14 +96,14 @@ class _PresenceSettingsPageState extends State<PresenceSettingsPage> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Sleep Timeout',
+            'Sleep',
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
                   fontWeight: FontWeight.bold,
                 ),
           ),
           const SizedBox(height: 4),
           Text(
-            'Automatically put the machine to sleep after a period of inactivity. '
+            'Put the machine to sleep after a period of inactivity. '
             'The timer resets whenever the machine is used.',
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
                   color: Theme.of(context)
@@ -171,7 +170,7 @@ class _PresenceSettingsPageState extends State<PresenceSettingsPage> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Wake Schedules',
+            'Wake schedule',
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
                   fontWeight: FontWeight.bold,
                 ),

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -1,290 +1,154 @@
 import 'dart:io';
 
-import 'package:file_picker/file_picker.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
-import 'package:reaprime/src/services/foreground_service.dart';
 import 'package:reaprime/build_info.dart';
-import 'package:reaprime/src/controllers/device_controller.dart';
-import 'package:reaprime/src/controllers/persistence_controller.dart';
-import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/controllers/presence_controller.dart';
-import 'package:reaprime/src/services/storage/bean_storage_service.dart';
-import 'package:reaprime/src/services/storage/grinder_storage_service.dart';
-import 'package:reaprime/src/services/storage/profile_storage_service.dart';
-import 'package:reaprime/src/settings/battery_charging_settings_page.dart';
-import 'package:reaprime/src/settings/data_management_page.dart';
-import 'package:reaprime/src/settings/device_management_page.dart';
-import 'package:reaprime/src/settings/presence_settings_page.dart';
-import 'package:reaprime/src/settings/charging_mode.dart';
-import 'package:reaprime/src/settings/gateway_mode.dart';
-import 'package:reaprime/src/settings/gateway_mode_info_dialog.dart';
-import 'package:reaprime/src/settings/plugins_settings_view.dart';
-import 'package:reaprime/src/settings/settings_service.dart';
-import 'package:reaprime/src/settings/update_dialog.dart';
 import 'package:reaprime/src/services/android_updater.dart';
 import 'package:reaprime/src/services/update_check_service.dart';
-import 'package:reaprime/src/account/decent_login_form.dart';
-import 'package:reaprime/src/services/account/decent_account_service.dart';
-import 'package:reaprime/src/webui_support/webui_service.dart';
+import 'package:reaprime/src/settings/battery_charging_settings_page.dart';
+import 'package:reaprime/src/settings/common.dart';
+import 'package:reaprime/src/settings/presence_settings_page.dart';
+import 'package:reaprime/src/settings/charging_mode.dart';
+import 'package:reaprime/src/settings/update_dialog.dart';
 import 'package:reaprime/src/webui_support/webui_storage.dart';
-import 'package:permission_handler/permission_handler.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'settings_controller.dart';
 
-/// Displays the various settings that can be customized by the user.
-class SettingsView extends StatefulWidget {
+/// Flat iOS-style list of settings. Heavy sub-pages (devices, data, skins,
+/// account, advanced) are standalone launcher destinations.
+class SettingsView extends StatelessWidget {
   const SettingsView({
     super.key,
     required this.controller,
-    required this.persistenceController,
-    required this.deviceController,
-    required this.presenceController,
-    required this.webUIService,
-    required this.webUIStorage,
     this.updateCheckService,
-    this.profileStorageService,
-    this.beanStorageService,
-    this.grinderStorageService,
-    this.workflowController,
-    this.decentAccountService,
+    required this.presenceController,
+    this.webUIStorage,
   });
 
   static const routeName = '/settings';
 
   final SettingsController controller;
-  final PersistenceController persistenceController;
-  final DeviceController deviceController;
   final PresenceController presenceController;
-  final WebUIService webUIService;
-  final WebUIStorage webUIStorage;
   final UpdateCheckService? updateCheckService;
-  final ProfileStorageService? profileStorageService;
-  final BeanStorageService? beanStorageService;
-  final GrinderStorageService? grinderStorageService;
-  final WorkflowController? workflowController;
-  final DecentAccountService? decentAccountService;
-
-  @override
-  State<SettingsView> createState() => _SettingsViewState();
-}
-
-class _SettingsViewState extends State<SettingsView>
-    with WidgetsBindingObserver {
-  String? _selectedSkinId;
-  static const String _customSkinId = '__custom__';
-  static const String _liveEditSkinId = '__live_edit__';
-  final Logger _log = Logger("Settings");
-  bool _storagePermissionGranted = false;
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addObserver(this);
-    _selectedSkinId = widget.webUIStorage.defaultSkin?.id;
-    _checkStoragePermission();
-  }
-
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    super.dispose();
-  }
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.resumed) {
-      _checkStoragePermission();
-    }
-  }
-
-  Future<void> _checkStoragePermission() async {
-    if (!Platform.isAndroid || BuildInfo.appStore) return;
-    final status = await Permission.manageExternalStorage.status;
-    if (mounted && status.isGranted != _storagePermissionGranted) {
-      setState(() => _storagePermissionGranted = status.isGranted);
-    }
-  }
+  final WebUIStorage? webUIStorage;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          spacing: 16,
-          children: [
-            _buildAppearanceSection(),
-            _buildGatewaySection(),
-            if (Platform.isAndroid || Platform.isIOS) _buildBatterySection(),
-            _buildPresenceSection(),
-            _buildDeviceManagementSection(),
-            _buildDataManagementSection(),
-            if (widget.decentAccountService != null)
-              _buildDecentAccountSection(),
-            _buildWebUISection(),
-            _buildAdvancedSection(),
-            _buildAboutSection(),
-          ],
-        ),
-      ),
-    );
-  }
-
-  // MARK: - Section Builders
-
-  Widget _buildAppearanceSection() {
-    return _SettingsSection(
-      title: 'Appearance',
-      icon: Icons.palette_outlined,
-      description: 'Customize the visual appearance of the app',
-      children: [
-        _SettingRow(
-          label: 'Theme',
-          child: DropdownButton<ThemeMode>(
-            isExpanded: true,
-            value: widget.controller.themeMode,
-            onChanged: widget.controller.updateThemeMode,
-            items: const [
-              DropdownMenuItem(
-                value: ThemeMode.system,
-                child: Text('System Theme'),
-              ),
-              DropdownMenuItem(
-                value: ThemeMode.light,
-                child: Text('Light Theme'),
-              ),
-              DropdownMenuItem(
-                value: ThemeMode.dark,
-                child: Text('Dark Theme'),
-              ),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildGatewaySection() {
-    return _SettingsSection(
-      title: 'Gateway & Control',
-      icon: Icons.settings_remote_outlined,
-      description: 'Configure how external clients can control the machine',
-      onInfoPressed: () => showGatewayModeInfoDialog(context),
-      children: [
-        MergeSemantics(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+      body: ListenableBuilder(
+        listenable: controller,
+        builder: (context, _) {
+          return ListView(
             children: [
-              Text(
-                'Gateway Mode',
-                style: Theme.of(
-                  context,
-                ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
+              SettingsTile(
+                icon: Icons.palette_outlined,
+                label: 'Appearance',
+                trailing: Text(_themeModeLabel(controller.themeMode)),
+                onTap: () => _showThemePicker(context),
               ),
-              const SizedBox(height: 8),
-              DropdownButton<GatewayMode>(
-                isExpanded: true,
-                value: widget.controller.gatewayMode,
-                onChanged: (v) {
-                  if (v != null) widget.controller.updateGatewayMode(v);
-                },
-                items: const [
-                  DropdownMenuItem(
-                    value: GatewayMode.full,
-                    child: Text('Full (App has no control)'),
-                  ),
-                  DropdownMenuItem(
-                    value: GatewayMode.tracking,
-                    child: Text(
-                      'Tracking (App will stop shot if target weight is reached)',
-                    ),
-                  ),
-                  DropdownMenuItem(
-                    value: GatewayMode.disabled,
-                    child: Text('Disabled (App has full control)'),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
+              SettingsDivider(),
 
-  Widget _buildBatterySection() {
-    return Semantics(
-      explicitChildNodes: true,
-      child: ShadCard(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                const Icon(Icons.battery_charging_full_outlined, size: 20),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    'Battery & Charging',
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
+              // Automatic update checks
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                child: ShadSwitch(
+                  value: controller.automaticUpdateCheck,
+                  onChanged: (v) async {
+                    await controller.setAutomaticUpdateCheck(v);
+                    if (v) {
+                      await updateCheckService?.enableAutomaticChecks();
+                    } else {
+                      await updateCheckService?.disableAutomaticChecks();
+                    }
+                  },
+                  label: const Text('Automatic update checks'),
+                  sublabel: const Text('Check for updates every 12 hours'),
                 ),
-              ],
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'Smart charging and night mode settings',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(
-                  context,
-                ).colorScheme.onSurface.withValues(alpha: 0.7),
               ),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'Mode: ${_chargingModeLabel(widget.controller.chargingMode)}',
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-            if (widget.controller.nightModeEnabled) ...[
-              const SizedBox(height: 4),
-              Text(
-                'Night mode enabled',
-                style: Theme.of(context).textTheme.bodySmall,
+              const SettingsDivider(),
+              //
+              // Check for updates
+              ListTile(
+                leading: const Icon(LucideIcons.refreshCcwDot),
+                title: const Text('Check for updates'),
+                trailing: updateCheckService?.hasAvailableUpdate == true
+                    ? Chip(
+                        label: Text(
+                          updateCheckService?.availableUpdate?.version ?? '',
+                          style: const TextStyle(fontSize: 12),
+                        ),
+                        backgroundColor: Theme.of(context).colorScheme.primary,
+                      )
+                    : null,
+                onTap: () => _checkForUpdates(context),
               ),
-            ],
-            const SizedBox(height: 12),
-            Semantics(
-              button: true,
-              label: 'Configure battery and charging settings',
-              child: ExcludeSemantics(
-                child: ShadButton.outline(
-                  onPressed: () {
+              const SettingsDivider(),
+
+              if (Platform.isAndroid || Platform.isIOS) ...[
+                SettingsTile(
+                  icon: Icons.battery_charging_full_outlined,
+                  label: 'Battery Charging',
+                  trailing: Text(_chargingModeLabel(controller.chargingMode)),
+                  onTap: () {
                     Navigator.of(context).push(
                       MaterialPageRoute(
                         builder: (_) => BatteryChargingSettingsPage(
-                          controller: widget.controller,
+                          controller: controller,
                         ),
                       ),
                     );
                   },
-                  child: const Text('Configure'),
                 ),
+                SettingsDivider(),
+              ],
+
+              SettingsTile(
+                icon: Icons.schedule_outlined,
+                label: 'Presence',
+                trailing: Text(_presenceSubtitle()),
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => PresenceSettingsPage(
+                        controller: controller,
+                        keepAwakeUntil: presenceController.keepAwakeUntil,
+                      ),
+                    ),
+                  );
+                },
               ),
-            ),
-          ],
-        ),
+              SettingsDivider(),
+
+              SettingsTile(
+                icon: Icons.info_outline,
+                label: 'About',
+                trailing: const Icon(Icons.chevron_right, size: 20),
+                onTap: () => _showAboutSection(context),
+              ),
+            ],
+          );
+        },
       ),
     );
   }
+
+  // MARK: - Label Helpers
+
+  static String _themeModeLabel(ThemeMode mode) {
+    switch (mode) {
+      case ThemeMode.system:
+        return 'System';
+      case ThemeMode.light:
+        return 'Light';
+      case ThemeMode.dark:
+        return 'Dark';
+    }
+  }
+
 
   String _chargingModeLabel(ChargingMode mode) {
     switch (mode) {
@@ -299,1034 +163,137 @@ class _SettingsViewState extends State<SettingsView>
     }
   }
 
-  Widget _buildPresenceSection() {
-    final enabled = widget.controller.userPresenceEnabled;
-    final timeout = widget.controller.sleepTimeoutMinutes;
-
-    String subtitle;
-    if (!enabled) {
-      subtitle = 'Disabled';
-    } else if (timeout > 0) {
-      subtitle = 'Sleep after $timeout min';
-    } else {
-      subtitle = 'Enabled, no sleep timeout';
-    }
-
-    return Semantics(
-      explicitChildNodes: true,
-      child: ShadCard(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                const Icon(Icons.schedule_outlined, size: 20),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    'Presence & Sleep',
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'Automatic sleep and scheduled wake settings',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(
-                  context,
-                ).colorScheme.onSurface.withValues(alpha: 0.7),
-              ),
-            ),
-            const SizedBox(height: 16),
-            Text(subtitle, style: Theme.of(context).textTheme.bodyMedium),
-            const SizedBox(height: 12),
-            Semantics(
-              button: true,
-              label: 'Configure presence and sleep settings',
-              child: ExcludeSemantics(
-                child: ShadButton.outline(
-                  onPressed: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => PresenceSettingsPage(
-                          controller: widget.controller,
-                          keepAwakeUntil:
-                              widget.presenceController.keepAwakeUntil,
-                        ),
-                      ),
-                    );
-                  },
-                  child: const Text('Configure'),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
+  String _presenceSubtitle() {
+    final enabled = controller.userPresenceEnabled;
+    final timeout = controller.sleepTimeoutMinutes;
+    if (!enabled) return 'Disabled';
+    if (timeout > 0) return 'Sleep after $timeout min';
+    return 'Enabled, no sleep timeout';
   }
 
-  Widget _buildDeviceManagementSection() {
-    // Resolve device names from DeviceController if available
-    final machineId = widget.controller.preferredMachineId;
-    final scaleId = widget.controller.preferredScaleId;
+  // MARK: - Dialogs
 
-    final machineName = _resolveDeviceName(machineId);
-    final scaleName = _resolveDeviceName(scaleId);
-
-    return Semantics(
-      explicitChildNodes: true,
-      child: ShadCard(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                const Icon(Icons.devices_outlined, size: 20),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    'Device Management',
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'Configure preferred auto-connect devices',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(
-                  context,
-                ).colorScheme.onSurface.withValues(alpha: 0.7),
-              ),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'Machine: ${machineName ?? "Not set"}',
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'Scale: ${scaleName ?? "Not set"}',
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-            const SizedBox(height: 12),
-            Semantics(
-              button: true,
-              label: 'Configure preferred devices',
-              child: ExcludeSemantics(
-                child: ShadButton.outline(
-                  onPressed: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => DeviceManagementPage(
-                          settingsController: widget.controller,
-                          deviceController: widget.deviceController,
-                        ),
-                      ),
-                    );
-                  },
-                  child: const Text('Configure'),
-                ),
-              ),
-            ),
-            const Divider(height: 32),
-            Text(
-              'Simulated Devices',
-              style: Theme.of(
-                context,
-              ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'Select which simulated devices appear in scan results',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(
-                  context,
-                ).colorScheme.onSurface.withValues(alpha: 0.7),
-              ),
-            ),
-            const SizedBox(height: 8),
-            for (final type in SimulatedDevicesTypes.values)
-              MergeSemantics(
-                child: ShadSwitch(
-                  value: widget.controller.simulatedDevices.contains(type),
-                  onChanged: (v) async {
-                    final current = Set<SimulatedDevicesTypes>.from(
-                      widget.controller.simulatedDevices,
-                    );
-                    if (v) {
-                      current.add(type);
-                    } else {
-                      current.remove(type);
-                    }
-                    _log.info("simulated devices: $current");
-                    await widget.controller.setSimulatedDevices(current);
-                  },
-                  label: Text(
-                    type.name[0].toUpperCase() + type.name.substring(1),
-                  ),
-                ),
-              ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildDataManagementSection() {
-    return Semantics(
-      explicitChildNodes: true,
-      child: ShadCard(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                const Icon(Icons.storage_outlined, size: 20),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    'Data Management',
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'Export, import, and backup your data',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(
-                  context,
-                ).colorScheme.onSurface.withValues(alpha: 0.7),
-              ),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'Backup, restore, and privacy settings',
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-            const SizedBox(height: 12),
-            Semantics(
-              button: true,
-              label: 'Configure data management',
-              child: ExcludeSemantics(
-                child: ShadButton.outline(
-                  onPressed: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => DataManagementPage(
-                          controller: widget.controller,
-                          persistenceController: widget.persistenceController,
-                          profileStorageService: widget.profileStorageService,
-                          beanStorageService: widget.beanStorageService,
-                          grinderStorageService: widget.grinderStorageService,
-                          workflowController: widget.workflowController,
-                        ),
-                      ),
-                    );
-                  },
-                  child: const Text('Configure'),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildDecentAccountSection() {
-    final accountService = widget.decentAccountService!;
-
-    return Semantics(
-      explicitChildNodes: true,
-      child: ShadCard(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                const Icon(Icons.account_circle_outlined, size: 20),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    'Decent Account',
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'Link your Decent Espresso account',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(
-                  context,
-                ).colorScheme.onSurface.withValues(alpha: 0.7),
-              ),
-            ),
-            const SizedBox(height: 16),
-            FutureBuilder<bool>(
-              future: accountService.isLoggedIn(),
-              builder: (context, snapshot) {
-                final loggedIn = snapshot.data ?? false;
-
-                if (loggedIn) {
-                  return FutureBuilder<String?>(
-                    future: accountService.getEmail(),
-                    builder: (context, emailSnap) {
-                      return Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            'Logged in as: ${emailSnap.data ?? ''}',
-                            style: Theme.of(context).textTheme.bodyMedium,
-                          ),
-                          const SizedBox(height: 12),
-                          Semantics(
-                            button: true,
-                            label: 'Unlink Decent account',
-                            child: ExcludeSemantics(
-                              child: ShadButton.destructive(
-                                onPressed: () async {
-                                  await accountService.logout();
-                                  setState(() {});
-                                },
-                                child: const Text('Unlink Account'),
-                              ),
-                            ),
-                          ),
-                        ],
-                      );
-                    },
-                  );
-                }
-
-                return Semantics(
-                  button: true,
-                  label: 'Link your Decent Espresso account',
-                  child: ExcludeSemantics(
-                    child: ShadButton.outline(
-                      onPressed: () =>
-                          _showLoginDialog(context, accountService),
-                      child: const Text('Link Account'),
-                    ),
-                  ),
-                );
-              },
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  void _showLoginDialog(
-    BuildContext context,
-    DecentAccountService accountService,
-  ) {
+  void _showThemePicker(BuildContext context) {
     showShadDialog(
       context: context,
       builder: (dialogContext) {
         return ShadDialog(
-          title: const Text('Link Decent Account'),
-          child: Padding(
-            padding: const EdgeInsets.only(top: 8),
-            child: DecentLoginForm(
-              accountService: accountService,
-              onSuccess: () {
-                Navigator.of(dialogContext).pop();
-                setState(() {});
-              },
-              secondaryLabel: 'Cancel',
-              onSecondary: () => Navigator.of(dialogContext).pop(),
-            ),
-          ),
-        );
-      },
-    );
-  }
-
-  Widget _buildStoragePermissionRow() {
-    if (!Platform.isAndroid || BuildInfo.appStore) {
-      return const SizedBox.shrink();
-    }
-
-    if (_storagePermissionGranted) {
-      return _SettingRow(
-        label: 'Storage Access',
-        child: Row(
-          children: [
-            Icon(Icons.check_circle, color: Colors.green, size: 20),
-            const SizedBox(width: 8),
-            const Text('Full storage access granted'),
-          ],
-        ),
-      );
-    }
-
-    return _SettingRow(
-      label: 'Storage Access',
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'Grant full storage access to live-edit skins from external folders without copying.',
-            style: Theme.of(context).textTheme.bodySmall,
-          ),
-          const SizedBox(height: 8),
-          Semantics(
-            button: true,
-            label: 'Grant full storage access',
-            child: ExcludeSemantics(
-              child: ShadButton.outline(
-                onPressed: () async {
-                  final result = await Permission.manageExternalStorage
-                      .request();
-                  if (result.isPermanentlyDenied) {
-                    await openAppSettings();
-                  }
-                  await _checkStoragePermission();
-                },
-                child: const Text('Grant Storage Access'),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildWebUISection() {
-    return _SettingsSection(
-      title: 'Web Interface',
-      icon: Icons.web_outlined,
-      description: 'Select and manage web-based user interface skins',
-      children: [
-        _SettingRow(label: 'Skin', child: _buildSkinSelector()),
-        _buildStoragePermissionRow(),
-        const Divider(height: 24),
-        if (!widget.webUIService.isServing)
-          Semantics(
-            button: true,
-            label: 'Start web interface server',
-            child: ExcludeSemantics(
-              child: ShadButton(
-                onPressed: _startSelectedSkin,
-                child: const Text("Start WebUI Server"),
-              ),
-            ),
-          )
-        else
-          Wrap(
-            spacing: 12,
-            runSpacing: 12,
+          title: const Text('Appearance'),
+          child: Material(
+            type: MaterialType.transparency,
+            child: Column(
+            mainAxisSize: MainAxisSize.min,
             children: [
-              Semantics(
-                button: true,
-                label: 'Open web interface in browser',
-                child: ExcludeSemantics(
-                  child: ShadButton(
-                    onPressed: () async {
-                      await _openWebUIInBrowser();
-                    },
-                    child: const Text("Open UI in browser"),
-                  ),
-                ),
+              ListTile(
+                title: const Text('System Theme'),
+                trailing: controller.themeMode == ThemeMode.system
+                    ? const Icon(Icons.check)
+                    : null,
+                onTap: () {
+                  controller.updateThemeMode(ThemeMode.system);
+                  Navigator.of(dialogContext).pop();
+                },
               ),
-              Semantics(
-                button: true,
-                label: 'Stop web interface server',
-                child: ExcludeSemantics(
-                  child: ShadButton.destructive(
-                    onPressed: () async {
-                      await widget.webUIService.stopServing();
-                      setState(() {});
-                    },
-                    child: const Text("Stop WebUI Server"),
-                  ),
-                ),
+              ListTile(
+                title: const Text('Light Theme'),
+                trailing: controller.themeMode == ThemeMode.light
+                    ? const Icon(Icons.check)
+                    : null,
+                onTap: () {
+                  controller.updateThemeMode(ThemeMode.light);
+                  Navigator.of(dialogContext).pop();
+                },
+              ),
+              ListTile(
+                title: const Text('Dark Theme'),
+                trailing: controller.themeMode == ThemeMode.dark
+                    ? const Icon(Icons.check)
+                    : null,
+                onTap: () {
+                  controller.updateThemeMode(ThemeMode.dark);
+                  Navigator.of(dialogContext).pop();
+                },
               ),
             ],
           ),
-        if (!BuildInfo.appStore) ...[
-          const Divider(height: 24),
-          Semantics(
-            button: true,
-            label: 'Check for skin updates',
-            child: ExcludeSemantics(
-              child: ShadButton.outline(
-                onPressed: () => _checkForSkinUpdates(context),
-                child: const Text("Check for Skin Updates"),
-              ),
-            ),
           ),
-        ],
-      ],
+        );
+      },
     );
   }
 
-  Widget _buildAdvancedSection() {
-    return _SettingsSection(
-      title: 'Advanced',
-      icon: Icons.tune_outlined,
-      description: 'Developer tools and advanced configuration',
-      children: [
-        _SettingRow(
-          label: 'Log Level',
-          child: DropdownButton<String>(
-            isExpanded: true,
-            value: widget.controller.logLevel,
-            onChanged: widget.controller.updateLogLevel,
-            items: const [
-              DropdownMenuItem(value: "FINE", child: Text('Fine')),
-              DropdownMenuItem(value: "INFO", child: Text('Info')),
-              DropdownMenuItem(value: "FINEST", child: Text('Finest')),
-              DropdownMenuItem(value: "WARNING", child: Text('Warning')),
-            ],
-          ),
-        ),
-        const Divider(height: 24),
-        MergeSemantics(
-          child: ShadSwitch(
-            value: widget.controller.automaticUpdateCheck,
-            onChanged: (v) async {
-              await widget.controller.setAutomaticUpdateCheck(v);
-              if (v) {
-                await widget.updateCheckService?.enableAutomaticChecks();
-              } else {
-                await widget.updateCheckService?.disableAutomaticChecks();
-              }
-            },
-            label: const Text("Automatic update checks"),
-            sublabel: const Text("Check for updates every 12 hours"),
-          ),
-        ),
-        const SizedBox(height: 16),
-        if (widget.updateCheckService?.hasAvailableUpdate == true) ...[
-          Semantics(
-            button: true,
-            label: "Update available",
-            child: ExcludeSemantics(
-              child: ShadButton(
-                onPressed: () {
-                  if (Platform.isAndroid) {
-                    _checkForUpdates(context);
-                  } else {
-                    final url = widget.updateCheckService?.getReleaseUrl();
-                    if (url != null) launchUrl(Uri.parse(url));
-                  }
-                },
-                leading: Icon(
-                  Icons.system_update,
-                  color: Theme.of(context).colorScheme.onPrimaryContainer,
-                ),
-                child: Text(
-                  'Update available: ${widget.updateCheckService?.availableUpdate?.version}',
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: Theme.of(context).colorScheme.onPrimaryContainer,
-                  ),
-                ),
-              ),
-            ),
-          ),
-          const SizedBox(height: 16),
-        ],
-        Wrap(
-          spacing: 12,
-          runSpacing: 12,
-          children: [
-            Semantics(
-              button: true,
-              label: 'Open plugins settings',
-              child: ExcludeSemantics(
-                child: ShadButton.outline(
-                  onPressed: () => Navigator.of(
-                    context,
-                  ).pushNamed(PluginsSettingsView.routeName),
-                  child: const Text("Plugins"),
-                ),
-              ),
-            ),
-            Semantics(
-              button: true,
-              label: 'Check for app updates',
-              child: ExcludeSemantics(
-                child: ShadButton.outline(
-                  onPressed: () => _checkForUpdates(context),
-                  child: const Text("Check for updates"),
-                ),
-              ),
+  void _showAboutSection(BuildContext context) {
+    showShadDialog(
+      context: context,
+      builder: (dialogContext) {
+        return ShadDialog(
+          title: const Text('About'),
+          actions: [
+            ShadButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('Close'),
             ),
           ],
-        ),
-        if (!BuildInfo.appStore) ...[
-          const Divider(height: 24),
-          Semantics(
-            button: true,
-            label: 'Exit Decent',
-            child: ExcludeSemantics(
-              child: ShadButton.destructive(
-                onPressed: () => _exitApp(),
-                child: const Text("Exit Decent"),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              InfoRow('Version', BuildInfo.version),
+              const SizedBox(height: 8),
+              InfoRow('Build', BuildInfo.buildNumber),
+              const SizedBox(height: 8),
+              InfoRow('Commit', BuildInfo.commitShort),
+              const SizedBox(height: 8),
+              InfoRow('Branch', BuildInfo.branch),
+              const SizedBox(height: 16),
+              const Divider(),
+              const SizedBox(height: 8),
+              Text(
+                'License',
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
-            ),
+              const SizedBox(height: 4),
+              Text(
+                'Copyright © 2025-2026 Decent Espresso',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              const SizedBox(height: 2),
+              Text(
+                'Licensed under GNU General Public License v3.0',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              const SizedBox(height: 12),
+              ShadButton.outline(
+                onPressed: () async {
+                  await launchUrl(
+                    Uri.parse('https://www.gnu.org/licenses/gpl-3.0.html'),
+                  );
+                },
+                child: const Text('View GPL v3 License'),
+              ),
+            ],
           ),
-        ],
-      ],
-    );
-  }
-
-  Widget _buildAboutSection() {
-    return _SettingsSection(
-      title: 'About',
-      icon: Icons.info_outline,
-      description: 'Version and build information',
-      children: [
-        GestureDetector(
-          onLongPress: () {
-            if (!kDebugMode) {
-              return;
-            }
-            widget.updateCheckService?.debugForceUpdate();
-            setState(() {});
-          },
-          child: _InfoRow('Version', BuildInfo.version),
-        ),
-        _InfoRow('Build', BuildInfo.buildNumber),
-        _InfoRow('Commit', BuildInfo.commitShort),
-        _InfoRow('Branch', BuildInfo.branch),
-        const Divider(height: 24),
-        Text(
-          'License',
-          style: Theme.of(
-            context,
-          ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
-        ),
-        const SizedBox(height: 4),
-        Text(
-          'Copyright © 2025-2026 Decent Espresso',
-          style: Theme.of(context).textTheme.bodySmall,
-        ),
-        const SizedBox(height: 2),
-        Text(
-          'Licensed under GNU General Public License v3.0',
-          style: Theme.of(context).textTheme.bodySmall,
-        ),
-        const SizedBox(height: 12),
-        Semantics(
-          button: true,
-          label: 'View GPL version 3 license',
-          child: ExcludeSemantics(
-            child: ShadButton.outline(
-              onPressed: () async {
-                await launchUrl(
-                  Uri.parse('https://www.gnu.org/licenses/gpl-3.0.html'),
-                );
-              },
-              child: const Text('View GPL v3 License'),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
-  // MARK: - Helper Widgets
-
-  Widget _buildSkinSelector() {
-    final installedSkins = widget.webUIStorage.installedSkins;
-
-    return DropdownButton<String>(
-      isExpanded: true,
-      value: _selectedSkinId,
-      onChanged: (value) async {
-        if (value == null) return;
-
-        setState(() => _selectedSkinId = value);
-
-        if (value == _customSkinId) {
-          await _pickCustomSkinZip(context);
-        } else if (value == _liveEditSkinId) {
-          await _pickLiveEditFolder(context);
-        } else if (widget.webUIService.isServing) {
-          await _restartServerWithSkin(value);
-        }
+        );
       },
-      items: [
-        ...installedSkins.map((skin) {
-          return DropdownMenuItem(
-            value: skin.id,
-            child: Row(
-              children: [
-                Icon(skin.isBundled ? Icons.verified : Icons.folder, size: 16),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(skin.name, overflow: TextOverflow.ellipsis),
-                ),
-                if (skin.version != null)
-                  Text(
-                    ' v${skin.version}',
-                    style: Theme.of(context).textTheme.bodySmall,
-                  ),
-                if (!skin.isBundled && !BuildInfo.appStore)
-                  SizedBox(
-                    width: 24,
-                    height: 24,
-                    child: IconButton(
-                      padding: EdgeInsets.zero,
-                      iconSize: 16,
-                      tooltip: 'Remove ${skin.name}',
-                      icon: const Icon(Icons.delete_outline),
-                      onPressed: () async {
-                        // Close the dropdown first
-                        Navigator.of(context).pop();
-
-                        final confirmed = await showDialog<bool>(
-                          context: context,
-                          builder: (dialogContext) => AlertDialog(
-                            title: const Text('Remove skin?'),
-                            content: Text(
-                              'Remove "${skin.name}"? This cannot be undone.',
-                            ),
-                            actions: [
-                              TextButton(
-                                onPressed: () => Navigator.of(
-                                  dialogContext,
-                                ).pop(false),
-                                child: const Text('Cancel'),
-                              ),
-                              TextButton(
-                                onPressed: () => Navigator.of(
-                                  dialogContext,
-                                ).pop(true),
-                                child: const Text('Remove'),
-                              ),
-                            ],
-                          ),
-                        );
-                        if (confirmed != true) return;
-
-                        try {
-                          await widget.webUIStorage.removeSkin(skin.id);
-
-                          if (_selectedSkinId == skin.id) {
-                            _selectedSkinId =
-                                widget.webUIStorage.defaultSkin?.id;
-                            if (widget.webUIService.isServing) {
-                              await widget.webUIService.stopServing();
-                            }
-                          }
-                        } catch (e) {
-                          if (mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(
-                                content: Text('Failed to remove skin: $e'),
-                              ),
-                            );
-                          }
-                        }
-
-                        setState(() {});
-                      },
-                    ),
-                  ),
-              ],
-            ),
-          );
-        }),
-        if (!BuildInfo.appStore)
-          const DropdownMenuItem(
-            value: _customSkinId,
-            child: Row(
-              children: [
-                Icon(Icons.archive_outlined, size: 16),
-                SizedBox(width: 8),
-                Text('Install from .zip...'),
-              ],
-            ),
-          ),
-        if (!BuildInfo.appStore &&
-            (Platform.isMacOS ||
-                Platform.isLinux ||
-                Platform.isWindows ||
-                (Platform.isAndroid &&
-                    (_storagePermissionGranted ||
-                        _selectedSkinId == _liveEditSkinId))))
-          const DropdownMenuItem(
-            value: _liveEditSkinId,
-            child: Row(
-              children: [
-                Icon(Icons.folder_open, size: 16),
-                SizedBox(width: 8),
-                Text('Live-edit from folder...'),
-              ],
-            ),
-          ),
-      ],
     );
-  }
-
-  // MARK: - WebUI Actions
-
-  Future<void> _restartServerWithSkin(String skinId) async {
-    try {
-      final skin = widget.webUIStorage.getSkin(skinId);
-      if (skin == null) throw Exception('Selected skin not found');
-
-      _log.info('Restarting WebUI server with skin: ${skin.name}');
-
-      await widget.webUIService.stopServing();
-      await widget.webUIService.serveFolderAtPath(skin.path);
-
-      try {
-        await widget.webUIStorage.setDefaultSkin(skin.id);
-        _log.info('Set default skin to: ${skin.id}');
-      } catch (e) {
-        _log.warning('Failed to set default skin: $e');
-      }
-
-      setState(() {});
-
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('WebUI restarted with ${skin.name}'),
-            backgroundColor: Colors.green,
-          ),
-        );
-      }
-    } catch (e) {
-      _log.severe('Failed to restart WebUI server', e);
-      if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Failed to restart WebUI: $e')));
-      }
-    }
-  }
-
-  Future<void> _startSelectedSkin() async {
-    if (_selectedSkinId == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Please select a skin first')),
-      );
-      return;
-    }
-
-    if (_selectedSkinId == _customSkinId) {
-      await _pickCustomSkinZip(context);
-      return;
-    }
-
-    if (_selectedSkinId == _liveEditSkinId) {
-      await _pickLiveEditFolder(context);
-      return;
-    }
-
-    try {
-      final skin = widget.webUIStorage.getSkin(_selectedSkinId!);
-      if (skin == null) throw Exception('Selected skin not found');
-
-      await widget.webUIService.serveFolderAtPath(skin.path);
-
-      try {
-        await widget.webUIStorage.setDefaultSkin(skin.id);
-        _log.info('Set default skin to: ${skin.id}');
-      } catch (e) {
-        _log.warning('Failed to set default skin: $e');
-      }
-
-      setState(() {});
-
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('WebUI started with ${skin.name}'),
-            backgroundColor: Colors.green,
-          ),
-        );
-      }
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Failed to start WebUI: $e')));
-      }
-    }
-  }
-
-  Future<void> _pickCustomSkinZip(BuildContext context) async {
-    final result = await FilePicker.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: ['zip'],
-    );
-
-    if (result == null || result.files.isEmpty) {
-      setState(() => _selectedSkinId = widget.webUIStorage.defaultSkin?.id);
-      return;
-    }
-
-    final filePath = result.files.single.path;
-    if (filePath == null) {
-      setState(() => _selectedSkinId = widget.webUIStorage.defaultSkin?.id);
-      return;
-    }
-
-    try {
-      final skinId = await widget.webUIStorage.installFromPath(filePath);
-      final skin = widget.webUIStorage.getSkin(skinId);
-      if (skin == null) {
-        throw Exception('Installed skin not found: $skinId');
-      }
-      await widget.webUIService.serveFolderAtPath(skin.path);
-      await widget.webUIStorage.setDefaultSkin(skinId);
-      setState(() => _selectedSkinId = skinId);
-
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Row(
-              children: [
-                const Expanded(child: Text('Custom skin installed and loaded')),
-                ShadButton.outline(
-                  onPressed: () async {
-                    await _openWebUIInBrowser();
-                  },
-                  child: const Text("Open"),
-                ),
-              ],
-            ),
-          ),
-        );
-      }
-    } catch (e) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Failed to install skin: $e')));
-      }
-      setState(() => _selectedSkinId = widget.webUIStorage.defaultSkin?.id);
-    }
-  }
-
-  Future<void> _pickLiveEditFolder(BuildContext context) async {
-    final selectedDirectory = await FilePicker.getDirectoryPath();
-
-    if (selectedDirectory != null) {
-      final indexFile = File('$selectedDirectory/index.html');
-      final itExists = await indexFile.exists();
-
-      if (itExists) {
-        await widget.webUIService.serveFolderAtPath(selectedDirectory);
-        setState(() {});
-
-        if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Row(
-                children: [
-                  Expanded(child: Text('Live-editing from $selectedDirectory')),
-                  ShadButton.outline(
-                    onPressed: () async {
-                      await _openWebUIInBrowser();
-                    },
-                    child: const Text("Open"),
-                  ),
-                ],
-              ),
-            ),
-          );
-        }
-      } else {
-        if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('index.html not found in selected folder'),
-            ),
-          );
-        }
-        setState(() => _selectedSkinId = widget.webUIStorage.defaultSkin?.id);
-      }
-    } else {
-      setState(() => _selectedSkinId = widget.webUIStorage.defaultSkin?.id);
-    }
-  }
-
-  Future<bool> _openWebUIInBrowser() async {
-    return await launchUrl(
-      Uri.parse(
-        'http://localhost:3000?_=${DateTime.now().millisecondsSinceEpoch}',
-      ),
-    );
-  }
-
-  // MARK: - Update Actions
-
-  Future<void> _checkForSkinUpdates(BuildContext context) async {
-    try {
-      if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Checking for skin updates...')),
-      );
-
-      await widget.webUIStorage.downloadRemoteSkins();
-
-      if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Skin updates completed'),
-          backgroundColor: Colors.green,
-        ),
-      );
-    } catch (e, stackTrace) {
-      _log.severe('Error checking for skin updates', e, stackTrace);
-      if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to check for skin updates: $e')),
-      );
-    }
-  }
-
-  Future<void> _exitApp() async {
-    if (Platform.isAndroid) {
-      await ForegroundTaskService.stop();
-    }
-    exit(0);
   }
 
   Future<void> _checkForUpdates(BuildContext context) async {
+    final log = Logger('Settings View');
     try {
       if (!context.mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Checking for updates...')));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Checking for updates...')),
+      );
 
-      // Check for app updates
-      final updateInfo = await widget.updateCheckService?.checkForUpdate();
+      final updateInfo = await updateCheckService?.checkForUpdate();
 
       if (!context.mounted) return;
 
       if (updateInfo != null) {
         if (Platform.isAndroid) {
-          // On Android, show download/install dialog
           final updater = AndroidUpdater(owner: 'tadelv', repo: 'reaprime');
           showDialog(
             context: context,
@@ -1338,8 +305,7 @@ class _SettingsViewState extends State<SettingsView>
             ),
           );
         } else {
-          // On other platforms, show dialog and open browser
-          final releaseUrl = widget.updateCheckService?.getReleaseUrl();
+          final releaseUrl = updateCheckService?.getReleaseUrl();
           showDialog(
             context: context,
             builder: (context) => AlertDialog(
@@ -1392,169 +358,13 @@ class _SettingsViewState extends State<SettingsView>
       }
 
       // Also update WebUI skins
-      await widget.webUIStorage.downloadRemoteSkins();
+      await webUIStorage?.downloadRemoteSkins();
     } catch (e, stackTrace) {
-      _log.severe('Error checking for updates', e, stackTrace);
+      log.severe('Error checking for updates', e, stackTrace);
       if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Failed to check for updates: $e')),
       );
     }
-  }
-
-  // MARK: - Helpers
-
-  String? _resolveDeviceName(String? deviceId) {
-    if (deviceId == null) return null;
-    try {
-      final device = widget.deviceController.devices.firstWhere(
-        (d) => d.deviceId == deviceId,
-      );
-      return device.name;
-    } catch (_) {
-      // Device not currently known — show truncated ID
-      if (deviceId.length > 8) {
-        return '...${deviceId.substring(deviceId.length - 8)}';
-      }
-      return deviceId;
-    }
-  }
-}
-
-// MARK: - Helper Widgets
-
-class _SettingsSection extends StatelessWidget {
-  final String title;
-  final IconData icon;
-  final String? description;
-  final VoidCallback? onInfoPressed;
-  final List<Widget> children;
-
-  const _SettingsSection({
-    required this.title,
-    required this.icon,
-    this.description,
-    this.onInfoPressed,
-    required this.children,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      explicitChildNodes: true,
-      child: ShadCard(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                ExcludeSemantics(child: Icon(icon, size: 20)),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    title,
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-                if (onInfoPressed != null)
-                  Semantics(
-                    button: true,
-                    label: 'Learn more about $title',
-                    child: ExcludeSemantics(
-                      child: IconButton(
-                        icon: const Icon(Icons.info_outline, size: 18),
-                        onPressed: onInfoPressed,
-                        tooltip: 'Learn more',
-                      ),
-                    ),
-                  ),
-              ],
-            ),
-            if (description != null) ...[
-              const SizedBox(height: 4),
-              Text(
-                description!,
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(
-                    context,
-                  ).colorScheme.onSurface.withValues(alpha: 0.7),
-                ),
-              ),
-            ],
-            const SizedBox(height: 16),
-            ...children,
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _SettingRow extends StatelessWidget {
-  final String label;
-  final Widget child;
-
-  const _SettingRow({required this.label, required this.child});
-
-  @override
-  Widget build(BuildContext context) {
-    return MergeSemantics(
-      child: Padding(
-        padding: const EdgeInsets.only(bottom: 12.0),
-        child: Row(
-          children: [
-            SizedBox(
-              width: 140,
-              child: Text(
-                label,
-                style: Theme.of(
-                  context,
-                ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
-              ),
-            ),
-            Expanded(child: child),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _InfoRow extends StatelessWidget {
-  final String label;
-  final String value;
-
-  const _InfoRow(this.label, this.value);
-
-  @override
-  Widget build(BuildContext context) {
-    return MergeSemantics(
-      child: Padding(
-        padding: const EdgeInsets.only(bottom: 8.0),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            SizedBox(
-              width: 80,
-              child: Text(
-                '$label:',
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
-            ),
-            Expanded(
-              child: Text(
-                value,
-                style: Theme.of(
-                  context,
-                ).textTheme.bodyMedium?.copyWith(fontFamily: 'monospace'),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
   }
 }

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -42,17 +42,20 @@ class SettingsView extends StatelessWidget {
       body: ListenableBuilder(
         listenable: controller,
         builder: (context, _) {
+          final isMobile = Platform.isAndroid || Platform.isIOS;
           return ListView(
             children: [
+              // MARK: General
+              const SettingsSectionHeader('General'),
               SettingsTile(
                 icon: Icons.palette_outlined,
                 label: 'Appearance',
                 trailing: Text(_themeModeLabel(controller.themeMode)),
                 onTap: () => _showThemePicker(context),
               ),
-              SettingsDivider(),
 
-              // Automatic update checks
+              // MARK: Updates
+              const SettingsSectionHeader('Updates'),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
                 child: ShadSwitch(
@@ -70,8 +73,6 @@ class SettingsView extends StatelessWidget {
                 ),
               ),
               const SettingsDivider(),
-              //
-              // Check for updates
               ListTile(
                 leading: const Icon(LucideIcons.refreshCcwDot),
                 title: const Text('Check for updates'),
@@ -86,12 +87,13 @@ class SettingsView extends StatelessWidget {
                     : null,
                 onTap: () => _checkForUpdates(context),
               ),
-              const SettingsDivider(),
 
-              if (Platform.isAndroid || Platform.isIOS) ...[
+              // MARK: Power
+              const SettingsSectionHeader('Power'),
+              if (isMobile) ...[
                 SettingsTile(
                   icon: Icons.battery_charging_full_outlined,
-                  label: 'Battery Charging',
+                  label: 'Battery & Charging',
                   trailing: Text(_chargingModeLabel(controller.chargingMode)),
                   onTap: () {
                     Navigator.of(context).push(
@@ -103,12 +105,11 @@ class SettingsView extends StatelessWidget {
                     );
                   },
                 ),
-                SettingsDivider(),
+                const SettingsDivider(),
               ],
-
               SettingsTile(
                 icon: Icons.schedule_outlined,
-                label: 'Presence',
+                label: 'Sleep & Wake',
                 trailing: Text(_presenceSubtitle()),
                 onTap: () {
                   Navigator.of(context).push(
@@ -121,8 +122,9 @@ class SettingsView extends StatelessWidget {
                   );
                 },
               ),
-              SettingsDivider(),
 
+              // MARK: About
+              const SettingsSectionHeader('About'),
               SettingsTile(
                 icon: Icons.info_outline,
                 label: 'About',
@@ -153,13 +155,13 @@ class SettingsView extends StatelessWidget {
   String _chargingModeLabel(ChargingMode mode) {
     switch (mode) {
       case ChargingMode.disabled:
-        return 'Disabled';
+        return 'Always charge';
       case ChargingMode.longevity:
-        return 'Longevity';
+        return 'Lifespan';
       case ChargingMode.balanced:
         return 'Balanced';
       case ChargingMode.highAvailability:
-        return 'High Availability';
+        return 'Always ready';
     }
   }
 

--- a/lib/src/skin_selector/skin_selector_page.dart
+++ b/lib/src/skin_selector/skin_selector_page.dart
@@ -1,0 +1,655 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
+import 'package:reaprime/build_info.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/webui_support/webui_service.dart';
+import 'package:reaprime/src/webui_support/webui_storage.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class SkinSelectorPage extends StatefulWidget {
+  const SkinSelectorPage({
+    super.key,
+    required this.settingsController,
+    required this.webUIService,
+    required this.webUIStorage,
+  });
+
+  static const routeName = '/skins';
+
+  final SettingsController settingsController;
+  final WebUIService webUIService;
+  final WebUIStorage webUIStorage;
+
+  @override
+  State<SkinSelectorPage> createState() => _SkinSelectorPageState();
+}
+
+class _SkinSelectorPageState extends State<SkinSelectorPage>
+    with WidgetsBindingObserver {
+  String? _selectedSkinId;
+  static const String _customSkinId = '__custom__';
+  static const String _liveEditSkinId = '__live_edit__';
+  final Logger _log = Logger('SkinSelector');
+  bool _storagePermissionGranted = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _selectedSkinId = widget.webUIStorage.defaultSkin?.id;
+    _checkStoragePermission();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _checkStoragePermission();
+    }
+  }
+
+  Future<void> _checkStoragePermission() async {
+    if (!Platform.isAndroid || BuildInfo.appStore) return;
+    final status = await Permission.manageExternalStorage.status;
+    if (mounted && status.isGranted != _storagePermissionGranted) {
+      setState(() => _storagePermissionGranted = status.isGranted);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Web Interface')),
+      body: SafeArea(
+        top: false,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            spacing: 16,
+            children: [
+              // Skin selector card
+              ShadCard(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(Icons.web_outlined, size: 20),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            'Active Skin',
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleMedium
+                                ?.copyWith(fontWeight: FontWeight.bold),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'Select and manage web-based user interface skins',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurface
+                                .withValues(alpha: 0.7),
+                          ),
+                    ),
+                    const SizedBox(height: 16),
+                    _buildSkinSelector(),
+                    const SizedBox(height: 16),
+                    _buildStoragePermissionRow(),
+                  ],
+                ),
+              ),
+
+              // Server controls card
+              ShadCard(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(Icons.cloud_outlined, size: 20),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            'Server',
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleMedium
+                                ?.copyWith(fontWeight: FontWeight.bold),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      widget.webUIService.isServing
+                          ? 'WebUI server is running'
+                          : 'WebUI server is stopped',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurface
+                                .withValues(alpha: 0.7),
+                          ),
+                    ),
+                    const SizedBox(height: 16),
+                    if (!widget.webUIService.isServing)
+                      _ActionButton(
+                        label: 'Start WebUI Server',
+                        icon: Icons.play_arrow,
+                        onPressed: _startSelectedSkin,
+                      )
+                    else
+                      Wrap(
+                        spacing: 12,
+                        runSpacing: 12,
+                        children: [
+                          _ActionButton(
+                            label: 'Open in Browser',
+                            icon: Icons.open_in_browser,
+                            onPressed: _openWebUIInBrowser,
+                          ),
+                          _ActionButton.destructive(
+                            label: 'Stop Server',
+                            icon: Icons.stop,
+                            onPressed: () async {
+                              await widget.webUIService.stopServing();
+                              setState(() {});
+                            },
+                          ),
+                        ],
+                      ),
+                    if (!BuildInfo.appStore) ...[
+                      const SizedBox(height: 12),
+                      _ActionButton.outline(
+                        label: 'Check for Skin Updates',
+                        icon: Icons.update,
+                        onPressed: () => _checkForSkinUpdates(context),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSkinSelector() {
+    final installedSkins = widget.webUIStorage.installedSkins;
+
+    return DropdownButton<String>(
+      isExpanded: true,
+      value: _selectedSkinId,
+      onChanged: (value) async {
+        if (value == null) return;
+
+        setState(() => _selectedSkinId = value);
+
+        if (value == _customSkinId) {
+          await _pickCustomSkinZip(context);
+        } else if (value == _liveEditSkinId) {
+          await _pickLiveEditFolder(context);
+        } else if (widget.webUIService.isServing) {
+          await _restartServerWithSkin(value);
+        }
+      },
+      items: [
+        ...installedSkins.map((skin) {
+          return DropdownMenuItem(
+            value: skin.id,
+            child: Row(
+              children: [
+                Icon(skin.isBundled ? Icons.verified : Icons.folder, size: 16),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(skin.name, overflow: TextOverflow.ellipsis),
+                ),
+                if (skin.version != null)
+                  Text(
+                    ' v${skin.version}',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                if (!skin.isBundled && !BuildInfo.appStore)
+                  SizedBox(
+                    width: 24,
+                    height: 24,
+                    child: IconButton(
+                      padding: EdgeInsets.zero,
+                      iconSize: 16,
+                      tooltip: 'Remove ${skin.name}',
+                      icon: const Icon(Icons.delete_outline),
+                      onPressed: () async {
+                        // Close the dropdown first
+                        Navigator.of(context).pop();
+
+                        final confirmed = await showDialog<bool>(
+                          context: context,
+                          builder: (dialogContext) => AlertDialog(
+                            title: const Text('Remove skin?'),
+                            content: Text(
+                              'Remove "${skin.name}"? This cannot be undone.',
+                            ),
+                            actions: [
+                              TextButton(
+                                onPressed: () =>
+                                    Navigator.of(dialogContext).pop(false),
+                                child: const Text('Cancel'),
+                              ),
+                              TextButton(
+                                onPressed: () =>
+                                    Navigator.of(dialogContext).pop(true),
+                                child: const Text('Remove'),
+                              ),
+                            ],
+                          ),
+                        );
+                        if (confirmed != true) return;
+
+                        try {
+                          await widget.webUIStorage.removeSkin(skin.id);
+
+                          if (_selectedSkinId == skin.id) {
+                            _selectedSkinId =
+                                widget.webUIStorage.defaultSkin?.id;
+                            if (widget.webUIService.isServing) {
+                              await widget.webUIService.stopServing();
+                            }
+                          }
+                        } catch (e) {
+                          if (mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                content: Text('Failed to remove skin: $e'),
+                              ),
+                            );
+                          }
+                        }
+
+                        setState(() {});
+                      },
+                    ),
+                  ),
+              ],
+            ),
+          );
+        }),
+        if (!BuildInfo.appStore)
+          const DropdownMenuItem(
+            value: _customSkinId,
+            child: Row(
+              children: [
+                Icon(Icons.archive_outlined, size: 16),
+                SizedBox(width: 8),
+                Text('Install from .zip...'),
+              ],
+            ),
+          ),
+        if (!BuildInfo.appStore &&
+            (Platform.isMacOS ||
+                Platform.isLinux ||
+                Platform.isWindows ||
+                (Platform.isAndroid &&
+                    (_storagePermissionGranted ||
+                        _selectedSkinId == _liveEditSkinId))))
+          const DropdownMenuItem(
+            value: _liveEditSkinId,
+            child: Row(
+              children: [
+                Icon(Icons.folder_open, size: 16),
+                SizedBox(width: 8),
+                Text('Live-edit from folder...'),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildStoragePermissionRow() {
+    if (!Platform.isAndroid || BuildInfo.appStore) {
+      return const SizedBox.shrink();
+    }
+
+    if (_storagePermissionGranted) {
+      return Row(
+        children: [
+          Icon(Icons.check_circle, color: Colors.green, size: 20),
+          const SizedBox(width: 8),
+          const Text('Full storage access granted'),
+        ],
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Grant full storage access to live-edit skins from external folders without copying.',
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+        const SizedBox(height: 8),
+        _ActionButton.outline(
+          label: 'Grant Storage Access',
+          icon: Icons.folder_open,
+          onPressed: () async {
+            final result = await Permission.manageExternalStorage.request();
+            if (result.isPermanentlyDenied) {
+              await openAppSettings();
+            }
+            await _checkStoragePermission();
+          },
+        ),
+      ],
+    );
+  }
+
+  // MARK: - WebUI Actions
+
+  Future<void> _restartServerWithSkin(String skinId) async {
+    try {
+      final skin = widget.webUIStorage.getSkin(skinId);
+      if (skin == null) throw Exception('Selected skin not found');
+
+      _log.info('Restarting WebUI server with skin: ${skin.name}');
+
+      await widget.webUIService.stopServing();
+      await widget.webUIService.serveFolderAtPath(skin.path);
+
+      try {
+        await widget.webUIStorage.setDefaultSkin(skin.id);
+        _log.info('Set default skin to: ${skin.id}');
+      } catch (e) {
+        _log.warning('Failed to set default skin: $e');
+      }
+
+      setState(() {});
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('WebUI restarted with ${skin.name}'),
+            backgroundColor: Colors.green,
+          ),
+        );
+      }
+    } catch (e) {
+      _log.severe('Failed to restart WebUI server', e);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to restart WebUI: $e')),
+        );
+      }
+    }
+  }
+
+  Future<void> _startSelectedSkin() async {
+    if (_selectedSkinId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please select a skin first')),
+      );
+      return;
+    }
+
+    if (_selectedSkinId == _customSkinId) {
+      await _pickCustomSkinZip(context);
+      return;
+    }
+
+    if (_selectedSkinId == _liveEditSkinId) {
+      await _pickLiveEditFolder(context);
+      return;
+    }
+
+    try {
+      final skin = widget.webUIStorage.getSkin(_selectedSkinId!);
+      if (skin == null) throw Exception('Selected skin not found');
+
+      await widget.webUIService.serveFolderAtPath(skin.path);
+
+      try {
+        await widget.webUIStorage.setDefaultSkin(skin.id);
+        _log.info('Set default skin to: ${skin.id}');
+      } catch (e) {
+        _log.warning('Failed to set default skin: $e');
+      }
+
+      setState(() {});
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('WebUI started with ${skin.name}'),
+            backgroundColor: Colors.green,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to start WebUI: $e')),
+        );
+      }
+    }
+  }
+
+  Future<void> _pickCustomSkinZip(BuildContext context) async {
+    final result = await FilePicker.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['zip'],
+    );
+
+    if (result == null || result.files.isEmpty) {
+      setState(() => _selectedSkinId = widget.webUIStorage.defaultSkin?.id);
+      return;
+    }
+
+    final filePath = result.files.single.path;
+    if (filePath == null) {
+      setState(() => _selectedSkinId = widget.webUIStorage.defaultSkin?.id);
+      return;
+    }
+
+    try {
+      final skinId = await widget.webUIStorage.installFromPath(filePath);
+      final skin = widget.webUIStorage.getSkin(skinId);
+      if (skin == null) {
+        throw Exception('Installed skin not found: $skinId');
+      }
+      await widget.webUIService.serveFolderAtPath(skin.path);
+      await widget.webUIStorage.setDefaultSkin(skinId);
+      setState(() => _selectedSkinId = skinId);
+
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Row(
+              children: [
+                const Expanded(child: Text('Custom skin installed and loaded')),
+                ShadButton.outline(
+                  onPressed: () async {
+                    await _openWebUIInBrowser();
+                  },
+                  child: const Text("Open"),
+                ),
+              ],
+            ),
+          ),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to install skin: $e')),
+        );
+      }
+      setState(() => _selectedSkinId = widget.webUIStorage.defaultSkin?.id);
+    }
+  }
+
+  Future<void> _pickLiveEditFolder(BuildContext context) async {
+    final selectedDirectory = await FilePicker.getDirectoryPath();
+
+    if (selectedDirectory != null) {
+      final indexFile = File('$selectedDirectory/index.html');
+      final itExists = await indexFile.exists();
+
+      if (itExists) {
+        await widget.webUIService.serveFolderAtPath(selectedDirectory);
+        setState(() {});
+
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Row(
+                children: [
+                  Expanded(
+                    child: Text('Live-editing from $selectedDirectory'),
+                  ),
+                  ShadButton.outline(
+                    onPressed: () async {
+                      await _openWebUIInBrowser();
+                    },
+                    child: const Text("Open"),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+      } else {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('index.html not found in selected folder'),
+            ),
+          );
+        }
+        setState(() => _selectedSkinId = widget.webUIStorage.defaultSkin?.id);
+      }
+    } else {
+      setState(() => _selectedSkinId = widget.webUIStorage.defaultSkin?.id);
+    }
+  }
+
+  Future<bool> _openWebUIInBrowser() async {
+    return await launchUrl(
+      Uri.parse(
+        'http://localhost:3000?_=${DateTime.now().millisecondsSinceEpoch}',
+      ),
+    );
+  }
+
+  Future<void> _checkForSkinUpdates(BuildContext context) async {
+    try {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Checking for skin updates...')),
+      );
+
+      await widget.webUIStorage.downloadRemoteSkins();
+
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Skin updates completed'),
+          backgroundColor: Colors.green,
+        ),
+      );
+    } catch (e, stackTrace) {
+      _log.severe('Error checking for skin updates', e, stackTrace);
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to check for skin updates: $e')),
+      );
+    }
+  }
+}
+
+/// Small helper for consistent action buttons in the skin selector.
+class _ActionButton extends StatelessWidget {
+  final String label;
+  final IconData icon;
+  final VoidCallback onPressed;
+  final bool isDestructive;
+  final bool isOutline;
+
+  const _ActionButton({
+    required this.label,
+    required this.icon,
+    required this.onPressed,
+    this.isDestructive = false,
+    this.isOutline = false,
+  });
+
+  factory _ActionButton.destructive(
+      {required String label,
+      required IconData icon,
+      required VoidCallback onPressed}) {
+    return _ActionButton(
+      label: label,
+      icon: icon,
+      onPressed: onPressed,
+      isDestructive: true,
+    );
+  }
+
+  factory _ActionButton.outline(
+      {required String label,
+      required IconData icon,
+      required VoidCallback onPressed}) {
+    return _ActionButton(
+      label: label,
+      icon: icon,
+      onPressed: onPressed,
+      isOutline: true,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final button = isDestructive
+        ? ShadButton.destructive(
+            leading: Icon(icon, size: 16),
+            onPressed: onPressed,
+            child: Text(label),
+          )
+        : isOutline
+            ? ShadButton.outline(
+                leading: Icon(icon, size: 16),
+                onPressed: onPressed,
+                child: Text(label),
+              )
+            : ShadButton(
+                leading: Icon(icon, size: 16),
+                onPressed: onPressed,
+                child: Text(label),
+              );
+
+    return Semantics(
+      button: true,
+      label: label,
+      child: ExcludeSemantics(child: button),
+    );
+  }
+}

--- a/lib/src/skin_selector/skin_selector_page.dart
+++ b/lib/src/skin_selector/skin_selector_page.dart
@@ -101,7 +101,7 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
                     ),
                     const SizedBox(height: 4),
                     Text(
-                      'Select and manage web-based user interface skins',
+                      'Choose and manage your skins',
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
                             color: Theme.of(context)
                                 .colorScheme
@@ -129,7 +129,7 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
                         const SizedBox(width: 8),
                         Expanded(
                           child: Text(
-                            'Server',
+                            'Skin Server',
                             style: Theme.of(context)
                                 .textTheme
                                 .titleMedium
@@ -141,8 +141,8 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
                     const SizedBox(height: 4),
                     Text(
                       widget.webUIService.isServing
-                          ? 'WebUI server is running'
-                          : 'WebUI server is stopped',
+                          ? 'Skin server is running'
+                          : 'Skin server is stopped',
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
                             color: Theme.of(context)
                                 .colorScheme
@@ -153,7 +153,7 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
                     const SizedBox(height: 16),
                     if (!widget.webUIService.isServing)
                       _ActionButton(
-                        label: 'Start WebUI Server',
+                        label: 'Start Skin Server',
                         icon: Icons.play_arrow,
                         onPressed: _startSelectedSkin,
                       )
@@ -168,7 +168,7 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
                             onPressed: _openWebUIInBrowser,
                           ),
                           _ActionButton.destructive(
-                            label: 'Stop Server',
+                            label: 'Stop Skin Server',
                             icon: Icons.stop,
                             onPressed: () async {
                               await widget.webUIService.stopServing();
@@ -388,7 +388,7 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('WebUI restarted with ${skin.name}'),
+            content: Text('Skin server restarted with ${skin.name}'),
             backgroundColor: Colors.green,
           ),
         );
@@ -397,7 +397,7 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
       _log.severe('Failed to restart WebUI server', e);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to restart WebUI: $e')),
+          SnackBar(content: Text('Failed to restart skin server: $e')),
         );
       }
     }
@@ -439,7 +439,7 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('WebUI started with ${skin.name}'),
+            content: Text('Skin server started with ${skin.name}'),
             backgroundColor: Colors.green,
           ),
         );
@@ -447,7 +447,7 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to start WebUI: $e')),
+          SnackBar(content: Text('Failed to start skin server: $e')),
         );
       }
     }

--- a/lib/src/theme/theme.dart
+++ b/lib/src/theme/theme.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class DecentColors {
+  const DecentColors._();
+
+  // Primary accent (teal/cyan)
+  static const Color teal = Color(0xFF47cdd9);
+  static const Color tealHover = Color(0xFF5cd3dd);
+  static const Color tealActive = Color(0xFF32c7d5);
+
+  // Warm neutrals
+  static const Color cream = Color(0xFFfaeed7);
+  static const Color offWhite = Color(0xFFf8f8f8);
+  static const Color white = Color(0xFFffffff);
+
+  // Banner
+  static const Color bannerBg = Color(0xFF494d53);
+  static const Color bannerOverlay = Color(0xFF3d4045);
+  static const Color bannerText = Color(0xFFd1d2d4);
+
+  // Text
+  static const Color bodyText = Color(0xFF444444);
+  static const Color heading = Color(0xFF333333);
+  static const Color strong = Color(0xFF545454);
+  static const Color dark = Color(0xFF222222);
+  static const Color muted = Color(0xFF949494);
+
+  // Borders  (rgba equivalents of 144,144,144 at various opacities)
+  static const Color border = Color(0x40909090);
+  static const Color borderHover = Color(0x13909090);
+  static const Color borderActive = Color(0x33909090);
+
+  // Dark mode specific
+  static const Color darkCard = Color(0xFF3d4045);
+  static const Color darkSecondary = Color(0xFF5a5e64);
+  static const Color darkMutedForeground = Color(0xFFa3a3a3);
+  static const Color darkSelection = Color(0xFF355172);
+
+  // Light muted background
+  static const Color lightMuted = Color(0xFFf5f5f5);
+
+  // Semantic
+  static const Color destructive = Color(0xFFef4444);
+  static const Color selection = Color(0xFFB4D7FF);
+}
+
+class DecentColorScheme extends ShadColorScheme {
+  const DecentColorScheme({
+    required super.background,
+    required super.foreground,
+    required super.card,
+    required super.cardForeground,
+    required super.popover,
+    required super.popoverForeground,
+    required super.primary,
+    required super.primaryForeground,
+    required super.secondary,
+    required super.secondaryForeground,
+    required super.muted,
+    required super.mutedForeground,
+    required super.accent,
+    required super.accentForeground,
+    required super.destructive,
+    required super.destructiveForeground,
+    required super.border,
+    required super.input,
+    required super.ring,
+    required super.selection,
+    super.custom,
+  });
+
+  const DecentColorScheme.light({
+    super.background = DecentColors.white,
+    super.foreground = DecentColors.bodyText,
+    super.card = DecentColors.white,
+    super.cardForeground = DecentColors.bodyText,
+    super.popover = DecentColors.white,
+    super.popoverForeground = DecentColors.bodyText,
+    super.primary = DecentColors.teal,
+    super.primaryForeground = DecentColors.white,
+    super.secondary = DecentColors.cream,
+    super.secondaryForeground = DecentColors.dark,
+    super.muted = DecentColors.lightMuted,
+    super.mutedForeground = DecentColors.muted,
+    super.accent = DecentColors.teal,
+    super.accentForeground = DecentColors.white,
+    super.destructive = DecentColors.destructive,
+    super.destructiveForeground = DecentColors.white,
+    super.border = DecentColors.border,
+    super.input = DecentColors.border,
+    super.ring = DecentColors.teal,
+    super.selection = DecentColors.selection,
+    super.custom,
+  });
+
+  const DecentColorScheme.dark({
+    super.background = DecentColors.bannerBg,
+    super.foreground = DecentColors.bannerText,
+    super.card = DecentColors.darkCard,
+    super.cardForeground = DecentColors.bannerText,
+    super.popover = DecentColors.darkCard,
+    super.popoverForeground = DecentColors.bannerText,
+    super.primary = DecentColors.teal,
+    super.primaryForeground = DecentColors.white,
+    super.secondary = DecentColors.darkSecondary,
+    super.secondaryForeground = DecentColors.white,
+    super.muted = DecentColors.darkSecondary,
+    super.mutedForeground = DecentColors.darkMutedForeground,
+    super.accent = DecentColors.tealHover,
+    super.accentForeground = DecentColors.white,
+    super.destructive = DecentColors.destructive,
+    super.destructiveForeground = DecentColors.white,
+    super.border = DecentColors.darkSecondary,
+    super.input = DecentColors.darkSecondary,
+    super.ring = DecentColors.teal,
+    super.selection = DecentColors.darkSelection,
+    super.custom,
+  });
+}
+
+ShadThemeData buildDecentTheme({
+  Brightness brightness = Brightness.light,
+}) {
+  return ShadThemeData(
+    colorScheme: brightness == Brightness.light
+        ? const DecentColorScheme.light()
+        : const DecentColorScheme.dark(),
+    brightness: brightness,
+  );
+}


### PR DESCRIPTION
First PR of the native UI redesign (design doc: `doc/plans/native-ui-redesign.md`). It bundles **PR1 and PR2** from the plan's PR breakdown. PR3 (onboarding restyle + Android warning) and PR4 (LandingFeature integration + browser hero card + QR) will follow as separate PRs.

## What's in here

### PR1 — Launcher + infrastructure
- New `LauncherView` (status bar + destination grid + Return-to-Skin) replacing the old HomeScreen
- Decent color scheme + theme work
- Skin-unavailable / browser-hero scaffolding, status bar, destination cards

### PR2 — Settings flattening + copy clarity
- Settings flattened into an iOS-style grouped list: **General / Updates / Power / About**
- Heavy sub-pages are standalone launcher destinations
- **Copy pass** (two grill sessions) removing jargon that didn't earn its keep:
  - **Presence → Sleep & Wake** ("presence" gone from UI; code unchanged)
  - **Gateway Mode**: unified subtitles across picker + info dialog, "this app" instead of "Rea"/"App", reordered Tracking-first (the common mode)
  - **Battery**: "High Availability" → "Always ready", "Night Mode" → "Overnight charging", "Emergency Floor" → "Low battery protection", Sleep/Morning → Bedtime/Wake-up
  - **Data**: "Decent app" import strings → "DE1 app" (the old name collided with this app's new display name, Decent.app)
  - **Devices**: title → "Devices", "Preferred Machine/Scale" → "Auto-connect Machine/Scale"
  - **Skins**: user-facing "WebUI server" → "Skin Server"
  - Advanced: Log Level reordered least→most verbose; dev-only "Debug view" moved here off the Devices page

## Open items (follow-ups, not blocking)
- **"Debug view"** (now on Advanced) still routes to `SampleItemListView` — Flutter sample-app boilerplate, not a real debug view. Needs replacing or removing.
- **`_isDegradedAndroid`** in `launcher_view.dart` is stubbed to `false` — the Android SDK-version check isn't wired yet (browser-hero path depends on it). Lands with PR3/PR4.
- **Account / Plugins** copy left as-is intentionally — reviewed, no jargon collisions (Enabled/Disabled there refers to boolean plugin *settings*, not lifecycle).
- Design doc stays in `doc/plans/` (not archived) since PR3/PR4 of the same effort are still pending.

## Verification
- `flutter analyze` — clean
- `flutter test` — 1470 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)