### PR TITLE
fix(felicita): prevent LateInitializationError on disconnect race

### DIFF
--- a/lib/src/models/device/impl/felicita/arc.dart
+++ b/lib/src/models/device/impl/felicita/arc.dart
@@ -113,7 +113,7 @@ class FelicitaArc implements Scale {
     // This is a no-op
   }
 
-  late StreamSubscription<Uint8List>? _notificationsSubscription;
+  StreamSubscription<Uint8List>? _notificationsSubscription;
 
   Future<void> _registerNotifications() async {
     await _transport.subscribe(serviceIdentifier.long, dataCharacteristic.long, _parseNotification);


### PR DESCRIPTION
## Summary

Removes `late` from `_notificationsSubscription` in `FelicitaArc` so the nil-guard in the disconnect callback doesn't crash.

## Problem

`FelicitaArc.onConnect()` sets up a disconnect listener that calls `_notificationsSubscription?.cancel()`. The field was declared `late`, but the disconnect callback can fire before any assignment — specifically when the BLE device drops between `connect()` and `_registerNotifications()`. The `BehaviorSubject` replays the `disconnected` state synchronously through the stream listener, triggering the callback and throwing a `LateInitializationError`.

## Fix

Drop `late` — the field defaults to `null` and the existing `?.cancel()` nil-guard handles it correctly. The transport manages its own notification subscription lifecycle internally.

## Verification

- `flutter analyze` — clean (1 file)