### PR TITLE
Add ?full=1 bulk read to the KV store

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -2053,7 +2053,14 @@ paths:
   # REA Key-Value Store for clients
   /api/v1/store/{namespace}:
     get:
-      summary: Get a list of all the keys in the specified key value namespace
+      summary: List keys in a namespace, or read the whole namespace with `?full=1`
+      description: >
+        By default returns an array of the keys stored under the namespace.
+        With `?full=1` returns the entire namespace as a `{key: value}` map in a
+        single request (instead of one GET per key). The full response supports
+        conditional requests: it sends an `ETag`, and an `If-None-Match` request
+        whose value matches returns `304 Not Modified`, which makes polling the
+        whole namespace cheap.
       tags: [Key value store]
       parameters:
         - name: namespace
@@ -2062,15 +2069,34 @@ paths:
           required: true
           schema:
             type: string
+        - name: full
+          in: query
+          required: false
+          description: "Set to `1` to return the whole namespace as a `{key: value}` map instead of a list of keys."
+          schema:
+            type: string
+            enum: ["1"]
       responses:
         "200":
-          description: Array of keys
+          description: >
+            Array of keys, or — when `?full=1` is set — an object mapping each
+            key to its stored JSON value.
+          headers:
+            ETag:
+              description: Present for `?full=1` responses; pass back via `If-None-Match` to poll cheaply.
+              schema:
+                type: string
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: string
+                oneOf:
+                  - type: array
+                    items:
+                      type: string
+                  - type: object
+                    additionalProperties: true
+        "304":
+          description: Returned for a `?full=1` request whose `If-None-Match` matches the current namespace ETag.
 
   /api/v1/store/{namespace}/{key}:
     get:

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -251,10 +251,12 @@ Settings fields include: `gatewayMode`, `themeMode`, `logLevel`, `weightFlowMult
 
 | Method | Path | Description | Handler |
 |--------|------|-------------|---------|
-| GET | `/api/v1/store/:namespace` | List keys in namespace | `kv_store_handler.dart` |
+| GET | `/api/v1/store/:namespace` | List keys in namespace (or `?full=1` for the whole namespace) | `kv_store_handler.dart` |
 | GET | `/api/v1/store/:namespace/:key` | Get value | |
 | POST | `/api/v1/store/:namespace/:key` | Set value | |
 | DELETE | `/api/v1/store/:namespace/:key` | Delete key | |
+
+`GET /api/v1/store/:namespace?full=1` returns the entire namespace as a `{key: value}` map in one request instead of one GET per key. It sends an `ETag`, so a repeat request with `If-None-Match` returns `304 Not Modified` when nothing changed — cheap to poll. Without the flag the endpoint returns just the array of keys.
 
 ### Data Management
 

--- a/lib/src/services/webserver/kv_store_handler.dart
+++ b/lib/src/services/webserver/kv_store_handler.dart
@@ -9,6 +9,13 @@ final class KvStoreHandler {
       if (namespace == null) {
         return jsonBadRequest({'error': 'Missing namespace'});
       }
+      // `?full=1` returns the whole namespace as a {key: value} map so a client
+      // can fetch (or poll) everything in one request instead of one GET per
+      // key. ETag/If-None-Match (via jsonOkConditional) lets a poll come back
+      // 304 when nothing changed. Without the flag we return just the key list.
+      if (req.url.queryParameters['full'] == '1') {
+        return jsonOkConditional(req, await store.getAll(namespace: namespace));
+      }
       return jsonOk(await store.keys(namespace: namespace));
     });
 


### PR DESCRIPTION
## Summary

- **Problem:** Reading a whole KV namespace required one `GET /api/v1/store/{namespace}/{key}` per key (after first listing keys), which is slow and chatty for clients that want to load or poll an entire namespace.
- **Why it matters:** Web skins / plugins that mirror a namespace (or poll it) had to issue N+1 requests; this collapses that to a single request.
- **What changed:** `GET /api/v1/store/{namespace}?full=1` now returns the whole namespace as a `{key: value}` map, served via `jsonOkConditional` so ETag / `If-None-Match` polling returns `304` when nothing changed. Without the flag the endpoint still returns just the key list (unchanged).
- **What did NOT change (scope boundary):** No change to the per-key GET/POST/DELETE routes, storage layer, or the default (no-flag) key-list response.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] REST API / handlers
- [x] Docs / specs

## Linked Issues

- N/A

## Root Cause (if bug fix)

N/A

## Regression Test Plan (if bug fix or refactor)

N/A

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` — documented the `full` query param, the object-map `200`, the `ETag` header, and the `304` response (YAML validated).
- [x] API docs updated: `doc/Api.md` — Key-Value Store table + a note describing `?full=1` and the conditional/ETag polling behavior.

## Security Impact (required)

- New or changed REST endpoints? **Yes** — new `?full=1` query mode on `GET /api/v1/store/{namespace}`.
- New or changed WebSocket topics? No
- New or changed network calls? No
- BLE/USB surface changed? No
- File system access changed? No
- Plugin sandbox boundary changed? No
- Risk/mitigation: Returns the full contents of a namespace in one response. The webserver is already unauthenticated and any client could already read every value key-by-key, so this exposes no new data — only a more efficient access path. No new write surface.

## User-Visible Changes

- New API capability: clients can fetch an entire KV namespace in one request via `GET /api/v1/store/{namespace}?full=1` (with conditional/ETag support). Existing endpoints and the default no-flag behavior are unchanged.

## Verification

### Local gates (run before pushing)

- [ ] `flutter analyze`
- [ ] `flutter test`
- [ ] `(cd packages/dye2-plugin && npm run build)`

### Manual verification (if applicable)

- Not yet exercised end-to-end in this PR. Suggested smoke test: `sb-dev start`, then `curl 'localhost:8080/api/v1/store/<ns>?full=1'` and confirm a `{key: value}` map plus a `304` on a repeat with `If-None-Match`.
- OpenAPI spec validated as parseable YAML after edit.

## Compatibility & Migration

- Backward compatible? **Yes** — additive query parameter; default behavior unchanged.
- Config / env changes needed? No
- Database migration needed? No

## Risks & Mitigations

- Risk: Large namespaces produce a large single response.
  - Mitigation: Opt-in via `?full=1`; conditional ETag avoids re-sending unchanged data on polls.
