### PR TITLE
fix: serial port ID + --no-account CLI flag

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -445,18 +445,28 @@ void main(List<String> args) async {
   final WebUIService webUIService = WebUIService();
   final WebUIStorage webUIStorage = WebUIStorage(settingsController);
 
-  final decentCredentialStore = await createCredentialStore();
-  final decentAccountService = DecentAccountService(
-    httpClient: http.Client(),
-    credentialStore: decentCredentialStore,
-  );
-  // Same credential store as the account service: the proxy reads the
-  // credentials that account login wrote, and never exposes them to callers.
-  final decentProxyService = DecentProxyService(
-    httpClient: http.Client(),
-    credentialStore: decentCredentialStore,
-  );
+  // Credential store + account service — skip on headless Linux where
+  // libsecret blocks on the XDG secrets portal (no desktop session).
+  DecentAccountService? decentAccountService;
+  DecentProxyService? decentProxyService;
   final proxyTokenService = ProxyTokenService();
+  if (cliArgs.noAccount) {
+    log.info('--no-account: skipping credential store and account service');
+    decentAccountService = null;
+    decentProxyService = null;
+  } else {
+    final decentCredentialStore = await createCredentialStore();
+    decentAccountService = DecentAccountService(
+      httpClient: http.Client(),
+      credentialStore: decentCredentialStore,
+    );
+    // Same credential store as the account service: the proxy reads the
+    // credentials that account login wrote, and never exposes them to callers.
+    decentProxyService = DecentProxyService(
+      httpClient: http.Client(),
+      credentialStore: decentCredentialStore,
+    );
+  }
   // Serve the skin token into :3000 HTML so skins can call the account proxy.
   webUIService.skinProxyToken = proxyTokenService.skinToken;
 

--- a/lib/src/cli/cli_args.dart
+++ b/lib/src/cli/cli_args.dart
@@ -5,6 +5,7 @@ class CliArgs {
   final bool serial;
   final bool bypassOnboarding;
   final bool direct;
+  final bool noAccount;
   final String? skinId;
   final String? skinPath;
 
@@ -12,6 +13,7 @@ class CliArgs {
     this.serial = false,
     this.bypassOnboarding = false,
     this.direct = false,
+    this.noAccount = false,
     this.skinId,
     this.skinPath,
   });
@@ -37,6 +39,11 @@ CliArgs parseCliArgs(List<String> args) {
     ..addOption(
       'skin-path',
       help: 'Serve skin directly from filesystem path.',
+    )
+    ..addFlag(
+      'no-account',
+      help: 'Bypass DecentAccountService (headless Linux with no keyring).',
+      defaultsTo: false,
     );
 
   final results = parser.parse(args);
@@ -44,6 +51,7 @@ CliArgs parseCliArgs(List<String> args) {
     serial: results['serial'] as bool,
     bypassOnboarding: results['bypass-onboarding'] as bool,
     direct: results['direct'] as bool,
+    noAccount: results['no-account'] as bool,
     skinId: results['skin'] as String?,
     skinPath: results['skin-path'] as String?,
   );

--- a/test/cli_options_test.dart
+++ b/test/cli_options_test.dart
@@ -8,6 +8,7 @@ void main() {
       expect(args.serial, isFalse);
       expect(args.bypassOnboarding, isFalse);
       expect(args.direct, isFalse);
+      expect(args.noAccount, isFalse);
       expect(args.skinId, isNull);
       expect(args.skinPath, isNull);
     });
@@ -37,17 +38,24 @@ void main() {
       expect(args.skinPath, '/home/keith/myskin');
     });
 
+    test('--no-account', () {
+      final args = parseCliArgs(['--no-account']);
+      expect(args.noAccount, isTrue);
+    });
+
     test('all flags combined', () {
       final args = parseCliArgs([
         '--serial',
         '--bypass-onboarding',
         '--direct',
+        '--no-account',
         '--skin=streamline.js',
         '--skin-path=/tmp/test-skin',
       ]);
       expect(args.serial, isTrue);
       expect(args.bypassOnboarding, isTrue);
       expect(args.direct, isTrue);
+      expect(args.noAccount, isTrue);
       expect(args.skinId, 'streamline.js');
       expect(args.skinPath, '/tmp/test-skin');
     });


### PR DESCRIPTION
## Fixes

### 1. URL-safe serial fallback IDs (`855bd57`)

`_DesktopSerialPort._computeId()` used raw port path (`/dev/ttyUSB0`) as fallback when USB vid/pid descriptors were unavailable (CH340/CP210x chips on Pi/Linux, macOS DriverKit). This broke WebSocket routing for SensorBasket — shelf matched `ws/v1/sensors/<id>/snapshot` with `<id>` capturing only the first path segment (`dev`), not the full ID.

Now uses port basename with `serial-` prefix (`serial-ttyUSB0`), which is URL-safe, stable per physical port, and consistent with the `usb-{vid}-{pid}-{serial}` format used by properly-detected DE1 devices.

**Observed on de1pi.local**: `GET /api/v1/devices` showed `"id": "/dev/ttyUSB0"` for SensorBasket, breaking the snapshot WebSocket endpoint.

### 2. `--no-account` CLI flag (`de35c56`)

Skips `DecentAccountService` + credential store + proxy service on headless Linux. On xvfb-only stations, libsecret blocks on the XDG secrets portal with no desktop session — the credential store construction itself hangs. Bypassing it entirely lets the app boot and serve REST/WebSocket without an account keyring.

The existing nullable plumbing throughout `AppRoot`, `MyApp`, `De1StateManager`, webserver, login step, and account page already handles a null account service gracefully — this just skips creation at `main()`.

**Observed on de1pi.local**: `PlatformException(KeyringLocked, KeyringLocked, null, null)` from `De1StateManager._checkSerialOwnership()`.

### Cal-station invocation

```bash
./decent.app --serial --bypass-onboarding --direct --no-account --skin-path=/home/keith/skin
```

Refs: `ReaPrime/TODO ^cli-options`, `^no-account-flag`