### PR TITLE
ci(ios): fix v0.7.8 release — SPM broke dSYM upload; bump actions off Node 20

### DIFF
--- a/.github/workflows/develop-builds.yml
+++ b/.github/workflows/develop-builds.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -43,24 +43,20 @@ jobs:
           flutter-version: '3.44.2'
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Install Android SDK 35
-        uses: android-actions/setup-android@v2
-        with:
-          api-level: 35
-          build-tools: 35.0.0
-          ndk: 27.0.12077973
+        uses: android-actions/setup-android@v4
 
       - name: Decode Android keystore
         run: |
           echo "${{ secrets.ANDROID_KEYSTORE_B64 }}" | base64 --decode > android/app/debug.keystore
 
       - name: Cache Flutter & Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.pub-cache
@@ -71,9 +67,9 @@ jobs:
         run: flutter pub get
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build DYE2 plugin
         run: |
@@ -87,7 +83,7 @@ jobs:
           FEEDBACK_TOKEN: ${{ secrets.FEEDBACK_TOKEN }}
 
       - name: Upload Android APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-apk
           path: build/app/outputs/flutter-apk/app-release.apk
@@ -97,7 +93,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -117,9 +113,9 @@ jobs:
         run: flutter pub get
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build DYE2 plugin
         run: |
@@ -220,7 +216,7 @@ jobs:
           ditto -c -k --keepParent Decent.app ../../../../../decent-macos-develop.zip
 
       - name: Upload macOS app
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-app
           path: decent-macos-develop.zip
@@ -230,7 +226,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -247,9 +243,9 @@ jobs:
         run: flutter pub get
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build DYE2 plugin
         run: |
@@ -263,7 +259,7 @@ jobs:
           FEEDBACK_TOKEN: ${{ secrets.FEEDBACK_TOKEN }}
 
       - name: Upload Linux app
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-app
           path: build/linux/x64/release/bundle
@@ -274,7 +270,7 @@ jobs:
     runs-on: ubuntu-22.04-arm     # ARM64 hosted runner label
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -296,9 +292,9 @@ jobs:
         run: flutter pub get
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build DYE2 plugin
         run: |
@@ -312,7 +308,7 @@ jobs:
           FEEDBACK_TOKEN: ${{ secrets.FEEDBACK_TOKEN }}
 
       - name: Upload Raspberry Pi build (ARM64)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: raspberrypi-linux-arm64-app
           path: build/linux/arm64/release/bundle
