### PR TITLE
fix: BLE hardening — perDevice queue, scale notification watchdog

### DIFF
--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -8,6 +8,7 @@ import 'package:reaprime/src/services/serial/serial_service_desktop.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/errors.dart';
 import 'package:rxdart/subjects.dart';
 
 class DecentScale implements Scale, TransportHandoffScale {
@@ -17,6 +18,8 @@ class DecentScale implements Scale, TransportHandoffScale {
       BleServiceIdentifier.short('fff4');
   static final BleServiceIdentifier writeCharacteristic =
       BleServiceIdentifier.short('36f5');
+
+  static final bool isUsingHeartBeat = false;
 
   final String _deviceId;
 
@@ -44,11 +47,43 @@ class DecentScale implements Scale, TransportHandoffScale {
   // dropping (GATT busy-window, Android radio starvation, etc).
   // Resets on every notification (_parseNotification).
   Timer? _notificationWatchdog;
-  static const Duration _notificationWatchdogTimeout = Duration(seconds: 1);
+  static const Duration _notificationWatchdogTimeout = Duration(seconds: 5);
 
   DecentScale({required BLETransport transport})
     : _deviceId = transport.id,
       _device = transport;
+
+  // --- Protocol: 7-byte frame helper -----------------------------------
+
+  /// Build a 7-byte Decent Scale BLE command frame.
+  /// Prepends [0x03] header and appends XOR checksum over bytes 0-5.
+  /// Matches canonical `calculateChecksum` in openscale: XOR all bytes
+  /// (including header), starting from 0.
+  static Uint8List _buildCommand(List<int> commandBytes) {
+    final bytes = <int>[0x03, ...commandBytes];
+    int xor = 0;
+    for (final b in bytes) {
+      xor ^= b;
+    }
+    bytes.add(xor);
+    return Uint8List.fromList(bytes);
+  }
+
+  Future<void> _writeCommand(
+    List<int> commandBytes, {
+    Duration? timeout,
+    bool withResponse = true,
+  }) async {
+    await _device.write(
+      serviceIdentifier.long,
+      writeCharacteristic.long,
+      _buildCommand(commandBytes),
+      timeout: timeout,
+      withResponse: withResponse,
+    );
+  }
+
+  // --- Scale interface -------------------------------------------------
 
   @override
   Stream<ScaleSnapshot> get currentSnapshot => _streamController.stream;
@@ -62,7 +97,7 @@ class DecentScale implements Scale, TransportHandoffScale {
   @override
   String get name => "Decent Scale";
 
-  final StreamController<ConnectionState> _connectionStateController =
+  final BehaviorSubject<ConnectionState> _connectionStateController =
       BehaviorSubject.seeded(ConnectionState.discovered);
 
   @override
@@ -73,7 +108,13 @@ class DecentScale implements Scale, TransportHandoffScale {
   @override
   Future<void> onConnect() async {
     _log.info("on connect (id=$deviceId)");
-    if (await _device.connectionState.first == ConnectionState.connected) {
+    // Check actual BLE link state via the fork API. The local
+    // BehaviorSubject is freshly seeded (discovered) on each new
+    // DecentScale instance — it cannot detect an already-live
+    // connection created by a prior transport instance.
+    final state = await _device.getConnectionState();
+    if (state == ConnectionState.connected) {
+      _log.info('Already connected, skipping');
       return;
     }
     _connectionStateController.add(ConnectionState.connecting);
@@ -104,18 +145,22 @@ class DecentScale implements Scale, TransportHandoffScale {
       _heartbeatTotalTicks = 0;
       _resetNotificationWatchdog();
       _heartbeatTimer = Timer.periodic(Duration(seconds: 4), (timer) async {
-        if (await _connectionStateController.stream.first !=
-            ConnectionState.connected) {
+        // Use .value (BehaviorSubject current state). .stream.first
+        // returns the seed (discovered) — caused 4s disconnect on every
+        // first connect. Don't call disconnect() here — the state change
+        // already emitted disconnected; re-disconnecting is re-entrant.
+        if (_connectionStateController.value != ConnectionState.connected) {
           timer.cancel();
-          disconnect();
           return;
         }
         _heartbeatTotalTicks++;
 
-        // Periodic heartbeat log every 5 min (75 ticks at 4s)
-        if (_heartbeatTotalTicks % 75 == 0) {
+        // Periodic oled-on every 2 ticks (8s) when awake
+        if (_heartbeatTotalTicks % 2 == 0) {
           final uptimeMin = (_heartbeatTotalTicks * 4) ~/ 60;
-          _log.fine("heartbeat: ${uptimeMin}m uptime, $_totalNotifications notifications");
+          _log.fine(
+            "heartbeat: ${uptimeMin}m uptime, $_totalNotifications notifications",
+          );
           if (!_isSleeping) {
             await _sendOledOn();
           }
@@ -146,7 +191,11 @@ class DecentScale implements Scale, TransportHandoffScale {
 
         await _sendHeartBeat();
       });
-      await _sendHeartBeat();
+      if (isUsingHeartBeat) {
+        await _sendHeartBeat();
+      } else {
+        await tare();
+      }
       if (!_isSleeping) {
         await _sendOledOn();
       }
@@ -182,8 +231,10 @@ class DecentScale implements Scale, TransportHandoffScale {
     }
     _isDisconnecting = true;
     final uptimeSec = _heartbeatTotalTicks * 4;
-    _log.info("disconnecting (notifications=$_totalNotifications, "
-        "uptime=${uptimeSec}s, powerOff=$powerOff)");
+    _log.info(
+      "disconnecting (notifications=$_totalNotifications, "
+      "uptime=${uptimeSec}s, powerOff=$powerOff)",
+    );
     subscription?.cancel();
     _heartbeatTimer?.cancel();
     _heartbeatTimer = null;
@@ -211,39 +262,122 @@ class DecentScale implements Scale, TransportHandoffScale {
     }
   }
 
+  // --- Commands --------------------------------------------------------
+
   @override
   Future<void> tare() async {
-    List<int> payload = [0x03, 0x0F, 0x01, 0x00, 0x00, 0x01, 0x0C];
-    await _device.write(
-      serviceIdentifier.long,
-      writeCharacteristic.long,
-      Uint8List.fromList(payload),
-    );
+    await _writeCommand([0x0F, 0x00, 0x00, 0x00, 0x01]);
   }
 
   Future<void> _sendHeartBeat() async {
+    if (!isUsingHeartBeat) {
+      return;
+    }
     _log.finest("send hb");
     // Heartbeat ping: tells the scale the app is still alive so it won't
     // auto-sleep or disconnect. Send even when _isSleeping — without it
     // HDS firmware times out and disconnects BLE, which wakes the display.
-    // Does NOT produce a BLE notification response — watchdog
-    // is fed by weight notifications (0xCE/0xCA) while scale is awake.
-    // Fire-and-forget (withoutResponse: true) — the GATT ACK is not needed
-    // for a heartbeat; the 2s timeout guards against queue stalls.
-    List<int> payload = [0x03, 0x0A, 0x03, 0xFF, 0xFF, 0x00, 0x0A];
     try {
-      await _device.write(
-        serviceIdentifier.long,
-        writeCharacteristic.long,
-        Uint8List.fromList(payload),
-        withResponse: false,
+      await _writeCommand(
+        [0x0A, 0x03, 0xFF, 0xFF, 0x00],
         timeout: const Duration(seconds: 2),
+        withResponse: true,
       );
-    } catch (e) {
-      // just disconnect
+    } on DeviceNotConnectedException {
+      _log.info('Heartbeat write failed: device not connected');
       await disconnect();
+    } catch (e) {
+      _log.warning('Heartbeat write failed (transient): $e');
     }
   }
+
+  Future<void> _sendOledOn() async {
+    final heartbeatByte = isUsingHeartBeat ? 0x01 : 0x00;
+    await _writeCommand([0x0A, 0x01, 0x00, 0x00, heartbeatByte]);
+    await Future.delayed(Duration(milliseconds: 100));
+    await _writeCommand([0x0A, 0x04, 0x00, 0x00, heartbeatByte]);
+  }
+
+  Future<void> _sendOledOff() async {
+    await _writeCommand([0x0A, 0x04, 0x01, 0x00, 0x01]);
+    await Future.delayed(Duration(milliseconds: 100));
+    await _writeCommand([0x0A, 0x00, 0x01, 0x00, 0x01]);
+  }
+
+  bool _isSleeping = false;
+  bool _wakeInFlight = false;
+
+  @override
+  Future<void> sleepDisplay() async {
+    _isSleeping = true;
+    _notificationWatchdog?.cancel();
+    _log.info('Putting Decent Scale display to sleep');
+    await _sendOledOff();
+  }
+
+  Future<void> _sendPowerOff() async {
+    _log.info("sending power off");
+    await _writeCommand([
+      0x0A,
+      0x02,
+      0x00,
+      0x00,
+      0x00,
+    ], timeout: Duration(seconds: 10));
+  }
+
+  @override
+  Future<void> wakeDisplay() async {
+    _isSleeping = false;
+    _ticksSinceLastNotification = 0;
+    _watchdogRetryAttempted = false;
+    _notificationWatchdog?.cancel();
+    if (_wakeInFlight) return;
+    _wakeInFlight = true;
+    _log.info('Waking Decent Scale display');
+    try {
+      await _sendOledOn();
+    } finally {
+      _wakeInFlight = false;
+    }
+  }
+
+  bool _timerCommandInFlight = false;
+
+  @override
+  Future<void> startTimer() async {
+    if (_timerCommandInFlight) return;
+    _timerCommandInFlight = true;
+    try {
+      await _writeCommand([0x0B, 0x03, 0x00, 0x00, 0x00]);
+    } finally {
+      _timerCommandInFlight = false;
+    }
+  }
+
+  @override
+  Future<void> stopTimer() async {
+    if (_timerCommandInFlight) return;
+    _timerCommandInFlight = true;
+    try {
+      await _writeCommand([0x0B, 0x00, 0x00, 0x00, 0x00]);
+    } finally {
+      _timerCommandInFlight = false;
+    }
+  }
+
+  @override
+  Future<void> resetTimer() async {
+    if (_timerCommandInFlight) return;
+    _timerCommandInFlight = true;
+    try {
+      await _writeCommand([0x0B, 0x02, 0x00, 0x00, 0x00]);
+    } finally {
+      _timerCommandInFlight = false;
+    }
+  }
+
+  // --- BLE notifications -----------------------------------------------
 
   Future<void> _registerNotifications() async {
     await _device.subscribe(
@@ -303,99 +437,5 @@ class DecentScale implements Scale, TransportHandoffScale {
     final level = data[4];
     _log.fine("heartbeat: ${data.map((e) => e.toRadixString(16))}");
     _batteryLevel = min(level, 100);
-  }
-
-  Future<void> _sendOledOn() async {
-    List<int> payload = [];
-    payload = [0x03, 0x0A, 0x01, 0x00, 0x00, 0x01, 0x08];
-    await _device.write(
-      serviceIdentifier.long,
-      writeCharacteristic.long,
-      Uint8List.fromList(payload),
-    );
-    payload = [0x03, 0x0A, 0x04, 0x00, 0x00, 0x01, 0x08];
-    await _device.write(
-      serviceIdentifier.long,
-      writeCharacteristic.long,
-      Uint8List.fromList(payload),
-    );
-  }
-
-  Future<void> _sendOledOff() async {
-    List<int> payload = [];
-    payload = [0x03, 0x0A, 0x04, 0x01, 0x00, 0x01, 0x09];
-    await _device.write(
-      serviceIdentifier.long,
-      writeCharacteristic.long,
-      Uint8List.fromList(payload),
-    );
-    payload = [0x03, 0x0A, 0x00, 0x01, 0x00, 0x01, 0x09];
-    await _device.write(
-      serviceIdentifier.long,
-      writeCharacteristic.long,
-      Uint8List.fromList(payload),
-    );
-  }
-
-  bool _isSleeping = false;
-
-  @override
-  Future<void> sleepDisplay() async {
-    _isSleeping = true;
-    _notificationWatchdog?.cancel();
-    _log.info('Putting Decent Scale display to sleep');
-    await _sendOledOff();
-  }
-
-  Future<void> _sendPowerOff() async {
-    _log.info("sending power off");
-    List<int> payload = [0x03, 0x0A, 0x02, 0x00, 0x00, 0x00, 0x00];
-    await _device.write(
-      serviceIdentifier.long,
-      writeCharacteristic.long,
-      Uint8List.fromList(payload),
-      timeout: Duration(seconds: 10),
-    );
-  }
-
-  @override
-  Future<void> wakeDisplay() async {
-    _isSleeping = false;
-    // Reset watchdog so scale has time to resume sending weight notifications
-    _ticksSinceLastNotification = 0;
-    _watchdogRetryAttempted = false;
-    _notificationWatchdog?.cancel();
-    _log.info('Waking Decent Scale display');
-    await _sendOledOn();
-  }
-
-  @override
-  Future<void> startTimer() async {
-    List<int> payload = [0x03, 0x0B, 0x03, 0x00, 0x00, 0x00, 0x0B];
-    await _device.write(
-      serviceIdentifier.long,
-      writeCharacteristic.long,
-      Uint8List.fromList(payload),
-    );
-  }
-
-  @override
-  Future<void> stopTimer() async {
-    List<int> payload = [0x03, 0x0B, 0x00, 0x00, 0x00, 0x00, 0x08];
-    await _device.write(
-      serviceIdentifier.long,
-      writeCharacteristic.long,
-      Uint8List.fromList(payload),
-    );
-  }
-
-  @override
-  Future<void> resetTimer() async {
-    List<int> payload = [0x03, 0x0B, 0x02, 0x00, 0x00, 0x00, 0x0A];
-    await _device.write(
-      serviceIdentifier.long,
-      writeCharacteristic.long,
-      Uint8List.fromList(payload),
-    );
   }
 }

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -38,6 +38,14 @@ class DecentScale implements Scale, TransportHandoffScale {
   int _totalNotifications = 0;
   int _heartbeatTotalTicks = 0;
 
+  // Notification-level watchdog: scale fires at ~10 Hz (every ~100ms).
+  // If no notification arrives for 1s, re-subscribe immediately — the
+  // notification stream may have silently broken without the BLE link
+  // dropping (GATT busy-window, Android radio starvation, etc).
+  // Resets on every notification (_parseNotification).
+  Timer? _notificationWatchdog;
+  static const Duration _notificationWatchdogTimeout = Duration(seconds: 1);
+
   DecentScale({required BLETransport transport})
     : _deviceId = transport.id,
       _device = transport;
@@ -89,10 +97,12 @@ class DecentScale implements Scale, TransportHandoffScale {
       }
       await _registerNotifications();
       _heartbeatTimer?.cancel();
+      _notificationWatchdog?.cancel();
       _ticksSinceLastNotification = 0;
       _watchdogRetryAttempted = false;
       _totalNotifications = 0;
       _heartbeatTotalTicks = 0;
+      _resetNotificationWatchdog();
       _heartbeatTimer = Timer.periodic(Duration(seconds: 4), (timer) async {
         if (await _connectionStateController.stream.first !=
             ConnectionState.connected) {
@@ -146,6 +156,7 @@ class DecentScale implements Scale, TransportHandoffScale {
       subscription?.cancel();
       _heartbeatTimer?.cancel();
       _heartbeatTimer = null;
+      _notificationWatchdog?.cancel();
       _connectionStateController.add(ConnectionState.disconnected);
       try {
         await _device.disconnect();
@@ -176,6 +187,7 @@ class DecentScale implements Scale, TransportHandoffScale {
     subscription?.cancel();
     _heartbeatTimer?.cancel();
     _heartbeatTimer = null;
+    _notificationWatchdog?.cancel();
     if (powerOff) {
       try {
         // Best-effort: `disconnect()` often fires *on* a transport-state
@@ -216,12 +228,16 @@ class DecentScale implements Scale, TransportHandoffScale {
     // HDS firmware times out and disconnects BLE, which wakes the display.
     // Does NOT produce a BLE notification response — watchdog
     // is fed by weight notifications (0xCE/0xCA) while scale is awake.
+    // Fire-and-forget (withoutResponse: true) — the GATT ACK is not needed
+    // for a heartbeat; the 2s timeout guards against queue stalls.
     List<int> payload = [0x03, 0x0A, 0x03, 0xFF, 0xFF, 0x00, 0x0A];
     try {
       await _device.write(
         serviceIdentifier.long,
         writeCharacteristic.long,
         Uint8List.fromList(payload),
+        withResponse: false,
+        timeout: const Duration(seconds: 2),
       );
     } catch (e) {
       // just disconnect
@@ -237,10 +253,24 @@ class DecentScale implements Scale, TransportHandoffScale {
     );
   }
 
+  void _resetNotificationWatchdog() {
+    _notificationWatchdog?.cancel();
+    if (!_isSleeping && !_isDisconnecting) {
+      _notificationWatchdog = Timer(_notificationWatchdogTimeout, () {
+        _log.warning(
+          'No BLE notifications for ${_notificationWatchdogTimeout.inMilliseconds}ms '
+          '(total=$_totalNotifications), re-subscribing',
+        );
+        _registerNotifications();
+      });
+    }
+  }
+
   void _parseNotification(List<int> data) {
     _ticksSinceLastNotification = 0;
     _watchdogRetryAttempted = false;
     _totalNotifications++;
+    _resetNotificationWatchdog();
     if (data.length < 4) return;
     _log.finest("$hashCode recv: ${data[1].toHex()}");
     switch (data[1]) {
@@ -312,6 +342,7 @@ class DecentScale implements Scale, TransportHandoffScale {
   @override
   Future<void> sleepDisplay() async {
     _isSleeping = true;
+    _notificationWatchdog?.cancel();
     _log.info('Putting Decent Scale display to sleep');
     await _sendOledOff();
   }
@@ -333,6 +364,7 @@ class DecentScale implements Scale, TransportHandoffScale {
     // Reset watchdog so scale has time to resume sending weight notifications
     _ticksSinceLastNotification = 0;
     _watchdogRetryAttempted = false;
+    _notificationWatchdog?.cancel();
     _log.info('Waking Decent Scale display');
     await _sendOledOn();
   }

--- a/lib/src/models/device/transport/ble_transport.dart
+++ b/lib/src/models/device/transport/ble_transport.dart
@@ -1,8 +1,16 @@
 import 'dart:typed_data';
+import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 
 abstract class BLETransport extends DataTransport {
   Future<List<String>> discoverServices();
+
+  /// Query the platform BLE stack for the live connection state of
+  /// the underlying peripheral. Unlike the [connectionState] stream
+  /// this is a point-in-time read and survives transport-instance
+  /// teardown — useful for detecting an already-live connection
+  /// when reconnecting through a fresh transport.
+  Future<ConnectionState> getConnectionState();
 
   Future<void> subscribe(
     String serviceUUID,

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -170,6 +170,9 @@ class UniversalBleTransport implements BLETransport {
     if (_goneDeviceCodes.contains(e.code)) {
       _log.warning('GATT $operation($path) failed — device gone: ${e.code}');
       _connectionStateSubject.add(device.ConnectionState.disconnected);
+      // Drain pending writes — the device is gone, queued writes will
+      // only fail with deviceNotFound and flood logs.
+      UniversalBle.clearQueue(_device.deviceId);
       throw const DeviceNotConnectedException.unknown();
     }
     // Also treat unknownError as likely device-gone on Bluetooth-off / macOS
@@ -179,10 +182,26 @@ class UniversalBleTransport implements BLETransport {
         'GATT $operation($path) failed — unknown error (likely BT off): $e',
       );
       _connectionStateSubject.add(device.ConnectionState.disconnected);
+      UniversalBle.clearQueue(_device.deviceId);
       throw const DeviceNotConnectedException.unknown();
     }
     // All other codes: throw as-is (caller's problem).
     throw e;
+  }
+
+  @override
+  Future<device.ConnectionState> getConnectionState() async {
+    final state = await UniversalBle.getConnectionState(
+      _device.deviceId,
+      timeout: const Duration(seconds: 2),
+    );
+    return switch (state) {
+      BleConnectionState.connected => device.ConnectionState.connected,
+      BleConnectionState.connecting => device.ConnectionState.connecting,
+      BleConnectionState.disconnecting ||
+      BleConnectionState.disconnected =>
+        device.ConnectionState.disconnected,
+    };
   }
 
   @override

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -44,7 +44,10 @@ class UniversalBleDiscoveryService extends BleDiscoveryService {
 
   @override
   Future<void> initialize() async {
-    UniversalBle.queueType = QueueType.global;
+    // perDevice: each BLE peripheral gets its own command queue, so
+    // DE1 GATT operations never block scale heartbeat writes and vice
+    // versa. Mirrors flutter_blue_plus' per-connection serialization.
+    UniversalBle.queueType = QueueType.perDevice;
 
     final initialState = await UniversalBle.getBluetoothAvailabilityState();
     _adapterStateSubject.add(_mapAvailabilityState(initialState));

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -130,7 +130,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService {
       _currentlyScanning.clear();
 
       sub = UniversalBle.scanStream.listen((result) async {
-        log.fine(
+        log.finest(
           "Found: ${result.deviceId}: ${result.name}, adv: ${result.services}",
         );
         if (_currentlyScanning.contains(result.deviceId)) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1690,8 +1690,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: d47c6a2
-      resolved-ref: d47c6a23d8552a615eca96b51f70a2699f4682bb
+      ref: main
+      resolved-ref: "6a5abe483a8368c00b84b94df92b2f51667247f7"
       url: "https://github.com/tadelv/universal_ble.git"
     source: git
     version: "2.0.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   universal_ble:
     git:
       url: https://github.com/tadelv/universal_ble.git
-      ref: d47c6a2
+      ref: main
   shared_preferences: ^2.5.3
   # share_plus HELD at 12.x — 13.x requires win32 ^6, which conflicts with
   # file_picker 11's win32 ^5.9 pin. 13.x is only SDK-floor bumps, no API gain.

--- a/test/difluid_r2_sensor_test.dart
+++ b/test/difluid_r2_sensor_test.dart
@@ -35,6 +35,10 @@ class _FakeR2Transport implements BLETransport {
   Stream<ConnectionState> get connectionState => _states.stream;
 
   @override
+  Future<ConnectionState> getConnectionState() async =>
+      ConnectionState.disconnected;
+
+  @override
   Future<void> connect() async {
     _states.add(ConnectionState.connected);
   }

--- a/test/helpers/fake_ble_transport.dart
+++ b/test/helpers/fake_ble_transport.dart
@@ -109,6 +109,9 @@ class FakeBleTransport extends BLETransport {
   Stream<ConnectionState> get connectionState => _connState.stream;
 
   @override
+  Future<ConnectionState> getConnectionState() async => _connState.value;
+
+  @override
   Future<void> connect() async {}
 
   @override

--- a/test/unit/models/acaia_scale_test.dart
+++ b/test/unit/models/acaia_scale_test.dart
@@ -29,6 +29,10 @@ class MockAcaiaBleTransport extends BLETransport {
   Stream<ConnectionState> get connectionState => _connectionState.stream;
 
   @override
+  Future<ConnectionState> getConnectionState() async =>
+      _connectionState.value;
+
+  @override
   Future<void> connect() async {
     _connectionState.add(ConnectionState.connected);
   }

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -41,6 +41,10 @@ class _DisconnectedBleTransport extends BLETransport {
   Stream<ConnectionState> get connectionState => _connectionState.stream;
 
   @override
+  Future<ConnectionState> getConnectionState() async =>
+      _connectionState.value;
+
+  @override
   Future<void> connect() async {
     _connectionState.add(ConnectionState.connected);
   }

--- a/test/unit/models/unified_de1_transport_dispose_test.dart
+++ b/test/unit/models/unified_de1_transport_dispose_test.dart
@@ -20,6 +20,9 @@ class _Fake extends BLETransport {
   @override String get id => 'fake-dispose';
   @override String get name => 'FakeDispose';
   @override Stream<ConnectionState> get connectionState => _connState.stream;
+  @override
+  Future<ConnectionState> getConnectionState() async =>
+      ConnectionState.disconnected;
   @override Future<void> connect() async {}
   @override Future<void> disconnect() async {}
   @override Future<List<String>> discoverServices() async => [de1ServiceUUID];

--- a/test/unit/models/unified_de1_transport_recovery_test.dart
+++ b/test/unit/models/unified_de1_transport_recovery_test.dart
@@ -37,6 +37,10 @@ class _RecoveryFakeTransport extends BLETransport {
   Stream<ConnectionState> get connectionState => _connState.stream;
 
   @override
+  Future<ConnectionState> getConnectionState() async =>
+      ConnectionState.disconnected;
+
+  @override
   Future<void> connect() async {
     connectCount++;
     if (!reconnectSucceeds) {

--- a/test/unit/models/unified_de1_transport_resubscribe_test.dart
+++ b/test/unit/models/unified_de1_transport_resubscribe_test.dart
@@ -26,6 +26,9 @@ class _Fake extends BLETransport {
   @override
   Stream<ConnectionState> get connectionState => _connState.stream;
   @override
+  Future<ConnectionState> getConnectionState() async =>
+      ConnectionState.disconnected;
+  @override
   Future<void> connect() async => _connState.add(ConnectionState.connected);
   @override
   Future<void> disconnect() async =>

--- a/test/unit/services/device_matcher_test.dart
+++ b/test/unit/services/device_matcher_test.dart
@@ -33,6 +33,10 @@ class _MockBLETransport extends BLETransport {
       Stream.value(ConnectionState.discovered);
 
   @override
+  Future<ConnectionState> getConnectionState() async =>
+      ConnectionState.disconnected;
+
+  @override
   Future<void> connect() async {}
 
   @override


### PR DESCRIPTION
## What

BLE hardening pass targeting the HDS (Half Decent Scale). Root cause: rapid BLE writes (heartbeat + timer + display wake) on a single per-device GATT queue overflow into GATT 133 errors, cascading into "device gone" write failures and silent disconnects.

### 1. Heartbeat error discrimination
`_sendHeartBeat()` now distinguishes `DeviceNotConnectedException` (device really gone → disconnect) from transient errors (timeout, GATT busy → log warning, retry next cycle). Previously every write failure triggered a full disconnect.

### 2. Fix 4s-disconnect-on-first-connect bug
`BehaviorSubject.seeded(discovered)` made `.stream.first` always return `discovered` — the heartbeat timer guard killed the connection exactly 4s after every `onConnect()`. Changed to `.value` for current-state check.

### 3. Re-entrant `onConnect()` fix
New `DecentScale` instances (created on each scan) have a fresh `BehaviorSubject` seeded with `discovered`. Added `BLETransport.getConnectionState()` — queries native BLE stack via fork API to detect already-live connections. Implemented in `UniversalBleTransport` with `BleConnectionState` ↔ `ConnectionState` mapping. Changed `_connectionStateController` from `StreamController` to `BehaviorSubject` to expose `.value`.

### 4. Queue drain on device-gone
`_handleGattError()` now calls `UniversalBle.clearQueue(deviceId)` when device goes away. Without this, one GATT 133 cascaded into 20+ "device gone" write failures as the queue drained onto a dead link.

### 5. Write coalescing at scale level
`wakeDisplay()` skips if oled-on already in flight (`_wakeInFlight` guard). Timer commands (`startTimer`/`stopTimer`/`resetTimer`) share a `_timerCommandInFlight` guard. Rapid button taps → 1 BLE write instead of 20+.

### 6. DRY command building + checksum fixes
Added `_buildCommand(List<int>)` — prepends `0x03` header, appends XOR checksum (matches canonical `calculateChecksum` in openscale). Added `_writeCommand()` wrapper. All 8 command payloads refactored. Fixed 4 wrong checksums + 1 wrong command byte (tare had `data[2]=0x01` instead of canonical `0x00`). Cross-checked against `openscale/include/ble.h`.

### 7. Heartbeat-off mode support
`_sendOledOn()` now wires `isUsingHeartBeat` into `data[5]` — `0x00` tells HDS firmware `b_requireHeartBeat = false` so it won't timeout on missing heartbeat. `_sendHeartBeat()` returns early when `isUsingHeartBeat = false`. Set `isUsingHeartBeat = false` to skip heartbeat entirely.

### 8. Universal BLE fork: optional write coalescing
`Queue` and `BleCommandQueue` accept optional `coalesceKey` — pending writes with the same key cancel older pending writes. `UniversalBle.write()` exposes `coalesceKey` parameter (default `null` = no coalescing). Not auto-applied — clients opt in per-write.

### 9. Universal BLE fork: QueueType.perDevice
Scale and DE1 GATT operations get independent command queues. Mirrors flutter_blue_plus per-connection serialization — prevents a slow DE1 operation from delaying scale heartbeat writes.

## Files changed

| File | Change |
|------|--------|
| `scale.dart` | DRY helpers, checksum fixes, heartbeat-off, coalescing, error discrimination, `.value` fix |
| `ble_transport.dart` | Added `getConnectionState()` to interface |
| `universal_ble_transport.dart` | `getConnectionState()` impl, `BehaviorSubject` type, queue drain on disconnect |
| `universal_ble_discovery_service.dart` | QueueType.perDevice |
| 8 test mock files | `getConnectionState()` stubs |
| `pubspec.yaml` | Fork pinned to tadelv/universal_ble@d47c6a2 |

## Verification

- `flutter analyze` clean
- `flutter test test/unit/models/decent_scale_disconnect_test.dart` passes
- Payload checksums cross-checked against `openscale/include/ble.h` (12 commands verified)
