### PR TITLE
App update API for skins (#306)

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3740,6 +3740,24 @@ paths:
                   - appStore
                   - fullVersion
                   - localIp
+  /api/v1/update:
+    get:
+      summary: Get app update state
+      description: |
+        Returns a snapshot of the app-update state machine. Pure read — does
+        NOT trigger a network check (force a re-check via the
+        `/ws/v1/update` WebSocket `{"command":"check"}`).
+
+        `installable` is true only on Android AND when an update is available;
+        on other platforms hand the user off to `releaseUrl`.
+      tags: [System]
+      responses:
+        "200":
+          description: Current update state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppUpdateState'
   /api/v1/logs:
     get:
       summary: Get recent log entries
@@ -3929,6 +3947,43 @@ paths:
 
 components:
   schemas:
+    AppUpdateState:
+      type: object
+      description: Snapshot of the app-update state machine.
+      properties:
+        phase:
+          type: string
+          enum: [idle, checking, available, downloading, installing, error]
+        currentVersion:
+          type: string
+          description: The running app version.
+        latestVersion:
+          type: string
+          nullable: true
+          description: The offered version, once known.
+        releaseNotes:
+          type: string
+          nullable: true
+        releaseUrl:
+          type: string
+          description: Release tag URL when known, otherwise the releases page. Always present.
+        installable:
+          type: boolean
+          description: True only on Android AND when an update is available.
+        progress:
+          type: number
+          format: float
+          nullable: true
+          description: Download progress 0..1 while phase is downloading.
+        error:
+          type: string
+          nullable: true
+          description: Set while phase is error.
+      required:
+        - phase
+        - currentVersion
+        - releaseUrl
+        - installable
     Error:
       type: object
       properties:

--- a/assets/api/websocket_v1.yml
+++ b/assets/api/websocket_v1.yml
@@ -117,6 +117,23 @@ channels:
         $ref: '#/components/messages/DisplayState'
       displayCommand:
         $ref: '#/components/messages/DisplayCommand'
+  Update:
+    address: ws/v1/update
+    description: |
+      Bidirectional app-update channel. Emits an `AppUpdateState` snapshot on
+      connect and on every state change. Accepts commands:
+      - `{"command": "check"}` — force a re-poll of GitHub releases.
+      - `{"command": "install"}` — on Android: auto-check if needed, then
+        download + launch the system installer. On other platforms this is not
+        supported and replies with a transient `{"error", "url"}`.
+      Command-level problems (unknown command, unsupported platform) come back
+      as a direct `{"error": ...}` reply; operational outcomes (download/install
+      progress and failures) flow through the `AppUpdateState` stream.
+    messages:
+      updateState:
+        $ref: '#/components/messages/UpdateState'
+      updateCommand:
+        $ref: '#/components/messages/UpdateCommand'
 
 operations:
   machineSnapshot:
@@ -179,6 +196,18 @@ operations:
       $ref: '#/channels/Display'
     messages:
       - $ref: '#/channels/Display/messages/displayCommand'
+  updateState:
+    action: receive
+    channel:
+      $ref: '#/channels/Update'
+    messages:
+      - $ref: '#/channels/Update/messages/updateState'
+  updateCommand:
+    action: send
+    channel:
+      $ref: '#/channels/Update'
+    messages:
+      - $ref: '#/channels/Update/messages/updateCommand'
 
 components:
   messages:
@@ -256,6 +285,18 @@ components:
       summary: Command sent by the client to control display brightness and wake-lock.
       payload:
         $ref: '#/components/schemas/DisplayCommand'
+    UpdateState:
+      name: UpdateState
+      title: App update state
+      summary: Snapshot of the app-update state machine.
+      payload:
+        $ref: '#/components/schemas/AppUpdateState'
+    UpdateCommand:
+      name: UpdateCommand
+      title: App update command
+      summary: Command sent by the client to check for or install an app update.
+      payload:
+        $ref: '#/components/schemas/UpdateCommand'
   schemas:
     Error:
       type: object
@@ -264,6 +305,43 @@ components:
           type: string
         st:
           type: string
+    AppUpdateState:
+      type: object
+      description: Snapshot of the app-update state machine.
+      required: [phase, currentVersion, releaseUrl, installable]
+      properties:
+        phase:
+          type: string
+          enum: [idle, checking, available, downloading, installing, error]
+        currentVersion:
+          type: string
+        latestVersion:
+          type: string
+          nullable: true
+        releaseNotes:
+          type: string
+          nullable: true
+        releaseUrl:
+          type: string
+          description: Release tag URL when known, otherwise the releases page.
+        installable:
+          type: boolean
+          description: True only on Android AND when an update is available.
+        progress:
+          type: number
+          format: float
+          nullable: true
+          description: Download progress 0..1 while phase is downloading.
+        error:
+          type: string
+          nullable: true
+    UpdateCommand:
+      type: object
+      required: [command]
+      properties:
+        command:
+          type: string
+          enum: [check, install]
     ConnectionError:
       type: object
       required: [kind, severity, timestamp, message]

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -282,6 +282,7 @@ The **proxy** lets clients *use* the account without ever seeing the credentials
 | Method | Path | Description | Handler |
 |--------|------|-------------|---------|
 | GET | `/api/v1/info` | Build metadata (version, commit, branch) + gateway LAN IP (`localIp`) | `info_handler.dart` |
+| GET | `/api/v1/update` | App-update state snapshot (`phase`, `latestVersion`, `releaseNotes`, `releaseUrl`, `installable`). Pure read — no network call; force a re-check via `/ws/v1/update`. | `update_handler.dart` |
 | POST | `/api/v1/feedback` | Submit feedback (creates GitHub issue) | `feedback_handler.dart` |
 | GET | `/api/v1/logs` | Recent log entries | `logs_handler.dart` |
 | GET | `/api/v1/webview/logs` | WebView console log forwarding | `webview_logs_handler.dart` |
@@ -317,6 +318,7 @@ All WebSocket endpoints are on port 8080 at `/ws/v1/...`. See [`assets/api/webso
 | `/ws/v1/logs` | App log stream | Timestamped log entries |
 | `/ws/v1/webview/logs` | WebView console log stream | WebView console messages |
 | `/ws/v1/display` | Display state changes | Brightness, wakelock |
+| `/ws/v1/update` | App-update state stream. Also accepts `{"command":"check"}` and `{"command":"install"}` (Android installs; other platforms reply `{"error","url"}`). | `phase`, `progress`, `latestVersion`, `installable` |
 
 ### `connectionStatus.error`
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -293,6 +293,7 @@ Only registered when the app is launched with `--dart-define=simulate=1`. Return
 
 | Method | Endpoint | Description | Handler |
 |--------|----------|-------------|---------|
+| POST | `/api/v1/debug/update/force` | Force a fake "update available" so the update API/UI can be tested without a real newer release. Optional query: `version` (default `99.0.0`), `downloadUrl` (default = real latest APK, so the download/install path runs end-to-end). | `debug_handler.dart` |
 | POST | `/api/v1/debug/scale/stall` | Pause mock scale weight emission (stays "connected") | `debug_handler.dart` |
 | POST | `/api/v1/debug/scale/resume` | Resume weight emission after stall | `debug_handler.dart` |
 | POST | `/api/v1/debug/scale/disconnect` | Simulate scale disconnect (emits disconnected state, stops data) | `debug_handler.dart` |

--- a/doc/plans/archive/app-update-api/app-update-api.md
+++ b/doc/plans/archive/app-update-api/app-update-api.md
@@ -1,0 +1,118 @@
+# App Update API (#306)
+
+**Issue:** [#306](https://github.com/tadelv/reaprime/issues/306) — "API support for updating Decent.app." User (Mark) wants a skin to be able to trigger an app update.
+
+**Branch:** `feature/app-update-api` → PR to `main`.
+
+## Goal
+
+Expose the existing update machinery (`UpdateCheckService` + `AndroidUpdater`) over the REST/WebSocket API so a WebUI skin can:
+1. read whether an update is available (version, notes, release URL), and
+2. trigger download + install on Android (other platforms hand off a GitHub URL).
+
+## Surface
+
+One source of truth — a single `AppUpdateState` stream owned by `UpdateCheckService` — exposed two ways:
+
+| Surface | Route | Role |
+|---|---|---|
+| Read | `GET /api/v1/update` | snapshot of current `AppUpdateState` (pure read, **no** network call) |
+| Live + control | `GET /ws/v1/update` (WebSocket) | streams state changes; accepts inbound `{command}` frames |
+
+Modeled on `devices_handler` (`devices_handler.dart:355+`): a WS that streams state snapshots **and** accepts `{command: ...}` inbound, with REST kept for the cheap one-shot read.
+
+### WebSocket commands
+
+```jsonc
+{"command": "check"}     // force re-poll GitHub releases
+{"command": "install"}   // Android: auto-check-if-needed -> download -> install
+                         // other:   transient {error, url}
+```
+
+- **`install` auto-checks**: if phase is `idle` (no known update), it runs the check first; if an update is found it proceeds, otherwise it settles back to `idle` (already latest). One call does the whole job.
+- **Coalesce duplicates**: a command received while `checking`/`downloading`/`installing` is a no-op (re-emit current state). Single in-flight op (mirrors the queue-with-coalesce idiom in `ConnectionManager`).
+
+### State model (new)
+
+```dart
+enum AppUpdatePhase { idle, checking, available, downloading, installing, error }
+
+class AppUpdateState {
+  final AppUpdatePhase phase;
+  final String  currentVersion;   // BuildInfo.version
+  final String? latestVersion;    // set once known (>= available)
+  final String? releaseNotes;
+  final String  releaseUrl;       // tag URL when known, else releases page
+  final bool    installable;      // Platform.isAndroid && update available
+  final double? progress;         // 0..1 while downloading
+  final String? error;            // set in phase == error
+  Map<String, dynamic> toJson();
+}
+```
+
+### Error channel split (mirrors `devices_handler`)
+
+- **Command-level** (unknown command, missing field, non-Android `install` not supported) → transient direct socket reply `{"error": "...", "url": "..."}`, **state stream untouched**.
+- **Operational** (download/install failure, install-permission missing) → `AppUpdateState{phase: error, error: ...}` in the stream, so `GET` and a reconnecting WS both see it.
+
+## Security
+
+**No new auth.** The whole `/api/v1/*` + `/ws/v1/*` surface runs on the documented LAN-trust model (only `/api/v1/account/proxy/` is token-gated, per `proxy_auth_middleware.dart`). Rationale:
+- The APK source is hardcoded (`owner: 'tadelv', repo: 'reaprime'`) — install can only ever fetch an official signed release, not arbitrary code.
+- Android install still goes through the OS `REQUEST_INSTALL_PACKAGES` confirmation dialog — **not silent**; a human at the tablet must tap "Install."
+- DE1 machine control is already unauthenticated on the same API, so this is not the weakest link.
+
+**Flag for the existing "put the whole API behind auth" TODO** — when that lands, this endpoint must be in scope; do not special-case it.
+
+## Changes
+
+### 1. `AppUpdateState` model (new file)
+`lib/src/services/app_update_state.dart` — enum + immutable class + `toJson()`.
+
+### 2. `UpdateCheckService` (extend — single source of truth)
+- Replace the `_availableUpdate` field with `BehaviorSubject<AppUpdateState>`.
+- Keep `availableUpdate` / `hasAvailableUpdate` getters as **thin wrappers** over the subject's value → `main.dart` `AppLifecycleObserver` and `update_dialog.dart` callers keep compiling unchanged (surgical: no UI edits).
+- Add `Stream<AppUpdateState> get updateState` (+ sync `value` getter for GET).
+- Add `Future<void> downloadAndInstall()`: drives `checking?` → `downloading{progress}` → `installing`, emitting on each transition; coalesces if already running; non-Android → no-op + signal not-supported to caller (handler turns it into the transient socket error).
+- `checkForUpdate()` updates the state stream (`checking` → `available` / `idle` / `error`).
+
+### 3. `AndroidUpdater.downloadUpdate()` (fix)
+Rewrite to a **streamed** download (`client.send()` + accumulate bytes against `Content-Length`) so `onProgress(0..1)` actually fires. Currently it reads `response.bodyBytes` whole and never calls `onProgress`. Also improves the in-app dialog (indeterminate → real bar) for free, but **no dialog edits in this PR**.
+
+### 4. `UpdateHandler` (new handler)
+`lib/src/services/webserver/update_handler.dart` — standalone handler (like `InfoHandler`), constructor takes `UpdateCheckService`.
+- `GET /api/v1/update` → `jsonOk(service.updateState.value.toJson())`.
+- `GET /ws/v1/update` → forward `service.updateState` to the socket; `socket.stream.listen` → `_handleCommand` (check / install) following the `devices_handler` shape exactly.
+
+### 5. Wiring
+- `webserver_service.dart`: add `UpdateCheckService? updateCheckService` named param to `startWebServer(...)`, thread to `_init`, instantiate `UpdateHandler`, `addRoutes(app)`.
+- `main.dart`: pass the existing `updateCheckService` into the `startWebServer(...)` call.
+
+### 6. Spec + docs (required, same PR)
+- `assets/api/rest_v1.yml` — `GET /api/v1/update`.
+- `assets/api/websocket_v1.yml` — `/ws/v1/update` topic + command frames.
+- `doc/Api.md` — user-facing endpoint + command reference.
+
+### 7. Obsidian
+Add a proper `#306` TODO entry under the ReaPrime TODO note (currently only in the sync-log line).
+
+## Testing
+
+| Tier | What |
+|---|---|
+| Unit | `UpdateCheckService` state machine: check → available/idle/error; `install` auto-check path; coalesce; non-Android `install` → not-supported. Mock `AndroidUpdater`. |
+| Unit | `AndroidUpdater.downloadUpdate` streamed progress: fake streamed `http.Client`, assert `onProgress` monotonic 0→1. |
+| Unit | `UpdateHandler`: GET returns snapshot; WS emits snapshot on connect; unknown command → `{error}`; non-Android install → `{error,url}`. |
+| End-to-end | `sb-dev` (macOS) + `websocat ws://localhost:8080/ws/v1/update`: connect → snapshot frame; `{command:"check"}` → `checking`→`idle`; `{command:"install"}` → transient `{error: not installable, url}` (macOS isn't Android). `curl /api/v1/update` → snapshot. |
+
+Android real-install path can't be exercised in sim — note as manual-on-tablet follow-up (not a release gate for the API itself, but call it out).
+
+## Out of scope (deliberately deferred)
+- `skip` / `setChannel` WS commands (YAGNI — issue asks only for "trigger update").
+- Auth (folded into the global "API behind auth" TODO).
+- Migrating `update_dialog.dart` to the state stream (works as-is via callbacks).
+- Self-update install on macOS/iOS/Linux/Windows (platform can't; URL hand-off only).
+
+## Open follow-ups
+- When global API auth lands, include `/api/v1/update` + `/ws/v1/update`.
+- Optional later: migrate the in-app dialog to read `updateState` (removes the callback plumbing).

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -471,6 +471,14 @@ void main() async {
   );
   displayController.initialize();
 
+  // Update check service — constructed before the web server so the update
+  // API (/api/v1/update, /ws/v1/update) shares its state. initialize() is
+  // still deferred below.
+  final updateCheckService = UpdateCheckService(
+    settingsService: SharedPreferencesSettingsService(),
+    webUIStorage: webUIStorage,
+  );
+
   try {
     await startWebServer(
       deviceController,
@@ -497,6 +505,7 @@ void main() async {
       decentAccountService: decentAccountService,
       decentProxyService: decentProxyService,
       proxyTokenService: proxyTokenService,
+      updateCheckService: updateCheckService,
     );
   } catch (e, st) {
     log.severe('failed to start web server', e, st);
@@ -532,11 +541,7 @@ void main() async {
       ) ??
       Level.FINE;
 
-  // Initialize update check service
-  final updateCheckService = UpdateCheckService(
-    settingsService: SharedPreferencesSettingsService(),
-    webUIStorage: webUIStorage,
-  );
+  // Defer the first update check / skin sync (service constructed above).
   Future.delayed(Duration(minutes: 10), () async {
     await updateCheckService.initialize();
   });

--- a/lib/src/services/android_updater.dart
+++ b/lib/src/services/android_updater.dart
@@ -152,27 +152,42 @@ class AndroidUpdater {
   }
 
   /// Download an APK file and save it to the app's cache directory
-  /// 
+  ///
   /// [updateInfo] - The update information containing the download URL
-  /// [onProgress] - Optional callback for download progress (0.0 to 1.0)
-  /// 
+  /// [onProgress] - Optional callback for download progress (0.0 to 1.0).
+  ///   Only fires when the server reports a Content-Length.
+  /// [cacheDir] - Target directory (defaults to the app temp dir); injected
+  ///   in tests to avoid the path_provider platform channel.
+  ///
   /// Returns the path to the downloaded APK file
   Future<String> downloadUpdate(
     UpdateInfo updateInfo, {
     Function(double progress)? onProgress,
+    Directory? cacheDir,
   }) async {
     try {
       _log.info('Downloading update from ${updateInfo.downloadUrl}');
 
-      final response = await _httpClient.get(Uri.parse(updateInfo.downloadUrl));
+      final request = http.Request('GET', Uri.parse(updateInfo.downloadUrl));
+      final response = await _httpClient.send(request);
 
       if (response.statusCode != 200) {
         throw Exception('Failed to download update: ${response.statusCode}');
       }
 
-      final bytes = response.bodyBytes;
-      final cacheDir = await getTemporaryDirectory();
-      final apkPath = '${cacheDir.path}/update_${updateInfo.version}.apk';
+      final total = response.contentLength;
+      final bytes = <int>[];
+      var received = 0;
+      await for (final chunk in response.stream) {
+        bytes.addAll(chunk);
+        received += chunk.length;
+        if (onProgress != null && total != null && total > 0) {
+          onProgress(received / total);
+        }
+      }
+
+      final dir = cacheDir ?? await getTemporaryDirectory();
+      final apkPath = '${dir.path}/update_${updateInfo.version}.apk';
       final apkFile = File(apkPath);
 
       await apkFile.writeAsBytes(bytes);

--- a/lib/src/services/app_update_state.dart
+++ b/lib/src/services/app_update_state.dart
@@ -1,0 +1,96 @@
+/// Phases of the app-update lifecycle, surfaced over the API
+/// (`GET /api/v1/update` and `GET /ws/v1/update`).
+enum AppUpdatePhase {
+  /// No update known (either not checked yet, or already on the latest).
+  idle,
+
+  /// A check against GitHub releases is in progress.
+  checking,
+
+  /// An update is available but no download has started.
+  available,
+
+  /// The update APK is downloading ([AppUpdateState.progress] is set).
+  downloading,
+
+  /// The system package installer has been launched.
+  installing,
+
+  /// The last operation failed ([AppUpdateState.error] is set).
+  error,
+}
+
+/// Immutable snapshot of the app-update state machine.
+///
+/// One source of truth lives in `UpdateCheckService` as a `BehaviorSubject`
+/// of this type; the REST snapshot and the WebSocket stream both read it.
+class AppUpdateState {
+  final AppUpdatePhase phase;
+
+  /// The currently running app version (`BuildInfo.version`).
+  final String currentVersion;
+
+  /// The latest version offered, once known (phase >= available).
+  final String? latestVersion;
+
+  /// Release notes for [latestVersion], if any.
+  final String? releaseNotes;
+
+  /// Where the user can get the release: the specific tag URL when known,
+  /// otherwise the releases page. Always present so a skin can hand off.
+  final String releaseUrl;
+
+  /// Whether this platform can install the update in-app (Android only) AND
+  /// an update is currently available.
+  final bool installable;
+
+  /// Download progress 0..1 while [phase] is downloading; null otherwise.
+  final double? progress;
+
+  /// Human-readable error message while [phase] is error; null otherwise.
+  final String? error;
+
+  const AppUpdateState({
+    required this.phase,
+    required this.currentVersion,
+    required this.releaseUrl,
+    required this.installable,
+    this.latestVersion,
+    this.releaseNotes,
+    this.progress,
+    this.error,
+  });
+
+  AppUpdateState copyWith({
+    AppUpdatePhase? phase,
+    String? currentVersion,
+    String? latestVersion,
+    String? releaseNotes,
+    String? releaseUrl,
+    bool? installable,
+    double? progress,
+    String? error,
+  }) {
+    return AppUpdateState(
+      phase: phase ?? this.phase,
+      currentVersion: currentVersion ?? this.currentVersion,
+      latestVersion: latestVersion ?? this.latestVersion,
+      releaseNotes: releaseNotes ?? this.releaseNotes,
+      releaseUrl: releaseUrl ?? this.releaseUrl,
+      installable: installable ?? this.installable,
+      progress: progress ?? this.progress,
+      error: error ?? this.error,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'phase': phase.name,
+        'currentVersion': currentVersion,
+        'latestVersion': latestVersion,
+        'releaseNotes': releaseNotes,
+        'releaseUrl': releaseUrl,
+        'installable': installable,
+        'progress': progress,
+        'error': error,
+      };
+}

--- a/lib/src/services/update_check_service.dart
+++ b/lib/src/services/update_check_service.dart
@@ -112,9 +112,17 @@ class UpdateCheckService {
     final update = _availableUpdate!;
     try {
       _emit(AppUpdatePhase.downloading, progress: 0);
+      // Throttle to ~1% steps — the raw callback fires per network chunk
+      // (thousands of times for a multi-MB APK), which would flood the WS.
+      var lastEmitted = 0.0;
       final path = await _updater.downloadUpdate(
         update,
-        onProgress: (p) => _emit(AppUpdatePhase.downloading, progress: p),
+        onProgress: (p) {
+          if (p - lastEmitted >= 0.01 || p >= 1.0) {
+            lastEmitted = p;
+            _emit(AppUpdatePhase.downloading, progress: p);
+          }
+        },
       );
 
       _emit(AppUpdatePhase.installing);
@@ -249,15 +257,21 @@ class UpdateCheckService {
   }
 
   /// Force an update to appear for testing. Only use in debug builds.
-  void debugForceUpdate() {
-    _log.info('DEBUG: forcing fake update notification');
+  ///
+  /// [downloadUrl] points at a real APK so the download/install path can be
+  /// exercised end-to-end; defaults to the latest released Android APK.
+  void debugForceUpdate({
+    String version = '99.0.0',
+    String? downloadUrl,
+  }) {
+    _log.info('DEBUG: forcing fake update notification ($version)');
     _availableUpdate = UpdateInfo(
-      version: '99.0.0',
-      downloadUrl:
-          'https://github.com/tadelv/reaprime/releases/latest',
-      releaseNotes: 'Fake update for testing the download banner.',
+      version: version,
+      downloadUrl: downloadUrl ??
+          'https://github.com/tadelv/reaprime/releases/download/v0.7.7/decent-android-0.7.7.apk',
+      releaseNotes: 'Forced update for testing the update API.',
       isPrerelease: false,
-      tagName: 'v99.0.0',
+      tagName: 'v$version',
     );
     _emit(AppUpdatePhase.available);
   }

--- a/lib/src/services/update_check_service.dart
+++ b/lib/src/services/update_check_service.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:logging/logging.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/services/android_updater.dart';
+import 'package:reaprime/src/services/app_update_state.dart';
 import 'package:reaprime/src/settings/settings_service.dart';
 import 'package:reaprime/src/webui_support/webui_storage.dart';
 
@@ -13,24 +16,121 @@ class UpdateCheckService {
   final AndroidUpdater _updater;
   final WebUIStorage _webUIStorage;
 
+  /// Whether this platform can install an update in-app (Android only).
+  /// Injectable so the state machine is testable off-device.
+  final bool _isAndroid;
+
   Timer? _periodicTimer;
   UpdateInfo? _availableUpdate;
-  
+
+  /// Single source of truth for the API surface (`/api/v1/update`,
+  /// `/ws/v1/update`). Derived from [_availableUpdate] plus the current phase.
+  late final BehaviorSubject<AppUpdateState> _state;
+
   static const Duration _checkInterval = (String.fromEnvironment("simulate") == "1") ? Duration(hours: 1) : Duration(hours: 12);
 
   UpdateCheckService({
     required SettingsService settingsService,
     AndroidUpdater? updater,
     required WebUIStorage webUIStorage,
+    bool? platformIsAndroid,
   })  : _settingsService = settingsService,
         _updater = updater ?? AndroidUpdater(owner: 'tadelv', repo: 'reaprime'),
-        _webUIStorage = webUIStorage;
+        _webUIStorage = webUIStorage,
+        _isAndroid = platformIsAndroid ?? Platform.isAndroid {
+    _state = BehaviorSubject.seeded(_snapshot(AppUpdatePhase.idle));
+  }
 
   /// Get the currently available update, if any
   UpdateInfo? get availableUpdate => _availableUpdate;
 
   /// Check if there's an available update
   bool get hasAvailableUpdate => _availableUpdate != null;
+
+  /// Live app-update state for the API (replays the latest value on listen).
+  Stream<AppUpdateState> get updateState => _state.stream;
+
+  /// Synchronous snapshot of the current app-update state (for the REST read).
+  AppUpdateState get currentState => _state.value;
+
+  /// Whether an in-app install can be triggered on this platform.
+  bool get canInstall => _isAndroid;
+
+  /// Build an [AppUpdateState] for [phase] from the current [_availableUpdate].
+  AppUpdateState _snapshot(
+    AppUpdatePhase phase, {
+    double? progress,
+    String? error,
+  }) {
+    final update = _availableUpdate;
+    final hasUpdate = update != null;
+    return AppUpdateState(
+      phase: phase,
+      currentVersion: BuildInfo.version,
+      latestVersion: update?.version,
+      releaseNotes: update?.releaseNotes,
+      releaseUrl: hasUpdate ? getReleaseUrl()! : getReleasesUrl(),
+      installable: _isAndroid && hasUpdate,
+      progress: progress,
+      error: error,
+    );
+  }
+
+  void _emit(AppUpdatePhase phase, {double? progress, String? error}) {
+    _state.add(_snapshot(phase, progress: progress, error: error));
+  }
+
+  bool get _inProgress => const {
+        AppUpdatePhase.checking,
+        AppUpdatePhase.downloading,
+        AppUpdatePhase.installing,
+      }.contains(_state.value.phase);
+
+  /// API command: force a re-check. No-op (coalesced) if an operation is
+  /// already in flight.
+  Future<void> requestCheck() async {
+    if (_inProgress) return;
+    await checkForUpdate();
+  }
+
+  /// API command: ensure an update is known (auto-checking if needed), then
+  /// download and launch the system installer. No-op (coalesced) if an
+  /// operation is already in flight. Only call when [canInstall] is true.
+  Future<void> downloadAndInstall() async {
+    if (_inProgress) return;
+    if (!_isAndroid) return;
+
+    // Auto-check if we have no known update yet.
+    if (_availableUpdate == null) {
+      await checkForUpdate();
+      if (_availableUpdate == null) {
+        // Already on the latest (checkForUpdate settled to idle).
+        return;
+      }
+    }
+
+    final update = _availableUpdate!;
+    try {
+      _emit(AppUpdatePhase.downloading, progress: 0);
+      final path = await _updater.downloadUpdate(
+        update,
+        onProgress: (p) => _emit(AppUpdatePhase.downloading, progress: p),
+      );
+
+      _emit(AppUpdatePhase.installing);
+      final started = await _updater.installUpdate(path);
+      if (!started) {
+        _emit(
+          AppUpdatePhase.error,
+          error: 'Installation permission required. Grant it and retry.',
+        );
+      }
+      // On success the OS installer takes over; the process is replaced.
+    } catch (e, st) {
+      _log.severe('Update download/install failed', e, st);
+      _emit(AppUpdatePhase.error, error: 'Update failed: $e');
+    }
+  }
 
   /// Initialize the service and start periodic checks
   Future<void> initialize() async {
@@ -80,6 +180,7 @@ class UpdateCheckService {
   /// Manually check for updates
   Future<UpdateInfo?> checkForUpdate() async {
     try {
+      _emit(AppUpdatePhase.checking);
       _log.info('Checking for updates (current: ${BuildInfo.version})');
 
       final updateInfo = await _updater.checkForUpdate(
@@ -106,9 +207,13 @@ class UpdateCheckService {
         _availableUpdate = null;
       }
 
+      _emit(_availableUpdate != null
+          ? AppUpdatePhase.available
+          : AppUpdatePhase.idle);
       return updateInfo;
     } catch (e, stackTrace) {
       _log.warning('Error checking for updates', e, stackTrace);
+      _emit(AppUpdatePhase.error, error: 'Update check failed: $e');
       return null;
     }
   }
@@ -140,6 +245,7 @@ class UpdateCheckService {
   /// Clear the available update notification
   void clearAvailableUpdate() {
     _availableUpdate = null;
+    _emit(AppUpdatePhase.idle);
   }
 
   /// Force an update to appear for testing. Only use in debug builds.
@@ -153,6 +259,7 @@ class UpdateCheckService {
       isPrerelease: false,
       tagName: 'v99.0.0',
     );
+    _emit(AppUpdatePhase.available);
   }
 
   /// Skip the current update version permanently
@@ -163,11 +270,13 @@ class UpdateCheckService {
       await _settingsService.setSkippedVersion(version);
     }
     _availableUpdate = null;
+    _emit(AppUpdatePhase.idle);
   }
 
   /// Dispose of resources
   void dispose() {
     _periodicTimer?.cancel();
     _updater.dispose();
+    _state.close();
   }
 }

--- a/lib/src/services/webserver/debug_handler.dart
+++ b/lib/src/services/webserver/debug_handler.dart
@@ -1,6 +1,7 @@
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
 import 'package:reaprime/src/models/device/impl/mock_scale/mock_scale.dart';
+import 'package:reaprime/src/services/update_check_service.dart';
 import 'package:reaprime/src/services/webserver/json_response.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
@@ -8,12 +9,32 @@ import 'package:shelf_plus/shelf_plus.dart';
 /// Only registered when running in simulate mode.
 class DebugHandler {
   final ScaleController _scaleController;
+  final UpdateCheckService? _updateCheckService;
   final Logger _log = Logger('DebugHandler');
 
-  DebugHandler({required ScaleController scaleController})
-      : _scaleController = scaleController;
+  DebugHandler({
+    required ScaleController scaleController,
+    UpdateCheckService? updateCheckService,
+  })  : _scaleController = scaleController,
+        _updateCheckService = updateCheckService;
 
   void addRoutes(RouterPlus app) {
+    // Force a fake "update available" so the update API/UI can be tested
+    // without a real newer release. `version`/`downloadUrl` query params
+    // override the defaults (default downloadUrl is a real APK so the
+    // download/install path runs end-to-end).
+    app.post('/api/v1/debug/update/force', (request) {
+      final svc = _updateCheckService;
+      if (svc == null) {
+        return jsonBadRequest({'error': 'UpdateCheckService unavailable'});
+      }
+      final version = request.url.queryParameters['version'] ?? '99.0.0';
+      final downloadUrl = request.url.queryParameters['downloadUrl'];
+      svc.debugForceUpdate(version: version, downloadUrl: downloadUrl);
+      _log.info('Forced update available: $version');
+      return jsonOk(svc.currentState.toJson());
+    });
+
     app.post('/api/v1/debug/scale/<command>', (request, command) async {
       final MockScale mock;
       try {

--- a/lib/src/services/webserver/update_handler.dart
+++ b/lib/src/services/webserver/update_handler.dart
@@ -1,0 +1,91 @@
+part of '../webserver_service.dart';
+
+/// App-update API: a thin REST read plus a live WebSocket that streams
+/// [AppUpdateState] and accepts `{command}` frames. Backed entirely by
+/// [UpdateCheckService] (single source of truth).
+///
+/// - `GET /api/v1/update`  — current state snapshot (no network call).
+/// - `GET /ws/v1/update`   — streams state; accepts `{"command":"check"}` and
+///   `{"command":"install"}`.
+///
+/// Command-level problems (bad command, unsupported platform) are reported as
+/// a transient direct socket reply `{"error": ...}`; operational outcomes flow
+/// through the state stream as `phase: error`. Mirrors `DevicesHandler`.
+class UpdateHandler {
+  final UpdateCheckService _service;
+  final log = Logger("UpdateHandler");
+
+  UpdateHandler({required UpdateCheckService service}) : _service = service;
+
+  void addRoutes(RouterPlus app) {
+    app.get('/api/v1/update', _getUpdate);
+    app.get('/ws/v1/update', sws.webSocketHandler(_handleSocket));
+  }
+
+  Response _getUpdate(Request request) {
+    return jsonOk(_service.currentState.toJson());
+  }
+
+  void _handleSocket(WebSocketChannel socket, String? protocol) {
+    log.fine("update websocket connected");
+
+    final sub = _service.updateState.listen((state) {
+      try {
+        socket.sink.add(jsonEncode(state.toJson()));
+      } catch (e, st) {
+        log.warning("failed to send update state", e, st);
+      }
+    });
+
+    socket.stream.listen(
+      (message) {
+        try {
+          final data = jsonDecode(message.toString()) as Map<String, dynamic>;
+          handleCommand(data, (obj) => socket.sink.add(jsonEncode(obj)));
+        } catch (e) {
+          socket.sink.add(jsonEncode({'error': 'Invalid JSON: $e'}));
+        }
+      },
+      onDone: () {
+        log.fine("update websocket disconnected");
+        sub.cancel();
+      },
+      onError: (e, st) {
+        log.warning("update websocket error", e, st);
+        sub.cancel();
+      },
+    );
+  }
+
+  /// Dispatch an inbound `{command}` frame. [reply] sends a transient
+  /// command-level response back to the caller (operational outcomes flow
+  /// through the state stream instead). Public for testing.
+  void handleCommand(
+    Map<String, dynamic> data,
+    void Function(Map<String, dynamic>) reply,
+  ) {
+    final command = data['command'] as String?;
+    if (command == null) {
+      reply({'error': 'Missing "command" field'});
+      return;
+    }
+
+    switch (command) {
+      case 'check':
+        _service.requestCheck();
+
+      case 'install':
+        if (!_service.canInstall) {
+          reply({
+            'error': 'In-app install is not supported on this platform',
+            'url': _service.currentState.releaseUrl,
+          });
+          return;
+        }
+        _service.downloadAndInstall();
+
+      default:
+        reply({'error': 'Unknown command: $command'});
+    }
+  }
+}

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -258,7 +258,10 @@ Future<void> startWebServer(
   DebugHandler? debugHandler;
   const simulateEnv = String.fromEnvironment("simulate");
   if (simulateEnv.isNotEmpty) {
-    debugHandler = DebugHandler(scaleController: scaleController);
+    debugHandler = DebugHandler(
+      scaleController: scaleController,
+      updateCheckService: updateCheckService,
+    );
   }
 
   // Start server

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -75,6 +75,8 @@ import 'package:reaprime/src/settings/charging_mode.dart';
 import 'package:reaprime/src/models/wake_schedule.dart';
 import 'package:reaprime/src/services/webview_log_service.dart';
 import 'package:reaprime/build_info.dart';
+import 'package:reaprime/src/services/update_check_service.dart';
+import 'package:reaprime/src/services/app_update_state.dart';
 import 'package:reaprime/src/services/webserver/info_handler.dart';
 import 'package:reaprime/src/services/webserver/debug_handler.dart';
 import 'package:reaprime/src/services/webserver/wifi_scale_handler.dart';
@@ -100,6 +102,7 @@ part 'webserver/presence_handler.dart';
 part 'webserver/display_handler.dart';
 part 'webserver/account_handler.dart';
 part 'webserver/account_proxy_handler.dart';
+part 'webserver/update_handler.dart';
 
 final log = Logger("Webservice");
 
@@ -128,6 +131,7 @@ Future<void> startWebServer(
   DecentAccountService? decentAccountService,
   DecentProxyService? decentProxyService,
   ProxyTokenService? proxyTokenService,
+  UpdateCheckService? updateCheckService,
 }) async {
   log.info("starting webserver");
   final de1Handler = De1Handler(
@@ -243,6 +247,10 @@ Future<void> startWebServer(
 
   final infoHandler = InfoHandler();
 
+  final updateHandler = updateCheckService == null
+      ? null
+      : UpdateHandler(service: updateCheckService);
+
   final wifiScaleHandler = wifiScaleDiscoveryService == null
       ? null
       : WifiScaleHandler(service: wifiScaleDiscoveryService);
@@ -283,6 +291,7 @@ Future<void> startWebServer(
       infoHandler,
       debugHandler,
       wifiScaleHandler,
+      updateHandler,
     ),
     '0.0.0.0',
     8080,
@@ -322,6 +331,7 @@ Handler _init(
   InfoHandler infoHandler,
   DebugHandler? debugHandler,
   WifiScaleHandler? wifiScaleHandler,
+  UpdateHandler? updateHandler,
 ) {
   log.info("called _init");
   var app = Router().plus;
@@ -363,6 +373,7 @@ Handler _init(
     grindersHandler.addRoutes(app);
   }
   infoHandler.addRoutes(app);
+  updateHandler?.addRoutes(app);
   if (debugHandler != null) {
     debugHandler.addRoutes(app);
   }

--- a/test/android_updater_download_test.dart
+++ b/test/android_updater_download_test.dart
@@ -1,0 +1,106 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:reaprime/src/services/android_updater.dart';
+
+void main() {
+  group('AndroidUpdater.downloadUpdate streamed progress', () {
+    late Directory tmp;
+
+    setUp(() {
+      tmp = Directory.systemTemp.createTempSync('updater_test');
+    });
+
+    tearDown(() {
+      if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+    });
+
+    UpdateInfo info() => UpdateInfo(
+          version: '1.2.3',
+          downloadUrl: 'https://example.com/app.apk',
+          releaseNotes: '',
+          isPrerelease: false,
+          tagName: 'v1.2.3',
+        );
+
+    test('reports monotonic progress ending at 1.0 and writes the file',
+        () async {
+      final chunks = <List<int>>[
+        List.filled(40, 0),
+        List.filled(40, 1),
+        List.filled(20, 2),
+      ];
+      const total = 100;
+
+      final client = MockClient.streaming((request, body) async {
+        return http.StreamedResponse(
+          Stream.fromIterable(chunks),
+          200,
+          contentLength: total,
+        );
+      });
+
+      final updater = AndroidUpdater(
+        owner: 'tadelv',
+        repo: 'reaprime',
+        httpClient: client,
+      );
+
+      final progress = <double>[];
+      final path = await updater.downloadUpdate(
+        info(),
+        cacheDir: tmp,
+        onProgress: progress.add,
+      );
+
+      expect(progress, isNotEmpty);
+      expect(progress.last, closeTo(1.0, 1e-9));
+      // monotonic non-decreasing
+      for (var i = 1; i < progress.length; i++) {
+        expect(progress[i], greaterThanOrEqualTo(progress[i - 1]));
+      }
+
+      final file = File(path);
+      expect(file.existsSync(), isTrue);
+      expect(file.lengthSync(), total);
+    });
+
+    test('throws on non-200 response', () async {
+      final client = MockClient.streaming((request, body) async {
+        return http.StreamedResponse(const Stream.empty(), 404);
+      });
+      final updater = AndroidUpdater(
+        owner: 'tadelv',
+        repo: 'reaprime',
+        httpClient: client,
+      );
+
+      expect(
+        () => updater.downloadUpdate(info(), cacheDir: tmp),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('omits progress when Content-Length is unknown', () async {
+      final client = MockClient.streaming((request, body) async {
+        return http.StreamedResponse(
+          Stream.fromIterable([List.filled(10, 0)]),
+          200, // no contentLength
+        );
+      });
+      final updater = AndroidUpdater(
+        owner: 'tadelv',
+        repo: 'reaprime',
+        httpClient: client,
+      );
+
+      final progress = <double>[];
+      await updater.downloadUpdate(info(), cacheDir: tmp,
+          onProgress: progress.add);
+
+      expect(progress, isEmpty);
+    });
+  });
+}

--- a/test/app_update_state_test.dart
+++ b/test/app_update_state_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/app_update_state.dart';
+
+void main() {
+  group('AppUpdateState', () {
+    test('toJson emits phase name and all fields', () {
+      const state = AppUpdateState(
+        phase: AppUpdatePhase.available,
+        currentVersion: '0.6.1',
+        latestVersion: '0.6.2',
+        releaseNotes: 'notes',
+        releaseUrl: 'https://github.com/tadelv/reaprime/releases/tag/v0.6.2',
+        installable: true,
+        progress: null,
+        error: null,
+      );
+
+      expect(state.toJson(), {
+        'phase': 'available',
+        'currentVersion': '0.6.1',
+        'latestVersion': '0.6.2',
+        'releaseNotes': 'notes',
+        'releaseUrl': 'https://github.com/tadelv/reaprime/releases/tag/v0.6.2',
+        'installable': true,
+        'progress': null,
+        'error': null,
+      });
+    });
+
+    test('idle snapshot keeps nullable fields null', () {
+      const state = AppUpdateState(
+        phase: AppUpdatePhase.idle,
+        currentVersion: '0.6.1',
+        releaseUrl: 'https://github.com/tadelv/reaprime/releases',
+        installable: false,
+      );
+
+      final json = state.toJson();
+      expect(json['phase'], 'idle');
+      expect(json['latestVersion'], isNull);
+      expect(json['progress'], isNull);
+      expect(json['error'], isNull);
+      expect(json['installable'], false);
+    });
+
+    test('copyWith overrides only provided fields', () {
+      const base = AppUpdateState(
+        phase: AppUpdatePhase.available,
+        currentVersion: '0.6.1',
+        latestVersion: '0.6.2',
+        releaseUrl: 'https://example/tag',
+        installable: true,
+      );
+
+      final downloading =
+          base.copyWith(phase: AppUpdatePhase.downloading, progress: 0.5);
+
+      expect(downloading.phase, AppUpdatePhase.downloading);
+      expect(downloading.progress, 0.5);
+      expect(downloading.latestVersion, '0.6.2');
+      expect(downloading.installable, true);
+    });
+  });
+}

--- a/test/update_check_service_test.dart
+++ b/test/update_check_service_test.dart
@@ -1,0 +1,247 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/android_updater.dart';
+import 'package:reaprime/src/services/app_update_state.dart';
+import 'package:reaprime/src/services/update_check_service.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/webui_support/webui_storage.dart';
+
+import 'helpers/mock_settings_service.dart';
+
+class _FakeUpdater extends AndroidUpdater {
+  _FakeUpdater() : super(owner: 'tadelv', repo: 'reaprime');
+
+  UpdateInfo? nextCheck;
+  bool throwOnCheck = false;
+  bool throwOnDownload = false;
+  bool installResult = true;
+  List<double> progressToEmit = const [];
+
+  int checkCalls = 0;
+  int downloadCalls = 0;
+  int installCalls = 0;
+
+  /// Gate to hold a download open for coalesce tests.
+  Completer<void>? downloadGate;
+
+  @override
+  Future<UpdateInfo?> checkForUpdate(
+    String currentVersion, {
+    UpdateChannel channel = UpdateChannel.stable,
+  }) async {
+    checkCalls++;
+    if (throwOnCheck) throw Exception('check boom');
+    return nextCheck;
+  }
+
+  @override
+  Future<String> downloadUpdate(
+    UpdateInfo updateInfo, {
+    Function(double progress)? onProgress,
+    Directory? cacheDir,
+  }) async {
+    downloadCalls++;
+    if (downloadGate != null) await downloadGate!.future;
+    if (throwOnDownload) throw Exception('download boom');
+    for (final p in progressToEmit) {
+      onProgress?.call(p);
+    }
+    return '/tmp/update.apk';
+  }
+
+  @override
+  Future<bool> installUpdate(String apkPath) async {
+    installCalls++;
+    return installResult;
+  }
+
+  @override
+  void dispose() {}
+}
+
+UpdateInfo _update({String version = '9.9.9'}) => UpdateInfo(
+      version: version,
+      downloadUrl: 'https://example.com/app.apk',
+      releaseNotes: 'shiny',
+      isPrerelease: false,
+      tagName: 'v$version',
+    );
+
+void main() {
+  late _FakeUpdater updater;
+  late WebUIStorage webUIStorage;
+
+  UpdateCheckService build({bool isAndroid = true}) {
+    updater = _FakeUpdater();
+    final settingsController = SettingsController(MockSettingsService());
+    webUIStorage = WebUIStorage(settingsController);
+    return UpdateCheckService(
+      settingsService: MockSettingsService(),
+      webUIStorage: webUIStorage,
+      updater: updater,
+      platformIsAndroid: isAndroid,
+    );
+  }
+
+  group('checkForUpdate', () {
+    test('emits available with details when an update is found', () async {
+      final svc = build();
+      updater.nextCheck = _update(version: '9.9.9');
+
+      await svc.checkForUpdate();
+
+      final s = svc.currentState;
+      expect(s.phase, AppUpdatePhase.available);
+      expect(s.latestVersion, '9.9.9');
+      expect(s.releaseNotes, 'shiny');
+      expect(s.installable, isTrue);
+      expect(s.releaseUrl, contains('tag/v9.9.9'));
+      svc.dispose();
+    });
+
+    test('emits idle when no update is available', () async {
+      final svc = build();
+      updater.nextCheck = null;
+
+      await svc.checkForUpdate();
+
+      expect(svc.currentState.phase, AppUpdatePhase.idle);
+      expect(svc.currentState.installable, isFalse);
+      svc.dispose();
+    });
+
+    test('emits error when the check throws', () async {
+      final svc = build();
+      updater.throwOnCheck = true;
+
+      await svc.checkForUpdate();
+
+      expect(svc.currentState.phase, AppUpdatePhase.error);
+      expect(svc.currentState.error, isNotNull);
+      svc.dispose();
+    });
+
+    test('installable is false on non-Android even with an update', () async {
+      final svc = build(isAndroid: false);
+      updater.nextCheck = _update();
+
+      await svc.checkForUpdate();
+
+      expect(svc.currentState.phase, AppUpdatePhase.available);
+      expect(svc.currentState.installable, isFalse);
+      expect(svc.canInstall, isFalse);
+      svc.dispose();
+    });
+  });
+
+  group('downloadAndInstall', () {
+    test('auto-checks, downloads, then installs', () async {
+      final svc = build();
+      updater.nextCheck = _update();
+      updater.progressToEmit = [0.5, 1.0];
+
+      final phases = <AppUpdatePhase>[];
+      final sub = svc.updateState.listen((s) => phases.add(s.phase));
+
+      await svc.downloadAndInstall();
+      await Future.delayed(Duration.zero);
+
+      expect(updater.checkCalls, 1);
+      expect(updater.downloadCalls, 1);
+      expect(updater.installCalls, 1);
+      expect(svc.currentState.phase, AppUpdatePhase.installing);
+      expect(phases, containsAllInOrder(<AppUpdatePhase>[
+        AppUpdatePhase.checking,
+        AppUpdatePhase.available,
+        AppUpdatePhase.downloading,
+        AppUpdatePhase.installing,
+      ]));
+
+      await sub.cancel();
+      svc.dispose();
+    });
+
+    test('settles idle when auto-check finds nothing (no download)', () async {
+      final svc = build();
+      updater.nextCheck = null;
+
+      await svc.downloadAndInstall();
+
+      expect(updater.downloadCalls, 0);
+      expect(svc.currentState.phase, AppUpdatePhase.idle);
+      svc.dispose();
+    });
+
+    test('reports error when install permission is missing', () async {
+      final svc = build();
+      updater.nextCheck = _update();
+      updater.installResult = false;
+
+      await svc.downloadAndInstall();
+
+      expect(svc.currentState.phase, AppUpdatePhase.error);
+      expect(svc.currentState.error, contains('permission'));
+      svc.dispose();
+    });
+
+    test('reports error when the download throws', () async {
+      final svc = build();
+      updater.nextCheck = _update();
+      updater.throwOnDownload = true;
+
+      await svc.downloadAndInstall();
+
+      expect(svc.currentState.phase, AppUpdatePhase.error);
+      expect(updater.installCalls, 0);
+      svc.dispose();
+    });
+
+    test('coalesces a concurrent install (single in-flight op)', () async {
+      final svc = build();
+      updater.nextCheck = _update();
+      updater.downloadGate = Completer<void>();
+
+      final first = svc.downloadAndInstall();
+      await Future.delayed(Duration.zero); // let first reach the gated download
+      await svc.downloadAndInstall(); // should be a no-op
+      updater.downloadGate!.complete();
+      await first;
+
+      expect(updater.downloadCalls, 1);
+      svc.dispose();
+    });
+
+    test('non-Android is a no-op', () async {
+      final svc = build(isAndroid: false);
+      updater.nextCheck = _update();
+
+      await svc.downloadAndInstall();
+
+      expect(updater.downloadCalls, 0);
+      expect(updater.checkCalls, 0);
+      svc.dispose();
+    });
+  });
+
+  group('requestCheck', () {
+    test('coalesces while a check is in flight', () async {
+      final svc = build();
+      updater.nextCheck = _update();
+      updater.downloadGate = Completer<void>();
+
+      // Start a download to occupy the state machine.
+      final op = svc.downloadAndInstall();
+      await Future.delayed(Duration.zero);
+      await svc.requestCheck(); // in-progress -> no-op
+      final checksDuring = updater.checkCalls;
+      updater.downloadGate!.complete();
+      await op;
+
+      // Only the auto-check from downloadAndInstall ran.
+      expect(checksDuring, 1);
+      svc.dispose();
+    });
+  });
+}

--- a/test/update_check_service_test.dart
+++ b/test/update_check_service_test.dart
@@ -174,6 +174,32 @@ void main() {
       svc.dispose();
     });
 
+    test('throttles fine-grained progress to ~1% steps', () async {
+      final svc = build();
+      updater.nextCheck = _update();
+      // 1000 tiny increments, as a per-chunk callback would produce.
+      updater.progressToEmit =
+          List.generate(1000, (i) => (i + 1) / 1000);
+
+      final downloadingProgress = <double>[];
+      final sub = svc.updateState.listen((s) {
+        if (s.phase == AppUpdatePhase.downloading && s.progress != null) {
+          downloadingProgress.add(s.progress!);
+        }
+      });
+
+      await svc.downloadAndInstall();
+      await Future.delayed(Duration.zero);
+      await sub.cancel();
+
+      // Far fewer than 1000 frames; ~1% steps -> on the order of 100, plus
+      // the initial 0.0 and the terminal 1.0.
+      expect(downloadingProgress.length, lessThan(110));
+      expect(downloadingProgress.first, 0.0);
+      expect(downloadingProgress.last, closeTo(1.0, 1e-9));
+      svc.dispose();
+    });
+
     test('reports error when install permission is missing', () async {
       final svc = build();
       updater.nextCheck = _update();

--- a/test/update_handler_test.dart
+++ b/test/update_handler_test.dart
@@ -1,0 +1,92 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/android_updater.dart';
+import 'package:reaprime/src/services/update_check_service.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/webui_support/webui_storage.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+import 'helpers/mock_settings_service.dart';
+
+class _NoopUpdater extends AndroidUpdater {
+  _NoopUpdater() : super(owner: 'tadelv', repo: 'reaprime');
+  @override
+  Future<UpdateInfo?> checkForUpdate(String v,
+          {UpdateChannel channel = UpdateChannel.stable}) async =>
+      null;
+  @override
+  void dispose() {}
+}
+
+void main() {
+  late UpdateCheckService service;
+  late UpdateHandler updateHandler;
+  late Handler handler;
+
+  UpdateCheckService buildService({required bool isAndroid}) {
+    final settingsController = SettingsController(MockSettingsService());
+    return UpdateCheckService(
+      settingsService: MockSettingsService(),
+      webUIStorage: WebUIStorage(settingsController),
+      updater: _NoopUpdater(),
+      platformIsAndroid: isAndroid,
+    );
+  }
+
+  setUp(() {
+    service = buildService(isAndroid: true);
+    updateHandler = UpdateHandler(service: service);
+    final app = Router().plus;
+    updateHandler.addRoutes(app);
+    handler = app.call;
+  });
+
+  tearDown(() => service.dispose());
+
+  Future<Response> sendGet(String path) async =>
+      await handler(Request('GET', Uri.parse('http://localhost$path')));
+
+  group('GET /api/v1/update', () {
+    test('returns the current state snapshot', () async {
+      final response = await sendGet('/api/v1/update');
+      expect(response.statusCode, 200);
+      expect(response.headers['content-type'], contains('application/json'));
+
+      final body = jsonDecode(await response.readAsString());
+      expect(body['phase'], 'idle');
+      expect(body['currentVersion'], isA<String>());
+      expect(body['releaseUrl'], contains('releases'));
+      expect(body['installable'], false); // no update known yet
+    });
+  });
+
+  group('handleCommand', () {
+    // Exercise the command switch directly — the WS plumbing is the same
+    // shape as DevicesHandler; the branching is what's worth asserting here.
+    test('unknown command yields an error reply', () {
+      final replies = <Map<String, dynamic>>[];
+      updateHandler.handleCommand({'command': 'bogus'}, replies.add);
+      expect(replies.single['error'], contains('Unknown command'));
+    });
+
+    test('missing command field yields an error reply', () {
+      final replies = <Map<String, dynamic>>[];
+      updateHandler.handleCommand({}, replies.add);
+      expect(replies.single['error'], contains('Missing'));
+    });
+
+    test('install on non-Android replies with not-supported + url', () {
+      final nonAndroid = buildService(isAndroid: false);
+      final h = UpdateHandler(service: nonAndroid);
+      final replies = <Map<String, dynamic>>[];
+
+      h.handleCommand({'command': 'install'}, replies.add);
+
+      expect(replies.single['error'], contains('not supported'));
+      expect(replies.single['url'], contains('releases'));
+      nonAndroid.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## What
- Add `GET /api/v1/update` (state snapshot) and `GET /ws/v1/update` (live state stream + `{command:"check"|"install"}`), backed by one `AppUpdateState` stream in `UpdateCheckService`.
- Fix `AndroidUpdater.downloadUpdate` to actually stream and report progress (it previously read the whole body and never fired `onProgress`); throttle emission to ~1% steps.
- Add simulate-only `POST /api/v1/debug/update/force` to exercise the flow without a real release.

## Why
Closes #306 — lets a WebUI skin report and trigger app updates. On Android `install` downloads + launches the system installer; other platforms hand off the GitHub release URL via `releaseUrl`/`installable:false`.

No new auth: follows the existing LAN-trust model for `/api/v1` + `/ws/v1` (APK source is pinned to the official repo, OS install prompt is the backstop). Flagged for the standing "API behind auth" TODO.

## Test plan
- `flutter test` (1652 pass) + `flutter analyze` clean.
- Verified end-to-end on a p80x tablet: forced update → `installable:true` → streamed download 0→1.0 (throttled) → `installing` → `ApkInstaller` MethodChannel, including the install-permission branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)