### PR TITLE
chore(settings): add advanced toggle for simulated WebViews on macOS

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -192,9 +192,11 @@ void main() async {
     WindowManager.instance.setMinimumSize(_defaultDesktopWindowSize);
     await WindowManager.instance.setAspectRatio(_defaultDesktopAspectRatio);
     await WindowManager.instance.setSize(_defaultDesktopWindowSize);
-    final startupSimulatedWebViewDevice = kDebugMode && Platform.isMacOS
-        ? await loadPersistedSimulatedWebViewDevice()
-        : null;
+    final startupSimulatedWebViewDevice =
+        await SharedPreferencesSettingsService().enableSimulatedWebViews() &&
+                Platform.isMacOS
+            ? await loadPersistedSimulatedWebViewDevice()
+            : null;
     if (startupSimulatedWebViewDevice != null) {
       await _setSimulatedWebViewDevice(
         startupSimulatedWebViewDevice,
@@ -952,7 +954,7 @@ class _AppRootState extends State<AppRoot> {
               }
             },
           ),
-          if (kDebugMode) ...[
+          if (widget.settingsController.enableSimulatedWebViews) ...[
             PlatformMenuItem(
               label: 'Use Native macOS WebView',
               shortcut: const SingleActivator(

--- a/lib/src/settings/advanced_page.dart
+++ b/lib/src/settings/advanced_page.dart
@@ -103,6 +103,22 @@ class AdvancedPage extends StatelessWidget {
                     ),
                   ),
                 ),
+              if (Platform.isMacOS) ...[
+                const SettingsDivider(),
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 8,
+                  ),
+                  child: ShadSwitch(
+                    value: controller.enableSimulatedWebViews,
+                    onChanged: (v) async {
+                      await controller.setEnableSimulatedWebViews(v);
+                    },
+                    label: const Text('Simulated WebViews'),
+                  ),
+                ),
+              ],
               const SettingsDivider(),
 
               // Debug view

--- a/lib/src/settings/settings_controller.dart
+++ b/lib/src/settings/settings_controller.dart
@@ -63,6 +63,7 @@ class SettingsController with ChangeNotifier {
   bool _onboardingCompleted = false;
   bool _accountStepSeen = false;
   bool _androidWarningDismissed = false;
+  bool _enableSimulatedWebViews = false;
 
   TelemetryService? _telemetryService;
 
@@ -93,6 +94,7 @@ class SettingsController with ChangeNotifier {
   bool get onboardingCompleted => _onboardingCompleted;
   bool get accountStepSeen => _accountStepSeen;
   bool get androidWarningDismissed => _androidWarningDismissed;
+  bool get enableSimulatedWebViews => _enableSimulatedWebViews;
 
   set telemetryService(TelemetryService service) => _telemetryService = service;
 
@@ -127,6 +129,8 @@ class SettingsController with ChangeNotifier {
     _accountStepSeen = await _settingsService.accountStepSeen();
     _androidWarningDismissed =
         await _settingsService.androidWarningDismissed();
+    _enableSimulatedWebViews =
+        await _settingsService.enableSimulatedWebViews();
 
     // Sync telemetry consent to TelemetryService if it exists
     if (_telemetryService != null) {
@@ -393,6 +397,13 @@ class SettingsController with ChangeNotifier {
     if (value == _androidWarningDismissed) return;
     _androidWarningDismissed = value;
     await _settingsService.setAndroidWarningDismissed(value);
+    notifyListeners();
+  }
+
+  Future<void> setEnableSimulatedWebViews(bool value) async {
+    if (value == _enableSimulatedWebViews) return;
+    _enableSimulatedWebViews = value;
+    await _settingsService.setEnableSimulatedWebViews(value);
     notifyListeners();
   }
 }

--- a/lib/src/settings/settings_service.dart
+++ b/lib/src/settings/settings_service.dart
@@ -70,6 +70,8 @@ abstract class SettingsService {
   Future<void> setAccountStepSeen(bool value);
   Future<bool> androidWarningDismissed();
   Future<void> setAndroidWarningDismissed(bool value);
+  Future<bool> enableSimulatedWebViews();
+  Future<void> setEnableSimulatedWebViews(bool value);
 }
 
 /// SharedPreferences-backed implementation of [SettingsService].
@@ -425,6 +427,17 @@ class SharedPreferencesSettingsService extends SettingsService {
   Future<void> setAndroidWarningDismissed(bool value) async {
     await prefs.setBool(SettingsKeys.androidWarningDismissed.name, value);
   }
+
+  @override
+  Future<bool> enableSimulatedWebViews() async {
+    return await prefs.getBool(SettingsKeys.enableSimulatedWebViews.name) ??
+        false;
+  }
+
+  @override
+  Future<void> setEnableSimulatedWebViews(bool value) async {
+    await prefs.setBool(SettingsKeys.enableSimulatedWebViews.name, value);
+  }
 }
 
 enum SettingsKeys {
@@ -457,6 +470,7 @@ enum SettingsKeys {
   onboardingCompleted,
   accountStepSeen,
   androidWarningDismissed,
+  enableSimulatedWebViews,
 }
 
 enum SimulatedDevicesTypes { machine, scale, sensor, bengle }

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -3,7 +3,6 @@ import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
@@ -755,7 +754,9 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
   UnmodifiableListView<UserScript>? _simulatedDeviceScripts(
     SimulatedWebViewDevice? simulatedDevice,
   ) {
-    if (!kDebugMode || !Platform.isMacOS || simulatedDevice == null) {
+    if (!widget.settingsController.enableSimulatedWebViews ||
+        !Platform.isMacOS ||
+        simulatedDevice == null) {
       return null;
     }
 

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -4,23 +4,13 @@ PODS:
   - flutter_libserialport (0.0.1):
     - FlutterMacOS
     - libserialport
-  - flutter_secure_storage_macos (6.1.3):
-    - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - libserialport (0.1.1)
-  - screen_retriever_macos (0.0.1):
-    - FlutterMacOS
-  - universal_ble (0.0.1):
-    - Flutter
-    - FlutterMacOS
 
 DEPENDENCIES:
   - flutter_js (from `Flutter/ephemeral/.symlinks/plugins/flutter_js/macos`)
   - flutter_libserialport (from `Flutter/ephemeral/.symlinks/plugins/flutter_libserialport/macos`)
-  - flutter_secure_storage_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
-  - universal_ble (from `Flutter/ephemeral/.symlinks/plugins/universal_ble/darwin`)
 
 SPEC REPOS:
   trunk:
@@ -31,23 +21,14 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_js/macos
   flutter_libserialport:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_libserialport/macos
-  flutter_secure_storage_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
-  screen_retriever_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
-  universal_ble:
-    :path: Flutter/ephemeral/.symlinks/plugins/universal_ble/darwin
 
 SPEC CHECKSUMS:
   flutter_js: 79c3c70d33ba464c67d8eb88639a61aa718cd8b8
   flutter_libserialport: 2c523cb8d8203fc6d1b0da88190da31ac970eb93
-  flutter_secure_storage_macos: 7f45e30f838cf2659862a4e4e3ee1c347c2b3b54
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   libserialport: 1cb25e66ef3c92a8e59c2ea3820302c3fa2268cd
-  screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
-  universal_ble: 45519b2aeafe62761e2c6309f8927edb5288b914
 
 PODFILE CHECKSUM: 89c84cf5c2351c1e554c6dea18d31a879fc3a19e
 

--- a/test/helpers/mock_settings_service.dart
+++ b/test/helpers/mock_settings_service.dart
@@ -36,6 +36,7 @@ class MockSettingsService extends SettingsService {
   bool _onboardingCompleted = true; // skip onboarding in tests
   bool _accountStepSeen = true; // skip account step in tests
   bool _androidWarningDismissed = true; // skip android warning in tests
+  bool _enableSimulatedWebViews = false;
 
   @override
   Future<ThemeMode> themeMode() async => _themeMode;
@@ -168,4 +169,9 @@ class MockSettingsService extends SettingsService {
   @override
   Future<void> setAndroidWarningDismissed(bool value) async =>
       _androidWarningDismissed = value;
+  @override
+  Future<bool> enableSimulatedWebViews() async => _enableSimulatedWebViews;
+  @override
+  Future<void> setEnableSimulatedWebViews(bool value) async =>
+      _enableSimulatedWebViews = value;
 }


### PR DESCRIPTION
Replace kDebugMode gate with a user-facing setting so simulated WebView device injection works in release builds on macOS. Adds `enableSimulatedWebViews` to SettingsService/SettingsController, a ShadSwitch on the advanced settings page (macOS only), and updates skin_view.dart and main.dart menu visibility to use the new setting.
