### PR TITLE
fix(apple): broaden crashlytics run-script search for iOS SPM archives

### DIFF
--- a/scripts/upload_crashlytics_symbols.sh
+++ b/scripts/upload_crashlytics_symbols.sh
@@ -33,11 +33,31 @@ if [ -z "$PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT" ]; then
   done
 fi
 
-# 3) Last-ditch: search DerivedData
+# 3) Last-ditch: search likely build roots for the SPM checkout.
+# `flutter build ipa` archives into an ArchiveIntermediates layout whose
+# SourcePackages dir lives under OBJROOT/SYMROOT/BUILD_ROOT (not necessarily
+# ~/Library/Developer/Xcode/DerivedData), so probe those too — that's the iOS
+# case macOS's direct build never hits.
 if [ -z "$PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT" ]; then
-  PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT=$(find "$HOME/Library/Developer/Xcode/DerivedData" \
-    -path "*SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run" \
-    -print -quit 2>/dev/null || true)
+  for root in \
+    "$BUILD_DIR" \
+    "${BUILD_DIR%/Build/*}" \
+    "$BUILD_ROOT" \
+    "${BUILD_ROOT%/Build/*}" \
+    "$OBJROOT" \
+    "$SYMROOT" \
+    "${SRCROOT}/../build" \
+    "${PROJECT_DIR}/../build" \
+    "$HOME/Library/Developer/Xcode/DerivedData"; do
+    [ -n "$root" ] && [ -d "$root" ] || continue
+    found=$(find "$root" \
+      -path "*SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run" \
+      -print -quit 2>/dev/null || true)
+    if [ -n "$found" ]; then
+      PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT="$found"
+      break
+    fi
+  done
 fi
 
 if [ -z "$PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT" ] || [ ! -f "$PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT" ]; then


### PR DESCRIPTION
## What
- Broaden `scripts/upload_crashlytics_symbols.sh` last-ditch search to probe `BUILD_DIR`/`BUILD_ROOT` ancestors, `OBJROOT`, `SYMROOT`, and the project `build/` tree — not just `~/Library/Developer/Xcode/DerivedData`.

## Why
Dev build #27597987321 (main) failed iOS only: `Crashlytics 'run' script not found`. The prior wrapper (90628288) fixed macOS but `flutter build ipa` archives into an ArchiveIntermediates layout whose SPM `SourcePackages` lives under `OBJROOT`/`SYMROOT`, which the DerivedData-only fallback never searched. macOS passed because its direct build leaves `SourcePackages` under `BUILD_ROOT` (matched by candidate #2).

## Test plan
- `bash -n` syntax check passes.
- Simulated archive-intermediates tree locally: find loop locates `run` via the `${BUILD_DIR%/Build/*}` root.
- Full verification is the iOS leg of the Development build workflow on this branch (Xcode 26.3 runner).