### PR TITLE
feat: add DiFluid R2 sensor support

### DIFF
--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -134,6 +134,7 @@ Discovery services use name-based matching via `DeviceMatcher` to create appropr
 - `DeviceMatcher.match()` takes a transport and advertised name, returns a `Device?`
 - Name rules map advertisement names to device factories
 - Service verification happens during `onConnect()` using `BleServiceIdentifier`
+- DiFluid R2 reflectometers are matched separately from DiFluid scales by advertised name and the R2 BLE service UUID, then exposed as `Sensor` devices with a `measure` command
 
 ### Service Lifecycle
 
@@ -399,6 +400,11 @@ Future<void> connectToScale(Scale scale) async {
 - Exposes sensor data streams
 
 **Pattern:** Mirrors ScaleController auto-connect logic
+
+DiFluid R2 reflectometers use the standard `Sensor` abstraction. After the
+sensor is connected, skins can call the `measure` command through the existing
+Sensors API and read TDS, temperature, refractive index, and status values from
+the sensor data stream.
 
 ### RememberedDevicesController
 
@@ -1027,4 +1033,3 @@ _log.info('Found serial ports: $ports');
 - **State Manager:** Orchestrator for machine state changes and related behaviors
 - **UUID:** Universally Unique Identifier, used to identify BLE services/devices
 - **Service Mapping:** Dictionary mapping UUIDs to device factory functions
-

--- a/lib/src/models/device/impl/difluid/difluid_r2_protocol.dart
+++ b/lib/src/models/device/impl/difluid/difluid_r2_protocol.dart
@@ -1,0 +1,214 @@
+import 'dart:typed_data';
+
+enum DifluidR2EventKind { ack, status, temperature, reading, error, unknown }
+
+final class DifluidR2Event {
+  const DifluidR2Event({
+    required this.kind,
+    required this.raw,
+    this.status,
+    this.measuring,
+    this.tds,
+    this.temperatureC,
+    this.refractiveIndex,
+    this.error,
+    this.package,
+  });
+
+  final DifluidR2EventKind kind;
+  final Uint8List raw;
+  final String? status;
+  final bool? measuring;
+  final double? tds;
+  final double? temperatureC;
+  final double? refractiveIndex;
+  final String? error;
+  final int? package;
+}
+
+final class DifluidR2ProtocolException implements Exception {
+  const DifluidR2ProtocolException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+final class DifluidR2Protocol {
+  static const int _header1 = 0xDF;
+  static const int _header2 = 0xDF;
+  static const int _functionDeviceSettings = 0x01;
+  static const int _functionDeviceAction = 0x03;
+  static const int _commandSetTemperatureUnit = 0x00;
+  static const int _commandSingleTest = 0x00;
+  static const int _commandKnownError = 0xFE;
+
+  static const Map<int, String> _statusCodes = {
+    0: 'finished',
+    4: 'average_started',
+    5: 'average_ongoing',
+    6: 'average_finished',
+    9: 'loop_finished',
+    11: 'started',
+  };
+
+  static const Map<int, String> _errorCodes = {
+    3: 'no_liquid',
+    4: 'beyond_range',
+  };
+
+  static Uint8List setCelsiusCommand() => _buildCommand(
+    _functionDeviceSettings,
+    _commandSetTemperatureUnit,
+    const [0x00],
+  );
+
+  static Uint8List singleTestCommand() =>
+      _buildCommand(_functionDeviceAction, _commandSingleTest);
+
+  static DifluidR2Event parse(Uint8List raw) {
+    if (raw.length < 6) {
+      throw const DifluidR2ProtocolException('packet too short');
+    }
+    if (raw[0] != _header1 || raw[1] != _header2) {
+      throw const DifluidR2ProtocolException('invalid packet header');
+    }
+
+    final dataLength = raw[4];
+    final expectedLength = 2 + 1 + 1 + 1 + dataLength + 1;
+    if (raw.length != expectedLength) {
+      throw DifluidR2ProtocolException(
+        'invalid packet length: got ${raw.length}, expected $expectedLength',
+      );
+    }
+    if (_checksum(raw.sublist(0, raw.length - 1)) != raw.last) {
+      throw const DifluidR2ProtocolException('invalid packet checksum');
+    }
+
+    final function = raw[2];
+    final command = raw[3];
+    final data = raw.sublist(5, raw.length - 1);
+
+    if (command == _commandKnownError) {
+      return _parseError(raw, data);
+    }
+
+    if (function == _functionDeviceSettings || data.isEmpty) {
+      return DifluidR2Event(kind: DifluidR2EventKind.ack, raw: raw);
+    }
+
+    final package = data[0];
+    return switch (package) {
+      0x00 => _parseStatus(raw, data),
+      0x01 => _parseTemperature(raw, data),
+      0x02 => _parseTds(raw, data),
+      _ => DifluidR2Event(
+        kind: DifluidR2EventKind.unknown,
+        raw: raw,
+        package: package,
+      ),
+    };
+  }
+
+  static Uint8List _buildCommand(
+    int function,
+    int command, [
+    List<int> data = const [],
+  ]) {
+    if (data.length > 255) {
+      throw ArgumentError('R2 command data is limited to 255 bytes');
+    }
+
+    final body = Uint8List.fromList([
+      _header1,
+      _header2,
+      function,
+      command,
+      data.length,
+      ...data,
+    ]);
+    return Uint8List.fromList([...body, _checksum(body)]);
+  }
+
+  static DifluidR2Event _parseStatus(Uint8List raw, Uint8List data) {
+    if (data.length < 2) {
+      throw const DifluidR2ProtocolException(
+        'status packet missing status code',
+      );
+    }
+
+    final code = data[1];
+    final status = _statusCodes[code] ?? 'unknown_$code';
+    final measuring = switch (code) {
+      4 || 5 || 11 => true,
+      0 || 6 || 9 => false,
+      _ => null,
+    };
+
+    return DifluidR2Event(
+      kind: DifluidR2EventKind.status,
+      raw: raw,
+      package: 0,
+      status: status,
+      measuring: measuring,
+    );
+  }
+
+  static DifluidR2Event _parseTemperature(Uint8List raw, Uint8List data) {
+    if (data.length < 6) {
+      throw const DifluidR2ProtocolException('temperature packet too short');
+    }
+
+    final prismX10 = _readUint16(data, 1);
+    final tankX10 = _readUint16(data, 3);
+    return DifluidR2Event(
+      kind: DifluidR2EventKind.temperature,
+      raw: raw,
+      package: 1,
+      temperatureC: (prismX10 + tankX10) / 20.0,
+    );
+  }
+
+  static DifluidR2Event _parseTds(Uint8List raw, Uint8List data) {
+    if (data.length < 3) {
+      throw const DifluidR2ProtocolException('TDS packet too short');
+    }
+
+    return DifluidR2Event(
+      kind: DifluidR2EventKind.reading,
+      raw: raw,
+      package: 2,
+      tds: _readUint16(data, 1) / 100.0,
+      refractiveIndex: data.length >= 7
+          ? _readUint32(data, 3) / 100000.0
+          : null,
+      measuring: false,
+    );
+  }
+
+  static DifluidR2Event _parseError(Uint8List raw, Uint8List data) {
+    var error = 'unknown_error';
+    if (data.length >= 2 && data[0] == 0x02) {
+      error = _errorCodes[data[1]] ?? 'unknown_error_${data[1]}';
+    }
+    return DifluidR2Event(
+      kind: DifluidR2EventKind.error,
+      raw: raw,
+      error: error,
+      measuring: false,
+    );
+  }
+
+  static int _readUint16(Uint8List data, int offset) =>
+      (data[offset] << 8) | data[offset + 1];
+
+  static int _readUint32(Uint8List data, int offset) =>
+      (data[offset] << 24) |
+      (data[offset + 1] << 16) |
+      (data[offset + 2] << 8) |
+      data[offset + 3];
+
+  static int _checksum(List<int> data) =>
+      data.fold<int>(0, (sum, value) => (sum + value) & 0xFF);
+}

--- a/lib/src/models/device/impl/difluid/difluid_r2_sensor.dart
+++ b/lib/src/models/device/impl/difluid/difluid_r2_sensor.dart
@@ -1,0 +1,252 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/device/ble_service_identifier.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/difluid/difluid_r2_protocol.dart';
+import 'package:reaprime/src/models/device/sensor.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:rxdart/rxdart.dart';
+
+class DifluidR2Sensor implements Sensor {
+  static final BleServiceIdentifier serviceIdentifier =
+      BleServiceIdentifier.long('000000ff-0000-1000-8000-00805f9b34fb');
+  static final BleServiceIdentifier dataCharacteristic =
+      BleServiceIdentifier.long('0000aa01-0000-1000-8000-00805f9b34fb');
+
+  final BLETransport _transport;
+  final Logger _log;
+  final BehaviorSubject<ConnectionState> _connectionState =
+      BehaviorSubject.seeded(ConnectionState.discovered);
+  final BehaviorSubject<Map<String, dynamic>> _data = BehaviorSubject();
+  final Set<Completer<Map<String, dynamic>>> _measurementWaiters = {};
+
+  StreamSubscription<ConnectionState>? _disconnectSub;
+  bool _initialized = false;
+  double? _lastTemperatureC;
+
+  DifluidR2Sensor({required BLETransport transport})
+    : _transport = transport,
+      _log = Logger('DifluidR2Sensor(${transport.name})');
+
+  @override
+  String get deviceId => _transport.id;
+
+  @override
+  String get name => 'DiFluid R2';
+
+  @override
+  DeviceType get type => DeviceType.sensor;
+
+  @override
+  Stream<ConnectionState> get connectionState => _connectionState.stream;
+
+  @override
+  Stream<Map<String, dynamic>> get data => _data.stream;
+
+  @override
+  SensorInfo get info => SensorInfo(
+    name: name,
+    vendor: 'DiFluid',
+    dataChannels: [
+      DataChannel(key: 'timestamp', type: 'string'),
+      DataChannel(key: 'tds', type: 'number', unit: 'percent'),
+      DataChannel(key: 'temperature', type: 'number', unit: 'Celsius'),
+      DataChannel(key: 'temperatureC', type: 'number', unit: 'Celsius'),
+      DataChannel(key: 'refractiveIndex', type: 'number'),
+      DataChannel(key: 'status', type: 'string'),
+      DataChannel(key: 'measuring', type: 'boolean'),
+      DataChannel(key: 'error', type: 'string'),
+    ],
+    commands: [
+      CommandDescriptor(
+        id: 'measure',
+        name: 'Measure TDS',
+        description: 'Trigger a single DiFluid R2 TDS reading.',
+        paramsSchema: {
+          'type': 'object',
+          'properties': {
+            'timeout': {'type': 'number'},
+          },
+        },
+        resultsSchema: {
+          'type': 'object',
+          'properties': {
+            'reading': {'type': 'object'},
+          },
+        },
+      ),
+    ],
+  );
+
+  @override
+  Future<void> onConnect() async {
+    if (_initialized) return;
+
+    _connectionState.add(ConnectionState.connecting);
+    try {
+      await _transport.connect();
+      _disconnectSub?.cancel();
+      _disconnectSub = _transport.connectionState
+          .where((state) => state == ConnectionState.disconnected)
+          .listen((_) {
+            _initialized = false;
+            _connectionState.add(ConnectionState.disconnected);
+          });
+
+      final services = await _transport.discoverServices();
+      if (!serviceIdentifier.matchesAny(services)) {
+        throw Exception(
+          'Expected service ${serviceIdentifier.long} not found. '
+          'Discovered services: $services',
+        );
+      }
+
+      await _transport.subscribe(
+        serviceIdentifier.long,
+        dataCharacteristic.long,
+        _handleNotification,
+      );
+      await _transport.write(
+        serviceIdentifier.long,
+        dataCharacteristic.long,
+        DifluidR2Protocol.setCelsiusCommand(),
+        withResponse: true,
+      );
+
+      _initialized = true;
+      _connectionState.add(ConnectionState.connected);
+    } catch (e, st) {
+      _log.warning('Failed to initialize DiFluid R2', e, st);
+      _initialized = false;
+      _connectionState.add(ConnectionState.disconnected);
+      await _disconnectSub?.cancel();
+      _disconnectSub = null;
+      try {
+        await _transport.disconnect();
+      } catch (_) {}
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> disconnect() async {
+    _initialized = false;
+    _completeWaitersWithError('R2 disconnected');
+    await _disconnectSub?.cancel();
+    _disconnectSub = null;
+    _connectionState.add(ConnectionState.disconnected);
+    await _transport.disconnect();
+  }
+
+  @override
+  Future<Map<String, dynamic>> execute(
+    String commandId,
+    Map<String, dynamic>? parameters,
+  ) async {
+    if (commandId != 'measure') {
+      throw UnsupportedError('Unsupported R2 command: $commandId');
+    }
+
+    await onConnect();
+    final timeout = _measurementTimeout(parameters);
+    final completer = Completer<Map<String, dynamic>>();
+    _measurementWaiters.add(completer);
+    try {
+      await _transport.write(
+        serviceIdentifier.long,
+        dataCharacteristic.long,
+        DifluidR2Protocol.singleTestCommand(),
+        withResponse: true,
+      );
+      return await completer.future.timeout(timeout);
+    } on TimeoutException {
+      throw TimeoutException('Timed out waiting for R2 reading', timeout);
+    } finally {
+      _measurementWaiters.remove(completer);
+    }
+  }
+
+  void _handleNotification(Uint8List raw) {
+    try {
+      final event = DifluidR2Protocol.parse(raw);
+      _handleEvent(event);
+    } on DifluidR2ProtocolException catch (e, st) {
+      _log.warning('Invalid R2 packet', e, st);
+      _data.add({
+        'timestamp': DateTime.now().toIso8601String(),
+        'error': e.message,
+      });
+    }
+  }
+
+  void _handleEvent(DifluidR2Event event) {
+    final snapshot = _snapshotForEvent(event);
+    if (snapshot == null) return;
+
+    _data.add(snapshot);
+    if (event.kind == DifluidR2EventKind.reading) {
+      _completeWaiters({'reading': snapshot});
+    } else if (event.kind == DifluidR2EventKind.error) {
+      _completeWaitersWithError(event.error ?? 'R2 measurement failed');
+    }
+  }
+
+  Map<String, dynamic>? _snapshotForEvent(DifluidR2Event event) {
+    final timestamp = DateTime.now().toIso8601String();
+    switch (event.kind) {
+      case DifluidR2EventKind.status:
+        return {
+          'timestamp': timestamp,
+          'status': event.status,
+          'measuring': event.measuring,
+        };
+      case DifluidR2EventKind.temperature:
+        _lastTemperatureC = event.temperatureC;
+        return {
+          'timestamp': timestamp,
+          'temperature': event.temperatureC,
+          'temperatureC': event.temperatureC,
+        };
+      case DifluidR2EventKind.reading:
+        return {
+          'timestamp': timestamp,
+          'tds': event.tds,
+          if (_lastTemperatureC != null) 'temperature': _lastTemperatureC,
+          if (_lastTemperatureC != null) 'temperatureC': _lastTemperatureC,
+          if (event.refractiveIndex != null)
+            'refractiveIndex': event.refractiveIndex,
+        };
+      case DifluidR2EventKind.error:
+        return {
+          'timestamp': timestamp,
+          'error': event.error,
+          'measuring': false,
+        };
+      case DifluidR2EventKind.ack:
+      case DifluidR2EventKind.unknown:
+        return null;
+    }
+  }
+
+  Duration _measurementTimeout(Map<String, dynamic>? parameters) {
+    final rawTimeout = parameters?['timeout'];
+    if (rawTimeout is num && rawTimeout > 0) {
+      return Duration(milliseconds: (rawTimeout * 1000).round());
+    }
+    return const Duration(seconds: 30);
+  }
+
+  void _completeWaiters(Map<String, dynamic> value) {
+    for (final waiter in List.of(_measurementWaiters)) {
+      if (!waiter.isCompleted) waiter.complete(value);
+    }
+  }
+
+  void _completeWaitersWithError(String message) {
+    for (final waiter in List.of(_measurementWaiters)) {
+      if (!waiter.isCompleted) waiter.completeError(Exception(message));
+    }
+  }
+}

--- a/lib/src/services/device_matcher.dart
+++ b/lib/src/services/device_matcher.dart
@@ -7,6 +7,7 @@ import 'package:reaprime/src/models/device/impl/bookoo/miniscale.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale.dart';
 import 'package:reaprime/src/models/device/impl/decent_temp/temperature.dart';
+import 'package:reaprime/src/models/device/impl/difluid/difluid_r2_sensor.dart';
 import 'package:reaprime/src/models/device/impl/difluid/difluid_scale.dart';
 import 'package:reaprime/src/models/device/impl/eureka/eureka_scale.dart';
 import 'package:reaprime/src/models/device/impl/felicita/arc.dart';
@@ -43,6 +44,7 @@ class DeviceMatcher {
     ],
     DeviceType.sensor => [
       DecentTemp.serviceIdentifier.long,
+      DifluidR2Sensor.serviceIdentifier.long,
     ],
   };
 
@@ -95,6 +97,9 @@ class DeviceMatcher {
 
     if (nameLower.contains('smartchef')) {
       return SmartChefScale(transport: transport);
+    }
+    if (nameLower.contains('difluid') && nameLower.contains('r2')) {
+      return DifluidR2Sensor(transport: transport);
     }
     if (nameLower.contains('aku') || nameLower.contains('varia')) {
       return VariaAkuScale(transport: transport);

--- a/test/difluid_r2_protocol_test.dart
+++ b/test/difluid_r2_protocol_test.dart
@@ -1,0 +1,63 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/difluid/difluid_r2_protocol.dart';
+
+void main() {
+  group('DifluidR2Protocol', () {
+    test('builds known setup and single-test commands', () {
+      expect(
+        DifluidR2Protocol.setCelsiusCommand(),
+        Uint8List.fromList([0xDF, 0xDF, 0x01, 0x00, 0x01, 0x00, 0xC0]),
+      );
+      expect(
+        DifluidR2Protocol.singleTestCommand(),
+        Uint8List.fromList([0xDF, 0xDF, 0x03, 0x00, 0x00, 0xC1]),
+      );
+    });
+
+    test('parses a TDS result packet with refractive index', () {
+      final packet = Uint8List.fromList([
+        0xDF,
+        0xDF,
+        0x03,
+        0x00,
+        0x07,
+        0x02,
+        0x03,
+        0xCA,
+        0x00,
+        0x02,
+        0x09,
+        0x14,
+        0xB6,
+      ]);
+
+      final event = DifluidR2Protocol.parse(packet);
+
+      expect(event.kind, DifluidR2EventKind.reading);
+      expect(event.tds, closeTo(9.7, 0.001));
+      expect(event.refractiveIndex, closeTo(1.33396, 0.00001));
+      expect(event.measuring, isFalse);
+    });
+
+    test('rejects packets with an invalid checksum', () {
+      final packet = Uint8List.fromList([
+        0xDF,
+        0xDF,
+        0x03,
+        0x00,
+        0x03,
+        0x02,
+        0x00,
+        0x0C,
+        0x00,
+      ]);
+
+      expect(
+        () => DifluidR2Protocol.parse(packet),
+        throwsA(isA<DifluidR2ProtocolException>()),
+      );
+    });
+  });
+}

--- a/test/difluid_r2_sensor_test.dart
+++ b/test/difluid_r2_sensor_test.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/difluid/difluid_r2_protocol.dart';
+import 'package:reaprime/src/models/device/impl/difluid/difluid_r2_sensor.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/services/device_matcher.dart';
+import 'package:rxdart/rxdart.dart';
+
+typedef _WriteRecord = ({
+  String serviceUuid,
+  String characteristicUuid,
+  Uint8List data,
+  bool withResponse,
+});
+
+class _FakeR2Transport implements BLETransport {
+  final BehaviorSubject<ConnectionState> _states = BehaviorSubject.seeded(
+    ConnectionState.discovered,
+  );
+  final List<_WriteRecord> writes = [];
+  void Function(Uint8List)? notificationHandler;
+  List<String> services = [DifluidR2Sensor.serviceIdentifier.long];
+  Uint8List? responsePacket;
+
+  @override
+  String get id => 'r2-test-id';
+
+  @override
+  String get name => 'DiFluid R2 301095';
+
+  @override
+  Stream<ConnectionState> get connectionState => _states.stream;
+
+  @override
+  Future<void> connect() async {
+    _states.add(ConnectionState.connected);
+  }
+
+  @override
+  Future<void> disconnect() async {
+    _states.add(ConnectionState.disconnected);
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _states.close();
+  }
+
+  @override
+  Future<List<String>> discoverServices() async => services;
+
+  @override
+  Future<Uint8List> read(
+    String serviceUUID,
+    String characteristicUUID, {
+    Duration? timeout,
+  }) async => Uint8List(0);
+
+  @override
+  Future<void> subscribe(
+    String serviceUUID,
+    String characteristicUUID,
+    void Function(Uint8List) callback,
+  ) async {
+    notificationHandler = callback;
+  }
+
+  @override
+  Future<void> write(
+    String serviceUUID,
+    String characteristicUUID,
+    Uint8List data, {
+    bool withResponse = true,
+    Duration? timeout,
+  }) async {
+    writes.add((
+      serviceUuid: serviceUUID,
+      characteristicUuid: characteristicUUID,
+      data: data,
+      withResponse: withResponse,
+    ));
+
+    if (_sameBytes(data, DifluidR2Protocol.singleTestCommand()) &&
+        responsePacket != null) {
+      scheduleMicrotask(() => notificationHandler?.call(responsePacket!));
+    }
+  }
+
+  @override
+  Future<void> setTransportPriority(bool prioritized) async {}
+}
+
+bool _sameBytes(Uint8List a, Uint8List b) {
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}
+
+void main() {
+  group('DifluidR2Sensor', () {
+    test('describes a TDS-capable measure command for skins', () {
+      final sensor = DifluidR2Sensor(transport: _FakeR2Transport());
+
+      expect(sensor.name, 'DiFluid R2');
+      expect(sensor.info.vendor, 'DiFluid');
+      expect(sensor.info.dataChannels.map((c) => c.key), contains('tds'));
+      expect(sensor.info.commands?.map((c) => c.id), contains('measure'));
+    });
+
+    test('connects, subscribes, sets Celsius, and measures TDS', () async {
+      final transport = _FakeR2Transport()
+        ..responsePacket = Uint8List.fromList([
+          0xDF,
+          0xDF,
+          0x03,
+          0x00,
+          0x03,
+          0x02,
+          0x03,
+          0xCA,
+          0x93,
+        ]);
+      final sensor = DifluidR2Sensor(transport: transport);
+
+      await sensor.onConnect();
+      final result = await sensor.execute('measure', {'timeout': 1});
+
+      expect(result['reading'], isA<Map>());
+      expect((result['reading'] as Map)['tds'], closeTo(9.7, 0.001));
+      expect(transport.notificationHandler, isNotNull);
+      expect(transport.writes, hasLength(2));
+      expect(
+        transport.writes.first.data,
+        DifluidR2Protocol.setCelsiusCommand(),
+      );
+      expect(transport.writes.last.data, DifluidR2Protocol.singleTestCommand());
+      expect(transport.writes.every((w) => w.withResponse), isTrue);
+    });
+
+    test('publishes readings to the data stream', () async {
+      final transport = _FakeR2Transport()
+        ..responsePacket = Uint8List.fromList([
+          0xDF,
+          0xDF,
+          0x03,
+          0x00,
+          0x03,
+          0x02,
+          0x00,
+          0x0C,
+          0xD2,
+        ]);
+      final sensor = DifluidR2Sensor(transport: transport);
+
+      await sensor.onConnect();
+      final nextReading = sensor.data.first;
+      await sensor.execute('measure', {'timeout': 1});
+
+      expect(await nextReading, containsPair('tds', 0.12));
+    });
+
+    test('matches DiFluid R2 devices separately from DiFluid scales', () async {
+      final matched = await DeviceMatcher.match(
+        transport: _FakeR2Transport(),
+        advertisedName: 'DiFluid R2 301095',
+      );
+
+      expect(matched, isA<DifluidR2Sensor>());
+      expect(
+        DeviceMatcher.serviceUuidsFor(DeviceType.sensor),
+        contains(DifluidR2Sensor.serviceIdentifier.long),
+      );
+    });
+  });
+}

--- a/test/unit/services/device_matcher_test.dart
+++ b/test/unit/services/device_matcher_test.dart
@@ -9,6 +9,7 @@ import 'package:reaprime/src/models/device/impl/blackcoffee/blackcoffee_scale.da
 import 'package:reaprime/src/models/device/impl/bookoo/miniscale.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale.dart';
+import 'package:reaprime/src/models/device/impl/difluid/difluid_r2_sensor.dart';
 import 'package:reaprime/src/models/device/impl/difluid/difluid_scale.dart';
 import 'package:reaprime/src/models/device/impl/eureka/eureka_scale.dart';
 import 'package:reaprime/src/models/device/impl/felicita/arc.dart';
@@ -28,7 +29,8 @@ class _MockBLETransport extends BLETransport {
   String get name => 'Mock';
 
   @override
-  Stream<ConnectionState> get connectionState => Stream.value(ConnectionState.discovered);
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.discovered);
 
   @override
   Future<void> connect() async {}
@@ -40,18 +42,27 @@ class _MockBLETransport extends BLETransport {
   Future<List<String>> discoverServices() async => [];
 
   @override
-  Future<Uint8List> read(String serviceUUID, String characteristicUUID,
-          {Duration? timeout}) async =>
-      Uint8List(0);
+  Future<Uint8List> read(
+    String serviceUUID,
+    String characteristicUUID, {
+    Duration? timeout,
+  }) async => Uint8List(0);
 
   @override
-  Future<void> subscribe(String serviceUUID, String characteristicUUID,
-          void Function(Uint8List) callback) async {}
+  Future<void> subscribe(
+    String serviceUUID,
+    String characteristicUUID,
+    void Function(Uint8List) callback,
+  ) async {}
 
   @override
   Future<void> write(
-          String serviceUUID, String characteristicUUID, Uint8List data,
-          {bool withResponse = true, Duration? timeout}) async {}
+    String serviceUUID,
+    String characteristicUUID,
+    Uint8List data, {
+    bool withResponse = true,
+    Duration? timeout,
+  }) async {}
 
   @override
   Future<void> setTransportPriority(bool prioritized) async {}
@@ -299,10 +310,19 @@ void main() {
       expect(device, isA<HiroiaScale>());
     });
 
-    test('Difluid matches', () async {
+    test('DiFluid R2 matches reflectometer sensor', () async {
       final device = await DeviceMatcher.match(
         transport: mockTransport,
         advertisedName: 'Difluid R2',
+      );
+
+      expect(device, isA<DifluidR2Sensor>());
+    });
+
+    test('other DiFluid devices still match the scale', () async {
+      final device = await DeviceMatcher.match(
+        transport: mockTransport,
+        advertisedName: 'Difluid Microbalance',
       );
 
       expect(device, isA<DifluidScale>());


### PR DESCRIPTION
## Summary
- add a native DiFluid R2 BLE protocol parser and `Sensor` implementation
- expose R2 readings through the existing Sensors API with TDS, temperature, refractive index, status, measuring, and error fields
- teach `DeviceMatcher` to route DiFluid R2 advertisements to the reflectometer sensor instead of the DiFluid scale
- document the R2 as a BLE sensor in the device-management guide

## Validation
- `dart format --output=none --set-exit-if-changed lib/src/models/device/impl/difluid/difluid_r2_protocol.dart lib/src/models/device/impl/difluid/difluid_r2_sensor.dart lib/src/services/device_matcher.dart test/difluid_r2_protocol_test.dart test/difluid_r2_sensor_test.dart test/unit/services/device_matcher_test.dart`
- `dart analyze lib/src/models/device/impl/difluid/difluid_r2_protocol.dart lib/src/models/device/impl/difluid/difluid_r2_sensor.dart lib/src/services/device_matcher.dart test/difluid_r2_protocol_test.dart test/difluid_r2_sensor_test.dart test/unit/services/device_matcher_test.dart`
- `flutter test test/difluid_r2_protocol_test.dart test/difluid_r2_sensor_test.dart test/unit/services/device_matcher_test.dart`
- `(cd packages/dye2-plugin && npm ci && npm run build)`

## Notes
- Full `flutter analyze` currently reports generated `build/ios` and `build/macos` Firebase SourcePackages issues plus missing optional asset directories in this checkout.
- Full `flutter test` currently has one unrelated setup failure: `test/webui_storage_bundled_test.dart` cannot load `assets/bundled_skins/manifest.json` in this clean worktree.
- Please keep this as draft until someone verifies the native BLE path against a physical DiFluid R2 device on target hardware.