### PR TITLE
fix: add onlyespressomachines=1 param to serials request

### DIFF
--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -54,7 +54,7 @@ class DecentAccountService {
     if (email == null || password == null) {
       throw StateError('not logged in');
     }
-    final response = await _authedGet(email, password, '/support/api/sn');
+    final response = await _authedGet(email, password, '/support/api/sn?onlyespressomachines=1');
     if (response.statusCode != 200) {
       throw Exception(
         'serial fetch failed (${response.statusCode}): ${response.body.trim()}',

--- a/test/services/account/decent_account_service_test.dart
+++ b/test/services/account/decent_account_service_test.dart
@@ -238,7 +238,7 @@ void main() {
       });
 
       test(
-        'calls /support/api/sn with Basic Auth from stored credentials',
+        'calls /support/api/sn?onlyespressomachines=1 with Basic Auth from stored credentials',
         () async {
           // base64("test@example.com:cryptpw_abc123")
           const expectedAuth =
@@ -249,7 +249,7 @@ void main() {
 
           await s.fetchSerialNumbers();
 
-          expect(capturedRequest.url.toString(), '$_baseUrl/support/api/sn');
+          expect(capturedRequest.url.toString(), '$_baseUrl/support/api/sn?onlyespressomachines=1');
           expect(capturedRequest.headers['authorization'], expectedAuth);
           expect(capturedRequest.method, 'GET');
         },


### PR DESCRIPTION
## What

Adds `?onlyespressomachines=1` query parameter to `GET /support/api/sn` in `DecentAccountService.fetchSerialNumbers()`.

## Why

As requested by John (BC [#9941956613](https://3.basecamp.com/3671212/buckets/42895019/todos/9941956613) follow-up): the serials query must filter to espresso machines only.

## Changes

- `lib/src/services/account/decent_account_service.dart` — add `?onlyespressomachines=1` to the URL
- `test/services/account/decent_account_service_test.dart` — update URL assertion to match

## Testing

All 41 tests across account service, proxy service, proxy handler, and proxy middleware pass. ✅