### PR TITLE
fix launcher water levels representation as well as water levels parsing

### DIFF
--- a/lib/src/launcher/widgets/status_bar.dart
+++ b/lib/src/launcher/widgets/status_bar.dart
@@ -280,7 +280,7 @@ class _WaterLevel extends StatelessWidget {
 
             return _StatusChip(
               icon: LucideIcons.glassWaterDir,
-              label: '${levels.currentLevel.toInt()}%',
+              label: '${levels.currentLevel.toInt()}mm',
               color: low ? Colors.orange : null,
             );
           },

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.parsing.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.parsing.dart
@@ -49,8 +49,8 @@ extension MessageParsing on UnifiedDe1 {
       var waterThreshold = data.getUint16(2, Endian.big);
 
       return De1WaterLevels(
-        currentLevel: waterlevel / 256,
-        refillLevel: waterThreshold / 256,
+        currentLevel: waterlevel / 256.0,
+        refillLevel: waterThreshold / 256.0,
       );
     } catch (e) {
       _log.severe("waternotify", e);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

> **Naming:** The display name is **Decent.app**. The repo, package, and bundle ID use legacy `reaprime` / `streamline-bridge` — see the naming table in [`CLAUDE.md`](CLAUDE.md).

- Problem:
- Why it matters: 
water levels should be reported in millimetres, not percentage
- What changed:
the suffix on the launcher status_bar.dart and division with float when parsing water level binary packet

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [x] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs

## Documentation Obligations (required)

These are **not optional**. Stale specs mislead clients and agents.

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A — no docs affected

## Security Impact (required)

This app runs a local web server (port 8080) and connects to BLE/USB hardware.

- New or changed REST endpoints? (`Yes/No`)
- New or changed WebSocket topics? (`Yes/No`)
- New or changed network calls? (`Yes/No`)
- BLE/USB surface changed? (`Yes/No`)
- File system access changed? (`Yes/No`)
- Plugin sandbox boundary changed? (`Yes/No`)
- If any `Yes`, explain risk and mitigation:

No security impact, a surface UI only change

## User-Visible Changes

Changed water level indicator suffix from `%` to `mm` in the launcher status bar

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds

### Manual verification (if applicable)

- OS / platform tested:
- Simulated devices? (`simulate=1`): `Yes/No`
- Real hardware? (DE1/Bengle/scale): `Yes/No`
- What you personally verified and how:
- Edge cases checked:
- What you did **not** verify:

Tested on M50Mini Android 14 tablet.