### PR TITLE
docs: correct Android minimum version to API 28

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ make dual-build
 
 ### Minimum Requirements
 
-- **Android**: 8.0 (API 26) or later
+- **Android**: 9.0 (API 28) or later
 - **macOS**: 10.14 or later
 - **Linux**: Modern distribution with GTK 3.0+
 - **Windows**: Windows 10 or later


### PR DESCRIPTION
README listed Android 8.0 (API 26) as the minimum, but \ndroid/app/build.gradle.kts\ sets \minSdk = 28\ (Android 9).

Aligns the documented requirement with the actual build config.

closes #308