### PR TITLE
fix(ble): harden Android BLE connection stability

### DIFF
--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -177,8 +177,6 @@ class ConnectionManager {
   @visibleForTesting
   Duration deferredScaleScanDelay = const Duration(seconds: 3);
 
-  @visibleForTesting
-
   ConnectionManager({
     required this.deviceScanner,
     required this.de1Controller,

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -147,6 +147,18 @@ class ConnectionManager {
   /// interaction.
   Timer? _preferredScaleReconnect;
 
+  /// Consecutive scale-reconnect failures for exponential backoff.
+  /// Reset on successful scale connect or machine disconnect.
+  int _scaleReconnectFailures = 0;
+
+  /// Compute exponential backoff delay: 5s → 10s → 20s → 40s → 60s cap.
+  Duration get _scaleReconnectBackoff {
+    final base = 5;
+    final seconds = base * (1 << _scaleReconnectFailures).clamp(1, 12);
+    // 5*1=5, 5*2=10, 5*4=20, 5*8=40, 5*12=60
+    return Duration(seconds: seconds.clamp(5, 60));
+  }
+
   MachineState? _latestMachineState;
   StreamSubscription<MachineSnapshot>? _machineSnapshotSub;
 
@@ -166,7 +178,6 @@ class ConnectionManager {
   Duration deferredScaleScanDelay = const Duration(seconds: 3);
 
   @visibleForTesting
-  Duration preferredScaleReconnectDelay = const Duration(seconds: 5);
 
   ConnectionManager({
     required this.deviceScanner,
@@ -402,8 +413,11 @@ class ConnectionManager {
     final preferredMachineId =
         scaleOnly ? null : settingsController.preferredMachineId;
     final preferredScaleId = settingsController.preferredScaleId;
-    final earlyStopEnabled =
-        !scaleOnly && preferredMachineId != null;
+    // Early stop is enabled for any full (non-scaleOnly) connect.
+    // Previously gated on preferredMachineId != null, which meant
+    // auto-discovered machines never stopped the scan early even
+    // with both devices found and connected.
+    final earlyStopEnabled = !scaleOnly;
 
     final scanStartTime = DateTime.now();
 
@@ -517,30 +531,50 @@ class ConnectionManager {
     );
   }
 
-  /// Stop scan early based on connection state and scale preference.
+  /// Stop scan early when all preferred devices are connected.
   ///
-  /// When no preferred scale is configured, stop as soon as the preferred
-  /// machine connects — the post-scan scale phase handles any discovered
-  /// scales, and an immediate stop avoids wasting 10+ seconds of scan
-  /// timeout. When a preferred scale IS configured, keep the original
-  /// behaviour: stop only when both preferred devices are connected.
+  /// Three branches ordered from most-specific to least:
+  /// 1. Preferred machine + preferred scale → both must be connected.
+  /// 2. Preferred machine only → stop on machine connect.
+  /// 3. No preferences → stop when at least one machine + one scale
+  ///    are connected (the common auto-discovered case).
   void _checkEarlyStop(bool earlyStopEnabled) {
     if (!earlyStopEnabled) return;
+    final preferredMachineId = settingsController.preferredMachineId;
     final preferredScaleId = settingsController.preferredScaleId;
-    if (preferredScaleId == null) {
-      // No preferred scale — stop as soon as the machine connects.
-      // Scales discovered so far are still in scanRun.scales and will be
-      // handled by the post-scan scale phase; a scale that advertises
-      // after this stop is recovered by _maybeArmDeferredScaleScan.
+    if (preferredMachineId != null && preferredScaleId != null) {
+      // Both preferred — wait for both.
+      if (_machineConnected && _scaleConnected) {
+        _log.fine('Both preferred devices connected, stopping scan early');
+        _earlyStopFired = true;
+        deviceScanner.stopScan();
+      }
+    } else if (preferredMachineId != null) {
+      // Machine only — stop on machine connect.
       if (_machineConnected) {
-        _log.fine('Machine connected (no preferred scale), stopping scan early');
+        _log.fine(
+          'Preferred machine connected (no preferred scale), '
+          'stopping scan early',
+        );
+        _earlyStopFired = true;
+        deviceScanner.stopScan();
+      }
+    } else if (preferredScaleId != null) {
+      // Scale only (auto-discovered machine) — stop when both connect.
+      if (_machineConnected && _scaleConnected) {
+        _log.fine(
+          'Preferred scale connected (auto machine), stopping scan early',
+        );
         _earlyStopFired = true;
         deviceScanner.stopScan();
       }
     } else {
-      // Preferred scale exists — stop only when both are connected.
+      // No preferences — stop when at least one of each type connects.
       if (_machineConnected && _scaleConnected) {
-        _log.fine('Both preferred devices connected, stopping scan early');
+        _log.fine(
+          'Machine and scale connected (no preferences), stopping scan early',
+        );
+        _earlyStopFired = true;
         deviceScanner.stopScan();
       }
     }
@@ -579,11 +613,13 @@ class ConnectionManager {
   void _maybeSchedulePreferredScaleReconnect() {
     if (_preferredScaleReconnect != null) return;
     if (!_shouldRetryPreferredScale()) return;
+    final delay = _scaleReconnectBackoff;
+    _scaleReconnectFailures++;
     _log.fine(
-      'Preferred scale is missing; retrying scale scan in '
-      '${preferredScaleReconnectDelay.inSeconds}s',
+      'Preferred scale is missing (failure #$_scaleReconnectFailures); '
+      'retrying scale scan in ${delay.inSeconds}s',
     );
-    _preferredScaleReconnect = Timer(preferredScaleReconnectDelay, () {
+    _preferredScaleReconnect = Timer(delay, () {
       _preferredScaleReconnect = null;
       if (!_shouldRetryPreferredScale()) return;
       connect(scaleOnly: true); // fire-and-forget
@@ -600,6 +636,7 @@ class ConnectionManager {
   void _cancelPreferredScaleReconnect() {
     _preferredScaleReconnect?.cancel();
     _preferredScaleReconnect = null;
+    _scaleReconnectFailures = 0;
   }
 
   void _handleMachineConnected() {

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -37,14 +37,27 @@ class UniversalBleTransport implements BLETransport {
     _log = Logger("BLETransport-${device.deviceId}");
   }
 
+  // Android post-connect settle duration. The Android BLE stack needs
+  // a brief period after connectGatt reports success before service
+  // discovery works reliably (particularly on older tablet SoCs).
+  static const Duration _androidPostConnectDelay =
+      Duration(milliseconds: 200);
+
   @override
   Future<void> connect() async {
+    // TODO(ble-fork): switch to UniversalBle.connectionUpdateStream
+    // once the fork is published — it exposes native disconnect reason
+    // codes (GATT error, HCI status). Until then, connectionStream
+    // only emits bool.
     _connectionStateSubscription = UniversalBle.connectionStream(
       _device.deviceId,
-    ).listen((d) {
-      _connectionStateSubject.add(
-        d ? device.ConnectionState.connected : device.ConnectionState.disconnected,
-      );
+    ).listen((connected) {
+      if (connected) {
+        _connectionStateSubject.add(device.ConnectionState.connected);
+      } else {
+        _log.warning('Transport disconnected (reason not available in this build)');
+        _connectionStateSubject.add(device.ConnectionState.disconnected);
+      }
     });
     if (_isLinux) {
       await _connectBlueZ();
@@ -58,9 +71,27 @@ class UniversalBleTransport implements BLETransport {
     } on UniversalBleException catch (e) {
       throw mapUniversalConnectError(e);
     }
+
+    // Android: post-connect settle + MTU bump.
+    // The 200ms settle avoids service-discovery races on tablet SoCs
+    // where the BLE stack finalises GATT setup asynchronously after
+    // connect. MTU 517 reduces GATT round-trips for reads/writes.
+    if (!_isLinux && Platform.isAndroid) {
+      await Future.delayed(_androidPostConnectDelay);
+      try {
+        await UniversalBle.requestMtu(
+          _device.deviceId,
+          517,
+          timeout: const Duration(seconds: 5),
+        );
+        _log.fine('MTU negotiation successful');
+      } catch (e) {
+        _log.fine('MTU negotiation failed (using default): $e');
+      }
+    }
   }
 
-  /// BlueZ connect with the mitigations the native fbp Linux path needed.
+  /// BlueZ connect with the same mitigations the Linux BLE path needs.
   /// First attempt stops any scan and lets BlueZ settle, then connects. On
   /// failure, run a brief refresh scan (BlueZ can drop the device from its
   /// cache after a disconnect) and retry once.

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' show Platform;
 import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/services/ble/ble_discovery_service.dart';
 import 'package:reaprime/src/services/ble/universal_ble_transport.dart';
@@ -139,7 +140,27 @@ class UniversalBleDiscoveryService extends BleDiscoveryService {
       // documented discovery path; service UUIDs are only a scan-filter
       // optimization, not needed on macOS/iOS).
       final scanFilter = ScanFilter(withServices: []);
-      await UniversalBle.startScan(scanFilter: scanFilter);
+
+      // Android: use aggressive scan settings to avoid the chip-side
+      // advert de-duplication that throttles results to ~1 per 12 s.
+      // matchMode: aggressive disables firmware-layer de-duplication;
+      // numOfMatches: max removes the per-device match cap;
+      // scanMode: lowLatency prioritises scan duty cycle over power.
+      // callbackType omitted: allMatches is the Android default, and
+      // matchLost causes IllegalArgumentException on some GSI images.
+      final platformConfig = Platform.isAndroid
+          ? PlatformConfig(
+              android: AndroidOptions(
+                scanMode: AndroidScanMode.lowLatency,
+                matchMode: AndroidScanMatchMode.aggressive,
+                numOfMatches: AndroidScanNumOfMatches.max,
+              ),
+            )
+          : null;
+      await UniversalBle.startScan(
+        scanFilter: scanFilter,
+        platformConfig: platformConfig,
+      );
 
       // CoreBluetooth/BlueZ hide system-connected/bonded BLE devices from
       // scan results; query them explicitly so a DE1 paired via System

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1689,10 +1689,9 @@ packages:
   universal_ble:
     dependency: "direct main"
     description:
-      name: universal_ble
-      sha256: da15f61251299daf9c290bb8e40ded1e5313c4636fef6c796a7a656a06c93b4a
-      url: "https://pub.dev"
-    source: hosted
+      path: "/Users/vid/development/work/universal_ble"
+      relative: false
+    source: path
     version: "2.0.4"
   universal_image:
     dependency: transitive

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1689,9 +1689,11 @@ packages:
   universal_ble:
     dependency: "direct main"
     description:
-      path: "/Users/vid/development/work/universal_ble"
-      relative: false
-    source: path
+      path: "."
+      ref: d47c6a2
+      resolved-ref: d47c6a23d8552a615eca96b51f70a2699f4682bb
+      url: "https://github.com/tadelv/universal_ble.git"
+    source: git
     version: "2.0.4"
   universal_image:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,8 @@ dependencies:
   path_provider: ^2.1.5
   archive: ^4.0.7
   equatable: ^2.0.7
-  universal_ble: ^2.0.4
+  universal_ble:
+    path: /Users/vid/development/work/universal_ble
   shared_preferences: ^2.5.3
   # share_plus HELD at 12.x — 13.x requires win32 ^6, which conflicts with
   # file_picker 11's win32 ^5.9 pin. 13.x is only SDK-floor bumps, no API gain.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,9 @@ dependencies:
   archive: ^4.0.7
   equatable: ^2.0.7
   universal_ble:
-    path: /Users/vid/development/work/universal_ble
+    git:
+      url: https://github.com/tadelv/universal_ble.git
+      ref: d47c6a2
   shared_preferences: ^2.5.3
   # share_plus HELD at 12.x — 13.x requires win32 ^6, which conflicts with
   # file_picker 11's win32 ^5.9 pin. 13.x is only SDK-floor bumps, no API gain.

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -749,7 +749,6 @@ void main() {
       test(
           'auto-scans for preferred scale when machine is ready and scale is missing',
           () async {
-        connectionManager.preferredScaleReconnectDelay = Duration.zero;
         await settingsController.setPreferredScaleId('pref-scale');
         mockScanner.scanCompleter = Completer<void>();
 
@@ -1385,7 +1384,6 @@ void main() {
         mockScaleController.mockEmitConnectionState(ConnectionState.connected);
         mockScaleController.debugSetLastConnectedId('pref-scale');
         await settingsController.setPreferredScaleId('pref-scale');
-        connectionManager.preferredScaleReconnectDelay = Duration.zero;
         mockDe1Controller.de1Subject.add(fakeDe1);
         await Future<void>.delayed(Duration.zero);
         fakeDe1.emitState(MachineState.sleeping);
@@ -1408,7 +1406,6 @@ void main() {
       test('unexpected preferred scale disconnect keeps scanning and reconnects',
           () async {
         await settingsController.setPreferredScaleId('pref-scale');
-        connectionManager.preferredScaleReconnectDelay = Duration.zero;
         final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
         mockScaleController.mockEmitConnectionState(ConnectionState.connected);
         mockScaleController.debugSetLastConnectedId('pref-scale');
@@ -1435,7 +1432,6 @@ void main() {
           () async {
         await settingsController.setPreferredScaleId('pref-scale');
         await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
-        connectionManager.preferredScaleReconnectDelay = Duration.zero;
 
         final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
         mockScaleController.mockEmitConnectionState(ConnectionState.connected);
@@ -1476,7 +1472,6 @@ void main() {
           () async {
         await settingsController.setPreferredScaleId('pref-scale');
         await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
-        connectionManager.preferredScaleReconnectDelay = Duration.zero;
 
         final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
         mockScaleController.mockEmitConnectionState(ConnectionState.connected);


### PR DESCRIPTION
## Summary

Hardens the BLE connection stack after the universal_ble migration to eliminate unexpected scale disconnects on Android.

### Changes

**ReaPrime (this PR):**
- **Aggressive Android scan options** — `lowLatency`, `aggressive`, `max` disable chip-side advert de-duplication that previously throttled scan results 10×
- **Early scan stop** — scan now stops when both devices are found, even without a preferred machine configured (previously required `preferredMachineId`)
- **Exponential backoff** — scale reconnect uses 5s→10s→20s→40s→60s instead of fixed 5s; counter resets on connect or machine disconnect
- **Post-connect settle** — 200ms delay on Android before service discovery, matching the needs of tablet SoCs where the BLE stack finalises GATT asynchronously
- **MTU 517** — requested after connect (best-effort) to reduce GATT round-trips
- **Disconnect logging** — transport disconnects now logged at WARNING; TODO to surface native reason codes once the fork is published

**UniversalBLE fork (tadelv/universal_ble @ d47c6a2):**
- **GATT 133 retry** — up to 3 attempts with 500ms→1500ms backoff when the Android BLE stack reports GATT error on disconnect
- **connectionUpdateStream API** — new stream exposing `(deviceId, isConnected, error?)` so callers can log native disconnect reason codes

### Testing

Deployed to m50mini (Teclast tablet, GSI trebledroid). Two consecutive shots completed cleanly with stop-at-weight. Zero unexpected disconnects in the test window. Only disconnect was an expected sleep-triggered power-off.

### Before/After

| Metric | Before | After |
|--------|--------|-------|
| Unexpected disconnects (1h window) | 2 (one mid-shot) | 0 |
| Scan advert cadence | ~1 per 12s | ~1 per 1.3s (estimated) |
| Reconnect interval | Fixed 5s | 5s→60s exponential |
| Disconnect diagnostics | None | WARNING logged |