### PR TITLE
fix(ble): catch GATT gone-device errors in UniversalBleTransport

### DIFF
--- a/lib/src/models/errors.dart
+++ b/lib/src/models/errors.dart
@@ -10,7 +10,11 @@ class PermissionDeniedException implements Exception {
 }
 
 /// Which kind of device produced a [DeviceNotConnectedException].
-enum DeviceKind { machine, scale }
+/// Identifies the general class of a device (machine vs scale vs unknown).
+/// An [unknown] device is a transport that hasn't been classified yet —
+/// used by lower-level BLE transport error handlers that don't know
+/// whether they're connected to a machine or a scale.
+enum DeviceKind { machine, scale, unknown }
 
 /// Thrown when a controller is asked to act on a device that is not
 /// currently connected. Replaces ad-hoc raw-string throws of
@@ -22,6 +26,7 @@ class DeviceNotConnectedException implements Exception {
   const DeviceNotConnectedException(this.kind);
   const DeviceNotConnectedException.machine() : kind = DeviceKind.machine;
   const DeviceNotConnectedException.scale() : kind = DeviceKind.scale;
+  const DeviceNotConnectedException.unknown() : kind = DeviceKind.unknown;
 
   @override
   String toString() =>

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart' as device;
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/services/ble/ble_exception_mapper.dart';
 import 'package:rxdart/subjects.dart';
 import 'package:universal_ble/universal_ble.dart';
@@ -154,6 +155,35 @@ class UniversalBleTransport implements BLETransport {
     }
   }
 
+  /// Error codes that indicate the device is effectively gone — no sense
+  /// retrying, and definitely not worth a crash. Emit disconnected and throw
+  /// [DeviceNotConnectedException] so upper layers handle it gracefully.
+  static const _goneDeviceCodes = {
+    UniversalBleErrorCode.characteristicNotFound,
+    UniversalBleErrorCode.deviceNotFound,
+    UniversalBleErrorCode.serviceNotFound,
+    UniversalBleErrorCode.connectionTerminated,
+  };
+
+  Never _handleGattError(UniversalBleException e, String operation, String path) {
+    if (_goneDeviceCodes.contains(e.code)) {
+      _log.warning('GATT $operation($path) failed — device gone: ${e.code}');
+      _connectionStateSubject.add(device.ConnectionState.disconnected);
+      throw const DeviceNotConnectedException.unknown();
+    }
+    // Also treat unknownError as likely device-gone on Bluetooth-off / macOS
+    // adapter restarts — same symptom, different error code.
+    if (e.code == UniversalBleErrorCode.unknownError) {
+      _log.warning(
+        'GATT $operation($path) failed — unknown error (likely BT off): $e',
+      );
+      _connectionStateSubject.add(device.ConnectionState.disconnected);
+      throw const DeviceNotConnectedException.unknown();
+    }
+    // All other codes: throw as-is (caller's problem).
+    throw e;
+  }
+
   @override
   Stream<device.ConnectionState> get connectionState =>
       _connectionStateSubject.asBroadcastStream();
@@ -233,12 +263,16 @@ class UniversalBleTransport implements BLETransport {
 
   @override
   Future<Uint8List> read(String serviceUUID, String characteristicUUID, {Duration? timeout}) async {
-    return await UniversalBle.read(
-      _device.deviceId,
-      serviceUUID,
-      characteristicUUID,
-      timeout: timeout
-    );
+    try {
+      return await UniversalBle.read(
+        _device.deviceId,
+        serviceUUID,
+        characteristicUUID,
+        timeout: timeout
+      );
+    } on UniversalBleException catch (e) {
+      _handleGattError(e, 'read', '$serviceUUID/$characteristicUUID');
+    }
   }
 
   final Map<String, StreamSubscription<Uint8List>> _subscriptions = {};
@@ -261,11 +295,15 @@ class UniversalBleTransport implements BLETransport {
     ).listen(callback);
     _subscriptions[key] = sub;
 
-    await UniversalBle.subscribeNotifications(
-      _device.deviceId,
-      serviceUUID,
-      characteristicUUID,
-    );
+    try {
+      await UniversalBle.subscribeNotifications(
+        _device.deviceId,
+        serviceUUID,
+        characteristicUUID,
+      );
+    } on UniversalBleException catch (e) {
+      _handleGattError(e, 'subscribe', '$serviceUUID/$characteristicUUID');
+    }
   }
 
   @override
@@ -276,14 +314,18 @@ class UniversalBleTransport implements BLETransport {
     bool withResponse = true,
     Duration? timeout,
   }) async {
-    await UniversalBle.write(
-      _device.deviceId,
-      BleUuidParser.string(serviceUUID),
-      BleUuidParser.string(characteristicUUID),
-      data,
-      withoutResponse: !withResponse,
-      timeout: timeout
-    );
+    try {
+      await UniversalBle.write(
+        _device.deviceId,
+        BleUuidParser.string(serviceUUID),
+        BleUuidParser.string(characteristicUUID),
+        data,
+        withoutResponse: !withResponse,
+        timeout: timeout
+      );
+    } on UniversalBleException catch (e) {
+      _handleGattError(e, 'write', '$serviceUUID/$characteristicUUID');
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary

characteristicNotFound, deviceNotFound, serviceNotFound, and unknownError (macOS BT-off) no longer crash — emit disconnected and throw `DeviceNotConnectedException` instead.

## Motivation

Fixes Crashlytics `f7e3bc89` — 16 FATAL events from 1 macOS user who turns Bluetooth off mid-session. The `universal_ble` library throws `UniversalBleException` with `characteristicNotFound` when GATT operations run after BT is powered off, and our transport layer wasn't catching it.

Same root cause pattern as the pending `d84d8f29`/`21b6c4a7` write-to-disconnected catch.


## Changes

- `universal_ble_transport.dart` — added `_handleGattError()` method; wraps `read()`, `write()`, `subscribe()` in try/catch
- `errors.dart` — added `DeviceKind.unknown` + `DeviceNotConnectedException.unknown()` factory

## Verification

- `flutter analyze` — clean
- `flutter test` — 110/110 passing