### PR TITLE
feat(settings): extend simulated WebViews to Windows and Linux

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -130,49 +130,6 @@ Set<SimulatedDevicesTypes> _parseSimulateFlag(String value) {
       .toSet();
 }
 
-const _defaultDesktopWindowSize = Size(1280, 800);
-const _defaultDesktopAspectRatio = 1.6;
-
-Future<Size> _simulatedWebViewWindowSize(
-  SimulatedWebViewDevice device,
-) async {
-  final titleBarHeight = Platform.isMacOS
-      ? await WindowManager.instance.getTitleBarHeight()
-      : 0;
-  return Size(
-    device.viewportSize.width,
-    device.viewportSize.height + titleBarHeight,
-  );
-}
-
-Future<void> _setSimulatedWebViewDevice(
-  SimulatedWebViewDevice? device, {
-  bool persist = true,
-}) async {
-  simulatedWebViewDevice.value = device;
-  if (persist) {
-    await persistSimulatedWebViewDevice(device);
-  }
-
-  if (device == null) {
-    await WindowManager.instance.setMinimumSize(_defaultDesktopWindowSize);
-    await WindowManager.instance.setAspectRatio(_defaultDesktopAspectRatio);
-    await WindowManager.instance.setSize(_defaultDesktopWindowSize);
-    await WindowManager.instance.center();
-    await WindowManager.instance.focus();
-    return;
-  }
-
-  final windowSize = await _simulatedWebViewWindowSize(device);
-  await WindowManager.instance.setMinimumSize(windowSize);
-  await WindowManager.instance.setAspectRatio(
-    windowSize.width / windowSize.height,
-  );
-  await WindowManager.instance.setSize(windowSize);
-  await WindowManager.instance.center();
-  await WindowManager.instance.focus();
-}
-
 void main(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
   final cliArgs = parseCliArgs(args);
@@ -189,18 +146,22 @@ void main(List<String> args) async {
 
   final log = Logger("Main");
 
-  if (Platform.isWindows || Platform.isMacOS) {
+  if (Platform.isWindows || Platform.isMacOS || Platform.isLinux) {
     await WindowManager.instance.ensureInitialized();
-    WindowManager.instance.setMinimumSize(_defaultDesktopWindowSize);
-    await WindowManager.instance.setAspectRatio(_defaultDesktopAspectRatio);
-    await WindowManager.instance.setSize(_defaultDesktopWindowSize);
+    // Windows/macOS lock to the default kiosk window size at startup. Linux is
+    // left free-form (its default windowing is unchanged); WindowManager is
+    // still initialized so a simulated WebView can resize the window on demand.
+    if (!Platform.isLinux) {
+      WindowManager.instance.setMinimumSize(defaultDesktopWindowSize);
+      await WindowManager.instance.setAspectRatio(defaultDesktopAspectRatio);
+      await WindowManager.instance.setSize(defaultDesktopWindowSize);
+    }
     final startupSimulatedWebViewDevice =
-        await SharedPreferencesSettingsService().enableSimulatedWebViews() &&
-                Platform.isMacOS
+        await SharedPreferencesSettingsService().enableSimulatedWebViews()
             ? await loadPersistedSimulatedWebViewDevice()
             : null;
     if (startupSimulatedWebViewDevice != null) {
-      await _setSimulatedWebViewDevice(
+      await setSimulatedWebViewDevice(
         startupSimulatedWebViewDevice,
         persist: false,
       );
@@ -944,7 +905,52 @@ class _AppRootState extends State<AppRoot> {
         child: child,
       );
     }
+    // Windows/Linux have no native menu bar, so mirror the macOS simulated-
+    // WebView menu shortcuts with Ctrl+Alt+<digit> bindings (Cmd→Ctrl) when the
+    // feature is enabled. The Advanced-settings picker is the discoverable path;
+    // these match the muscle memory of the macOS menu accelerators.
+    if ((Platform.isWindows || Platform.isLinux) &&
+        widget.settingsController.enableSimulatedWebViews) {
+      return CallbackShortcuts(
+        bindings: _simulatedWebViewShortcuts(),
+        child: child,
+      );
+    }
     return child;
+  }
+
+  /// `Ctrl+Alt+<digit>` accelerators for switching the simulated WebView on
+  /// Windows/Linux, mirroring the macOS Cmd+Alt menu shortcuts in
+  /// [_buildPlatformMenus]: 0 → native, 8 → T50 Mini, 7 → P80X, 6 → P85 Pro.
+  Map<ShortcutActivator, VoidCallback> _simulatedWebViewShortcuts() {
+    return {
+      const SingleActivator(
+        LogicalKeyboardKey.digit0,
+        control: true,
+        alt: true,
+      ): () => unawaited(setSimulatedWebViewDevice(null)),
+      const SingleActivator(
+        LogicalKeyboardKey.digit8,
+        control: true,
+        alt: true,
+      ): () => unawaited(
+        setSimulatedWebViewDevice(SimulatedWebViewDevice.teclastT50Mini),
+      ),
+      const SingleActivator(
+        LogicalKeyboardKey.digit7,
+        control: true,
+        alt: true,
+      ): () => unawaited(
+        setSimulatedWebViewDevice(SimulatedWebViewDevice.teclastP80X),
+      ),
+      const SingleActivator(
+        LogicalKeyboardKey.digit6,
+        control: true,
+        alt: true,
+      ): () => unawaited(
+        setSimulatedWebViewDevice(SimulatedWebViewDevice.teclastP85Pro),
+      ),
+    };
   }
 
   List<PlatformMenuItem> _buildPlatformMenus() {
@@ -1004,7 +1010,7 @@ class _AppRootState extends State<AppRoot> {
                 meta: true,
               ),
               onSelected: () async {
-                await _setSimulatedWebViewDevice(null);
+                await setSimulatedWebViewDevice(null);
               },
             ),
             PlatformMenuItem(
@@ -1015,7 +1021,7 @@ class _AppRootState extends State<AppRoot> {
                 meta: true,
               ),
               onSelected: () async {
-                await _setSimulatedWebViewDevice(
+                await setSimulatedWebViewDevice(
                   SimulatedWebViewDevice.teclastT50Mini,
                 );
               },
@@ -1028,7 +1034,7 @@ class _AppRootState extends State<AppRoot> {
                 meta: true,
               ),
               onSelected: () async {
-                await _setSimulatedWebViewDevice(
+                await setSimulatedWebViewDevice(
                   SimulatedWebViewDevice.teclastP80X,
                 );
               },
@@ -1041,7 +1047,7 @@ class _AppRootState extends State<AppRoot> {
                 meta: true,
               ),
               onSelected: () async {
-                await _setSimulatedWebViewDevice(
+                await setSimulatedWebViewDevice(
                   SimulatedWebViewDevice.teclastP85Pro,
                 );
               },

--- a/lib/src/settings/advanced_page.dart
+++ b/lib/src/settings/advanced_page.dart
@@ -10,6 +10,7 @@ import 'dart:io';
 
 import 'package:reaprime/src/settings/gateway_mode.dart';
 import 'package:reaprime/src/settings/gateway_mode_info_dialog.dart';
+import 'package:reaprime/src/skin_feature/simulated_webview_device.dart';
 
 class AdvancedPage extends StatelessWidget {
   const AdvancedPage({
@@ -103,7 +104,9 @@ class AdvancedPage extends StatelessWidget {
                     ),
                   ),
                 ),
-              if (Platform.isMacOS) ...[
+              if (Platform.isMacOS ||
+                  Platform.isWindows ||
+                  Platform.isLinux) ...[
                 const SettingsDivider(),
                 Padding(
                   padding: const EdgeInsets.symmetric(
@@ -114,10 +117,28 @@ class AdvancedPage extends StatelessWidget {
                     value: controller.enableSimulatedWebViews,
                     onChanged: (v) async {
                       await controller.setEnableSimulatedWebViews(v);
+                      // Disabling returns to the native WebView so the window
+                      // snaps back to its normal size and no device shims linger.
+                      if (!v) {
+                        await setSimulatedWebViewDevice(null);
+                      }
                     },
                     label: const Text('Simulated WebViews'),
                   ),
                 ),
+                if (controller.enableSimulatedWebViews)
+                  ValueListenableBuilder<SimulatedWebViewDevice?>(
+                    valueListenable: simulatedWebViewDevice,
+                    builder: (context, selected, _) {
+                      return SettingsTile(
+                        icon: Icons.devices_outlined,
+                        label: 'Simulated Device',
+                        trailing: Text(selected?.name ?? 'Native WebView'),
+                        onTap: () =>
+                            _showSimulatedWebViewPicker(context, selected),
+                      );
+                    },
+                  ),
               ],
               const SettingsDivider(),
 
@@ -157,6 +178,62 @@ class AdvancedPage extends StatelessWidget {
           );
         },
       ),
+    );
+  }
+
+  void _showSimulatedWebViewPicker(
+    BuildContext context,
+    SimulatedWebViewDevice? selected,
+  ) {
+    showShadDialog(
+      context: context,
+      builder: (dialogContext) {
+        return ShadDialog(
+          title: const Text('Simulated Device'),
+          description: const Text(
+            'Resize the window and spoof viewport/touch APIs to preview skins '
+            'as they appear on Decent tablets.',
+          ),
+          child: Material(
+            type: MaterialType.transparency,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ListTile(
+                  title: const Text('Native WebView'),
+                  subtitle: Text(
+                    'Use this machine\'s real WebView, no spoofing.',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  trailing: selected == null ? const Icon(Icons.check) : null,
+                  onTap: () {
+                    setSimulatedWebViewDevice(null);
+                    Navigator.of(dialogContext).pop();
+                  },
+                ),
+                ...simulatedWebViewDevices.map((device) {
+                  return ListTile(
+                    title: Text(device.name),
+                    subtitle: Text(
+                      '${device.viewportSize.width.toInt()}'
+                      '×${device.viewportSize.height.toInt()} @ '
+                      '${device.devicePixelRatio.toStringAsFixed(2)}x',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    trailing: selected?.id == device.id
+                        ? const Icon(Icons.check)
+                        : null,
+                    onTap: () {
+                      setSimulatedWebViewDevice(device);
+                      Navigator.of(dialogContext).pop();
+                    },
+                  );
+                }),
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 

--- a/lib/src/skin_feature/simulated_webview_device.dart
+++ b/lib/src/skin_feature/simulated_webview_device.dart
@@ -1,7 +1,9 @@
+import 'dart:io';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:window_manager/window_manager.dart';
 
 const simulatedWebViewDevicePreferenceKey = 'simulatedWebViewDevice';
 
@@ -72,6 +74,13 @@ class SimulatedWebViewDevice {
   );
 }
 
+/// All selectable simulated WebView devices, in the order shown to the user.
+const simulatedWebViewDevices = <SimulatedWebViewDevice>[
+  SimulatedWebViewDevice.teclastT50Mini,
+  SimulatedWebViewDevice.teclastP80X,
+  SimulatedWebViewDevice.teclastP85Pro,
+];
+
 final simulatedWebViewDevice = ValueNotifier<SimulatedWebViewDevice?>(null);
 
 SimulatedWebViewDevice? simulatedWebViewDeviceById(String? id) {
@@ -103,4 +112,55 @@ Future<void> persistSimulatedWebViewDevice(
     return;
   }
   await prefs.setString(simulatedWebViewDevicePreferenceKey, device.id);
+}
+
+/// Default desktop window geometry, restored when no device is simulated.
+const defaultDesktopWindowSize = Size(1280, 800);
+const defaultDesktopAspectRatio = 1.6;
+
+Future<Size> simulatedWebViewWindowSize(
+  SimulatedWebViewDevice device,
+) async {
+  final titleBarHeight = Platform.isMacOS
+      ? await WindowManager.instance.getTitleBarHeight()
+      : 0;
+  return Size(
+    device.viewportSize.width,
+    device.viewportSize.height + titleBarHeight,
+  );
+}
+
+/// Applies [device] as the active simulated WebView: updates the global
+/// [simulatedWebViewDevice] notifier (which drives skin_view's script
+/// injection), optionally persists the choice, and resizes the desktop window
+/// to match the device viewport. Passing null restores the default window.
+///
+/// Desktop-only — it drives [WindowManager], so callers must gate on a desktop
+/// platform (macOS/Windows/Linux) before invoking.
+Future<void> setSimulatedWebViewDevice(
+  SimulatedWebViewDevice? device, {
+  bool persist = true,
+}) async {
+  simulatedWebViewDevice.value = device;
+  if (persist) {
+    await persistSimulatedWebViewDevice(device);
+  }
+
+  if (device == null) {
+    await WindowManager.instance.setMinimumSize(defaultDesktopWindowSize);
+    await WindowManager.instance.setAspectRatio(defaultDesktopAspectRatio);
+    await WindowManager.instance.setSize(defaultDesktopWindowSize);
+    await WindowManager.instance.center();
+    await WindowManager.instance.focus();
+    return;
+  }
+
+  final windowSize = await simulatedWebViewWindowSize(device);
+  await WindowManager.instance.setMinimumSize(windowSize);
+  await WindowManager.instance.setAspectRatio(
+    windowSize.width / windowSize.height,
+  );
+  await WindowManager.instance.setSize(windowSize);
+  await WindowManager.instance.center();
+  await WindowManager.instance.focus();
 }

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -699,7 +699,8 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
 
   /// Scripts injected into the skin at document start, before any page script
   /// runs. Always carries the host-identity beacon; appends the simulated-device
-  /// shims only in the macOS debug harness.
+  /// shims only on desktop (macOS/Windows/Linux) when simulated WebViews are
+  /// enabled and a device is selected.
   UnmodifiableListView<UserScript> _initialUserScripts(
     SimulatedWebViewDevice? simulatedDevice,
   ) {
@@ -754,8 +755,10 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
   UnmodifiableListView<UserScript>? _simulatedDeviceScripts(
     SimulatedWebViewDevice? simulatedDevice,
   ) {
+    final isDesktop =
+        Platform.isMacOS || Platform.isWindows || Platform.isLinux;
     if (!widget.settingsController.enableSimulatedWebViews ||
-        !Platform.isMacOS ||
+        !isDesktop ||
         simulatedDevice == null) {
       return null;
     }

--- a/test/unit/controllers/settings_controller_test.dart
+++ b/test/unit/controllers/settings_controller_test.dart
@@ -5,7 +5,9 @@ import 'package:reaprime/src/settings/settings_service.dart';
 /// Spy settings service that tracks calls to setSimulatedDevices.
 class _SpySettingsService implements SettingsService {
   int setSimulatedDevicesCallCount = 0;
+  int setEnableSimulatedWebViewsCallCount = 0;
   Set<SimulatedDevicesTypes> _simulatedDevices = {};
+  bool _enableSimulatedWebViews = false;
   String? _preferredMachineId;
   String? _preferredScaleId;
 
@@ -15,6 +17,13 @@ class _SpySettingsService implements SettingsService {
   Future<void> setSimulatedDevices(Set<SimulatedDevicesTypes> value) async {
     setSimulatedDevicesCallCount++;
     _simulatedDevices = value;
+  }
+  @override
+  Future<bool> enableSimulatedWebViews() async => _enableSimulatedWebViews;
+  @override
+  Future<void> setEnableSimulatedWebViews(bool value) async {
+    setEnableSimulatedWebViewsCallCount++;
+    _enableSimulatedWebViews = value;
   }
   @override
   Future<String?> preferredMachineId() async => _preferredMachineId;
@@ -149,6 +158,42 @@ void main() {
 
       expect(controller.preferredMachineId, 'MockDe1');
       expect(controller.preferredScaleId, isNull);
+    });
+  });
+
+  group('SettingsController.setEnableSimulatedWebViews', () {
+    test('persists and updates the in-memory value', () async {
+      final spy = _SpySettingsService();
+      final controller = SettingsController(spy);
+
+      await controller.setEnableSimulatedWebViews(true);
+
+      expect(controller.enableSimulatedWebViews, isTrue);
+      expect(spy.setEnableSimulatedWebViewsCallCount, 1);
+    });
+
+    test('notifies listeners on change', () async {
+      final spy = _SpySettingsService();
+      final controller = SettingsController(spy);
+      var notified = false;
+      controller.addListener(() => notified = true);
+
+      await controller.setEnableSimulatedWebViews(true);
+
+      expect(notified, isTrue);
+    });
+
+    test('is a no-op when the value is unchanged', () async {
+      final spy = _SpySettingsService();
+      final controller = SettingsController(spy);
+      var notified = false;
+      controller.addListener(() => notified = true);
+
+      // Default is false; setting false again should neither persist nor notify.
+      await controller.setEnableSimulatedWebViews(false);
+
+      expect(spy.setEnableSimulatedWebViewsCallCount, 0);
+      expect(notified, isFalse);
     });
   });
 }

--- a/test/unit/skin_feature/simulated_webview_device_test.dart
+++ b/test/unit/skin_feature/simulated_webview_device_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/skin_feature/simulated_webview_device.dart';
+
+void main() {
+  group('simulatedWebViewDevices', () {
+    test('every selectable device round-trips through its persisted id', () {
+      // The advanced-settings picker offers `simulatedWebViewDevices`, while
+      // startup reload resolves the persisted choice via
+      // `simulatedWebViewDeviceById`. If the two drift, a device a user picks
+      // won't survive a restart — so keep them in lockstep.
+      for (final device in simulatedWebViewDevices) {
+        expect(
+          simulatedWebViewDeviceById(device.id),
+          same(device),
+          reason:
+              'Device "${device.name}" (${device.id}) is offered in the picker '
+              'but cannot be reloaded from its persisted id.',
+        );
+      }
+    });
+
+    test('device ids are unique', () {
+      final ids = simulatedWebViewDevices.map((d) => d.id).toList();
+      expect(ids.toSet().length, ids.length);
+    });
+
+    test('unknown or null id resolves to null', () {
+      expect(simulatedWebViewDeviceById('does-not-exist'), isNull);
+      expect(simulatedWebViewDeviceById(null), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **Problem:** The simulated-WebView harness (resize the window to a Decent tablet's viewport and spoof viewport/touch/DPR APIs so skins can be previewed at real device resolutions) was macOS-only.
- **Why it matters:** Windows/Linux contributors couldn't preview skins at tablet resolutions. macOS selects a device via the native menu bar, which Flutter doesn't render on other desktop platforms, so the feature was gated to macOS throughout.
- **What changed:** Extended the gates to all desktop platforms, added a settings-page device picker (the cross-platform replacement for the macOS menu bar), and added matching `Ctrl+Alt+<digit>` keyboard accelerators on Windows/Linux.
- **What did NOT change (scope boundary):** Android/iOS are untouched; the macOS native menu and its Cmd+Alt shortcuts are unchanged; Linux's default (non-simulating) windowing stays free-form.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] WebUI skins
- [x] UI / Flutter widgets

## Linked Issues

- N/A

## Root Cause (if bug fix)

- N/A — not a bug fix.

## Regression Test Plan (if bug fix or refactor)

- N/A (feature). Added unit coverage:
  - [x] Unit test
  - Target test or file: `test/unit/controllers/settings_controller_test.dart`, `test/unit/skin_feature/simulated_webview_device_test.dart`
  - Scenario locked in: `SettingsController.setEnableSimulatedWebViews` persists/notifies/no-ops; every picker device round-trips through `simulatedWebViewDeviceById` so a selection survives a restart.

## Documentation Obligations (required)

- [x] N/A — no docs affected (settings-UI developer feature; no REST/WebSocket/plugin/skin/profile/device docs touched).

## Security Impact (required)

- New or changed REST endpoints? No
- New or changed WebSocket topics? No
- New or changed network calls? No
- BLE/USB surface changed? No
- File system access changed? No (reuses the existing `enableSimulatedWebViews` SharedPreferences key)
- Plugin sandbox boundary changed? No

## User-Visible Changes

A "Simulated WebViews" toggle and a "Simulated Device" picker now appear in Advanced settings on Windows and Linux (previously macOS-only). When enabled, `Ctrl+Alt+0/8/7/6` switch the simulated device (0 native, 8 T50 Mini, 7 P80X, 6 P85 Pro), mirroring the macOS Cmd+Alt menu accelerators. Default off; no behavior change unless enabled.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all 1636 pass
- [ ] `(cd packages/dye2-plugin && npm run build)` — N/A (no plugin changes)

### Manual verification (if applicable)

- OS / platform tested: macOS (unit + analyze)
- Simulated devices? (`simulate=1`): No
- Real hardware? (DE1/Bengle/scale): No
- What I personally verified and how: `flutter analyze` clean; full `flutter test` green (1636 tests).
- What I did **not** verify: running the app on a Windows or Linux build — the window-resize behavior (especially Linux/Wayland) and the keyboard accelerators are unverified on real targets.

### Evidence

- `flutter test` → `All tests passed!` (1636 tests)

## Compatibility & Migration

- Backward compatible? Yes
- Config / env changes needed? No
- Database migration needed? No

## Risks & Mitigations

- Risk: `window_manager` resize may behave differently on Linux/Wayland.
  - Mitigation: init-only on Linux; default windowing unchanged unless the user opts in.
- Risk: the root-level `CallbackShortcuts` relies on Flutter's focus/key system, so on Windows/Linux the accelerators may not fire while a focused `InAppWebView` swallows key events (the macOS native menu would still catch them at the OS level).
  - Mitigation: the Advanced-settings picker works regardless of focus and is the primary, discoverable path.
- Risk: title-bar-height compensation in `simulatedWebViewWindowSize` is macOS-only, so Win/Linux content area may sit a few px off the exact viewport.
  - Mitigation: minor cosmetic only; can refine after on-device testing.
