### PR TITLE
fix(ble): catch deviceDisconnected in gone-device GATT handler

### DIFF
--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -163,6 +163,7 @@ class UniversalBleTransport implements BLETransport {
     UniversalBleErrorCode.deviceNotFound,
     UniversalBleErrorCode.serviceNotFound,
     UniversalBleErrorCode.connectionTerminated,
+    UniversalBleErrorCode.deviceDisconnected,
   };
 
   Never _handleGattError(UniversalBleException e, String operation, String path) {


### PR DESCRIPTION
## Summary

Adds `UniversalBleErrorCode.deviceDisconnected` to the gone-device catch set introduced in #358.

## Motivation

#358 caught `characteristicNotFound` and related errors from `universal_ble`, but missed `deviceDisconnected` — the direct `universal_ble` equivalent of the old `FlutterBluePlusException` "Device is disconnected".

Without this, the write-to-disconnected race (Crashlytics `d84d8f29` / `21b6c4a7`) would still FATAL post-YABSR when a user on the new BLE stack hits the same scale disconnect → reconnect → write-on-dead-device sequence.

## Changes

- `universal_ble_transport.dart`: +1 line — `UniversalBleErrorCode.deviceDisconnected` added to `_goneDeviceCodes`

## Verification

- `flutter analyze` — clean