### PR TITLE
feat(plugins): add Decent account proxy bridge

### DIFF
--- a/.agents/skills/decent-app/scenarios/plugin-decent-proxy.md
+++ b/.agents/skills/decent-app/scenarios/plugin-decent-proxy.md
@@ -1,0 +1,149 @@
+# Scenario: Plugin Decent-account proxy bridge (`host.decentProxy`)
+
+Verifies the plugin path of the account proxy (#298): a plugin that declares the
+`proxy.decent_api` manifest permission can reach `DecentProxyService` via the Dart
+bridge, and a plugin that does **not** declare it is rejected before dispatch (and
+the attempt is logged). Credentials never appear in plugin-visible data.
+
+Because plugins can only be driven from the JS runtime (the install-from-URL REST
+route is a stub), this scenario **side-loads two tiny fixture plugins** that each
+expose an HTTP endpoint which calls `host.decentProxy(...)` and returns the outcome
+— making the gate curl-observable.
+
+The discriminator is network-independent: in simulate mode no Decent account is
+linked, so a *granted* plugin reaches the service and gets
+`DecentAccountNotLinkedException` (gate **passed**), while a *denied* plugin gets
+`Plugin permission required: proxy.decent_api` (gate **rejected**).
+
+## Preconditions
+
+Fixture plugins live in the app documents `plugins/` dir, which is scanned at boot.
+On sandboxed macOS that is:
+
+```bash
+PLUGINS_DIR="$HOME/Library/Containers/net.tadel.reaprime/Data/Documents/plugins"
+# Linux (non-sandboxed): $HOME/.local/share/net.tadel.reaprime/plugins  (verify per build)
+mkdir -p "$PLUGINS_DIR/proxy-smoke-granted" "$PLUGINS_DIR/proxy-smoke-denied"
+```
+
+Write the **granted** fixture (declares `proxy.decent_api`):
+
+```bash
+cat > "$PLUGINS_DIR/proxy-smoke-granted/manifest.json" <<'JSON'
+{
+  "id": "proxy-smoke-granted",
+  "name": "Proxy Smoke (granted)",
+  "author": "decent-app scenarios",
+  "description": "Calls host.decentProxy with proxy.decent_api declared.",
+  "version": "1.0.0",
+  "apiVersion": 1,
+  "permissions": ["log", "proxy.decent_api"],
+  "settings": {},
+  "api": [ { "id": "probe", "type": "http", "data": {} } ]
+}
+JSON
+
+cat > "$PLUGINS_DIR/proxy-smoke-granted/plugin.js" <<'JS'
+function createPlugin(host) {
+  "use strict";
+  return {
+    id: "proxy-smoke-granted",
+    onLoad: function () { host.log("proxy-smoke-granted loaded"); },
+    onUnload: function () {},
+    onEvent: function () {},
+    __httpRequestHandler: function (request) {
+      if (request.endpoint === "probe") {
+        return host.decentProxy("support/api/sn", {})
+          .then(function (res) {
+            return { status: 200, headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ gate: "passed", upstreamStatus: res.status }) };
+          })
+          .catch(function (err) {
+            var msg = (err && err.message) ? err.message : String(err);
+            var denied = msg.toLowerCase().indexOf("permission") !== -1;
+            return { status: 200, headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ gate: denied ? "denied" : "passed", error: msg }) };
+          });
+      }
+      return { status: 404, headers: {}, body: "Not found" };
+    }
+  };
+}
+JS
+```
+
+Write the **denied** fixture — identical except the id and the omitted permission:
+
+```bash
+sed 's/proxy-smoke-granted/proxy-smoke-denied/g' \
+  "$PLUGINS_DIR/proxy-smoke-granted/plugin.js" > "$PLUGINS_DIR/proxy-smoke-denied/plugin.js"
+
+cat > "$PLUGINS_DIR/proxy-smoke-denied/manifest.json" <<'JSON'
+{
+  "id": "proxy-smoke-denied",
+  "name": "Proxy Smoke (denied)",
+  "author": "decent-app scenarios",
+  "description": "Calls host.decentProxy WITHOUT proxy.decent_api declared.",
+  "version": "1.0.0",
+  "apiVersion": 1,
+  "permissions": ["log"],
+  "settings": {},
+  "api": [ { "id": "probe", "type": "http", "data": {} } ]
+}
+JSON
+```
+
+Start (the boot scan picks up the fixtures — drop the files **before** start):
+
+```bash
+scripts/sb-dev.sh start --platform macos --connect-machine MockDe1
+```
+
+## Steps
+
+```bash
+# Both fixtures are scanned but not yet loaded
+curl -s http://localhost:8080/api/v1/plugins \
+  | jq -c '.[] | select(.id|startswith("proxy-smoke")) | {id,loaded}'
+
+# Enable (loads them into the JS runtime)
+curl -sf -X POST http://localhost:8080/api/v1/plugins/proxy-smoke-granted/enable >/dev/null
+curl -sf -X POST http://localhost:8080/api/v1/plugins/proxy-smoke-denied/enable  >/dev/null
+
+# Probe each plugin's HTTP endpoint — the handler calls host.decentProxy()
+granted=$(curl -s http://localhost:8080/api/v1/plugins/proxy-smoke-granted/probe)
+denied=$(curl -s  http://localhost:8080/api/v1/plugins/proxy-smoke-denied/probe)
+echo "granted: $granted"
+echo "denied:  $denied"
+```
+
+Expected:
+
+```text
+granted: {"gate":"passed","error":"DecentAccountNotLinkedException: no account linked"}
+denied:  {"gate":"denied","error":"Bad state: Plugin permission required: proxy.decent_api"}
+```
+
+One-shot assertion:
+
+```bash
+echo "$granted" | jq -e '.gate=="passed"' >/dev/null || { echo FAIL granted; exit 1; }
+echo "$denied"  | jq -e '.gate=="denied"' >/dev/null || { echo FAIL denied;  exit 1; }
+echo OK
+```
+
+The rejection is also logged (the `attempt is logged` acceptance criterion):
+
+```bash
+scripts/sb-dev.sh logs -n 200 | grep "attempted Decent proxy access without permission"
+# -> WARNING PluginManager - Plugin proxy-smoke-denied attempted Decent proxy access without permission
+```
+
+No credentials appear in any plugin-visible response (only `gate` / `error` / `upstreamStatus`).
+
+## Postconditions
+
+```bash
+scripts/sb-dev.sh stop
+rm -rf "$PLUGINS_DIR/proxy-smoke-granted" "$PLUGINS_DIR/proxy-smoke-denied"
+```

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -5167,7 +5167,7 @@ components:
           type: string
         permissions:
           type: string
-          enum: [log, emit, pluginStorage]
+          enum: [log, emit, pluginStorage, pluginNotify, proxy.decent_api]
         settings:
           description: Plugin settings schema
           type: object

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -5166,8 +5166,10 @@ components:
         apiVersion:
           type: string
         permissions:
-          type: string
-          enum: [log, emit, pluginStorage, pluginNotify, proxy.decent_api]
+          type: array
+          items:
+            type: string
+            enum: [log, emit, pluginStorage, pluginNotify, proxy.decent_api]
         settings:
           description: Plugin settings schema
           type: object

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -5169,7 +5169,7 @@ components:
           type: array
           items:
             type: string
-            enum: [log, emit, pluginStorage, pluginNotify, proxy.decent_api]
+            enum: [log, api, emit, pluginStorage, pluginNotify, proxy.decent_api]
         settings:
           description: Plugin settings schema
           type: object

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -59,6 +59,7 @@ A Decent.app plugin consists of two required files:
   - `api`: Ability to make HTTP requests
   - `emit`: Emit events to the Flutter app
   - `pluginStorage`: Persistent storage
+  - `proxy.decent_api`: Call the linked Decent account proxy through `host.decentProxy`
 - **settings**: User-configurable options with `type` (`string`, `number`, `boolean`) and optional `secure` flag for passwords
 - **api**: Events this plugin emits, used for documentation and type checking
 
@@ -126,6 +127,22 @@ host.storage({
 ```
 
 **Note:** namespace is not used by Decent.app internally, the plugin storage is namespaced to the plugins' identifier.
+
+### `host.decentProxy(path, options)`
+Call the Decent account proxy without exposing stored credentials to plugin code. The plugin must declare the `proxy.decent_api` permission in `manifest.json`; calls without that permission are rejected and logged.
+
+```javascript
+const response = await host.decentProxy("support/api/sn", {
+  method: "GET",
+  query: { onlyespressomachines: "1" }
+});
+
+if (response.status === 200) {
+  const serials = response.body.trim().split("\n");
+}
+```
+
+The returned object has `{ status, headers, body }`. Only `GET` is supported for plugins in the phase-1 bridge. The existing proxy allowlist still applies, so plugin requests are restricted to the supported Decent backend path prefix.
 
 ## Events System
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -158,8 +158,8 @@ void main(List<String> args) async {
     }
     final startupSimulatedWebViewDevice =
         await SharedPreferencesSettingsService().enableSimulatedWebViews()
-            ? await loadPersistedSimulatedWebViewDevice()
-            : null;
+        ? await loadPersistedSimulatedWebViewDevice()
+        : null;
     if (startupSimulatedWebViewDevice != null) {
       await setSimulatedWebViewDevice(
         startupSimulatedWebViewDevice,
@@ -396,13 +396,6 @@ void main(List<String> args) async {
     workflowController: workflowController,
     persistenceController: persistenceController,
   );
-  final PluginLoaderService pluginService = PluginLoaderService(
-    kvStore: HiveStoreService(defaultNamespace: "plugins")..initialize(),
-  );
-  // Don't initialize plugins yet - wait for permissions to be granted
-  // pluginService.initialize() will be called from PermissionsView after permissions are granted
-  pluginService.pluginManager.de1Controller = de1Controller;
-
   final WebUIService webUIService = WebUIService();
   final WebUIStorage webUIStorage = WebUIStorage(settingsController);
 
@@ -430,6 +423,14 @@ void main(List<String> args) async {
   }
   // Serve the skin token into :3000 HTML so skins can call the account proxy.
   webUIService.skinProxyToken = proxyTokenService.skinToken;
+
+  final PluginLoaderService pluginService = PluginLoaderService(
+    kvStore: HiveStoreService(defaultNamespace: "plugins")..initialize(),
+    decentProxyService: decentProxyService,
+  );
+  // Don't initialize plugins yet - wait for permissions to be granted
+  // pluginService.initialize() will be called from PermissionsView after permissions are granted
+  pluginService.pluginManager.de1Controller = de1Controller;
 
   BatteryController? batteryController;
   if (Platform.isAndroid || Platform.isIOS) {
@@ -492,9 +493,13 @@ void main(List<String> args) async {
   settingsController.addListener(() {
     // Merge dart-define devices with user-selected devices from settings
     const simEnv = String.fromEnvironment("simulate");
-    final dartDefineDevices = simEnv.isNotEmpty ? _parseSimulateFlag(simEnv) : <SimulatedDevicesTypes>{};
-    simulatedDevicesService.enabledDevices =
-        {...dartDefineDevices, ...settingsController.simulatedDevices};
+    final dartDefineDevices = simEnv.isNotEmpty
+        ? _parseSimulateFlag(simEnv)
+        : <SimulatedDevicesTypes>{};
+    simulatedDevicesService.enabledDevices = {
+      ...dartDefineDevices,
+      ...settingsController.simulatedDevices,
+    };
   });
   await settingsController.loadSettings();
 
@@ -691,8 +696,7 @@ class AppLifecycleObserver with WidgetsBindingObserver {
                 if (Platform.isAndroid) {
                   _showAndroidDownloadDialog(context, updateInfo);
                 } else {
-                  final releaseUrl =
-                      updateCheckService?.getReleaseUrl();
+                  final releaseUrl = updateCheckService?.getReleaseUrl();
                   if (releaseUrl != null) {
                     launchUrl(Uri.parse(releaseUrl));
                   }
@@ -723,50 +727,48 @@ class AppLifecycleObserver with WidgetsBindingObserver {
       final releaseUrl = updateCheckService?.getReleaseUrl();
       showDialog(
         context: context,
-        builder:
-            (ctx) => AlertDialog(
-              title: Text('Update ${info.version}'),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text('Version ${info.version} is available'),
-                  const SizedBox(height: 8),
-                  Text(
-                    'Current version: ${BuildInfo.version}',
-                  ),
-                  if (info.releaseNotes.isNotEmpty) ...[
-                    const SizedBox(height: 16),
-                    const Text(
-                      'Release Notes:',
-                      style: TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                    const SizedBox(height: 8),
-                    Container(
-                      constraints:
-                          const BoxConstraints(maxHeight: 200),
-                      child: SingleChildScrollView(
-                        child: Text(info.releaseNotes),
-                      ),
-                    ),
-                  ],
-                ],
+        builder: (ctx) => AlertDialog(
+          title: Text('Update ${info.version}'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Version ${info.version} is available'),
+              const SizedBox(height: 8),
+              Text(
+                'Current version: ${BuildInfo.version}',
               ),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.of(ctx).pop(),
-                  child: const Text('Later'),
+              if (info.releaseNotes.isNotEmpty) ...[
+                const SizedBox(height: 16),
+                const Text(
+                  'Release Notes:',
+                  style: TextStyle(fontWeight: FontWeight.bold),
                 ),
-                if (releaseUrl != null)
-                  ElevatedButton(
-                    onPressed: () {
-                      Navigator.of(ctx).pop();
-                      launchUrl(Uri.parse(releaseUrl));
-                    },
-                    child: const Text('Download'),
+                const SizedBox(height: 8),
+                Container(
+                  constraints: const BoxConstraints(maxHeight: 200),
+                  child: SingleChildScrollView(
+                    child: Text(info.releaseNotes),
                   ),
+                ),
               ],
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: const Text('Later'),
             ),
+            if (releaseUrl != null)
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.of(ctx).pop();
+                  launchUrl(Uri.parse(releaseUrl));
+                },
+                child: const Text('Download'),
+              ),
+          ],
+        ),
       );
     }
   }
@@ -939,7 +941,8 @@ class _AppRootState extends State<AppRoot> {
         LogicalKeyboardKey.digit0,
         control: true,
         alt: true,
-      ): () => unawaited(setSimulatedWebViewDevice(null)),
+      ): () =>
+          unawaited(setSimulatedWebViewDevice(null)),
       const SingleActivator(
         LogicalKeyboardKey.digit8,
         control: true,
@@ -1086,8 +1089,7 @@ class _AndroidQuickUpdateDialog extends StatefulWidget {
       _AndroidQuickUpdateDialogState();
 }
 
-class _AndroidQuickUpdateDialogState
-    extends State<_AndroidQuickUpdateDialog> {
+class _AndroidQuickUpdateDialogState extends State<_AndroidQuickUpdateDialog> {
   bool _isDownloading = true;
   bool _isInstalling = false;
   String? _error;

--- a/lib/src/plugins/plugin_decent_proxy_bridge.dart
+++ b/lib/src/plugins/plugin_decent_proxy_bridge.dart
@@ -1,0 +1,53 @@
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/services/account/decent_proxy_service.dart';
+
+class PluginDecentProxyBridge {
+  final DecentProxyService? decentProxyService;
+  final Logger _log;
+
+  PluginDecentProxyBridge({
+    required this.decentProxyService,
+    Logger? log,
+  }) : _log = log ?? Logger('PluginDecentProxyBridge');
+
+  Future<Map<String, dynamic>> proxyForPlugin({
+    required String pluginId,
+    required PluginManifest? manifest,
+    required String? path,
+    String method = 'GET',
+    Map<String, String>? query,
+  }) async {
+    if (manifest == null) {
+      throw StateError('Plugin is not loaded: $pluginId');
+    }
+    if (!manifest.permissions.contains(PluginPermissions.proxyDecentApi)) {
+      _log.warning(
+        'Plugin $pluginId attempted Decent proxy access without permission',
+      );
+      throw StateError('Plugin permission required: proxy.decent_api');
+    }
+    if (decentProxyService == null) {
+      throw StateError('Decent account proxy is not available');
+    }
+    if (path == null || path.trim().isEmpty) {
+      throw ArgumentError('Decent proxy path is required');
+    }
+
+    final normalizedMethod = method.toUpperCase();
+    if (normalizedMethod != 'GET') {
+      throw UnsupportedError('Decent proxy only supports GET for plugins');
+    }
+
+    final response = await decentProxyService!.proxyGet(
+      callerId: 'plugin:$pluginId',
+      path: path,
+      query: query,
+    );
+    return {
+      'status': response.statusCode,
+      'headers': response.headers,
+      'body': response.body,
+    };
+  }
+}

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -10,6 +10,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
 import 'package:reaprime/src/plugins/plugin_runtime.dart';
+import 'package:reaprime/src/services/account/decent_proxy_service.dart';
 import 'package:reaprime/build_info.dart';
 
 class PluginSettingsValidationException implements Exception {
@@ -29,9 +30,15 @@ class PluginLoaderService {
   late SharedPreferences _prefs;
   final Map<String, PluginManifest> _availablePluginsCache = {};
 
-  PluginLoaderService({required KeyValueStoreService kvStore, bool? appStoreMode})
-    : pluginManager = PluginManager(kvStore: kvStore),
-      _appStoreMode = appStoreMode ?? BuildInfo.appStore;
+  PluginLoaderService({
+    required KeyValueStoreService kvStore,
+    DecentProxyService? decentProxyService,
+    bool? appStoreMode,
+  }) : pluginManager = PluginManager(
+         kvStore: kvStore,
+         decentProxyService: decentProxyService,
+       ),
+       _appStoreMode = appStoreMode ?? BuildInfo.appStore;
 
   bool _initialized = false;
 
@@ -340,12 +347,15 @@ class PluginLoaderService {
           '$pluginPath/manifest.json',
         );
         if (kReleaseMode) {
-          final newManifest = PluginManifest.fromJson(jsonDecode(manifestAsset));
+          final newManifest = PluginManifest.fromJson(
+            jsonDecode(manifestAsset),
+          );
           final existingManifestFile = File('${destDir.path}/manifest.json');
           final existingManifest = PluginManifest.fromJson(
             jsonDecode(await existingManifestFile.readAsString()),
           );
-          if (_compareVersions(newManifest.version, existingManifest.version) <= 0) {
+          if (_compareVersions(newManifest.version, existingManifest.version) <=
+              0) {
             // existing plugin has same or newer version
             _log.fine(
               "not overriding bundled plugin: [bundled: ${newManifest.version}], [existing: ${existingManifest.version}]",
@@ -515,7 +525,9 @@ class PluginLoaderService {
     // Validate each setting against schema
     for (final key in settings.keys) {
       if (!manifestSettings.containsKey(key)) {
-        throw PluginSettingsValidationException('Setting "$key" not defined in plugin manifest');
+        throw PluginSettingsValidationException(
+          'Setting "$key" not defined in plugin manifest',
+        );
       }
 
       // TODO: Add more sophisticated validation based on schema type

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -62,7 +62,121 @@ class PluginManager {
         
         // Add HTTP response handling
         globalThis.__pendingHttpRequests = new Map();
-        globalThis.__pendingDecentProxyRequests = new Map();
+        const __nativeSendMessage = sendMessage;
+        const __nativeJsonStringify = JSON.stringify.bind(JSON);
+        const __NativePromise = Promise;
+        const __NativeError = Error;
+        const __nativeFreeze = Object.freeze.bind(Object);
+        const __nativeReflectApply = Reflect.apply.bind(Reflect);
+        const __nativePromiseThen = Promise.prototype.then;
+        const __nativePromiseCatch = Promise.prototype.catch;
+        const __nativePromiseFinally = Promise.prototype.finally;
+        const __nativeMapHas = Map.prototype.has;
+        const __nativeMapGet = Map.prototype.get;
+        const __nativeMapSet = Map.prototype.set;
+        const __nativeMapDelete = Map.prototype.delete;
+
+        const __pendingDecentProxyRequests = new Map();
+        let __decentProxySeq = 0;
+        const __decentProxyNonce =
+          Date.now().toString(36) + "_" + Math.random().toString(36).slice(2);
+
+        function __mapHas(map, key) {
+          return __nativeReflectApply(__nativeMapHas, map, [key]);
+        }
+
+        function __mapGet(map, key) {
+          return __nativeReflectApply(__nativeMapGet, map, [key]);
+        }
+
+        function __mapSet(map, key, value) {
+          return __nativeReflectApply(__nativeMapSet, map, [key, value]);
+        }
+
+        function __mapDelete(map, key) {
+          return __nativeReflectApply(__nativeMapDelete, map, [key]);
+        }
+
+        function __pendingDecentProxyByPlugin(pluginId) {
+          if (!__mapHas(__pendingDecentProxyRequests, pluginId)) {
+            __mapSet(__pendingDecentProxyRequests, pluginId, new Map());
+          }
+          return __mapGet(__pendingDecentProxyRequests, pluginId);
+        }
+
+        function __sendHostMessage(message) {
+          __nativeSendMessage("host", __nativeJsonStringify(message));
+        }
+
+        function __wrapDecentProxyPromise(promise) {
+          const wrapped = {
+            then(onFulfilled, onRejected) {
+              return __nativeReflectApply(__nativePromiseThen, promise, [
+                onFulfilled,
+                onRejected
+              ]);
+            },
+            catch(onRejected) {
+              return __nativeReflectApply(__nativePromiseCatch, promise, [
+                onRejected
+              ]);
+            }
+          };
+          if (typeof __nativePromiseFinally === "function") {
+            wrapped.finally = function (onFinally) {
+              return __nativeReflectApply(__nativePromiseFinally, promise, [
+                onFinally
+              ]);
+            };
+          }
+          return __nativeFreeze(wrapped);
+        }
+
+        function __decentProxy(pluginId, bridgeToken, path, method, query) {
+          const requestId = "__decent_proxy_" + __decentProxyNonce + "_" + (++__decentProxySeq);
+          const promise = new __NativePromise((resolve, reject) => {
+            const pendingByPlugin = __pendingDecentProxyByPlugin(pluginId);
+            __mapSet(pendingByPlugin, requestId, { resolve, reject });
+            try {
+              __sendHostMessage({
+                pluginId: pluginId,
+                bridgeToken: bridgeToken,
+                type: "decentProxy",
+                requestId: requestId,
+                path: path,
+                method: method,
+                query: query
+              });
+            } catch (e) {
+              __mapDelete(pendingByPlugin, requestId);
+              reject(e);
+            }
+          });
+          return __wrapDecentProxyPromise(promise);
+        }
+
+        function __completeDecentProxyRequest(pluginId, requestId, response) {
+          const pendingByPlugin = __mapGet(__pendingDecentProxyRequests, pluginId);
+          if (!pendingByPlugin) return;
+          const pending = __mapGet(pendingByPlugin, requestId);
+          if (!pending) return;
+          __mapDelete(pendingByPlugin, requestId);
+          if (response && response.error) {
+            pending.reject(new __NativeError(response.error));
+            return;
+          }
+          pending.resolve(response);
+        }
+
+        Object.defineProperty(globalThis, "__reaprimePluginBridge", {
+          value: __nativeFreeze({
+            decentProxy: __decentProxy,
+            completeDecentProxyRequest: __completeDecentProxyRequest
+          }),
+          writable: false,
+          configurable: false,
+          enumerable: false
+        });
         
         globalThis.__registerHttpRequest = function (pluginId, requestId) {
           if (!globalThis.__pendingHttpRequests.has(pluginId)) {
@@ -90,30 +204,6 @@ class PluginManager {
             requestId: requestId,
             payload: response
           }));
-        };
-
-        globalThis.__registerDecentProxyRequest = function (pluginId, requestId) {
-          if (!globalThis.__pendingDecentProxyRequests.has(pluginId)) {
-            globalThis.__pendingDecentProxyRequests.set(pluginId, new Map());
-          }
-          return new Promise((resolve, reject) => {
-            globalThis.__pendingDecentProxyRequests
-              .get(pluginId)
-              .set(requestId, { resolve, reject });
-          });
-        };
-
-        globalThis.__handleDecentProxyResponse = function (pluginId, requestId, response) {
-          const pendingByPlugin = globalThis.__pendingDecentProxyRequests.get(pluginId);
-          if (!pendingByPlugin) return;
-          const pending = pendingByPlugin.get(requestId);
-          if (!pending) return;
-          pendingByPlugin.delete(requestId);
-          if (response && response.error) {
-            pending.reject(new Error(response.error));
-            return;
-          }
-          pending.resolve(response);
         };
 
         // Provide btoa function if not available
@@ -202,17 +292,6 @@ class PluginManager {
               method: method,
               headers: headers,
               body: body
-            }));
-          },
-          decentProxy(pluginId, bridgeToken, requestId, path, method, query) {
-            sendMessage("host", JSON.stringify({
-              pluginId: pluginId,
-              bridgeToken: bridgeToken,
-              type: "decentProxy",
-              requestId: requestId,
-              path: path,
-              method: method,
-              query: query
             }));
           }
         };
@@ -356,20 +435,13 @@ class PluginManager {
           emit: (type, payload) => globalThis.host.emit(pluginId, type, payload),
           storage: (cmd) => globalThis.host.storage(pluginId, cmd),
           decentProxy: (path, options = {}) => {
-            const requestId = pluginId + "_decent_" + Date.now() + "_" + Math.random().toString(36).substr(2, 9);
-            return new Promise((resolve, reject) => {
-              if (globalThis.__registerDecentProxyRequest) {
-                globalThis.__registerDecentProxyRequest(pluginId, requestId).then(resolve).catch(reject);
-              }
-              globalThis.host.decentProxy(
-                pluginId,
-                ${jsonEncode(decentProxyBridgeToken)},
-                requestId,
-                path,
-                options.method || "GET",
-                options.query || {}
-              );
-            });
+            return globalThis.__reaprimePluginBridge.decentProxy(
+              pluginId,
+              ${jsonEncode(decentProxyBridgeToken)},
+              path,
+              options.method || "GET",
+              options.query || {}
+            );
           },
           // Add HTTP request capability
           httpRequest: (endpoint, method, headers, body) => {
@@ -648,7 +720,7 @@ class PluginManager {
     Map<String, dynamic> response,
   ) {
     js.evaluate('''
-      globalThis.__handleDecentProxyResponse(
+      globalThis.__reaprimePluginBridge.completeDecentProxyRequest(
         ${jsonEncode(pluginId)},
         ${jsonEncode(requestId)},
         ${jsonEncode(response)}

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -1,17 +1,20 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:flutter_js/flutter_js.dart';
 import 'package:logging/logging.dart';
 
 import 'plugin_manifest.dart';
+import 'plugin_decent_proxy_bridge.dart';
 import 'plugin_runtime.dart';
 import 'plugin_types.dart';
 import '../services/storage/kv_store_service.dart';
 import '../controllers/de1_controller.dart';
 import '../models/device/de1_interface.dart';
 import '../models/device/machine.dart';
+import '../services/account/decent_proxy_service.dart';
 
 class PluginManager {
   final _log = Logger("PluginManager");
@@ -19,6 +22,9 @@ class PluginManager {
   final Map<String, PluginRuntime> _plugins = {};
   final JavascriptRuntime js;
   final KeyValueStoreService kvStore;
+  final DecentProxyService? decentProxyService;
+  late final PluginDecentProxyBridge _decentProxyBridge;
+  final Map<String, String> _decentProxyBridgeTokens = {};
 
   final StreamController<Map<String, dynamic>> _emitController =
       StreamController.broadcast();
@@ -31,8 +37,12 @@ class PluginManager {
 
   De1Controller? get de1Controller => _de1controller;
 
-  PluginManager({required this.kvStore})
+  PluginManager({required this.kvStore, this.decentProxyService})
     : js = getJavascriptRuntime(xhr: false) {
+    _decentProxyBridge = PluginDecentProxyBridge(
+      decentProxyService: decentProxyService,
+      log: _log,
+    );
     // js.enableHandlePromises();
     // js.enableXhr();
     // js.enableFetch();
@@ -52,6 +62,7 @@ class PluginManager {
         
         // Add HTTP response handling
         globalThis.__pendingHttpRequests = new Map();
+        globalThis.__pendingDecentProxyRequests = new Map();
         
         globalThis.__registerHttpRequest = function (pluginId, requestId) {
           if (!globalThis.__pendingHttpRequests.has(pluginId)) {
@@ -79,6 +90,30 @@ class PluginManager {
             requestId: requestId,
             payload: response
           }));
+        };
+
+        globalThis.__registerDecentProxyRequest = function (pluginId, requestId) {
+          if (!globalThis.__pendingDecentProxyRequests.has(pluginId)) {
+            globalThis.__pendingDecentProxyRequests.set(pluginId, new Map());
+          }
+          return new Promise((resolve, reject) => {
+            globalThis.__pendingDecentProxyRequests
+              .get(pluginId)
+              .set(requestId, { resolve, reject });
+          });
+        };
+
+        globalThis.__handleDecentProxyResponse = function (pluginId, requestId, response) {
+          const pendingByPlugin = globalThis.__pendingDecentProxyRequests.get(pluginId);
+          if (!pendingByPlugin) return;
+          const pending = pendingByPlugin.get(requestId);
+          if (!pending) return;
+          pendingByPlugin.delete(requestId);
+          if (response && response.error) {
+            pending.reject(new Error(response.error));
+            return;
+          }
+          pending.resolve(response);
         };
 
         // Provide btoa function if not available
@@ -168,6 +203,17 @@ class PluginManager {
               headers: headers,
               body: body
             }));
+          },
+          decentProxy(pluginId, bridgeToken, requestId, path, method, query) {
+            sendMessage("host", JSON.stringify({
+              pluginId: pluginId,
+              bridgeToken: bridgeToken,
+              type: "decentProxy",
+              requestId: requestId,
+              path: path,
+              method: method,
+              query: query
+            }));
           }
         };
       })();
@@ -244,7 +290,7 @@ class PluginManager {
       })();
     ''');
 
-    js.onMessage("host", (raw) {
+    js.onMessage("host", (raw) async {
       try {
         _log.finest("receiving: $raw");
         final msg = raw as Map<String, dynamic>;
@@ -262,7 +308,7 @@ class PluginManager {
           // Handle HTTP responses from plugin
           _handlePluginApiResponse(pluginId, msg);
         } else {
-          _handleMessage(pluginId, msg);
+          await _handleMessage(pluginId, msg);
         }
       } catch (e, st) {
         _log.warning("Invalid JS message", e, st);
@@ -292,12 +338,15 @@ class PluginManager {
     await unloadPlugin(id);
 
     final runtime = PluginRuntime(pluginId: id, manifest: manifest);
+    final decentProxyBridgeToken = _newBridgeToken();
 
     _plugins[id] = runtime;
+    _decentProxyBridgeTokens[id] = decentProxyBridgeToken;
 
     try {
       // Direct injection approach with standard factory name
-      final wrapperCode = '''
+      final wrapperCode =
+          '''
       (function () {
         const pluginId = "$id";
         
@@ -306,6 +355,22 @@ class PluginManager {
           log: (msg) => globalThis.host.log(pluginId, msg),
           emit: (type, payload) => globalThis.host.emit(pluginId, type, payload),
           storage: (cmd) => globalThis.host.storage(pluginId, cmd),
+          decentProxy: (path, options = {}) => {
+            const requestId = pluginId + "_decent_" + Date.now() + "_" + Math.random().toString(36).substr(2, 9);
+            return new Promise((resolve, reject) => {
+              if (globalThis.__registerDecentProxyRequest) {
+                globalThis.__registerDecentProxyRequest(pluginId, requestId).then(resolve).catch(reject);
+              }
+              globalThis.host.decentProxy(
+                pluginId,
+                ${jsonEncode(decentProxyBridgeToken)},
+                requestId,
+                path,
+                options.method || "GET",
+                options.query || {}
+              );
+            });
+          },
           // Add HTTP request capability
           httpRequest: (endpoint, method, headers, body) => {
             const requestId = pluginId + "_" + Date.now() + "_" + Math.random().toString(36).substr(2, 9);
@@ -370,6 +435,7 @@ class PluginManager {
       _log.info("loaded: $id");
     } catch (e, st) {
       _plugins.remove(id);
+      _decentProxyBridgeTokens.remove(id);
       js.evaluate('''
       delete globalThis.__plugins__["$id"];
     ''');
@@ -386,6 +452,7 @@ class PluginManager {
 
   Future<void> unloadPlugin(String id) async {
     final runtime = _plugins.remove(id);
+    _decentProxyBridgeTokens.remove(id);
     if (runtime == null) return;
 
     try {
@@ -482,7 +549,7 @@ class PluginManager {
   // JS → Dart messages
   // ─────────────────────────────────────────────
 
-  void _handleMessage(String pluginId, Map<String, dynamic> msg) {
+  Future<void> _handleMessage(String pluginId, Map<String, dynamic> msg) async {
     _log.finest("handle message: $msg");
     final type = msg['type'];
     final payload = msg['payload'];
@@ -500,9 +567,94 @@ class PluginManager {
 
       case 'pluginStorage':
         final cmd = PluginStorageCommand.fromPlugin(payload);
-        _handlePluginStorage(pluginId, cmd);
+        await _handlePluginStorage(pluginId, cmd);
+        break;
+
+      case 'decentProxy':
+        await _handleDecentProxyMessage(pluginId, msg);
         break;
     }
+  }
+
+  Future<void> _handleDecentProxyMessage(
+    String pluginId,
+    Map<String, dynamic> msg,
+  ) async {
+    final requestId = msg['requestId'] as String?;
+    if (requestId == null) {
+      _log.warning('Decent proxy message from $pluginId missing requestId');
+      return;
+    }
+    if (msg['bridgeToken'] != _decentProxyBridgeTokens[pluginId]) {
+      _log.warning('Decent proxy message from $pluginId has invalid token');
+      _completeDecentProxyRequest(pluginId, requestId, {
+        'error': 'Invalid plugin proxy caller',
+      });
+      return;
+    }
+
+    try {
+      final response = await proxyDecentApiForManifest(
+        pluginId: pluginId,
+        manifest: _plugins[pluginId]?.manifest,
+        path: msg['path'] as String?,
+        method: (msg['method'] as String?) ?? 'GET',
+        query: _stringMap(msg['query']),
+      );
+      _completeDecentProxyRequest(pluginId, requestId, response);
+    } catch (e) {
+      _completeDecentProxyRequest(pluginId, requestId, {
+        'error': e.toString(),
+      });
+    }
+  }
+
+  String _newBridgeToken() {
+    final random = Random.secure();
+    final bytes = List<int>.generate(32, (_) => random.nextInt(256));
+    return base64Url.encode(bytes);
+  }
+
+  Future<Map<String, dynamic>> proxyDecentApiForManifest({
+    required String pluginId,
+    required PluginManifest? manifest,
+    required String? path,
+    String method = 'GET',
+    Map<String, String>? query,
+  }) async {
+    return _decentProxyBridge.proxyForPlugin(
+      pluginId: pluginId,
+      manifest: manifest,
+      path: path,
+      method: method,
+      query: query,
+    );
+  }
+
+  Map<String, String>? _stringMap(dynamic value) {
+    if (value is! Map) return null;
+    final out = <String, String>{};
+    value.forEach((key, value) {
+      if (value != null) {
+        out[key.toString()] = value.toString();
+      }
+    });
+    return out.isEmpty ? null : out;
+  }
+
+  void _completeDecentProxyRequest(
+    String pluginId,
+    String requestId,
+    Map<String, dynamic> response,
+  ) {
+    js.evaluate('''
+      globalThis.__handleDecentProxyResponse(
+        ${jsonEncode(pluginId)},
+        ${jsonEncode(requestId)},
+        ${jsonEncode(response)}
+      );
+    ''');
+    js.executePendingJob();
   }
 
   Future<void> _handlePluginStorage(

--- a/lib/src/plugins/plugin_manifest.dart
+++ b/lib/src/plugins/plugin_manifest.dart
@@ -54,6 +54,7 @@ class PluginManifest {
 
 enum PluginPermissions {
   log('log'),
+  api('api'),
   emit('emit'),
   pluginStorage('pluginStorage'),
   pluginNotify('pluginNotify'),

--- a/lib/src/plugins/plugin_manifest.dart
+++ b/lib/src/plugins/plugin_manifest.dart
@@ -45,7 +45,7 @@ class PluginManifest {
       'description': description,
       'version': version,
       'apiVersion': apiVersion,
-      'permissions': permissions.map((e) => e.name).toList(),
+      'permissions': permissions.map((e) => e.wireName).toList(),
       'settings': settings,
       'api': api?.toJson(),
     };
@@ -53,13 +53,20 @@ class PluginManifest {
 }
 
 enum PluginPermissions {
-  log,
-  emit,
-  pluginStorage,
-  pluginNotify;
+  log('log'),
+  emit('emit'),
+  pluginStorage('pluginStorage'),
+  pluginNotify('pluginNotify'),
+  proxyDecentApi('proxy.decent_api');
+
+  final String wireName;
+
+  const PluginPermissions(this.wireName);
 
   static PluginPermissions? fromString(String value) {
-    return PluginPermissions.values.firstWhereOrNull((e) => e.name == value);
+    return PluginPermissions.values.firstWhereOrNull(
+      (e) => e.wireName == value || e.name == value,
+    );
   }
 }
 

--- a/lib/src/settings/plugins_settings_view.dart
+++ b/lib/src/settings/plugins_settings_view.dart
@@ -209,7 +209,7 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
                         plugin.permissions
                             .map(
                               (permission) => Chip(
-                                label: Text(permission.name),
+                                label: Text(permission.wireName),
                                 backgroundColor:
                                     Theme.of(context).colorScheme.tertiary,
                                 labelStyle:

--- a/test/plugins/plugin_decent_proxy_bridge_test.dart
+++ b/test/plugins/plugin_decent_proxy_bridge_test.dart
@@ -1,0 +1,144 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/plugins/plugin_decent_proxy_bridge.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:reaprime/src/services/account/decent_proxy_service.dart';
+
+class FakeCredentialStore implements CredentialStore {
+  final Map<String, String> _values = {};
+
+  @override
+  Future<String?> read({required String key}) async => _values[key];
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    _values.remove(key);
+  }
+}
+
+void main() {
+  late FakeCredentialStore store;
+
+  setUp(() {
+    store = FakeCredentialStore();
+  });
+
+  Future<void> linkAccount() async {
+    await store.write(key: 'email', value: 'user@example.com');
+    await store.write(key: 'password', value: 'cryptpw_abc123');
+  }
+
+  PluginManifest manifestWith(Set<PluginPermissions> permissions) {
+    return PluginManifest(
+      id: 'test.plugin',
+      name: 'Test Plugin',
+      author: 'Test',
+      description: 'Test',
+      version: '1.0.0',
+      apiVersion: 1,
+      permissions: permissions,
+      settings: {},
+      api: PluginApi(endpoints: []),
+    );
+  }
+
+  PluginDecentProxyBridge bridge(
+    http_testing.MockClientHandler handler,
+  ) {
+    return PluginDecentProxyBridge(
+      decentProxyService: DecentProxyService(
+        httpClient: http_testing.MockClient(handler),
+        credentialStore: store,
+      ),
+    );
+  }
+
+  test('declared permission forwards GET through DecentProxyService', () async {
+    await linkAccount();
+    late http.Request upstream;
+    final records = <LogRecord>[];
+    final sub = Logger('DecentProxy').onRecord.listen(records.add);
+    addTearDown(sub.cancel);
+
+    final result =
+        await bridge((request) async {
+          upstream = request;
+          return http.Response(
+            'SN001',
+            200,
+            headers: {'content-type': 'text/plain'},
+          );
+        }).proxyForPlugin(
+          pluginId: 'test.plugin',
+          manifest: manifestWith({PluginPermissions.proxyDecentApi}),
+          path: 'support/api/sn',
+          query: {'onlyespressomachines': '1'},
+        );
+
+    expect(result['status'], 200);
+    expect(result['body'], 'SN001');
+    expect(result['headers'], containsPair('content-type', 'text/plain'));
+    expect(
+      upstream.url.toString(),
+      'https://decentespresso.com/support/api/sn?onlyespressomachines=1',
+    );
+    expect(
+      upstream.headers['authorization'],
+      'Basic ${base64Encode(utf8.encode('user@example.com:cryptpw_abc123'))}',
+    );
+    expect(
+      records.any((r) => r.message.contains('plugin:test.plugin')),
+      isTrue,
+    );
+  });
+
+  test('missing permission rejects before upstream is called', () async {
+    await linkAccount();
+    var upstreamCalled = false;
+
+    await expectLater(
+      bridge((request) async {
+        upstreamCalled = true;
+        return http.Response('must not happen', 200);
+      }).proxyForPlugin(
+        pluginId: 'test.plugin',
+        manifest: manifestWith({}),
+        path: 'support/api/sn',
+      ),
+      throwsA(isA<StateError>()),
+    );
+
+    expect(upstreamCalled, isFalse);
+  });
+
+  test('credentials are not returned to plugin-visible data', () async {
+    await linkAccount();
+
+    final result =
+        await bridge((request) async {
+          return http.Response(
+            'ok',
+            200,
+            headers: {'authorization': 'Basic leaked'},
+          );
+        }).proxyForPlugin(
+          pluginId: 'test.plugin',
+          manifest: manifestWith({PluginPermissions.proxyDecentApi}),
+          path: 'support/api/sn',
+        );
+
+    final serialized = jsonEncode(result);
+    expect(serialized.contains('cryptpw_abc123'), isFalse);
+    expect(serialized.toLowerCase().contains('authorization'), isFalse);
+  });
+}

--- a/test/plugins/plugin_manager_decent_proxy_bridge_test.dart
+++ b/test/plugins/plugin_manager_decent_proxy_bridge_test.dart
@@ -1,0 +1,276 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:reaprime/src/services/account/decent_proxy_service.dart';
+import 'package:reaprime/src/services/storage/kv_store_service.dart';
+
+class FakeCredentialStore implements CredentialStore {
+  final Map<String, String> _values = {};
+
+  @override
+  Future<String?> read({required String key}) async => _values[key];
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    _values.remove(key);
+  }
+}
+
+class FakeKeyValueStoreService implements KeyValueStoreService {
+  final Map<String, Map<String, Object>> _store = {};
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> set({
+    String namespace = 'default',
+    required String key,
+    required Object value,
+  }) async {
+    _store.putIfAbsent(namespace, () => {})[key] = value;
+  }
+
+  @override
+  Future<bool> delete({
+    String namespace = 'default',
+    required String key,
+  }) async {
+    return _store[namespace]?.remove(key) != null;
+  }
+
+  @override
+  Future<Object?> get({
+    String namespace = 'default',
+    required String key,
+  }) async {
+    return _store[namespace]?[key];
+  }
+
+  @override
+  Future<List<String>> keys({String namespace = 'default'}) async {
+    return _store[namespace]?.keys.toList() ?? [];
+  }
+
+  @override
+  List<String> get namespaces => _store.keys.toList();
+
+  @override
+  Future<Map<String, Object>> getAll({String namespace = 'default'}) async {
+    return Map<String, Object>.from(_store[namespace] ?? {});
+  }
+}
+
+void main() {
+  PluginManifest manifest({
+    required String id,
+    Set<PluginPermissions> permissions = const {},
+  }) {
+    return PluginManifest(
+      id: id,
+      name: id,
+      author: 'Test',
+      description: 'Test',
+      version: '1.0.0',
+      apiVersion: 1,
+      permissions: permissions,
+      settings: {},
+      api: PluginApi(endpoints: []),
+    );
+  }
+
+  test(
+    'Decent proxy bridge token and responses are not observable through globals',
+    () async {
+      final credentialStore = FakeCredentialStore();
+      await credentialStore.write(key: 'email', value: 'user@example.com');
+      await credentialStore.write(key: 'password', value: 'cryptpw_abc123');
+
+      var upstreamCalls = 0;
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        decentProxyService: DecentProxyService(
+          credentialStore: credentialStore,
+          httpClient: http_testing.MockClient((request) async {
+            upstreamCalls += 1;
+            return http.Response(
+              jsonEncode({'serial': 'SN001'}),
+              200,
+              headers: {'content-type': 'application/json'},
+            );
+          }),
+        ),
+      );
+
+      await manager.loadPlugin(
+        id: 'spy.plugin',
+        manifest: manifest(id: 'spy.plugin'),
+        settings: {},
+        jsCode: r'''
+          function createPlugin(host) {
+            const spy = globalThis.__spy = {
+              tokenCount: 0,
+              responseCount: 0,
+              canReplaceBridgeMethod: false,
+              hasLegacyProxyHook: typeof globalThis.host.decentProxy === "function",
+              hasLegacyResponseHook: typeof globalThis.__handleDecentProxyResponse === "function"
+            };
+
+            const legacyProxy = globalThis.host.decentProxy;
+            if (typeof legacyProxy === "function") {
+              globalThis.host.decentProxy = function (...args) {
+                spy.tokenCount += 1;
+                return legacyProxy.apply(this, args);
+              };
+            }
+
+            const legacyResponse = globalThis.__handleDecentProxyResponse;
+            if (typeof legacyResponse === "function") {
+              globalThis.__handleDecentProxyResponse = function (...args) {
+                spy.responseCount += 1;
+                return legacyResponse.apply(this, args);
+              };
+            }
+
+            const originalThen = Promise.prototype.then;
+            Promise.prototype.then = function (onFulfilled, onRejected) {
+              return originalThen.call(this, function (value) {
+                if (value && value.status === 200 && value.body === '{"serial":"SN001"}') {
+                  spy.responseCount += 1;
+                }
+                return typeof onFulfilled === "function"
+                  ? onFulfilled(value)
+                  : value;
+              }, onRejected);
+            };
+
+            function wrapPending(value) {
+              if (value && typeof value.resolve === "function" && !value.__spyWrapped) {
+                const originalResolve = value.resolve;
+                value.__spyWrapped = true;
+                value.resolve = function (response) {
+                  if (response && response.status === 200 && response.body === '{"serial":"SN001"}') {
+                    spy.responseCount += 1;
+                  }
+                  return originalResolve(response);
+                };
+              }
+              return value;
+            }
+
+            const originalMapSet = Map.prototype.set;
+            Map.prototype.set = function (key, value) {
+              return originalMapSet.call(this, key, wrapPending(value));
+            };
+
+            const originalMapGet = Map.prototype.get;
+            Map.prototype.get = function (key) {
+              return wrapPending(originalMapGet.call(this, key));
+            };
+
+            const bridge = globalThis.__reaprimePluginBridge;
+            if (bridge) {
+              const original = bridge.decentProxy;
+              try {
+                bridge.decentProxy = function (...args) {
+                  spy.tokenCount += 1;
+                  return original.apply(this, args);
+                };
+              } catch (e) {
+                // Non-strict runtimes may throw for frozen properties.
+              }
+              spy.canReplaceBridgeMethod = bridge.decentProxy !== original;
+            }
+
+            return {
+              id: "spy.plugin",
+              onEvent(evt) {
+                if (evt.name === "report") {
+                  host.emit("spyReport", spy);
+                }
+              }
+            };
+          }
+        ''',
+      );
+
+      final proxyResult = expectLater(
+        manager.emitStream,
+        emits(
+          allOf(
+            containsPair('pluginId', 'privileged.plugin'),
+            containsPair('event', 'proxyResult'),
+            containsPair(
+              'payload',
+              allOf(
+                containsPair('status', 200),
+                containsPair('body', '{"serial":"SN001"}'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await manager.loadPlugin(
+        id: 'privileged.plugin',
+        manifest: manifest(
+          id: 'privileged.plugin',
+          permissions: {PluginPermissions.proxyDecentApi},
+        ),
+        settings: {},
+        jsCode: r'''
+          function createPlugin(host) {
+            return {
+              id: "privileged.plugin",
+              onLoad() {
+                host.decentProxy("support/api/sn", {
+                  query: { onlyespressomachines: "1" }
+                }).then((response) => {
+                  host.emit("proxyResult", response);
+                }).catch((error) => {
+                  host.emit("proxyError", { message: String(error) });
+                });
+              }
+            };
+          }
+        ''',
+      );
+
+      await proxyResult.timeout(const Duration(seconds: 5));
+      expect(upstreamCalls, 1);
+
+      final spyReport = expectLater(
+        manager.emitStream,
+        emits(
+          allOf(
+            containsPair('pluginId', 'spy.plugin'),
+            containsPair('event', 'spyReport'),
+            containsPair(
+              'payload',
+              allOf(
+                containsPair('tokenCount', 0),
+                containsPair('responseCount', 0),
+                containsPair('canReplaceBridgeMethod', false),
+                containsPair('hasLegacyProxyHook', false),
+                containsPair('hasLegacyResponseHook', false),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      manager.dispatchEvent('spy.plugin', 'report', {});
+      await spyReport.timeout(const Duration(seconds: 5));
+    },
+  );
+}

--- a/test/plugins/plugin_manifest_permissions_test.dart
+++ b/test/plugins/plugin_manifest_permissions_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
 
 void main() {
-  test('parses proxy.decent_api as proxyDecentApi permission', () {
+  test('parses manifest permission wire values', () {
     final manifest = PluginManifest.fromJson(<String, dynamic>{
       'id': 'test.plugin',
       'name': 'Test Plugin',
@@ -10,12 +10,13 @@ void main() {
       'description': 'Test',
       'version': '1.0.0',
       'apiVersion': 1,
-      'permissions': ['log', 'proxy.decent_api'],
+      'permissions': ['log', 'api', 'proxy.decent_api'],
       'settings': <String, dynamic>{},
       'api': <dynamic>[],
     });
 
     expect(manifest.permissions, contains(PluginPermissions.log));
+    expect(manifest.permissions, contains(PluginPermissions.api));
     expect(manifest.permissions, contains(PluginPermissions.proxyDecentApi));
   });
 
@@ -28,6 +29,7 @@ void main() {
       version: '1.0.0',
       apiVersion: 1,
       permissions: {
+        PluginPermissions.api,
         PluginPermissions.pluginStorage,
         PluginPermissions.proxyDecentApi,
       },
@@ -37,7 +39,7 @@ void main() {
 
     expect(
       manifest.toJson()['permissions'],
-      containsAll(['pluginStorage', 'proxy.decent_api']),
+      containsAll(['api', 'pluginStorage', 'proxy.decent_api']),
     );
   });
 }

--- a/test/plugins/plugin_manifest_permissions_test.dart
+++ b/test/plugins/plugin_manifest_permissions_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+
+void main() {
+  test('parses proxy.decent_api as proxyDecentApi permission', () {
+    final manifest = PluginManifest.fromJson(<String, dynamic>{
+      'id': 'test.plugin',
+      'name': 'Test Plugin',
+      'author': 'Test',
+      'description': 'Test',
+      'version': '1.0.0',
+      'apiVersion': 1,
+      'permissions': ['log', 'proxy.decent_api'],
+      'settings': <String, dynamic>{},
+      'api': <dynamic>[],
+    });
+
+    expect(manifest.permissions, contains(PluginPermissions.log));
+    expect(manifest.permissions, contains(PluginPermissions.proxyDecentApi));
+  });
+
+  test('serializes permissions using manifest wire values', () {
+    final manifest = PluginManifest(
+      id: 'test.plugin',
+      name: 'Test Plugin',
+      author: 'Test',
+      description: 'Test',
+      version: '1.0.0',
+      apiVersion: 1,
+      permissions: {
+        PluginPermissions.pluginStorage,
+        PluginPermissions.proxyDecentApi,
+      },
+      settings: {},
+      api: PluginApi(endpoints: []),
+    );
+
+    expect(
+      manifest.toJson()['permissions'],
+      containsAll(['pluginStorage', 'proxy.decent_api']),
+    );
+  });
+}

--- a/test/plugins_settings_view_appstore_test.dart
+++ b/test/plugins_settings_view_appstore_test.dart
@@ -6,11 +6,18 @@ import 'package:reaprime/src/settings/plugins_settings_view.dart';
 
 /// A fake PluginLoaderService that avoids creating a real PluginManager/JS runtime.
 class FakePluginLoaderService extends Fake implements PluginLoaderService {
+  FakePluginLoaderService({this.plugins = const []});
+
+  final List<PluginManifest> plugins;
+
   @override
-  List<PluginManifest> get availablePlugins => [];
+  List<PluginManifest> get availablePlugins => plugins;
 
   @override
   bool isPluginLoaded(String pluginId) => false;
+
+  @override
+  Future<bool> shouldAutoLoad(String pluginId) async => false;
 }
 
 void main() {
@@ -21,8 +28,9 @@ void main() {
   });
 
   group('PluginsSettingsView install button visibility', () {
-    testWidgets('shows install button when allowInstall is true',
-        (tester) async {
+    testWidgets('shows install button when allowInstall is true', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         ShadApp(
           home: PluginsSettingsView(
@@ -37,8 +45,9 @@ void main() {
       expect(find.byTooltip('Refresh Plugins'), findsOneWidget);
     });
 
-    testWidgets('hides install button when allowInstall is false',
-        (tester) async {
+    testWidgets('hides install button when allowInstall is false', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         ShadApp(
           home: PluginsSettingsView(
@@ -53,5 +62,34 @@ void main() {
       // Refresh button should still be present
       expect(find.byTooltip('Refresh Plugins'), findsOneWidget);
     });
+  });
+
+  testWidgets('renders manifest permission wire names', (tester) async {
+    final manifest = PluginManifest(
+      id: 'proxy.reaplugin',
+      name: 'Proxy Plugin',
+      author: 'Test',
+      description: 'Test plugin',
+      version: '1.0.0',
+      apiVersion: 1,
+      permissions: {PluginPermissions.proxyDecentApi},
+      settings: {},
+      api: PluginApi(endpoints: []),
+    );
+
+    fakePluginLoaderService = FakePluginLoaderService(plugins: [manifest]);
+
+    await tester.pumpWidget(
+      ShadApp(
+        home: PluginsSettingsView(
+          pluginLoaderService: fakePluginLoaderService,
+          allowInstall: false,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('proxy.decent_api'), findsOneWidget);
+    expect(find.text('proxyDecentApi'), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary
- Adds the `proxy.decent_api` plugin manifest permission.
- Injects `DecentProxyService` into plugin loading and exposes `host.decentProxy(path, { method, query })` for plugin GET calls.
- Enforces declared permission before dispatch, uses caller id `plugin:<id>`, and keeps credentials out of plugin-visible responses.
- Adds a per-plugin bridge token so one plugin cannot spoof another plugin's proxy permission.

Fixes #298

## Validation
- `npm.cmd ci --cache D:\ingestion\reaprime-main\_work\tools\npm-cache`
- `npm.cmd run build`
- `flutter analyze --no-pub`
- `flutter test --no-pub test\plugins\plugin_manifest_permissions_test.dart test\plugins\plugin_decent_proxy_bridge_test.dart --reporter=compact`
- `flutter test --no-pub --reporter=compact` with QuickJS DLL directory on `PATH`
- `git diff --check`