### PR TITLE
Retry dropped MMR notifies on connect instead of failing the whole connect

### DIFF
--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart
@@ -5,6 +5,20 @@ part of 'unified_de1.dart';
 /// entire connect call chain forever. See comms-harden #2.
 const _mmrReadTimeout = Duration(seconds: 4);
 
+/// Extra read attempts before giving up (total attempts = retries + 1).
+/// On Android the notify subscription can report success during the
+/// post-connect GATT-busy window yet drop the first response — the same
+/// init-timing fragility flutter_blue_plus documents for `setNotifyValue`
+/// (#656 ERROR_GATT_WRITE_REQUEST_BUSY, #771 writeDescriptor returned
+/// false). A single dropped notify on the first `onConnect` read
+/// (`v13Model`) used to abort the entire connect; re-issuing the read a
+/// few times naturally defers past the busy window. The upstream 30s
+/// connect timeout still caps a genuinely unresponsive device.
+const _mmrReadRetries = 2;
+
+/// Settle between MMR read attempts so the GATT stack can quiesce.
+const _mmrReadRetrySettle = Duration(milliseconds: 300);
+
 extension UnifiedDe1MMR on UnifiedDe1 {
   Future<List<int>> _mmrRead(MMRItem item, {int length = 0}) =>
       _mmrReadRaw(item.address, length: length, label: item.name);
@@ -18,45 +32,57 @@ extension UnifiedDe1MMR on UnifiedDe1 {
   Future<List<int>> _mmrReadRaw(int address,
       {int length = 0, String? label}) async {
     final logLabel = label ?? '0x${address.toRadixString(16)}';
-    _log.info("mmr read: $logLabel");
     ByteData bytes = ByteData(20);
     bytes.setInt32(0, address, Endian.big);
     var buffer = bytes.buffer.asUint8List();
     buffer[0] = (length % 0xFF);
 
-    _log.fine(
-      'sending read req ${buffer.map((e) => e.toRadixString(16)).toList()}',
-    );
+    for (var attempt = 0;; attempt++) {
+      _log.info(
+        "mmr read: $logLabel${attempt > 0 ? ' (retry $attempt)' : ''}",
+      );
+      _log.fine(
+        'sending read req ${buffer.map((e) => e.toRadixString(16)).toList()}',
+      );
 
-    // Subscribe BEFORE writing to avoid race where the response arrives
-    // between writeWithResponse completing and firstWhere subscribing.
-    final responseFuture = _mmr
-        .map((d) => d.buffer.asUint8List().toList())
-        .firstWhere((element) {
-          if (buffer[1] == element[1] &&
-              buffer[2] == element[2] &&
-              buffer[3] == element[3]) {
-            return true;
-          } else {
-            return false;
-          }
-        }, orElse: () => <int>[])
-        .timeout(
-          _mmrReadTimeout,
-          onTimeout: () =>
-              throw MmrTimeoutException(logLabel, _mmrReadTimeout),
+      // Subscribe BEFORE writing to avoid race where the response arrives
+      // between writeWithResponse completing and firstWhere subscribing.
+      // A timeout (or a closed stream) yields an empty list so the loop can
+      // retry; only the final attempt throws MmrTimeoutException — keeping
+      // the exception type that `shouldForwardToTelemetry` filters on.
+      final responseFuture = _mmr
+          .map((d) => d.buffer.asUint8List().toList())
+          .firstWhere(
+            (element) =>
+                buffer[1] == element[1] &&
+                buffer[2] == element[2] &&
+                buffer[3] == element[3],
+            orElse: () => <int>[],
+          )
+          .timeout(_mmrReadTimeout, onTimeout: () => <int>[]);
+
+      await _transport.writeWithResponse(
+        Endpoint.readFromMMR,
+        Uint8List.fromList(buffer),
+      );
+
+      final result = await responseFuture;
+      if (result.isNotEmpty) {
+        _log.info(
+          "listen event Result:  ${result.map((e) => e.toRadixString(16)).toList()}",
         );
+        return result;
+      }
 
-    await _transport.writeWithResponse(
-      Endpoint.readFromMMR,
-      Uint8List.fromList(buffer),
-    );
-
-    var result = await responseFuture;
-    _log.info(
-      "listen event Result:  ${result.map((e) => e.toRadixString(16)).toList()}",
-    );
-    return result;
+      if (attempt >= _mmrReadRetries) {
+        throw MmrTimeoutException(logLabel, _mmrReadTimeout);
+      }
+      _log.warning(
+        'mmr read $logLabel timed out (attempt ${attempt + 1} of '
+        '${_mmrReadRetries + 1}), retrying',
+      );
+      await Future<void>.delayed(_mmrReadRetrySettle);
+    }
   }
 
   /// Address-only MMR write for capability mixins; see [_mmrReadRaw].

--- a/test/helpers/fake_ble_transport.dart
+++ b/test/helpers/fake_ble_transport.dart
@@ -60,6 +60,12 @@ class FakeBleTransport extends BLETransport {
   /// Ordered writes seen by the transport.
   final List<FakeBleWrite> writes = [];
 
+  /// Number of upcoming matching MMR read requests whose notification is
+  /// silently dropped (the queued response is left intact for a retry).
+  /// Simulates the Android post-connect notify-loss the `_mmrReadRaw`
+  /// retry guards against.
+  int dropNextMmrResponses = 0;
+
   /// Queue an integer to be returned when a read request to [item] hits
   /// the MMR write characteristic.
   void queueMmrResponseInt(MmrAddress item, int value) {
@@ -146,6 +152,12 @@ class FakeBleTransport extends BLETransport {
     // when the test has queued a response for the requested address.
     if (characteristicUUID != Endpoint.readFromMMR.uuid) return;
     if (data.length < 4) return;
+    // Drop this notification (but keep the queued response) to simulate a
+    // lost notify; the retry's next write will be answered.
+    if (dropNextMmrResponses > 0) {
+      dropNextMmrResponses--;
+      return;
+    }
     final addrMid1 = data[1];
     final addrMid2 = data[2];
     final addrLow = data[3];

--- a/test/models/device/unified_de1_crashlytics_triage_test.dart
+++ b/test/models/device/unified_de1_crashlytics_triage_test.dart
@@ -115,9 +115,11 @@ void main() {
         );
 
         await sub.cancel();
+        // onConnect's first MMR read now retries (3 * 4s + settle) against
+        // the silent stub before throwing MmrTimeoutException; allow headroom.
         await onConnectFuture;
       },
-      timeout: const Timeout(Duration(seconds: 10)),
+      timeout: const Timeout(Duration(seconds: 20)),
     );
   });
 

--- a/test/models/device/unified_de1_mmr_test.dart
+++ b/test/models/device/unified_de1_mmr_test.dart
@@ -80,13 +80,15 @@ void main() {
     test(
       'throws MmrTimeoutException when no matching response arrives',
       () async {
-        // getSteamFlow -> _readMMRScaled -> _readMMRInt -> _mmrRead
+        // getSteamFlow -> _readMMRScaled -> _readMMRInt -> _mmrRead.
+        // _mmrRead now retries (3 attempts * 4s + settle ~= 12.6s) before
+        // throwing, so allow headroom past the per-attempt timeout.
         await expectLater(
           () => de1.getSteamFlow(),
           throwsA(isA<MmrTimeoutException>()),
         );
       },
-      timeout: const Timeout(Duration(seconds: 10)),
+      timeout: const Timeout(Duration(seconds: 20)),
     );
   });
 }

