### PR TITLE
fix: heal stuck screen brightness on wake

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -544,6 +544,7 @@ void main(List<String> args) async {
     AppLifecycleObserver(
       updateCheckService: updateCheckService,
       de1Controller: de1Controller,
+      displayController: displayController,
     ),
   );
 
@@ -584,6 +585,7 @@ class AppLifecycleObserver with WidgetsBindingObserver {
   final _log = Logger("App Lifecycle");
   final UpdateCheckService? updateCheckService;
   final De1Controller? de1Controller;
+  final DisplayController? displayController;
 
   late Timer _memTimer;
   bool _wasBackgrounded = false;
@@ -591,7 +593,11 @@ class AppLifecycleObserver with WidgetsBindingObserver {
   StreamSubscription? _stateStreamSubscription;
   int? _lastMachineState;
 
-  AppLifecycleObserver({this.updateCheckService, this.de1Controller}) {
+  AppLifecycleObserver({
+    this.updateCheckService,
+    this.de1Controller,
+    this.displayController,
+  }) {
     _memTimer = Timer.periodic(Duration(minutes: 5), (t) {
       final rss = ProcessInfo.currentRss / (1024 * 1024);
       _log.info("[MEM] RSS=${rss.toStringAsFixed(1)}MB");
@@ -640,6 +646,11 @@ class AppLifecycleObserver with WidgetsBindingObserver {
     if (state == AppLifecycleState.resumed) {
       // Resume if needed
       _log.info("state: resumed");
+
+      // Re-assert screen brightness: a write issued while the window was paused
+      // (e.g. the wake restore firing as the screen turned back on) may not have
+      // stuck, leaving the screen dark with no other trigger to recover.
+      unawaited(displayController?.onAppResumed() ?? Future<void>.value());
 
       // Check for updates when app comes to foreground
       if (_wasBackgrounded && updateCheckService?.hasAvailableUpdate == true) {

--- a/lib/src/controllers/display_controller.dart
+++ b/lib/src/controllers/display_controller.dart
@@ -301,15 +301,30 @@ class DisplayController {
     final previousState = _currentMachineState;
     _currentMachineState = snapshot.state.state;
 
-    if (previousState == _currentMachineState) return;
+    _syncBrightnessForMachineState();
 
-    // Save the user's brightness before sleep; restore it whenever the machine
-    // is awake again. This is deliberately keyed off the awake *condition*, not
-    // the precise sleeping->idle edge: if that edge is ever lost — e.g. a BLE
-    // reconnect resets our last-seen state to null, or we start up against an
-    // already-sleeping machine — an edge-triggered restore leaves the screen
-    // stuck dark with no recovery. Level-triggering self-heals on the next
-    // snapshot instead.
+    // Wake-lock only needs re-evaluating when the state actually changes.
+    if (previousState != _currentMachineState) {
+      unawaited(_evaluateWakeLock());
+    }
+  }
+
+  /// Save the user's brightness before sleep; restore it whenever the machine
+  /// is awake again.
+  ///
+  /// Keyed off the awake *condition*, not the precise sleeping->idle edge, and
+  /// re-evaluated on *every* snapshot rather than only on a transition. Two
+  /// things break an edge-triggered restore and leave the screen stuck at the
+  /// sleep-dim (0):
+  ///   * the edge is never observed — a BLE reconnect resets our last-seen
+  ///     state to null, or we start up against an already-sleeping machine;
+  ///   * a stray brightness-0 write lands *after* we've already processed the
+  ///     wake transition — e.g. a skin's deferred sleep-dim arriving a beat
+  ///     after the machine woke, or a buffered "sleeping" frame replayed on a
+  ///     websocket reconnect — so there is no later edge to heal it.
+  /// Re-checking each snapshot self-heals both. It is self-limiting: once
+  /// restored, [_requestedBrightness] is non-zero so the branch stops firing.
+  void _syncBrightnessForMachineState() {
     if (_currentMachineState == MachineState.sleeping) {
       // Never capture a dimmed value: a skin drives brightness to 0 for its
       // sleep screen, and remembering that would "restore" to black next wake.
@@ -320,8 +335,19 @@ class DisplayController {
       _log.info('Awake with screen still dimmed — restoring brightness');
       unawaited(setBrightness(_preSleepBrightness));
     }
+  }
 
-    unawaited(_evaluateWakeLock());
+  /// Re-assert screen brightness after the app window resumes.
+  ///
+  /// A brightness write issued while the activity was paused — e.g. the wake
+  /// restore firing right as the tablet screen was turning back on — can
+  /// silently fail to take effect on Android, and nothing else re-applies it,
+  /// so the screen stays dark even though our state believes it is restored.
+  /// On resume the window is ready again: re-run the restore check and push the
+  /// current value to the OS so a write that never stuck is reapplied.
+  Future<void> onAppResumed() async {
+    _syncBrightnessForMachineState();
+    await _applyBrightness();
   }
 
   // ---------------------------------------------------------------------------

--- a/test/controllers/display_controller_test.dart
+++ b/test/controllers/display_controller_test.dart
@@ -665,6 +665,109 @@ void main() {
         controller.dispose();
       });
     });
+
+    test(
+        'restores brightness when a dim-0 lands after the machine is already awake',
+        () {
+      fakeAsync((async) {
+        final controller = _createController(de1Controller,
+            settingsController: settingsCtrl);
+        controller.initialize();
+        async.flushMicrotasks();
+
+        de1Controller.setDe1(testDe1); // seeds idle (awake)
+        async.flushMicrotasks();
+
+        controller.setBrightness(100);
+        async.flushMicrotasks();
+
+        // A normal sleep then wake. The skin's sleep-dim write is still in
+        // flight when the wake transition is processed.
+        testDe1.emitState(MachineState.sleeping); // captures preSleep = 100
+        async.flushMicrotasks();
+        testDe1.emitState(MachineState.idle); // wake; brightness still 100
+        async.flushMicrotasks();
+        expect(controller.currentState.brightness, 100);
+
+        // The deferred sleep-dim finally lands — but the machine is already
+        // awake and will emit no further state transition.
+        controller.setBrightness(0);
+        async.flushMicrotasks();
+        expect(controller.currentState.brightness, 0);
+
+        // The next telemetry frame is the same awake state (no transition). The
+        // old edge-gated logic ignored it and left the screen stuck at 0; the
+        // per-snapshot restore heals it.
+        testDe1.emitState(MachineState.idle);
+        async.flushMicrotasks();
+        expect(controller.currentState.brightness, 100);
+
+        controller.dispose();
+      });
+    });
+
+    test('onAppResumed restores brightness when awake and still dimmed', () {
+      fakeAsync((async) {
+        final controller = _createController(de1Controller,
+            settingsController: settingsCtrl);
+        controller.initialize();
+        async.flushMicrotasks();
+
+        de1Controller.setDe1(testDe1); // idle (awake), preSleep defaults to 100
+        async.flushMicrotasks();
+
+        // Screen dark while awake (e.g. a stray dim with no follow-up snapshot).
+        controller.setBrightness(0);
+        async.flushMicrotasks();
+        expect(controller.currentState.brightness, 0);
+
+        controller.onAppResumed();
+        async.flushMicrotasks();
+
+        // Resume heals it back to the saved pre-sleep value.
+        expect(controller.currentState.brightness, 100);
+
+        controller.dispose();
+      });
+    });
+
+    test(
+        'onAppResumed re-applies brightness so an OS write that did not stick recovers',
+        () {
+      fakeAsync((async) {
+        var resetCount = 0;
+        final controller = DisplayController(
+          de1Controller: de1Controller,
+          settingsController: settingsCtrl,
+          setBrightness: (_) async {},
+          resetBrightness: () async {
+            resetCount++;
+          },
+          enableWakeLock: () async {},
+          disableWakeLock: () async {},
+          platformSupport:
+              const DisplayPlatformSupport(brightness: true, wakeLock: true),
+        );
+        controller.initialize();
+        async.flushMicrotasks();
+
+        de1Controller.setDe1(testDe1);
+        async.flushMicrotasks();
+
+        controller.setBrightness(100); // 100 == OS auto -> resetBrightness
+        async.flushMicrotasks();
+        final before = resetCount;
+
+        // Even though our state already believes brightness is 100, the write
+        // issued at wake may not have stuck, so resume must re-assert it.
+        controller.onAppResumed();
+        async.flushMicrotasks();
+
+        expect(resetCount, greaterThan(before));
+
+        controller.dispose();
+      });
+    });
   });
 
   group('battery brightness cap', () {


### PR DESCRIPTION
## Summary

- **Problem:** After the machine wakes from sleep the screen sometimes stays dark, and/or the reported brightness sticks at 0% even though the screen is lit.
- **Why it matters:** The user is left with a black or apparently-misconfigured display after every affected wake, with no recovery short of manually re-setting brightness.
- **What changed:** `DisplayController` now re-evaluates the sleep/wake brightness save-restore on *every* machine snapshot (not only on a state transition), and re-asserts brightness on app resume via a new `onAppResumed()` hook wired into `AppLifecycleObserver`.
- **What did NOT change (scope boundary):** No REST/WebSocket endpoints, payloads, or topics changed. The companion skin-side change (Beanie tracking `ws/v1/display` live instead of a one-shot GET) lives in the Beanie repo and is **not** part of this PR.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / Flutter widgets

(Specifically: screen-brightness / display control + app-lifecycle observer. Reacts to the machine-state snapshot stream; no machine/shot logic changed.)

## Linked Issues

- N/A (no tracked issue)

## Root Cause (if bug fix)

- **Root cause:** The wake-restore in `DisplayController._onSnapshot` only ran on a machine state *transition* — the `previousState == _currentMachineState` early-return suppressed it on every other snapshot. The prior fix (`3f3fe5fb`) made the restore *level*-keyed ("awake && brightness 0") but left it behind that transition gate, so it was not actually re-evaluated frame-to-frame. Two situations then leave brightness stuck at the sleep-dim of 0:
  1. A stray `setBrightness(0)` lands just after the wake transition was already processed (a skin's deferred sleep-dim, or a buffered "sleeping" frame replayed on a websocket reconnect) — no later transition fires, so the restore never re-evaluates.
  2. The restore fires but the OS brightness write does not stick because the activity window was still paused as the screen turned back on, and nothing re-applies it.
- **Missing detection or guardrail:** No re-evaluation on the continuous `shotSample`-driven snapshots that flow while awake; no re-assert on window resume.
- **Contributing context:** Whether the symptom shows as a dark screen vs a stuck 0% readout depends on whether Android happened to reset its own per-app brightness override on the screen power-cycle.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
- **Target test or file:** `test/controllers/display_controller_test.dart`
- **Scenario the test should lock in:** (1) a dim-0 that lands while already awake is healed on the next same-state snapshot; (2) `onAppResumed()` restores a still-dimmed-while-awake screen; (3) `onAppResumed()` re-applies brightness to the OS even when the value is unchanged (covers a write that did not stick). Three new tests added; all fail against the old edge-gated logic.

## Documentation Obligations (required)

- [x] N/A — no docs affected (no endpoint/spec/skin/plugin/profile/device-flow change)

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `No`
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`

## User-Visible Changes

- Screen brightness reliably restores when the machine wakes, and the reported brightness no longer sticks at 0%.
- Behavior note: brightness can no longer be *held* at exactly 0 while the machine is awake — an awake frame at 0 restores the saved pre-sleep value. This matches the existing design where 0 is a skin-driven sleep artifact, not a user setting.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (changed files)
- [x] `flutter test` — display-controller suite all pass (36, incl. 3 new); full suite 1669 pass / 1 fail (`devices_ws_test`, unrelated device-scan flake that passes in isolation on rerun)
- [ ] `(cd packages/dye2-plugin && npm run build)` — N/A (plugin untouched)

### Manual verification (if applicable)

- OS / platform tested: logic covered by unit tests under `fakeAsync`
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: ran the new + existing `display_controller_test.dart` (pass), `flutter analyze` (clean)
- What you did **not** verify: an on-device sleep/wake cycle on the DE1 tablet

### Evidence

- [x] Test output (3 new tests fail on the old edge-gated logic, pass with this change)

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`

## Risks & Mitigations

- Risk: the save/restore now runs on every snapshot (a few Hz while awake).
  - Mitigation: it is a cheap no-op unless awake-and-dimmed, and self-limiting (once restored, requested brightness is non-zero so the branch stops firing). Wake-lock evaluation stays gated on transitions.