@@ -322,7 +318,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -342,7 +338,7 @@ jobs:
         run: flutter pub get
 
       - name: Cache Flutter & CocoaPods
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.pub-cache
@@ -350,9 +346,9 @@ jobs:
           key: ${{ runner.os }}-ios-flutter-${{ hashFiles('**/pubspec.yaml', '**/Podfile.lock') }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build DYE2 plugin
         run: |
@@ -445,7 +441,7 @@ jobs:
           FEEDBACK_TOKEN: ${{ secrets.FEEDBACK_TOKEN }}
 
       - name: Upload iOS IPA
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-ipa
           path: build/ios/ipa/*.ipa
@@ -460,7 +456,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -479,9 +475,9 @@ jobs:
         run: flutter pub get
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build DYE2 plugin
         run: |
@@ -496,7 +492,7 @@ jobs:
           FEEDBACK_TOKEN: ${{ secrets.FEEDBACK_TOKEN }}
 
       - name: Upload Windows app
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-app
           path: build/windows/x64/runner/Release

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -27,9 +27,9 @@ jobs:
           cache: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: packages/dye2-plugin/package-lock.json
 
@@ -87,7 +87,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -101,9 +101,9 @@ jobs:
           cache: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: packages/dye2-plugin/package-lock.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -27,24 +27,20 @@ jobs:
           flutter-version: '3.44.2'
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Install Android SDK 35
-        uses: android-actions/setup-android@v2
-        with:
-          api-level: 35
-          build-tools: 35.0.0
-          ndk: 27.0.12077973
+        uses: android-actions/setup-android@v4
 
       - name: Decode Android keystore
         run: |
           echo "${{ secrets.ANDROID_KEYSTORE_B64 }}" | base64 --decode > android/app/debug.keystore
 
       - name: Cache Flutter & Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.pub-cache
@@ -55,9 +51,9 @@ jobs:
         run: flutter pub get
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build DYE2 plugin
         run: |
@@ -84,7 +80,7 @@ jobs:
              build/app/outputs/flutter-apk/decent-android-${{ steps.version.outputs.version }}.apk
 
       - name: Upload Android APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-apk
           path: build/app/outputs/flutter-apk/decent-android-${{ steps.version.outputs.version }}.apk
@@ -93,7 +89,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -109,9 +105,9 @@ jobs:
           brew install automake libtool
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build DYE2 plugin
         run: |
@@ -220,7 +216,7 @@ jobs:
           cd build/macos/Build/Products/Release
           ditto -c -k --keepParent Decent.app ../../../../../decent-macos-${{ steps.version.outputs.version }}.zip
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: macos-app
           path: decent-macos-${{ steps.version.outputs.version }}.zip
@@ -229,7 +225,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -246,9 +242,9 @@ jobs:
         run: flutter pub get
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build DYE2 plugin
         run: |
@@ -273,7 +269,7 @@ jobs:
           tar -czf ../../../../decent-linux-x64-${{ steps.version.outputs.version }}.tar.gz bundle
 
       - name: Upload Linux app artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-app
           path: decent-linux-x64-${{ steps.version.outputs.version }}.tar.gz
@@ -283,7 +279,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -305,9 +301,9 @@ jobs:
         run: flutter pub get
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build DYE2 plugin
         run: |
@@ -332,7 +328,7 @@ jobs:
           tar -czf ../../../../decent-linux-arm64-${{ steps.version.outputs.version }}.tar.gz bundle
 
       - name: Upload Raspberry Pi build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: raspberrypi-linux-arm64-app
           path: decent-linux-arm64-${{ steps.version.outputs.version }}.tar.gz
@@ -344,7 +340,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -363,9 +359,9 @@ jobs:
         run: flutter pub get
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build DYE2 plugin
         run: |
@@ -392,7 +388,7 @@ jobs:
           Compress-Archive -Path build/windows/x64/runner/Release/* -DestinationPath decent-windows-x64-${{ steps.version.outputs.version }}.zip
 
       - name: Upload Windows app artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-app
           path: decent-windows-x64-${{ steps.version.outputs.version }}.zip
@@ -401,7 +397,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -429,7 +425,7 @@ jobs:
         run: flutter pub get
 
       - name: Cache Flutter & CocoaPods
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.pub-cache
@@ -437,9 +433,9 @@ jobs:
           key: ${{ runner.os }}-ios-flutter-${{ hashFiles('**/pubspec.yaml', '**/Podfile.lock') }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build DYE2 plugin
         run: |
@@ -597,7 +593,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -609,7 +605,7 @@ jobs:
           echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: release-artifacts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,6 +414,14 @@ jobs:
           channel: 'stable'
           flutter-version: '3.44.2'
 
+      # Flutter >=3.44 defaults Swift Package Manager on, which skips
+      # `pod install` so ios/Pods (and FirebaseCrashlytics/upload-symbols)
+      # never gets generated and the dSYM upload step below fails. The iOS
+      # project is committed as CocoaPods (0 SPM refs) and local dev runs
+      # with SPM disabled, so pin CI to the same CocoaPods path.
+      - name: Disable Swift Package Manager (use CocoaPods)
+        run: flutter config --no-enable-swift-package-manager
+
       - name: Install FlutterFire CLI
         run: dart pub global activate flutterfire_cli
 


### PR DESCRIPTION
## Summary

- **Problem:** The `v0.7.8` Create Release run failed at `build-ios` → *Upload dSYMs to Firebase Crashlytics* with `ProcessException: No such file or directory` for `ios/Pods/FirebaseCrashlytics/upload-symbols`, killing the job before the TestFlight upload. No iOS build shipped.
- **Why it matters:** iOS never reached TestFlight (desktop platforms published fine — `create-release` doesn't depend on `build-ios`). Also every job spammed deprecated Node 20 runtime warnings.
- **What changed:** (1) Disable Swift Package Manager in the iOS job so CocoaPods runs `pod install` and regenerates `ios/Pods`. (2) Bump GitHub Actions to Node 24 majors + `setup-node` to Node 22, drop dead `setup-android` inputs.
- **What did NOT change (scope boundary):** No app/Dart code. CI workflows only. The macOS build path (SPM + build-phase wrapper) is untouched.

## Change Type (select all)

- [x] Bug fix
- [x] Chore / infra

## Scope (select all touched areas)

- [x] CI / build / infra

## Linked Issues

- N/A

## Root Cause (if bug fix)

- Root cause: Commit `59f90573` bumped the CI Flutter pin `3.41.8 → 3.44.2` (after v0.7.7). Flutter ≥3.44 defaults Swift Package Manager **on**, so `flutter build ipa` did `Adding Swift Package Manager integration...` and skipped `pod install`. The iOS project is committed as CocoaPods (0 SPM refs) and the standalone dSYM step hardcodes `ios/Pods/FirebaseCrashlytics/upload-symbols` — which never gets generated under SPM → process exec fails.
- Missing detection or guardrail: The dSYM upload step is fatal and runs before TestFlight, so a symbol-upload hiccup blocks the whole iOS release. (Left fatal here since the real fix restores the file; a `continue-on-error` guard is a possible future hardening.)
- Contributing context: v0.7.7 passed because it ran Flutter <3.44 (CocoaPods). Local dev already runs with SPM disabled (`enable-swift-package-manager: false`); CI now matches.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Existing coverage already sufficient
- Target test or file: `.github/workflows/release.yml` (`build-ios` job) — exercised on the next tag push.
- Scenario the test should lock in: iOS release build generates `ios/Pods` and the dSYM upload + TestFlight steps succeed.
- If no new test added, why not: CI-only change; the release workflow itself is the test. `pr-checks.yml` validates the bumped `checkout@v5`/`setup-node@v6` on this PR.

## Documentation Obligations (required)

- [x] N/A — no docs affected

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `No`
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`

## User-Visible Changes

None.

## Verification

### Local gates (run before pushing)

- [x] YAML validates (`yaml.safe_load` on all three workflows)
- [ ] `flutter analyze` — N/A (no Dart changes)
- [ ] `flutter test` — N/A (no Dart changes)

### Manual verification (if applicable)

- OS / platform tested: CI workflow change; validated by inspecting the failed `v0.7.8` run log (root cause confirmed: `Adding Swift Package Manager integration...` + missing `ios/Pods`).
- Verified action majors exist and run on Node 24 (`git ls-remote` + `setup-android` v4 `action.yml` shows `using: node24`, `accept-android-sdk-licenses` default `true`).
- What I did **not** verify: a live re-tagged release run (pending merge).

### Evidence

- [x] Log snippets (failing iOS step):
```
Unhandled exception:
ProcessException: No such file or directory
  Command: ios/Pods/FirebaseCrashlytics/upload-symbols --validate --flutter-project .../app_id_file.json
#4 UploadCrashlyticsSymbols.run (package:flutterfire_cli/src/commands/upload_symbols.dart:368:44)
```
```
build-ios  Build IPA  Adding Swift Package Manager integration...  80.3s
```

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`

## Risks & Mitigations

- Risk: Major action bumps (`upload-artifact` v4→v7, `download-artifact` v4→v8, `setup-android` v2→v4) could have behavior changes.
  - Mitigation: `pr-checks.yml` exercises checkout/setup-node here; `develop-builds.yml` exercises Android/artifact paths on merge to develop before any release tag. `setup-android` v4 keeps `accept-android-sdk-licenses: true` and Gradle downloads SDK components, so dropping the (always-ignored) `api-level`/`build-tools`/`ndk` inputs is a no-op.
- Risk: Re-tagging to ship the iOS build reruns the full matrix.
  - Mitigation: expected; `softprops/action-gh-release@v2` updates the existing release idempotently.
