### PR TITLE
fix: surface native disconnect reason via connectionUpdateStream

### DIFF
--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -46,17 +46,17 @@ class UniversalBleTransport implements BLETransport {
 
   @override
   Future<void> connect() async {
-    // TODO(ble-fork): switch to UniversalBle.connectionUpdateStream
-    // once the fork is published — it exposes native disconnect reason
-    // codes (GATT error, HCI status). Until then, connectionStream
-    // only emits bool.
-    _connectionStateSubscription = UniversalBle.connectionStream(
+    // Use connectionUpdateStream (from our universal_ble fork) to get
+    // native disconnect reason codes (GATT error, HCI status) — the
+    // standard connectionStream only emits bool.
+    _connectionStateSubscription = UniversalBle.connectionUpdateStream(
       _device.deviceId,
-    ).listen((connected) {
-      if (connected) {
+    ).listen((update) {
+      if (update.isConnected) {
         _connectionStateSubject.add(device.ConnectionState.connected);
       } else {
-        _log.warning('Transport disconnected (reason not available in this build)');
+        final reason = update.error ?? 'unknown';
+        _log.warning('Transport disconnected: $reason');
         _connectionStateSubject.add(device.ConnectionState.disconnected);
       }
     });


### PR DESCRIPTION
## What

Replaces `UniversalBle.connectionStream` (bool-only) with `connectionUpdateStream` from our fork, which exposes the native HCI/GATT error string on disconnect.

## Why

Scale dropped mid-shot today at 15:09:48 and all we got was:

> `Transport disconnected (reason not available in this build)`

Our universal_ble fork at `d47c6a2` already publishes `connectionUpdateStream` which returns `({String deviceId, bool isConnected, String? error})` — the error field contains the native disconnect reason. The TODO to migrate from `connectionStream` just never got enacted.

## Change

- `connectionStream` → `connectionUpdateStream` in `universal_ble_transport.dart`
- Extract `update.error` into the disconnect warning log

## Verification

- `dart analyze` clean
- No test mocks use `connectionStream` — no test changes needed