### PR TITLE
fix(account-proxy): pin proxy CORS to skin origins

### DIFF
--- a/.agents/skills/decent-app/scenarios/account-proxy-cors.md
+++ b/.agents/skills/decent-app/scenarios/account-proxy-cors.md
@@ -1,0 +1,71 @@
+# Scenario: Account-proxy CORS pinned to skin origin
+
+Verifies the defense-in-depth CORS hardening (#301): on `/api/v1/account/proxy/*`
+the `Access-Control-Allow-Origin` is **pinned** to the known skin origin(s)
+(loopback + the device LAN IP, on the skin port `:3000`) instead of the global
+permissive value. Non-proxy API paths keep their existing permissive CORS.
+
+The CORS headers are applied by an outer middleware that post-processes every
+response on the proxy path, so the behaviour is observable **without a valid proxy
+token** — an unauthenticated `401` on the proxy path still carries the pinned
+(or absent) ACAO header. That makes this a pure-`curl` smoke test.
+
+## Preconditions
+
+```bash
+scripts/sb-dev.sh start --platform macos --connect-machine MockDe1
+P=/api/v1/account/proxy/support/api/sn
+```
+
+## Steps
+
+```bash
+# 1. Allowed skin origin -> ACAO echoes that origin (not '*') + Vary: Origin
+curl -s -D - -o /dev/null -H "Origin: http://localhost:3000" \
+  "http://localhost:8080$P" | grep -iE "access-control-allow-origin|^vary"
+# -> access-control-allow-origin: http://localhost:3000
+# -> vary: Origin
+
+# 2. Disallowed origin on the proxy path -> NO permissive ACAO at all
+curl -s -D - -o /dev/null -H "Origin: http://evil.example:3000" \
+  "http://localhost:8080$P" | grep -iE "access-control-allow-origin" \
+  && echo "FAIL: proxy path leaked ACAO to disallowed origin" || echo "OK: no ACAO"
+
+# 3. Non-proxy API path is unchanged (stays permissive)
+curl -s -D - -o /dev/null -H "Origin: http://evil.example:3000" \
+  "http://localhost:8080/api/v1/info" | grep -iE "access-control-allow-origin"
+# -> access-control-allow-origin present (permissive, pre-existing behaviour)
+
+# 4. OPTIONS preflight follows the same rule
+curl -s -D - -o /dev/null -X OPTIONS \
+  -H "Origin: http://localhost:3000" -H "Access-Control-Request-Method: GET" \
+  "http://localhost:8080$P" | grep -iE "access-control-allow-origin|^vary"
+# -> access-control-allow-origin: http://localhost:3000 ; vary: Origin
+curl -s -D - -o /dev/null -X OPTIONS \
+  -H "Origin: http://evil.example:3000" -H "Access-Control-Request-Method: GET" \
+  "http://localhost:8080$P" | grep -iE "access-control-allow-origin" \
+  && echo "FAIL: preflight leaked ACAO" || echo "OK: preflight no ACAO"
+```
+
+One-shot assertion:
+
+```bash
+allowed=$(curl -s -D - -o /dev/null -H "Origin: http://localhost:3000" "http://localhost:8080$P" \
+  | awk 'BEGIN{IGNORECASE=1}/access-control-allow-origin:/{print $2}' | tr -d '\r')
+denied=$(curl -s -D - -o /dev/null -H "Origin: http://evil.example:3000" "http://localhost:8080$P" \
+  | awk 'BEGIN{IGNORECASE=1}/access-control-allow-origin:/{print $2}' | tr -d '\r')
+test "$allowed" = "http://localhost:3000" || { echo "FAIL allowed: '$allowed'"; exit 1; }
+test -z "$denied" || { echo "FAIL denied leaked: '$denied'"; exit 1; }
+echo OK
+```
+
+The device LAN-IP origin (`http://<device-ip>:3000`) is also allowed — the allowlist
+is rebuilt per request, so an IP learned after startup works. Loopback variants
+(`127.0.0.1`, `[::1]`) are included. mDNS/`*.local` hostnames are intentionally not
+in the allowlist (open question carried from the design doc).
+
+## Postconditions
+
+```bash
+scripts/sb-dev.sh stop
+```

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -287,6 +287,7 @@ Future<void> startWebServer(
       accountHandler,
       accountProxyHandler,
       proxyTokenService,
+      accountProxyCorsAllowedOrigins(webUIService),
       dataExportHandler,
       dataSyncHandler,
       beansHandler,
@@ -327,6 +328,7 @@ Handler _init(
   AccountHandler? accountHandler,
   AccountProxyHandler? accountProxyHandler,
   ProxyTokenService? proxyTokenService,
+  Set<String> accountProxyAllowedOrigins,
   DataExportHandler dataExportHandler,
   DataSyncHandler dataSyncHandler,
   BeansHandler? beansHandler,
@@ -382,6 +384,7 @@ Handler _init(
   }
 
   final handler = const Pipeline()
+      .addMiddleware(accountProxyCorsMiddleware(accountProxyAllowedOrigins))
       .addMiddleware(
         logRequests(
           logger: (msg, isError) {
@@ -412,6 +415,73 @@ Handler _init(
       .addHandler(app.call);
 
   return handler;
+}
+
+Set<String> accountProxyCorsAllowedOrigins(WebUIService webUIService) {
+  final port = webUIService.port;
+  final origins = <String>{
+    'http://localhost:$port',
+    'http://127.0.0.1:$port',
+    'http://[::1]:$port',
+  };
+
+  final deviceIp = webUIService.deviceIp().trim();
+  if (deviceIp.isNotEmpty) {
+    origins.add('http://$deviceIp:$port');
+  }
+
+  return origins;
+}
+
+Middleware accountProxyCorsMiddleware(
+  Set<String> allowedOrigins, {
+  String pathPrefix = '/api/v1/account/proxy/',
+}) {
+  return (Handler inner) {
+    return (Request request) async {
+      final response = await inner(request);
+      if (!request.requestedUri.path.startsWith(pathPrefix)) {
+        return response;
+      }
+
+      final headerUpdates = _removeHeaderUpdates(
+        response,
+        'access-control-allow-origin',
+      );
+
+      final origin = request.headers['origin'];
+      if (origin != null && allowedOrigins.contains(origin)) {
+        headerUpdates.addAll(_removeHeaderUpdates(response, 'vary'));
+        headerUpdates['Access-Control-Allow-Origin'] = origin;
+        headerUpdates['Vary'] = _appendVary(response.headers['vary'], 'Origin');
+      }
+
+      return response.change(headers: headerUpdates);
+    };
+  };
+}
+
+Map<String, Object?> _removeHeaderUpdates(Response response, String name) {
+  final lowerName = name.toLowerCase();
+  final updates = <String, Object?>{};
+  final matchingKeys = response.headersAll.keys.where(
+    (key) => key.toLowerCase() == lowerName,
+  );
+  for (final key in matchingKeys) {
+    updates[key] = null;
+  }
+  return updates;
+}
+
+String _appendVary(String? value, String headerName) {
+  if (value == null || value.trim().isEmpty) {
+    return headerName;
+  }
+  final values = value.split(',').map((part) => part.trim().toLowerCase());
+  if (values.contains(headerName.toLowerCase())) {
+    return value;
+  }
+  return '$value, $headerName';
 }
 
 Future<void> startApiDocsServer() async {

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -287,7 +287,7 @@ Future<void> startWebServer(
       accountHandler,
       accountProxyHandler,
       proxyTokenService,
-      accountProxyCorsAllowedOrigins(webUIService),
+      () => accountProxyCorsAllowedOrigins(webUIService),
       dataExportHandler,
       dataSyncHandler,
       beansHandler,
@@ -328,7 +328,7 @@ Handler _init(
   AccountHandler? accountHandler,
   AccountProxyHandler? accountProxyHandler,
   ProxyTokenService? proxyTokenService,
-  Set<String> accountProxyAllowedOrigins,
+  Set<String> Function() accountProxyAllowedOrigins,
   DataExportHandler dataExportHandler,
   DataSyncHandler dataSyncHandler,
   BeansHandler? beansHandler,
@@ -434,7 +434,7 @@ Set<String> accountProxyCorsAllowedOrigins(WebUIService webUIService) {
 }
 
 Middleware accountProxyCorsMiddleware(
-  Set<String> allowedOrigins, {
+  Set<String> Function() allowedOrigins, {
   String pathPrefix = '/api/v1/account/proxy/',
 }) {
   return (Handler inner) {
@@ -450,7 +450,7 @@ Middleware accountProxyCorsMiddleware(
       );
 
       final origin = request.headers['origin'];
-      if (origin != null && allowedOrigins.contains(origin)) {
+      if (origin != null && allowedOrigins().contains(origin)) {
         headerUpdates.addAll(_removeHeaderUpdates(response, 'vary'));
         headerUpdates['Access-Control-Allow-Origin'] = origin;
         headerUpdates['Vary'] = _appendVary(response.headers['vary'], 'Origin');

--- a/test/webserver/account_proxy_cors_middleware_test.dart
+++ b/test/webserver/account_proxy_cors_middleware_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:shelf/shelf.dart';
+import 'package:shelf_cors_headers/shelf_cors_headers.dart';
+
+void main() {
+  late Handler handler;
+
+  setUp(() {
+    handler = const Pipeline()
+        .addMiddleware(
+          accountProxyCorsMiddleware({
+            'http://localhost:3000',
+            'http://127.0.0.1:3000',
+            'http://192.168.4.20:3000',
+          }),
+        )
+        .addMiddleware(
+          corsHeaders(
+            headers: {
+              'Access-Control-Expose-Headers': 'ETag',
+              'Access-Control-Allow-Headers':
+                  'Accept, Authorization, Content-Type',
+            },
+          ),
+        )
+        .addHandler((_) => Response.ok('ok'));
+  });
+
+  Future<Response> request(
+    String method,
+    String path, {
+    String? origin,
+  }) async {
+    final headers = <String, String>{};
+    if (origin != null) {
+      headers['origin'] = origin;
+    }
+    return await handler(
+      Request(
+        method,
+        Uri.parse('http://localhost$path'),
+        headers: headers,
+      ),
+    );
+  }
+
+  test(
+    'proxy request from an allowed skin origin echoes that origin',
+    () async {
+      final response = await request(
+        'GET',
+        '/api/v1/account/proxy/support/api/sn',
+        origin: 'http://192.168.4.20:3000',
+      );
+
+      expect(
+        response.headers['access-control-allow-origin'],
+        'http://192.168.4.20:3000',
+      );
+      expect(response.headers['vary'], contains('Origin'));
+    },
+  );
+
+  test(
+    'proxy request from a disallowed origin does not get wildcard ACAO',
+    () async {
+      final response = await request(
+        'GET',
+        '/api/v1/account/proxy/support/api/sn',
+        origin: 'https://evil.example',
+      );
+
+      expect(response.headers['access-control-allow-origin'], isNull);
+      expect(response.headers.values, isNot(contains('*')));
+    },
+  );
+
+  test(
+    'proxy preflight from an allowed skin origin echoes that origin',
+    () async {
+      final response = await request(
+        'OPTIONS',
+        '/api/v1/account/proxy/support/api/sn',
+        origin: 'http://localhost:3000',
+      );
+
+      expect(
+        response.headers['access-control-allow-origin'],
+        'http://localhost:3000',
+      );
+    },
+  );
+
+  test('non-proxy API paths keep the existing permissive CORS', () async {
+    final response = await request(
+      'GET',
+      '/api/v1/devices',
+      origin: 'https://any.example',
+    );
+
+    expect(
+      response.headers['access-control-allow-origin'],
+      'https://any.example',
+    );
+  });
+}

--- a/test/webserver/account_proxy_cors_middleware_test.dart
+++ b/test/webserver/account_proxy_cors_middleware_test.dart
@@ -5,16 +5,16 @@ import 'package:shelf_cors_headers/shelf_cors_headers.dart';
 
 void main() {
   late Handler handler;
+  late Set<String> allowedOrigins;
 
   setUp(() {
+    allowedOrigins = {
+      'http://localhost:3000',
+      'http://127.0.0.1:3000',
+    };
+
     handler = const Pipeline()
-        .addMiddleware(
-          accountProxyCorsMiddleware({
-            'http://localhost:3000',
-            'http://127.0.0.1:3000',
-            'http://192.168.4.20:3000',
-          }),
-        )
+        .addMiddleware(accountProxyCorsMiddleware(() => allowedOrigins))
         .addMiddleware(
           corsHeaders(
             headers: {
@@ -48,6 +48,8 @@ void main() {
   test(
     'proxy request from an allowed skin origin echoes that origin',
     () async {
+      allowedOrigins.add('http://192.168.4.20:3000');
+
       final response = await request(
         'GET',
         '/api/v1/account/proxy/support/api/sn',
@@ -59,6 +61,31 @@ void main() {
         'http://192.168.4.20:3000',
       );
       expect(response.headers['vary'], contains('Origin'));
+    },
+  );
+
+  test(
+    'proxy request allows a LAN skin origin learned after handler startup',
+    () async {
+      final before = await request(
+        'GET',
+        '/api/v1/account/proxy/support/api/sn',
+        origin: 'http://192.168.4.20:3000',
+      );
+
+      allowedOrigins.add('http://192.168.4.20:3000');
+
+      final after = await request(
+        'GET',
+        '/api/v1/account/proxy/support/api/sn',
+        origin: 'http://192.168.4.20:3000',
+      );
+
+      expect(before.headers['access-control-allow-origin'], isNull);
+      expect(
+        after.headers['access-control-allow-origin'],
+        'http://192.168.4.20:3000',
+      );
     },
   );
 


### PR DESCRIPTION
## Summary
- Adds path-scoped CORS handling for `/api/v1/account/proxy/*`.
- Allows the served skin origins on port 3000 and strips the permissive proxy ACAO header for disallowed origins.
- Leaves existing non-proxy API CORS behavior unchanged.

Fixes #301

## Validation
- `npm.cmd ci --cache D:\ingestion\reaprime-main\_work\tools\npm-cache`
- `npm.cmd run build`
- `flutter analyze --no-pub`
- `flutter test --no-pub test\webserver\account_proxy_cors_middleware_test.dart --reporter=compact`
- `flutter test --no-pub --reporter=compact` with QuickJS DLL directory on `PATH`
- `git diff --check`