--- a/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
@@ -154,6 +154,23 @@ void main() {
       expect(result.sublist(4, 8), [0xDE, 0xAD, 0xBE, 0xEF]);
     });
 
+    test('readMmrRaw retries after a dropped notify, then returns the value',
+        () async {
+      const addr = _CapabilityAddr(
+        address: 0x00802800,
+        length: 4,
+        name: 'cupWarmerStatus',
+        kind: MmrValueKind.bytes,
+      );
+      // First read request's notification is lost; the queued response
+      // survives for the retry, which lands after the 4s timeout + settle.
+      transport.dropNextMmrResponses = 1;
+      transport.queueMmrResponseRaw(addr, [0xDE, 0xAD, 0xBE, 0xEF]);
+
+      final result = await de1.capRead(addr);
+      expect(result.sublist(4, 8), [0xDE, 0xAD, 0xBE, 0xEF]);
+    }, timeout: const Timeout(Duration(seconds: 30)));
+
     test('writeMmrRaw sends the bytes on the wire for non-MMRItem', () async {
       const addr = _CapabilityAddr(
         address: 0x00803000,


### PR DESCRIPTION
## What
- `_mmrReadRaw` now retries the MMR read (3 attempts, 300ms settle) instead of aborting the connect on a single dropped notify. Only the final attempt throws `MmrTimeoutException`, preserving the type `shouldForwardToTelemetry` drops.

## Why
On the m50mini (Teclast, GSI "trebledroid vanilla"), the first `onConnect` MMR read (`v13Model`) intermittently times out: `subscribe()` + `writeWithResponse` both succeed but the first response notification is silently lost during the post-connect GATT-busy window — the documented flutter_blue_plus Android init-timing fragility ([#656](https://github.com/chipweinberger/flutter_blue_plus/issues/656), [#771](https://github.com/chipweinberger/flutter_blue_plus/issues/771)). That aborted the entire connect; recovery only came ~9s later when EarlyConnectWatcher re-fired and the no-op-reconnect path re-subscribed the characteristic. The retry re-issues the read past the busy window; the upstream 30s connect timeout still caps a genuinely dead device.

## Test plan
- New `protected_surface_test`: dropped-then-retry read returns the value (via `FakeBleTransport.dropNextMmrResponses`).
- Two silent-transport timeouts bumped 10→20s (3 attempts now take ~12.6s).
- Full suite green (1618), `flutter analyze` clean.
- Smoke-tested on m50mini hardware: 2 connects, working well.