### PR TITLE
fix: restore screen brightness when awake, not on the sleep edge

### DIFF
--- a/lib/src/controllers/display_controller.dart
+++ b/lib/src/controllers/display_controller.dart
@@ -303,13 +303,21 @@ class DisplayController {
 
     if (previousState == _currentMachineState) return;
 
-    // Save brightness before sleep; restore when machine wakes
+    // Save the user's brightness before sleep; restore it whenever the machine
+    // is awake again. This is deliberately keyed off the awake *condition*, not
+    // the precise sleeping->idle edge: if that edge is ever lost — e.g. a BLE
+    // reconnect resets our last-seen state to null, or we start up against an
+    // already-sleeping machine — an edge-triggered restore leaves the screen
+    // stuck dark with no recovery. Level-triggering self-heals on the next
+    // snapshot instead.
     if (_currentMachineState == MachineState.sleeping) {
-      _preSleepBrightness = _requestedBrightness;
-    } else if (previousState == MachineState.sleeping &&
-        (_currentMachineState == MachineState.idle ||
-            _currentMachineState == MachineState.schedIdle)) {
-      _log.info('Machine woke from sleep, restoring brightness');
+      // Never capture a dimmed value: a skin drives brightness to 0 for its
+      // sleep screen, and remembering that would "restore" to black next wake.
+      if (_requestedBrightness > 0) {
+        _preSleepBrightness = _requestedBrightness;
+      }
+    } else if (_requestedBrightness == 0 && _preSleepBrightness > 0) {
+      _log.info('Awake with screen still dimmed — restoring brightness');
       unawaited(setBrightness(_preSleepBrightness));
     }
 

--- a/test/controllers/display_controller_test.dart
+++ b/test/controllers/display_controller_test.dart
@@ -631,6 +631,40 @@ void main() {
         controller.dispose();
       });
     });
+
+    test('restores brightness on wake even when the sleep->idle edge is missed',
+        () {
+      fakeAsync((async) {
+        final controller = _createController(de1Controller,
+            settingsController: settingsCtrl);
+        controller.initialize();
+        async.flushMicrotasks();
+
+        de1Controller.setDe1(testDe1);
+        async.flushMicrotasks();
+
+        // Awake at full brightness, then the skin blacks the screen for sleep.
+        controller.setBrightness(100);
+        testDe1.emitState(MachineState.sleeping);
+        async.flushMicrotasks();
+        controller.setBrightness(0);
+        async.flushMicrotasks();
+        expect(controller.currentState.brightness, 0);
+
+        // A BLE reconnect during sleep swaps in a fresh De1Interface, resetting
+        // the controller's last-seen machine state to null. The reconnected
+        // stream is already awake (idle), so the sleeping->idle transition is
+        // never observed: an edge-triggered restore misses it and leaves the
+        // screen stuck dark. The restore must instead fire off the awake state.
+        final reconnected = _TestDe1();
+        de1Controller.setDe1(reconnected);
+        async.flushMicrotasks();
+
+        expect(controller.currentState.brightness, 100);
+
+        controller.dispose();
+      });
+    });
   });
 
   group('battery brightness cap', () {


### PR DESCRIPTION
## Summary

- **Problem:** Coming out of sleep, the tablet screen sometimes stayed fully dark (brightness `0`) even though the machine was awake and usable.
- **Why it matters:** A black-but-awake screen looks broken and only recovered on an app restart or the next machine-state change.
- **What changed:** Restore brightness off the **awake condition** (machine awake + brightness still `0` → restore the saved pre-sleep value) instead of catching the exact `sleeping → idle` transition; and never capture a dimmed value as `_preSleepBrightness`.
- **What did NOT change (scope boundary):** No change to the `/api/v1/display` REST/WS surface, the battery brightness cap, wake-lock logic, or any skin behavior. The DE1 dim is still driven by the skin; only the *restore* is hardened.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] Machine state / shot logic
- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs

## Linked Issues

- N/A — no tracking issue (intermittent field report).

## Root Cause (if bug fix)

- **Root cause:** Brightness restore in `DisplayController._onSnapshot` was edge-triggered — it only fired when it observed the exact `sleeping → idle|schedIdle` transition. When that edge is lost the screen stayed dimmed with no recovery. The edge is lost when a BLE reconnect swaps in a new `De1Interface` (`_onDe1Changed` resets `_currentMachineState` to `null`), so the wake snapshot arrives as `null → idle`, or when the controller starts up against an already-sleeping machine.
- **Missing detection or guardrail:** No level-triggered fallback re-asserting "an awake screen must not stay at `0`", and no guard against saving a `0` brightness as the restore target (a dimmed value captured as `_preSleepBrightness` makes later wakes "restore" to black).
- **Contributing context:** Needs a BLE reconnect (or app start) to coincide with sleep — intermittent, so it reproduced rarely.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- **Target test or file:** `test/controllers/display_controller_test.dart` → `restores brightness on wake even when the sleep->idle edge is missed`
- **Scenario the test should lock in:** connect → brightness 100 → sleep → skin dims to `0` → BLE reconnect (fresh `De1Interface` resets last-seen state) → wake; assert brightness is restored to 100. Fails on the old edge-triggered logic (`Actual: <0>`), passes with this change.

## Documentation Obligations (required)

- [x] N/A — no docs affected (the `/api/v1/display` endpoints and their behavior are unchanged; this is internal controller logic).

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `No`
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`

## User-Visible Changes

Screen brightness now reliably returns when the machine wakes, even if the wake transition wasn't cleanly observed (e.g. after a BLE reconnect during sleep). Previously the screen could stay dark until the next machine-state change.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean on changed files (no new warnings)
- [x] `flutter test` — all pass (1628 tests)
- [ ] `(cd packages/dye2-plugin && npm run build)` — N/A, no plugin change

### Manual verification (if applicable)

- OS / platform tested: macOS (analysis/tests); the real-world trigger is an intermittent BLE reconnect during sleep.
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: the failure is a rare timing/transient (lost wake edge), so it's pinned down deterministically with a unit test rather than by hand.
- Edge cases checked: reconnect during sleep (last-seen state reset); dimmed-value-not-captured-as-pre-sleep guard.
- What you did **not** verify: on-hardware reproduction (intermittent by nature).

### Evidence

- [x] Test output (failing before + passing after)

​```
# origin/main (pre-fix):
test/controllers/display_controller_test.dart 663:9  ...
  Expected: <100>
    Actual: <0>
00:00 +0 -1: Some tests failed.

# with the fix:
00:00 +1: All tests passed!
​```

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`

## Risks & Mitigations

- **Risk:** Restoring on "awake + brightness `0`" could override an intentional `0`-while-awake set by a skin.
  - **Mitigation:** brightness `0` while awake is a fully black screen with no legitimate use; restoring the saved pre-sleep value is the desired behavior.
