### PR TITLE
Fix profile move-on race for mixed weight and firmware exits

### DIFF
--- a/doc/Profiles.md
+++ b/doc/Profiles.md
@@ -11,10 +11,19 @@ The REA Profile data object definition lives in `lib/src/models/data/profile.dar
 Step transitions can be owned by either the DE1 firmware or the app. Firmware
 owns pressure/flow `exit` conditions because they are encoded into the profile
 sent to the machine. The app owns per-step `weight` exits because only the
-tablet sees the external scale. If a step defines both `weight` and `exit`, REA
-keeps the machine self-sufficient and lets firmware own that transition; the
-tablet will not send an additional `skipStep` for the same frame. To make
-weight own a step transition, remove the firmware `exit` from that step.
+tablet sees the external scale.
+
+If a step defines both `weight` and `exit`, either condition can trigger the
+transition. To avoid a race where the tablet's `skipStep` command arrives after
+firmware already advanced the frame (accidentally skipping the *next* step),
+the app checks proximity to the firmware exit threshold before acting:
+
+- **Far from threshold** — the app sends `skipStep` immediately (no race risk).
+- **Near threshold** — the app defers for up to 3 snapshot frames, checking
+  whether the sensor is trending toward the firmware exit. If firmware advances
+  the frame during this window, the app does nothing. If the deferral cap is
+  reached, the app fires `skipStep` regardless.
+- **Exit value ≤ 0** — treated as weight-only (no meaningful firmware exit).
 
 ## Key Capabilities
 

--- a/doc/Profiles.md
+++ b/doc/Profiles.md
@@ -8,6 +8,14 @@ REA supports loading profiles to the espresso machine either directly through th
 
 The REA Profile data object definition lives in `lib/src/models/data/profile.dart`.
 
+Step transitions can be owned by either the DE1 firmware or the app. Firmware
+owns pressure/flow `exit` conditions because they are encoded into the profile
+sent to the machine. The app owns per-step `weight` exits because only the
+tablet sees the external scale. If a step defines both `weight` and `exit`, REA
+keeps the machine self-sufficient and lets firmware own that transition; the
+tablet will not send an additional `skipStep` for the same frame. To make
+weight own a step transition, remove the firmware `exit` from that step.
+
 ## Key Capabilities
 
 - List, create, update, and delete profiles via REST API

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -58,6 +58,7 @@ import 'package:reaprime/src/skin_selector/skin_selector_page.dart';
 import 'debug_feature/debug_item_details_view.dart';
 
 import 'debug_feature/debug_item_list_view.dart';
+import 'settings/feature_flags.dart';
 import 'settings/gateway_mode.dart';
 import 'settings/settings_controller.dart';
 import 'settings/settings_view.dart';
@@ -431,6 +432,8 @@ class _MyAppState extends State<MyApp> {
                           blockOnNoScale: widget.settingsController.blockOnNoScale,
                           weightFlowMultiplier: widget.settingsController.weightFlowMultiplier,
                           volumeFlowMultiplier: widget.settingsController.volumeFlowMultiplier,
+                          stepExitArbiterEnabled: widget.settingsController
+                              .isFeatureFlagEnabled(FeatureFlag.stepExitArbiter),
                         );
                       }
                       return RealtimeShotFeature(

--- a/lib/src/controllers/de1_state_manager.dart
+++ b/lib/src/controllers/de1_state_manager.dart
@@ -18,6 +18,7 @@ import 'package:reaprime/src/realtime_shot_feature/realtime_shot_feature.dart';
 import 'package:reaprime/src/realtime_steam_feature/realtime_steam_feature.dart';
 import 'package:reaprime/src/launcher/launcher_view.dart';
 import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:reaprime/src/settings/feature_flags.dart';
 import 'package:reaprime/src/settings/gateway_mode.dart';
 import 'package:reaprime/src/settings/scale_power_mode.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
@@ -574,6 +575,8 @@ class De1StateManager with WidgetsBindingObserver {
       blockOnNoScale: _settingsController.blockOnNoScale,
       weightFlowMultiplier: _settingsController.weightFlowMultiplier,
       volumeFlowMultiplier: _settingsController.volumeFlowMultiplier,
+      stepExitArbiterEnabled: _settingsController
+          .isFeatureFlagEnabled(FeatureFlag.stepExitArbiter),
     );
 
     _currentShotSnapshots.clear();

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -44,6 +44,7 @@ class ShotSequencer {
 
   // Skip step on weight specific
   List<int> skippedSteps = [];
+  final Set<int> _mixedExitWeightSuppressedFrames = {};
 
   // Volume counting state
   double _accumulatedVolume = 0.0;
@@ -59,8 +60,10 @@ class ShotSequencer {
   // this value follows the tail, not the graph. Null when no scale weighs the
   // shot.
   static const double _settleFlowThreshold = 0.4; // g/s; |flow| below = still
-  static const int _settleSampleCount = 3; // consecutive still samples = settled
-  static const double _removalFlowThreshold = 3.0; // g/s; flow < -this = removal
+  static const int _settleSampleCount =
+      3; // consecutive still samples = settled
+  static const double _removalFlowThreshold =
+      3.0; // g/s; flow < -this = removal
   static const double _spikeFlowJump = 3.0; // g/s; flow rising vs prev = spike
   static const Duration _stoppingBackstop = Duration(seconds: 4);
   double? _trustedFinalYield;
@@ -82,12 +85,12 @@ class ShotSequencer {
     required bool blockOnNoScale,
     required double weightFlowMultiplier,
     required double volumeFlowMultiplier,
-  })  : _bypassSAW = bypassSAW,
-        _blockOnNoScale = blockOnNoScale,
-        _weightFlowMultiplier = weightFlowMultiplier,
-        _volumeFlowMultiplier = volumeFlowMultiplier,
-        _machineHasAutonomousSAW =
-            de1controller.connectedDe1() is BengleInterface {
+  }) : _bypassSAW = bypassSAW,
+       _blockOnNoScale = blockOnNoScale,
+       _weightFlowMultiplier = weightFlowMultiplier,
+       _volumeFlowMultiplier = volumeFlowMultiplier,
+       _machineHasAutonomousSAW =
+           de1controller.connectedDe1() is BengleInterface {
     _log.info(
       "Initializing ShotSequencer (weightFlowMultiplier: $_weightFlowMultiplier, volumeFlowMultiplier: $_volumeFlowMultiplier, machineHasAutonomousSAW: $_machineHasAutonomousSAW)",
     );
@@ -97,7 +100,8 @@ class ShotSequencer {
     _scaleTared = _bypassSAW;
 
     final scaleConnected =
-        scaleController.currentConnectionState == device.ConnectionState.connected;
+        scaleController.currentConnectionState ==
+        device.ConnectionState.connected;
 
     if (_blockOnNoScale && !scaleConnected) {
       // The sequencer is created reactively, after the machine has already
@@ -112,7 +116,10 @@ class ShotSequencer {
           details: 'No scale connected, blocking shot',
         ),
       );
-      de1controller.connectedDe1().requestState(MachineState.idle).catchError(
+      de1controller
+          .connectedDe1()
+          .requestState(MachineState.idle)
+          .catchError(
             (error) =>
                 _log.warning("Failed to abort shot for blockOnNoScale: $error"),
           );
@@ -147,7 +154,9 @@ class ShotSequencer {
       );
 
       // Monitor scale connection during shot
-      _scaleConnectionSubscription = scaleController.connectionState.listen((state) {
+      _scaleConnectionSubscription = scaleController.connectionState.listen((
+        state,
+      ) {
         if (state == device.ConnectionState.disconnected && !_scaleLost) {
           if (_state != ShotState.idle && _state != ShotState.finished) {
             _scaleLost = true;
@@ -306,6 +315,7 @@ class ShotSequencer {
           _settleSamples = 0;
           _prevStoppingFlow = null;
           skippedSteps.clear();
+          _mixedExitWeightSuppressedFrames.clear();
 
           if (_bypassSAW == false && scale != null && !_scaleLost) {
             _log.info(
@@ -353,19 +363,9 @@ class ShotSequencer {
           double weightFlow = scale.weightFlow;
           double projectedWeight =
               currentWeight + (weightFlow * _weightFlowMultiplier);
+          final int profileFrame = machine.profileFrame;
 
-          if (targetProfile.steps.length > machine.profileFrame &&
-              skippedSteps.contains(machine.profileFrame) == false &&
-              targetProfile.steps[machine.profileFrame].weight != null &&
-              targetProfile.steps[machine.profileFrame].weight! > 0) {
-            var stepExitWeight =
-                targetProfile.steps[machine.profileFrame].weight!;
-            if (projectedWeight >= stepExitWeight) {
-              _log.info("Step weight reached, moving on");
-              skippedSteps.add(machine.profileFrame);
-              de1controller.connectedDe1().requestState(MachineState.skipStep);
-            }
-          }
+          _handleStepWeightExit(profileFrame, projectedWeight);
           if (!_machineHasAutonomousSAW &&
               targetYield > 0 &&
               projectedWeight >= targetYield) {
@@ -441,6 +441,39 @@ class ShotSequencer {
         break;
     }
     _log.finest("State out: ${_state.name}");
+  }
+
+  void _handleStepWeightExit(int profileFrame, double projectedWeight) {
+    if (profileFrame < 0 || profileFrame >= targetProfile.steps.length) {
+      return;
+    }
+
+    final step = targetProfile.steps[profileFrame];
+    final stepExitWeight = step.weight;
+    if (stepExitWeight == null || stepExitWeight <= 0) {
+      return;
+    }
+
+    if (step.exit != null) {
+      if (_mixedExitWeightSuppressedFrames.add(profileFrame)) {
+        _log.info(
+          "Step $profileFrame (${step.name}) has both weight and firmware "
+          "exit conditions. Firmware owns the frame transition; suppressing "
+          "tablet skipStep.",
+        );
+      }
+      return;
+    }
+
+    if (skippedSteps.contains(profileFrame)) {
+      return;
+    }
+
+    if (projectedWeight >= stepExitWeight) {
+      _log.info("Step weight reached, moving on");
+      skippedSteps.add(profileFrame);
+      de1controller.connectedDe1().requestState(MachineState.skipStep);
+    }
   }
 
   void _enterStopping(WeightSnapshot? scale) {

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -24,6 +24,7 @@ class ShotSequencer {
   final bool _blockOnNoScale;
   final double _weightFlowMultiplier;
   final double _volumeFlowMultiplier;
+  final bool _stepExitArbiterEnabled;
 
   /// `true` when the connected machine runs its own autonomous SAW
   /// (currently only Bengle). The app's SAW loop must defer to FW to
@@ -87,14 +88,16 @@ class ShotSequencer {
     required bool blockOnNoScale,
     required double weightFlowMultiplier,
     required double volumeFlowMultiplier,
+    required bool stepExitArbiterEnabled,
   }) : _bypassSAW = bypassSAW,
        _blockOnNoScale = blockOnNoScale,
        _weightFlowMultiplier = weightFlowMultiplier,
        _volumeFlowMultiplier = volumeFlowMultiplier,
+       _stepExitArbiterEnabled = stepExitArbiterEnabled,
        _machineHasAutonomousSAW =
            de1controller.connectedDe1() is BengleInterface {
     _log.info(
-      "Initializing ShotSequencer (weightFlowMultiplier: $_weightFlowMultiplier, volumeFlowMultiplier: $_volumeFlowMultiplier, machineHasAutonomousSAW: $_machineHasAutonomousSAW)",
+      "Initializing ShotSequencer (weightFlowMultiplier: $_weightFlowMultiplier, volumeFlowMultiplier: $_volumeFlowMultiplier, machineHasAutonomousSAW: $_machineHasAutonomousSAW, stepExitArbiterEnabled: $_stepExitArbiterEnabled)",
     );
 
     // When the app won't tare (SAW bypass), trust the scale's readings as-is —
@@ -475,7 +478,7 @@ class ShotSequencer {
     }
 
     // Mixed step: consult the arbiter to avoid racing firmware.
-    if (step.exit != null) {
+    if (_stepExitArbiterEnabled && step.exit != null) {
       final verdict = _stepExitArbiter.evaluate(
         profileFrame: profileFrame,
         exit: step.exit!,

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -4,6 +4,7 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/persistence_controller.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/controllers/step_exit_arbiter.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/data/shot_snapshot.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
@@ -44,7 +45,8 @@ class ShotSequencer {
 
   // Skip step on weight specific
   List<int> skippedSteps = [];
-  final Set<int> _mixedExitWeightSuppressedFrames = {};
+  final StepExitArbiter _stepExitArbiter = StepExitArbiter();
+  int _lastProfileFrame = -1;
 
   // Volume counting state
   double _accumulatedVolume = 0.0;
@@ -315,7 +317,8 @@ class ShotSequencer {
           _settleSamples = 0;
           _prevStoppingFlow = null;
           skippedSteps.clear();
-          _mixedExitWeightSuppressedFrames.clear();
+          _stepExitArbiter.reset();
+          _lastProfileFrame = -1;
 
           if (_bypassSAW == false && scale != null && !_scaleLost) {
             _log.info(
@@ -365,7 +368,12 @@ class ShotSequencer {
               currentWeight + (weightFlow * _weightFlowMultiplier);
           final int profileFrame = machine.profileFrame;
 
-          _handleStepWeightExit(profileFrame, projectedWeight);
+          if (profileFrame != _lastProfileFrame) {
+            _stepExitArbiter.onFrameAdvanced(profileFrame);
+            _lastProfileFrame = profileFrame;
+          }
+
+          _handleStepWeightExit(profileFrame, projectedWeight, machine);
           if (!_machineHasAutonomousSAW &&
               targetYield > 0 &&
               projectedWeight >= targetYield) {
@@ -443,7 +451,11 @@ class ShotSequencer {
     _log.finest("State out: ${_state.name}");
   }
 
-  void _handleStepWeightExit(int profileFrame, double projectedWeight) {
+  void _handleStepWeightExit(
+    int profileFrame,
+    double projectedWeight,
+    MachineSnapshot machineSnapshot,
+  ) {
     if (profileFrame < 0 || profileFrame >= targetProfile.steps.length) {
       return;
     }
@@ -454,26 +466,30 @@ class ShotSequencer {
       return;
     }
 
-    if (step.exit != null) {
-      if (_mixedExitWeightSuppressedFrames.add(profileFrame)) {
-        _log.info(
-          "Step $profileFrame (${step.name}) has both weight and firmware "
-          "exit conditions. Firmware owns the frame transition; suppressing "
-          "tablet skipStep.",
-        );
-      }
-      return;
-    }
-
     if (skippedSteps.contains(profileFrame)) {
       return;
     }
 
-    if (projectedWeight >= stepExitWeight) {
-      _log.info("Step weight reached, moving on");
-      skippedSteps.add(profileFrame);
-      de1controller.connectedDe1().requestState(MachineState.skipStep);
+    if (projectedWeight < stepExitWeight) {
+      return;
     }
+
+    // Mixed step: consult the arbiter to avoid racing firmware.
+    if (step.exit != null) {
+      final verdict = _stepExitArbiter.evaluate(
+        profileFrame: profileFrame,
+        exit: step.exit!,
+        currentPressure: machineSnapshot.pressure,
+        currentFlow: machineSnapshot.flow,
+      );
+      if (verdict == StepExitVerdict.defer) {
+        return;
+      }
+    }
+
+    _log.info("Step weight reached, moving on");
+    skippedSteps.add(profileFrame);
+    de1controller.connectedDe1().requestState(MachineState.skipStep);
   }
 
   void _enterStopping(WeightSnapshot? scale) {
@@ -566,3 +582,8 @@ class ShotDecision {
 
   const ShotDecision({required this.reason, this.details});
 }
+
+
+
+
+

--- a/lib/src/controllers/step_exit_arbiter.dart
+++ b/lib/src/controllers/step_exit_arbiter.dart
@@ -1,0 +1,186 @@
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/data/profile.dart';
+
+/// Decides whether the tablet should send `skipStep` on a mixed step
+/// (both weight exit and firmware exit conditions), or defer to let
+/// firmware handle the transition.
+///
+/// On each snapshot where projected weight exceeds the step's weight
+/// threshold, [evaluate] checks how close the current sensor reading is
+/// to the firmware exit threshold:
+///
+/// - **Far away** → `fire` immediately (no race risk).
+/// - **Near** → defer up to [maxDeferralFrames], checking the trend.
+///   If the sensor is trending toward the threshold, firmware might fire
+///   on its own — wait. If not trending, fire sooner.
+/// - **Past threshold** → defer once (firmware should fire imminently).
+/// - **Max deferral reached** → `fire` regardless (cap the wait).
+///
+/// Created per-shot alongside [ShotSequencer]. Call [reset] at shot start
+/// and [onFrameAdvanced] when `profileFrame` changes.
+class StepExitArbiter {
+  static final _log = Logger('StepExitArbiter');
+
+  /// Maximum frames to defer before firing skipStep regardless.
+  /// At ~10 Hz DE1 snapshot rate, 3 frames ≈ 300 ms of deferral.
+  static const int maxDeferralFrames = 3;
+
+  /// If pressure is within this many bar of the exit threshold,
+  /// the firmware exit is "near" and we enter deferral.
+  static const double pressureProximityAbsolute = 1.5; // bar
+
+  /// If flow is within this many ml/s of the exit threshold,
+  /// the firmware exit is "near" and we enter deferral.
+  static const double flowProximityAbsolute = 0.8; // ml/s
+
+  final Map<int, _DeferralState> _deferrals = {};
+
+  StepExitArbiter();
+
+  /// Evaluate whether to fire or defer a tablet `skipStep` for a mixed
+  /// step (weight exit reached, firmware exit also present).
+  ///
+  /// [profileFrame] is the current step index from the machine snapshot.
+  /// [exit] is the firmware exit condition on this step.
+  /// [currentPressure] and [currentFlow] are the live sensor readings.
+  StepExitVerdict evaluate({
+    required int profileFrame,
+    required StepExitCondition exit,
+    required double currentPressure,
+    required double currentFlow,
+  }) {
+    // No-op firmware exit (e.g. pressure over 0) — treat as weight-only.
+    if (exit.value <= 0) {
+      _log.fine(
+        'Frame $profileFrame: firmware exit value ${exit.value} ≤ 0, '
+        'treating as weight-only.',
+      );
+      return StepExitVerdict.fire;
+    }
+
+    final sensorValue = switch (exit.type) {
+      ExitType.pressure => currentPressure,
+      ExitType.flow => currentFlow,
+    };
+
+    // Distance: how far the sensor is from triggering the firmware exit.
+    // Positive = hasn't triggered yet.
+    final distance = switch (exit.condition) {
+      ExitCondition.over => exit.value - sensorValue,
+      ExitCondition.under => sensorValue - exit.value,
+    };
+
+    // Sensor already past threshold — firmware should fire imminently.
+    // Defer once to give it a chance.
+    if (distance <= 0) {
+      final deferral = _deferrals.putIfAbsent(
+        profileFrame,
+        () => _DeferralState(),
+      );
+      deferral.record(sensorValue);
+      if (deferral.frameCount >= maxDeferralFrames) {
+        _log.info(
+          'Frame $profileFrame: sensor past firmware threshold '
+          '(distance=$distance) for $maxDeferralFrames frames — firing.',
+        );
+        return StepExitVerdict.fire;
+      }
+      _log.fine(
+        'Frame $profileFrame: sensor past firmware threshold '
+        '(distance=$distance), deferring '
+        '(${deferral.frameCount}/$maxDeferralFrames).',
+      );
+      return StepExitVerdict.defer;
+    }
+
+    final proximityThreshold = switch (exit.type) {
+      ExitType.pressure => pressureProximityAbsolute,
+      ExitType.flow => flowProximityAbsolute,
+    };
+
+    // Far from threshold — no race risk.
+    if (distance > proximityThreshold) {
+      _log.info(
+        'Frame $profileFrame: firmware exit far '
+        '(distance=$distance > $proximityThreshold) — firing skipStep.',
+      );
+      return StepExitVerdict.fire;
+    }
+
+    // Near threshold — enter deferral tracking.
+    final deferral = _deferrals.putIfAbsent(
+      profileFrame,
+      () => _DeferralState(),
+    );
+    deferral.record(sensorValue);
+
+    if (deferral.frameCount >= maxDeferralFrames) {
+      _log.info(
+        'Frame $profileFrame: max deferral ($maxDeferralFrames frames) '
+        'reached — firing skipStep.',
+      );
+      return StepExitVerdict.fire;
+    }
+
+    if (deferral.isTrending(exit.condition)) {
+      _log.fine(
+        'Frame $profileFrame: near firmware threshold '
+        '(distance=$distance) and trending — deferring '
+        '(${deferral.frameCount}/$maxDeferralFrames).',
+      );
+      return StepExitVerdict.defer;
+    }
+
+    // Not trending toward threshold — firmware unlikely to fire.
+    _log.info(
+      'Frame $profileFrame: near firmware threshold '
+      '(distance=$distance) but NOT trending — firing skipStep.',
+    );
+    return StepExitVerdict.fire;
+  }
+
+  /// Notify that the machine's profileFrame has changed.
+  /// Clears any deferral state for frames other than [newFrame].
+  void onFrameAdvanced(int newFrame) {
+    _deferrals.removeWhere((frame, _) => frame != newFrame);
+  }
+
+  /// Reset all state. Call at shot start.
+  void reset() {
+    _deferrals.clear();
+  }
+}
+
+/// The arbiter's recommendation for a mixed-step weight exit.
+enum StepExitVerdict {
+  /// Send `skipStep` now.
+  fire,
+
+  /// Wait — firmware exit may fire on its own.
+  defer,
+}
+
+class _DeferralState {
+  int frameCount = 0;
+  final List<double> readings = [];
+
+  void record(double sensorValue) {
+    readings.add(sensorValue);
+    frameCount++;
+  }
+
+  /// Whether the latest reading is moving toward the exit condition
+  /// threshold compared to the previous reading.
+  ///
+  /// On the first sample (no prior reading), assumes trending
+  /// (conservative: gives firmware the benefit of the doubt).
+  bool isTrending(ExitCondition condition) {
+    if (readings.length < 2) return true;
+    final prev = readings[readings.length - 2];
+    final curr = readings.last;
+    return switch (condition) {
+      ExitCondition.over => curr > prev,
+      ExitCondition.under => curr < prev,
+    };
+  }
+}

--- a/lib/src/controllers/step_exit_arbiter.dart
+++ b/lib/src/controllers/step_exit_arbiter.dart
@@ -25,13 +25,19 @@ class StepExitArbiter {
   /// At ~10 Hz DE1 snapshot rate, 3 frames ≈ 300 ms of deferral.
   static const int maxDeferralFrames = 3;
 
-  /// If pressure is within this many bar of the exit threshold,
-  /// the firmware exit is "near" and we enter deferral.
-  static const double pressureProximityAbsolute = 1.5; // bar
+  /// Proximity window as fraction of exit threshold.
+  /// At 20%, a 9-bar exit enters deferral ~1.8 bar from threshold;
+  /// a 2-bar exit enters ~0.4 bar out. Calibrated to DE1 sensor
+  /// noise at 10 Hz — wide enough to catch genuine firmware approaches,
+  /// narrow enough not to stall low-threshold steps.
+  static const double pressureProximityFraction = 0.20;
 
-  /// If flow is within this many ml/s of the exit threshold,
-  /// the firmware exit is "near" and we enter deferral.
-  static const double flowProximityAbsolute = 0.8; // ml/s
+  /// Proximity window as fraction of flow exit threshold.
+  static const double flowProximityFraction = 0.25;
+
+  /// Absolute floor so low-threshold exits still have meaningful windows.
+  static const double pressureProximityMinimum = 0.3; // bar
+  static const double flowProximityMinimum = 0.2; // ml/s
 
   final Map<int, _DeferralState> _deferrals = {};
 
@@ -93,10 +99,16 @@ class StepExitArbiter {
       return StepExitVerdict.defer;
     }
 
-    final proximityThreshold = switch (exit.type) {
-      ExitType.pressure => pressureProximityAbsolute,
-      ExitType.flow => flowProximityAbsolute,
+    final proximityFraction = switch (exit.type) {
+      ExitType.pressure => pressureProximityFraction,
+      ExitType.flow => flowProximityFraction,
     };
+    final proximityMinimum = switch (exit.type) {
+      ExitType.pressure => pressureProximityMinimum,
+      ExitType.flow => flowProximityMinimum,
+    };
+    final proximityThreshold = (exit.value * proximityFraction)
+        .clamp(proximityMinimum, double.infinity);
 
     // Far from threshold — no race risk.
     if (distance > proximityThreshold) {
@@ -140,9 +152,10 @@ class StepExitArbiter {
   }
 
   /// Notify that the machine's profileFrame has changed.
-  /// Clears any deferral state for frames other than [newFrame].
+  /// Clears deferral state for frames the machine has passed
+  /// (frames below [newFrame]), since firmware never revisits them.
   void onFrameAdvanced(int newFrame) {
-    _deferrals.removeWhere((frame, _) => frame != newFrame);
+    _deferrals.removeWhere((frame, _) => frame < newFrame);
   }
 
   /// Reset all state. Call at shot start.
@@ -169,18 +182,23 @@ class _DeferralState {
     frameCount++;
   }
 
-  /// Whether the latest reading is moving toward the exit condition
-  /// threshold compared to the previous reading.
+  /// Whether the latest readings are moving toward the exit condition
+  /// threshold. Requires all available pairwise comparisons to point
+  /// toward the exit — a single reversal flips to "not trending."
   ///
   /// On the first sample (no prior reading), assumes trending
   /// (conservative: gives firmware the benefit of the doubt).
   bool isTrending(ExitCondition condition) {
     if (readings.length < 2) return true;
-    final prev = readings[readings.length - 2];
-    final curr = readings.last;
-    return switch (condition) {
-      ExitCondition.over => curr > prev,
-      ExitCondition.under => curr < prev,
-    };
+    for (var i = readings.length - 1; i >= 1; i--) {
+      final prev = readings[i - 1];
+      final curr = readings[i];
+      final stepTowards = switch (condition) {
+        ExitCondition.over => curr > prev,
+        ExitCondition.under => curr < prev,
+      };
+      if (!stepTowards) return false;
+    }
+    return true;
   }
 }

--- a/lib/src/settings/advanced_page.dart
+++ b/lib/src/settings/advanced_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/settings/common.dart';
+import 'package:reaprime/src/settings/feature_flags.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/settings/settings_service.dart';
 import 'package:reaprime/src/debug_feature/debug_item_list_view.dart';
@@ -66,6 +67,47 @@ class AdvancedPage extends StatelessWidget {
                 label: 'Gateway Mode',
                 trailing: Text(_gatewayModeLabel(controller.gatewayMode)),
                 onTap: () => _showGatewayModePicker(context),
+              ),
+              const SettingsDivider(),
+
+              // Experimental Features
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
+                child: Text(
+                  'Experimental Features',
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
+                child: ShadSwitch(
+                  value: controller
+                      .isFeatureFlagEnabled(FeatureFlag.stepExitArbiter),
+                  onChanged: (v) async {
+                    await controller.setFeatureFlag(
+                      FeatureFlag.stepExitArbiter,
+                      v,
+                    );
+                  },
+                  label: const Text('Smart Step Advance'),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                ),
+                child: Text(
+                  'When a profile step has both a weight and firmware exit condition, '
+                  'defer the weight-based advance to avoid racing the DE1 and skipping '
+                  'a step. Disable if you experience unexpected step behavior.',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
               ),
               const SettingsDivider(),
 

--- a/lib/src/settings/feature_flags.dart
+++ b/lib/src/settings/feature_flags.dart
@@ -1,0 +1,18 @@
+/// Identifiers for all feature flags in the app.
+///
+/// Add new flags here as the first entry point. Each flag is a key
+/// into [FeatureFlagService] (or [SettingsController.isFeatureFlagEnabled])
+/// and corresponds to a persisted bool in SharedPreferences.
+enum FeatureFlag {
+  /// When enabled, the tablet defers `skipStep` on mixed weight/firmware
+  /// exit steps to avoid racing firmware (issue #269).
+  ///
+  /// Default: **true** (opt-out — the fix is the new default behavior).
+  stepExitArbiter,
+}
+
+/// Default values for each flag. Flags that ship as "on" default to true;
+/// flags that ship as experimental default to false.
+const Map<FeatureFlag, bool> defaultFeatureFlagValues = {
+  FeatureFlag.stepExitArbiter: true,
+};

--- a/lib/src/settings/settings_controller.dart
+++ b/lib/src/settings/settings_controller.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/settings/charging_mode.dart';
+import 'package:reaprime/src/settings/feature_flags.dart';
 import 'package:reaprime/src/settings/gateway_mode.dart';
 import 'package:reaprime/src/settings/scale_power_mode.dart';
 import 'package:reaprime/src/services/telemetry/telemetry_service.dart';
@@ -65,6 +66,9 @@ class SettingsController with ChangeNotifier {
   bool _androidWarningDismissed = false;
   bool _enableSimulatedWebViews = false;
 
+  // Feature flags — loaded once at startup, hot-swappable at runtime.
+  final Map<FeatureFlag, bool> _featureFlags = {};
+
   TelemetryService? _telemetryService;
 
   // Allow Widgets to read the user's preferred ThemeMode.
@@ -95,6 +99,10 @@ class SettingsController with ChangeNotifier {
   bool get accountStepSeen => _accountStepSeen;
   bool get androidWarningDismissed => _androidWarningDismissed;
   bool get enableSimulatedWebViews => _enableSimulatedWebViews;
+
+  // Feature flags
+  bool isFeatureFlagEnabled(FeatureFlag flag) =>
+      _featureFlags[flag] ?? defaultFeatureFlagValues[flag]!;
 
   set telemetryService(TelemetryService service) => _telemetryService = service;
 
@@ -131,6 +139,12 @@ class SettingsController with ChangeNotifier {
         await _settingsService.androidWarningDismissed();
     _enableSimulatedWebViews =
         await _settingsService.enableSimulatedWebViews();
+
+    // Load feature flags
+    for (final flag in FeatureFlag.values) {
+      final stored = await _settingsService.featureFlag(flag);
+      _featureFlags[flag] = stored ?? defaultFeatureFlagValues[flag]!;
+    }
 
     // Sync telemetry consent to TelemetryService if it exists
     if (_telemetryService != null) {
@@ -404,6 +418,13 @@ class SettingsController with ChangeNotifier {
     if (value == _enableSimulatedWebViews) return;
     _enableSimulatedWebViews = value;
     await _settingsService.setEnableSimulatedWebViews(value);
+    notifyListeners();
+  }
+
+  Future<void> setFeatureFlag(FeatureFlag flag, bool value) async {
+    if (value == _featureFlags[flag]) return;
+    _featureFlags[flag] = value;
+    await _settingsService.setFeatureFlag(flag, value);
     notifyListeners();
   }
 }

--- a/lib/src/settings/settings_service.dart
+++ b/lib/src/settings/settings_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_js/quickjs/ffi.dart';
 import 'package:reaprime/src/settings/charging_mode.dart';
+import 'package:reaprime/src/settings/feature_flags.dart';
 import 'package:reaprime/src/settings/gateway_mode.dart';
 import 'package:reaprime/src/settings/scale_power_mode.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -72,6 +73,10 @@ abstract class SettingsService {
   Future<void> setAndroidWarningDismissed(bool value);
   Future<bool> enableSimulatedWebViews();
   Future<void> setEnableSimulatedWebViews(bool value);
+
+  // Feature flags
+  Future<bool?> featureFlag(FeatureFlag flag);
+  Future<void> setFeatureFlag(FeatureFlag flag, bool value);
 }
 
 /// SharedPreferences-backed implementation of [SettingsService].
@@ -437,6 +442,19 @@ class SharedPreferencesSettingsService extends SettingsService {
   @override
   Future<void> setEnableSimulatedWebViews(bool value) async {
     await prefs.setBool(SettingsKeys.enableSimulatedWebViews.name, value);
+  }
+
+  // Feature flags
+  static const _featureFlagPrefix = 'featureFlag';
+
+  @override
+  Future<bool?> featureFlag(FeatureFlag flag) async {
+    return await prefs.getBool('$_featureFlagPrefix.${flag.name}');
+  }
+
+  @override
+  Future<void> setFeatureFlag(FeatureFlag flag, bool value) async {
+    await prefs.setBool('$_featureFlagPrefix.${flag.name}', value);
   }
 }
 

--- a/test/controllers/shot_sequencer_bengle_bypass_test.dart
+++ b/test/controllers/shot_sequencer_bengle_bypass_test.dart
@@ -265,6 +265,7 @@ void main() {
           blockOnNoScale: false,
           weightFlowMultiplier: 0.0,
           volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
         );
 
         async.elapse(const Duration(milliseconds: 10));

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -44,9 +44,9 @@ class _TestDe1Controller extends De1Controller {
   final TestDe1 testDe1;
 
   _TestDe1Controller(this.testDe1)
-      : super(
-          controller: DeviceController([_FakeDiscoveryService()]),
-        );
+    : super(
+        controller: DeviceController([_FakeDiscoveryService()]),
+      );
 
   @override
   De1Interface connectedDe1() => testDe1;
@@ -63,7 +63,7 @@ class _TestScaleController extends ScaleController {
   final BehaviorSubject<WeightSnapshot> _weight = BehaviorSubject();
 
   _TestScaleController(this.testScale)
-      : _connectionState = BehaviorSubject.seeded(ConnectionState.connected);
+    : _connectionState = BehaviorSubject.seeded(ConnectionState.connected);
 
   @override
   Stream<ConnectionState> get connectionState => _connectionState.stream;
@@ -83,11 +83,13 @@ class _TestScaleController extends ScaleController {
   }
 
   void emitWeight(double weight, {double weightFlow = 0.0}) {
-    _weight.add(WeightSnapshot(
-      timestamp: DateTime(2026, 1, 15, 8, 0),
-      weight: weight,
-      weightFlow: weightFlow,
-    ));
+    _weight.add(
+      WeightSnapshot(
+        timestamp: DateTime(2026, 1, 15, 8, 0),
+        weight: weight,
+        weightFlow: weightFlow,
+      ),
+    );
   }
 
   void simulateDisconnect() {
@@ -133,8 +135,7 @@ class _NullStorageService implements StorageService {
     String? profileTitle,
     String? search,
     bool ascending = false,
-  }) async =>
-      [];
+  }) async => [];
   @override
   @override
   Future<int> countShots({
@@ -146,8 +147,7 @@ class _NullStorageService implements StorageService {
     String? coffeeRoaster,
     String? profileTitle,
     String? search,
-  }) async =>
-      0;
+  }) async => 0;
   @override
   Future<ShotRecord?> getLatestShot() async => null;
   @override
@@ -196,6 +196,38 @@ Profile _simpleProfile() {
   );
 }
 
+Profile _profileWithSteps(List<ProfileStep> steps) {
+  return Profile(
+    version: '2',
+    title: 'Test Profile',
+    notes: '',
+    author: 'test',
+    beverageType: BeverageType.espresso,
+    targetVolumeCountStart: 0,
+    tankTemperature: 0,
+    targetWeight: 200,
+    steps: steps,
+  );
+}
+
+ProfileStepPressure _pressureStep({
+  required String name,
+  double? weight,
+  StepExitCondition? exit,
+}) {
+  return ProfileStepPressure(
+    name: name,
+    transition: TransitionType.fast,
+    exit: exit,
+    volume: 0,
+    seconds: 30,
+    weight: weight,
+    temperature: 93,
+    sensor: TemperatureSensor.coffee,
+    pressure: 9,
+  );
+}
+
 void main() {
   group('ShotSequencer — scale disconnect during shot', () {
     late TestDe1 testDe1;
@@ -210,8 +242,9 @@ void main() {
       testScale = TestScale();
       de1Controller = _TestDe1Controller(testDe1);
       scaleController = _TestScaleController(testScale);
-      persistenceController =
-          PersistenceController(storageService: _NullStorageService());
+      persistenceController = PersistenceController(
+        storageService: _NullStorageService(),
+      );
       profile = _simpleProfile();
     });
 
@@ -237,6 +270,19 @@ void main() {
       testDe1.emitStateAndSubstate(
         MachineState.espresso,
         MachineSubstate.pouring,
+      );
+    }
+
+    void emitPouringFrame(int profileFrame) {
+      final current = testDe1.snapshotSubject.value;
+      testDe1.emitSnapshot(
+        current.copyWith(
+          state: const MachineStateSnapshot(
+            state: MachineState.espresso,
+            substate: MachineSubstate.pouring,
+          ),
+          profileFrame: profileFrame,
+        ),
       );
     }
 
@@ -292,59 +338,61 @@ void main() {
       });
     });
 
-    test('does not crash when scale disconnects and timer stop is attempted',
-        () {
-      fakeAsync((async) {
-        // Emit initial weight so withLatestFrom has a value
-        scaleController.emitWeight(0.0);
+    test(
+      'does not crash when scale disconnects and timer stop is attempted',
+      () {
+        fakeAsync((async) {
+          // Emit initial weight so withLatestFrom has a value
+          scaleController.emitWeight(0.0);
 
-        final shotSequencer = ShotSequencer(
-          scaleController: scaleController,
-          de1controller: de1Controller,
-          persistenceController: persistenceController,
-          targetProfile: profile,
-          targetYield: 36.0,
-          bypassSAW: false,
-          blockOnNoScale: false,
-          weightFlowMultiplier: 0.0,
-          volumeFlowMultiplier: 0.0,
-        );
+          final shotSequencer = ShotSequencer(
+            scaleController: scaleController,
+            de1controller: de1Controller,
+            persistenceController: persistenceController,
+            targetProfile: profile,
+            targetYield: 36.0,
+            bypassSAW: false,
+            blockOnNoScale: false,
+            weightFlowMultiplier: 0.0,
+            volumeFlowMultiplier: 0.0,
+          );
 
-        async.elapse(Duration(milliseconds: 10));
-        driveToPouring(shotSequencer);
-        async.elapse(Duration(milliseconds: 10));
+          async.elapse(Duration(milliseconds: 10));
+          driveToPouring(shotSequencer);
+          async.elapse(Duration(milliseconds: 10));
 
-        // Disconnect the scale
-        scaleController.simulateDisconnect();
-        async.elapse(Duration(milliseconds: 10));
+          // Disconnect the scale
+          scaleController.simulateDisconnect();
+          async.elapse(Duration(milliseconds: 10));
 
-        // Machine ends the shot — this transitions to stopping state.
-        testDe1.emitStateAndSubstate(
-          MachineState.espresso,
-          MachineSubstate.pouringDone,
-        );
-        async.elapse(Duration(milliseconds: 10));
+          // Machine ends the shot — this transitions to stopping state.
+          testDe1.emitStateAndSubstate(
+            MachineState.espresso,
+            MachineSubstate.pouringDone,
+          );
+          async.elapse(Duration(milliseconds: 10));
 
-        // Now emit another snapshot. The ShotSequencer is in the stopping
-        // state, which calls scaleController.connectedScale().stopTimer().
-        // With the bug, connectedScale() throws because scale is disconnected.
-        expect(
-          () {
-            testDe1.emitStateAndSubstate(
-              MachineState.espresso,
-              MachineSubstate.pouringDone,
-            );
-            async.elapse(Duration(milliseconds: 10));
-          },
-          returnsNormally,
-          reason:
-              'Should not crash when scale disconnects and shot ends — '
-              'connectedScale() throws when scale is gone',
-        );
+          // Now emit another snapshot. The ShotSequencer is in the stopping
+          // state, which calls scaleController.connectedScale().stopTimer().
+          // With the bug, connectedScale() throws because scale is disconnected.
+          expect(
+            () {
+              testDe1.emitStateAndSubstate(
+                MachineState.espresso,
+                MachineSubstate.pouringDone,
+              );
+              async.elapse(Duration(milliseconds: 10));
+            },
+            returnsNormally,
+            reason:
+                'Should not crash when scale disconnects and shot ends — '
+                'connectedScale() throws when scale is gone',
+          );
 
-        shotSequencer.dispose();
-      });
-    });
+          shotSequencer.dispose();
+        });
+      },
+    );
 
     test('SAW still works normally when scale stays connected', () {
       fakeAsync((async) {
@@ -384,6 +432,137 @@ void main() {
           reason:
               'SAW should fire when scale is connected and weight exceeds target',
         );
+
+        shotSequencer.dispose();
+      });
+    });
+
+    test('mixed weight and firmware exit step does not send skipStep', () {
+      fakeAsync((async) {
+        profile = _profileWithSteps([
+          _pressureStep(
+            name: 'mixed',
+            weight: 10,
+            exit: const StepExitCondition(
+              type: ExitType.pressure,
+              condition: ExitCondition.over,
+              value: 2,
+            ),
+          ),
+        ]);
+        scaleController.emitWeight(0.0);
+
+        final shotSequencer = ShotSequencer(
+          scaleController: scaleController,
+          de1controller: de1Controller,
+          persistenceController: persistenceController,
+          targetProfile: profile,
+          targetYield: 200.0,
+          bypassSAW: false,
+          blockOnNoScale: false,
+          weightFlowMultiplier: 0.0,
+          volumeFlowMultiplier: 0.0,
+        );
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring(shotSequencer);
+        async.elapse(Duration(milliseconds: 10));
+
+        scaleController.emitWeight(12.0);
+        emitPouringFrame(0);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(
+          testDe1.requestedStates,
+          isNot(contains(MachineState.skipStep)),
+          reason:
+              'Mixed weight + firmware-exit steps are firmware-owned to avoid '
+              'a queued tablet skip racing with the firmware frame advance.',
+        );
+
+        shotSequencer.dispose();
+      });
+    });
+
+    test('pure weight step still sends skipStep', () {
+      fakeAsync((async) {
+        profile = _profileWithSteps([
+          _pressureStep(name: 'weight-only', weight: 10),
+        ]);
+        scaleController.emitWeight(0.0);
+
+        final shotSequencer = ShotSequencer(
+          scaleController: scaleController,
+          de1controller: de1Controller,
+          persistenceController: persistenceController,
+          targetProfile: profile,
+          targetYield: 200.0,
+          bypassSAW: false,
+          blockOnNoScale: false,
+          weightFlowMultiplier: 0.0,
+          volumeFlowMultiplier: 0.0,
+        );
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring(shotSequencer);
+        async.elapse(Duration(milliseconds: 10));
+
+        scaleController.emitWeight(12.0);
+        emitPouringFrame(0);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(testDe1.requestedStates, contains(MachineState.skipStep));
+
+        shotSequencer.dispose();
+      });
+    });
+
+    test('mixed-exit suppression is frame-local', () {
+      fakeAsync((async) {
+        profile = _profileWithSteps([
+          _pressureStep(
+            name: 'firmware-owned',
+            weight: 10,
+            exit: const StepExitCondition(
+              type: ExitType.pressure,
+              condition: ExitCondition.over,
+              value: 2,
+            ),
+          ),
+          _pressureStep(name: 'weight-owned', weight: 20),
+        ]);
+        scaleController.emitWeight(0.0);
+
+        final shotSequencer = ShotSequencer(
+          scaleController: scaleController,
+          de1controller: de1Controller,
+          persistenceController: persistenceController,
+          targetProfile: profile,
+          targetYield: 200.0,
+          bypassSAW: false,
+          blockOnNoScale: false,
+          weightFlowMultiplier: 0.0,
+          volumeFlowMultiplier: 0.0,
+        );
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring(shotSequencer);
+        async.elapse(Duration(milliseconds: 10));
+
+        scaleController.emitWeight(12.0);
+        emitPouringFrame(0);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(
+          testDe1.requestedStates,
+          isNot(contains(MachineState.skipStep)),
+        );
+
+        scaleController.emitWeight(22.0);
+        emitPouringFrame(1);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(testDe1.requestedStates, contains(MachineState.skipStep));
 
         shotSequencer.dispose();
       });
@@ -589,7 +768,8 @@ void main() {
         expect(
           states,
           contains(ShotState.finished),
-          reason: 'settling finalizes the shot without waiting for the backstop',
+          reason:
+              'settling finalizes the shot without waiting for the backstop',
         );
 
         shotSequencer.dispose();
@@ -810,8 +990,9 @@ void main() {
       testScale = TestScale();
       de1Controller = _TestDe1Controller(testDe1);
       scaleController = _TestScaleController(testScale);
-      persistenceController =
-          PersistenceController(storageService: _NullStorageService());
+      persistenceController = PersistenceController(
+        storageService: _NullStorageService(),
+      );
       profile = _simpleProfile();
     });
 
@@ -823,83 +1004,86 @@ void main() {
     });
 
     test(
-        'aborts shot and emits noScale decision when no scale connected at start',
-        () {
-      fakeAsync((async) {
-        // No scale at shot start.
-        scaleController.simulateDisconnect();
+      'aborts shot and emits noScale decision when no scale connected at start',
+      () {
+        fakeAsync((async) {
+          // No scale at shot start.
+          scaleController.simulateDisconnect();
 
-        final shotSequencer = ShotSequencer(
-          scaleController: scaleController,
-          de1controller: de1Controller,
-          persistenceController: persistenceController,
-          targetProfile: profile,
-          targetYield: 36.0,
-          bypassSAW: false,
-          blockOnNoScale: true,
-          weightFlowMultiplier: 0.0,
-          volumeFlowMultiplier: 0.0,
-        );
+          final shotSequencer = ShotSequencer(
+            scaleController: scaleController,
+            de1controller: de1Controller,
+            persistenceController: persistenceController,
+            targetProfile: profile,
+            targetYield: 36.0,
+            bypassSAW: false,
+            blockOnNoScale: true,
+            weightFlowMultiplier: 0.0,
+            volumeFlowMultiplier: 0.0,
+          );
 
-        final decisions = <ShotDecision>[];
-        final snapshots = <ShotSnapshot>[];
-        shotSequencer.decisions.listen(decisions.add);
-        shotSequencer.shotData.listen(snapshots.add);
+          final decisions = <ShotDecision>[];
+          final snapshots = <ShotSnapshot>[];
+          shotSequencer.decisions.listen(decisions.add);
+          shotSequencer.shotData.listen(snapshots.add);
 
-        async.elapse(Duration(milliseconds: 10));
+          async.elapse(Duration(milliseconds: 10));
 
-        // Machine entered espresso (e.g. via GHC) — drive snapshots that would
-        // normally be tracked.
-        testDe1.emitStateAndSubstate(
-          MachineState.espresso,
-          MachineSubstate.pouring,
-        );
-        async.elapse(Duration(milliseconds: 10));
+          // Machine entered espresso (e.g. via GHC) — drive snapshots that would
+          // normally be tracked.
+          testDe1.emitStateAndSubstate(
+            MachineState.espresso,
+            MachineSubstate.pouring,
+          );
+          async.elapse(Duration(milliseconds: 10));
 
-        expect(
-          testDe1.requestedStates,
-          contains(MachineState.idle),
-          reason: 'shot should be aborted back to idle',
-        );
-        expect(decisions, hasLength(1));
-        expect(decisions.single.reason, ShotDecisionReason.noScale);
-        expect(
-          snapshots,
-          isEmpty,
-          reason: 'no monitoring should be wired when the shot is blocked',
-        );
+          expect(
+            testDe1.requestedStates,
+            contains(MachineState.idle),
+            reason: 'shot should be aborted back to idle',
+          );
+          expect(decisions, hasLength(1));
+          expect(decisions.single.reason, ShotDecisionReason.noScale);
+          expect(
+            snapshots,
+            isEmpty,
+            reason: 'no monitoring should be wired when the shot is blocked',
+          );
 
-        shotSequencer.dispose();
-      });
-    });
+          shotSequencer.dispose();
+        });
+      },
+    );
 
-    test('does not block when blockOnNoScale is false and no scale connected',
-        () {
-      fakeAsync((async) {
-        scaleController.simulateDisconnect();
+    test(
+      'does not block when blockOnNoScale is false and no scale connected',
+      () {
+        fakeAsync((async) {
+          scaleController.simulateDisconnect();
 
-        final shotSequencer = ShotSequencer(
-          scaleController: scaleController,
-          de1controller: de1Controller,
-          persistenceController: persistenceController,
-          targetProfile: profile,
-          targetYield: 36.0,
-          bypassSAW: false,
-          blockOnNoScale: false,
-          weightFlowMultiplier: 0.0,
-          volumeFlowMultiplier: 0.0,
-        );
+          final shotSequencer = ShotSequencer(
+            scaleController: scaleController,
+            de1controller: de1Controller,
+            persistenceController: persistenceController,
+            targetProfile: profile,
+            targetYield: 36.0,
+            bypassSAW: false,
+            blockOnNoScale: false,
+            weightFlowMultiplier: 0.0,
+            volumeFlowMultiplier: 0.0,
+          );
 
-        final decisions = <ShotDecision>[];
-        shotSequencer.decisions.listen(decisions.add);
+          final decisions = <ShotDecision>[];
+          shotSequencer.decisions.listen(decisions.add);
 
-        async.elapse(Duration(milliseconds: 10));
+          async.elapse(Duration(milliseconds: 10));
 
-        expect(testDe1.requestedStates, isEmpty);
-        expect(decisions, isEmpty);
+          expect(testDe1.requestedStates, isEmpty);
+          expect(decisions, isEmpty);
 
-        shotSequencer.dispose();
-      });
-    });
+          shotSequencer.dispose();
+        });
+      },
+    );
   });
 }

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -347,6 +347,7 @@ void main() {
           blockOnNoScale: false,
           weightFlowMultiplier: 0.0,
           volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
         );
 
         async.elapse(Duration(milliseconds: 10));
@@ -401,6 +402,7 @@ void main() {
             blockOnNoScale: false,
             weightFlowMultiplier: 0.0,
             volumeFlowMultiplier: 0.0,
+            stepExitArbiterEnabled: true,
           );
 
           async.elapse(Duration(milliseconds: 10));
@@ -455,6 +457,7 @@ void main() {
           blockOnNoScale: false,
           weightFlowMultiplier: 0.0,
           volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
         );
 
         async.elapse(Duration(milliseconds: 10));
@@ -510,6 +513,7 @@ void main() {
           blockOnNoScale: false,
           weightFlowMultiplier: 0.0,
           volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
         );
 
         async.elapse(Duration(milliseconds: 10));
@@ -559,6 +563,7 @@ void main() {
           blockOnNoScale: false,
           weightFlowMultiplier: 0.0,
           volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
         );
 
         async.elapse(Duration(milliseconds: 10));
@@ -624,6 +629,7 @@ void main() {
           blockOnNoScale: false,
           weightFlowMultiplier: 0.0,
           volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
         );
 
         async.elapse(Duration(milliseconds: 10));
@@ -661,6 +667,7 @@ void main() {
           blockOnNoScale: false,
           weightFlowMultiplier: 0.0,
           volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
         );
 
         async.elapse(Duration(milliseconds: 10));
@@ -705,6 +712,7 @@ void main() {
           blockOnNoScale: false,
           weightFlowMultiplier: 0.0,
           volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
         );
 
         async.elapse(Duration(milliseconds: 10));
@@ -759,6 +767,7 @@ void main() {
           blockOnNoScale: false,
           weightFlowMultiplier: 0.0,
           volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
         );
 
         async.elapse(Duration(milliseconds: 10));
@@ -821,6 +830,7 @@ void main() {
           blockOnNoScale: false,
           weightFlowMultiplier: 0.0,
           volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
         );
 
         async.elapse(Duration(milliseconds: 10));
@@ -872,6 +882,7 @@ void main() {
           blockOnNoScale: false,
           weightFlowMultiplier: 0.0,
           volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
         );
 
         async.elapse(Duration(milliseconds: 10));
@@ -919,6 +930,7 @@ void main() {
           blockOnNoScale: false,
           weightFlowMultiplier: 0.0,
           volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
         );
 
         async.elapse(Duration(milliseconds: 10));
@@ -969,6 +981,7 @@ void main() {
           blockOnNoScale: false,
           weightFlowMultiplier: 0.0,
           volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
         );
 
         async.elapse(Duration(milliseconds: 10));
@@ -1028,6 +1041,7 @@ void main() {
           blockOnNoScale: false,
           weightFlowMultiplier: 0.0,
           volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
         );
 
         final states = <ShotState>[];
@@ -1085,6 +1099,7 @@ void main() {
             blockOnNoScale: false,
             weightFlowMultiplier: 0.0,
             volumeFlowMultiplier: 0.0,
+            stepExitArbiterEnabled: true,
           );
 
           final recorded = <ShotSnapshot>[];
@@ -1162,6 +1177,7 @@ void main() {
           blockOnNoScale: false,
           weightFlowMultiplier: 0.0,
           volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
         );
 
         final recorded = <ShotSnapshot>[];
@@ -1233,6 +1249,7 @@ void main() {
           blockOnNoScale: false,
           weightFlowMultiplier: 0.0,
           volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
         );
 
         final states = <ShotState>[];
@@ -1310,6 +1327,7 @@ void main() {
             blockOnNoScale: true,
             weightFlowMultiplier: 0.0,
             volumeFlowMultiplier: 0.0,
+            stepExitArbiterEnabled: true,
           );
 
           final decisions = <ShotDecision>[];
@@ -1361,6 +1379,7 @@ void main() {
             blockOnNoScale: false,
             weightFlowMultiplier: 0.0,
             volumeFlowMultiplier: 0.0,
+            stepExitArbiterEnabled: true,
           );
 
           final decisions = <ShotDecision>[];
@@ -1375,5 +1394,113 @@ void main() {
         });
       },
     );
+  });
+
+  group('ShotSequencer — step exit arbiter disabled', () {
+    late TestDe1 testDe1;
+    late TestScale testScale;
+    late _TestDe1Controller de1Controller;
+    late _TestScaleController scaleController;
+    late PersistenceController persistenceController;
+    late Profile profile;
+
+    setUp(() {
+      testDe1 = TestDe1();
+      testScale = TestScale();
+      de1Controller = _TestDe1Controller(testDe1);
+      scaleController = _TestScaleController(testScale);
+      persistenceController = PersistenceController(
+        storageService: _NullStorageService(),
+      );
+      profile = _profileWithSteps([
+        _pressureStep(
+          name: 'mixed-near',
+          weight: 10,
+          exit: const StepExitCondition(
+            type: ExitType.pressure,
+            condition: ExitCondition.over,
+            value: 5,
+          ),
+        ),
+      ]);
+    });
+
+    tearDown(() {
+      testDe1.dispose();
+      testScale.dispose();
+      scaleController.dispose();
+      persistenceController.dispose();
+    });
+
+    /// Drive the ShotSequencer state machine from idle → pouring.
+    void driveToPouring(ShotSequencer shotSequencer) {
+      testDe1.emitStateAndSubstate(
+        MachineState.espresso,
+        MachineSubstate.preparingForShot,
+      );
+      testDe1.emitStateAndSubstate(
+        MachineState.espresso,
+        MachineSubstate.pouring,
+      );
+    }
+
+    void emitPouringFrameWithPressure(int profileFrame, double pressure) {
+      final current = testDe1.snapshotSubject.value;
+      testDe1.emitSnapshot(
+        current.copyWith(
+          state: const MachineStateSnapshot(
+            state: MachineState.espresso,
+            substate: MachineSubstate.pouring,
+          ),
+          profileFrame: profileFrame,
+          pressure: pressure,
+        ),
+      );
+    }
+
+    test('fires skipStep immediately even when firmware exit is near', () {
+      fakeAsync((async) {
+        // Same scenario as the arbiter-enabled 'defer' test:
+        // pressure exit at 5 bar, emitting pressure 4.0 (near threshold).
+        // With the arbiter disabled, the weight exit should fire immediately
+        // without deferral — pre-fix behavior.
+        scaleController.emitWeight(0.0);
+
+        final shotSequencer = ShotSequencer(
+          scaleController: scaleController,
+          de1controller: de1Controller,
+          persistenceController: persistenceController,
+          targetProfile: profile,
+          targetYield: 200.0,
+          bypassSAW: false,
+          blockOnNoScale: false,
+          weightFlowMultiplier: 0.0,
+          volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: false,
+        );
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring(shotSequencer);
+        async.elapse(Duration(milliseconds: 10));
+
+        // Weight exceeds step threshold (12 > 10)
+        scaleController.emitWeight(12.0);
+        // Pressure near threshold (4.0, exit at 5.0)
+        emitPouringFrameWithPressure(0, 4.0);
+        async.elapse(Duration(milliseconds: 10));
+
+        // With arbiter disabled, skipStep fires immediately despite
+        // being near the firmware exit threshold.
+        expect(
+          testDe1.requestedStates,
+          contains(MachineState.skipStep),
+          reason:
+              'With stepExitArbiter disabled, weight exit should fire '
+              'immediately even when near firmware threshold.',
+        );
+
+        shotSequencer.dispose();
+      });
+    });
   });
 }

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -228,6 +228,24 @@ ProfileStepPressure _pressureStep({
   );
 }
 
+ProfileStepFlow _flowStep({
+  required String name,
+  double? weight,
+  StepExitCondition? exit,
+}) {
+  return ProfileStepFlow(
+    name: name,
+    transition: TransitionType.fast,
+    exit: exit,
+    volume: 0,
+    seconds: 30,
+    weight: weight,
+    temperature: 93,
+    sensor: TemperatureSensor.coffee,
+    flow: 4,
+  );
+}
+
 void main() {
   group('ShotSequencer — scale disconnect during shot', () {
     late TestDe1 testDe1;
@@ -296,6 +314,20 @@ void main() {
           ),
           profileFrame: profileFrame,
           pressure: pressure,
+        ),
+      );
+    }
+
+    void emitPouringFrameWithFlow(int profileFrame, double flow) {
+      final current = testDe1.snapshotSubject.value;
+      testDe1.emitSnapshot(
+        current.copyWith(
+          state: const MachineStateSnapshot(
+            state: MachineState.espresso,
+            substate: MachineSubstate.pouring,
+          ),
+          profileFrame: profileFrame,
+          flow: flow,
         ),
       );
     }
@@ -756,6 +788,70 @@ void main() {
           reason:
               'Frame 0 deferral cancelled by firmware advance. '
               'Frame 1 weight not yet reached.',
+        );
+
+        shotSequencer.dispose();
+      });
+    });
+
+    test('mixed flow-under step defers when near threshold', () {
+      fakeAsync((async) {
+        // Flow exit under 2.0 ml/s. Emit flow 2.5 → distance 0.5, proximity =
+        // 2.0 * 0.25 = 0.5 → boundary (not > 0.5) → near → defer.
+        profile = _profileWithSteps([
+          _flowStep(
+            name: 'flow-near',
+            weight: 10,
+            exit: const StepExitCondition(
+              type: ExitType.flow,
+              condition: ExitCondition.under,
+              value: 2.0,
+            ),
+          ),
+        ]);
+        scaleController.emitWeight(0.0);
+
+        final shotSequencer = ShotSequencer(
+          scaleController: scaleController,
+          de1controller: de1Controller,
+          persistenceController: persistenceController,
+          targetProfile: profile,
+          targetYield: 200.0,
+          bypassSAW: false,
+          blockOnNoScale: false,
+          weightFlowMultiplier: 0.0,
+          volumeFlowMultiplier: 0.0,
+        );
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring(shotSequencer);
+        async.elapse(Duration(milliseconds: 10));
+
+        // Weight above threshold, flow near firmware exit.
+        scaleController.emitWeight(12.0);
+        emitPouringFrameWithFlow(0, 2.5);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(
+          testDe1.requestedStates,
+          isNot(contains(MachineState.skipStep)),
+          reason:
+              'Flow near under-2.0 exit → defer to avoid racing firmware.',
+        );
+
+        // After max deferral frames (3), fires regardless.
+        scaleController.emitWeight(12.0);
+        emitPouringFrameWithFlow(0, 2.3);
+        async.elapse(Duration(milliseconds: 10));
+
+        scaleController.emitWeight(12.0);
+        emitPouringFrameWithFlow(0, 2.1);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(
+          testDe1.requestedStates,
+          contains(MachineState.skipStep),
+          reason: 'Max deferral → fire.',
         );
 
         shotSequencer.dispose();

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -286,6 +286,20 @@ void main() {
       );
     }
 
+    void emitPouringFrameWithPressure(int profileFrame, double pressure) {
+      final current = testDe1.snapshotSubject.value;
+      testDe1.emitSnapshot(
+        current.copyWith(
+          state: const MachineStateSnapshot(
+            state: MachineState.espresso,
+            substate: MachineSubstate.pouring,
+          ),
+          profileFrame: profileFrame,
+          pressure: pressure,
+        ),
+      );
+    }
+
     test('disables SAW when scale disconnects during pouring', () {
       fakeAsync((async) {
         // Emit initial weight so withLatestFrom has a value to combine with
@@ -437,16 +451,18 @@ void main() {
       });
     });
 
-    test('mixed weight and firmware exit step does not send skipStep', () {
+    test('mixed step fires skipStep when firmware exit is far', () {
       fakeAsync((async) {
+        // Pressure exit at 9 bar, default snapshot pressure is 0 →
+        // distance 9.0 >> 1.5 bar proximity → arbiter says fire.
         profile = _profileWithSteps([
           _pressureStep(
-            name: 'mixed',
+            name: 'mixed-far',
             weight: 10,
             exit: const StepExitCondition(
               type: ExitType.pressure,
               condition: ExitCondition.over,
-              value: 2,
+              value: 9,
             ),
           ),
         ]);
@@ -474,10 +490,122 @@ void main() {
 
         expect(
           testDe1.requestedStates,
+          contains(MachineState.skipStep),
+          reason:
+              'Firmware exit is far from threshold (pressure 0, exit at 9) — '
+              'weight exit should fire immediately.',
+        );
+
+        shotSequencer.dispose();
+      });
+    });
+
+    test('mixed step defers skipStep when firmware exit is near', () {
+      fakeAsync((async) {
+        // Pressure exit at 5 bar. We'll emit snapshots with pressure 4.0
+        // (distance 1.0 < 1.5 proximity) → arbiter defers.
+        profile = _profileWithSteps([
+          _pressureStep(
+            name: 'mixed-near',
+            weight: 10,
+            exit: const StepExitCondition(
+              type: ExitType.pressure,
+              condition: ExitCondition.over,
+              value: 5,
+            ),
+          ),
+        ]);
+        scaleController.emitWeight(0.0);
+
+        final shotSequencer = ShotSequencer(
+          scaleController: scaleController,
+          de1controller: de1Controller,
+          persistenceController: persistenceController,
+          targetProfile: profile,
+          targetYield: 200.0,
+          bypassSAW: false,
+          blockOnNoScale: false,
+          weightFlowMultiplier: 0.0,
+          volumeFlowMultiplier: 0.0,
+        );
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring(shotSequencer);
+        async.elapse(Duration(milliseconds: 10));
+
+        // Emit weight above step threshold with pressure near firmware exit.
+        scaleController.emitWeight(12.0);
+        emitPouringFrameWithPressure(0, 4.0);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(
+          testDe1.requestedStates,
           isNot(contains(MachineState.skipStep)),
           reason:
-              'Mixed weight + firmware-exit steps are firmware-owned to avoid '
-              'a queued tablet skip racing with the firmware frame advance.',
+              'Firmware exit is near (pressure 4.0, exit at 5.0) — '
+              'should defer to avoid racing firmware.',
+        );
+
+        // After max deferral frames (3), fires regardless.
+        scaleController.emitWeight(12.0);
+        emitPouringFrameWithPressure(0, 4.2);
+        async.elapse(Duration(milliseconds: 10));
+
+        scaleController.emitWeight(12.0);
+        emitPouringFrameWithPressure(0, 4.4);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(
+          testDe1.requestedStates,
+          contains(MachineState.skipStep),
+          reason:
+              'After max deferral (3 frames), weight exit fires regardless.',
+        );
+
+        shotSequencer.dispose();
+      });
+    });
+
+    test('mixed step skips deferral when firmware exit has value 0', () {
+      fakeAsync((async) {
+        // Exit value 0 is a no-op — arbiter treats it as weight-only.
+        profile = _profileWithSteps([
+          _pressureStep(
+            name: 'noop-exit',
+            weight: 10,
+            exit: const StepExitCondition(
+              type: ExitType.pressure,
+              condition: ExitCondition.over,
+              value: 0,
+            ),
+          ),
+        ]);
+        scaleController.emitWeight(0.0);
+
+        final shotSequencer = ShotSequencer(
+          scaleController: scaleController,
+          de1controller: de1Controller,
+          persistenceController: persistenceController,
+          targetProfile: profile,
+          targetYield: 200.0,
+          bypassSAW: false,
+          blockOnNoScale: false,
+          weightFlowMultiplier: 0.0,
+          volumeFlowMultiplier: 0.0,
+        );
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring(shotSequencer);
+        async.elapse(Duration(milliseconds: 10));
+
+        scaleController.emitWeight(12.0);
+        emitPouringFrame(0);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(
+          testDe1.requestedStates,
+          contains(MachineState.skipStep),
+          reason: 'Exit value 0 is a no-op — weight fires immediately.',
         );
 
         shotSequencer.dispose();
@@ -517,16 +645,18 @@ void main() {
       });
     });
 
-    test('mixed-exit suppression is frame-local', () {
+    test('mixed-exit deferral is frame-local', () {
       fakeAsync((async) {
+        // Frame 0: mixed step with near firmware exit → defers.
+        // Frame 1: pure weight step → fires immediately.
         profile = _profileWithSteps([
           _pressureStep(
-            name: 'firmware-owned',
+            name: 'near-exit',
             weight: 10,
             exit: const StepExitCondition(
               type: ExitType.pressure,
               condition: ExitCondition.over,
-              value: 2,
+              value: 5,
             ),
           ),
           _pressureStep(name: 'weight-owned', weight: 20),
@@ -549,8 +679,9 @@ void main() {
         driveToPouring(shotSequencer);
         async.elapse(Duration(milliseconds: 10));
 
+        // Frame 0: near firmware exit → defers
         scaleController.emitWeight(12.0);
-        emitPouringFrame(0);
+        emitPouringFrameWithPressure(0, 4.0);
         async.elapse(Duration(milliseconds: 10));
 
         expect(
@@ -558,11 +689,74 @@ void main() {
           isNot(contains(MachineState.skipStep)),
         );
 
+        // Frame 1: pure weight step → fires
         scaleController.emitWeight(22.0);
         emitPouringFrame(1);
         async.elapse(Duration(milliseconds: 10));
 
         expect(testDe1.requestedStates, contains(MachineState.skipStep));
+
+        shotSequencer.dispose();
+      });
+    });
+
+    test('firmware frame advance cancels pending deferral', () {
+      fakeAsync((async) {
+        // Two-step profile: frame 0 has mixed exit (near), frame 1 weight-only.
+        profile = _profileWithSteps([
+          _pressureStep(
+            name: 'near-exit',
+            weight: 10,
+            exit: const StepExitCondition(
+              type: ExitType.pressure,
+              condition: ExitCondition.over,
+              value: 5,
+            ),
+          ),
+          _pressureStep(name: 'next-step', weight: 50),
+        ]);
+        scaleController.emitWeight(0.0);
+
+        final shotSequencer = ShotSequencer(
+          scaleController: scaleController,
+          de1controller: de1Controller,
+          persistenceController: persistenceController,
+          targetProfile: profile,
+          targetYield: 200.0,
+          bypassSAW: false,
+          blockOnNoScale: false,
+          weightFlowMultiplier: 0.0,
+          volumeFlowMultiplier: 0.0,
+        );
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring(shotSequencer);
+        async.elapse(Duration(milliseconds: 10));
+
+        // Frame 0: weight reached, near firmware exit → defers
+        scaleController.emitWeight(12.0);
+        emitPouringFrameWithPressure(0, 4.0);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(
+          testDe1.requestedStates,
+          isNot(contains(MachineState.skipStep)),
+          reason: 'Deferred on frame 0',
+        );
+
+        // Firmware advances to frame 1 (firmware handled the exit itself).
+        // Weight 12.0 is below frame 1's weight threshold (50), so no skip.
+        scaleController.emitWeight(12.0);
+        emitPouringFrame(1);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(
+          testDe1.requestedStates,
+          isNot(contains(MachineState.skipStep)),
+          reason:
+              'Frame 0 deferral cancelled by firmware advance. '
+              'Frame 1 weight not yet reached.',
+        );
 
         shotSequencer.dispose();
       });

--- a/test/controllers/step_exit_arbiter_test.dart
+++ b/test/controllers/step_exit_arbiter_test.dart
@@ -1,0 +1,363 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/step_exit_arbiter.dart';
+import 'package:reaprime/src/models/data/profile.dart';
+
+void main() {
+  late StepExitArbiter arbiter;
+
+  setUp(() {
+    arbiter = StepExitArbiter();
+  });
+
+  // ---------------------------------------------------------------
+  // Pressure / over
+  // ---------------------------------------------------------------
+
+  group('pressure over exit', () {
+    const exit = StepExitCondition(
+      type: ExitType.pressure,
+      condition: ExitCondition.over,
+      value: 6.0,
+    );
+
+    test('far from threshold fires immediately', () {
+      // Current pressure 2.0, exit at 6.0 → distance 4.0 > 1.5
+      final verdict = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 2.0,
+        currentFlow: 3.0,
+      );
+      expect(verdict, StepExitVerdict.fire);
+    });
+
+    test('near threshold and trending defers', () {
+      // Current pressure 5.0, exit at 6.0 → distance 1.0 < 1.5
+      final v1 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.0,
+        currentFlow: 3.0,
+      );
+      // First sample assumes trending → defer
+      expect(v1, StepExitVerdict.defer);
+
+      // Second sample still trending up
+      final v2 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.3,
+        currentFlow: 3.0,
+      );
+      expect(v2, StepExitVerdict.defer);
+    });
+
+    test('near threshold trending hits max deferral then fires', () {
+      for (var i = 0; i < StepExitArbiter.maxDeferralFrames - 1; i++) {
+        final v = arbiter.evaluate(
+          profileFrame: 0,
+          exit: exit,
+          currentPressure: 5.0 + i * 0.2,
+          currentFlow: 3.0,
+        );
+        expect(v, StepExitVerdict.defer, reason: 'frame $i should defer');
+      }
+
+      // Max deferral reached
+      final vFinal = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.6,
+        currentFlow: 3.0,
+      );
+      expect(vFinal, StepExitVerdict.fire);
+    });
+
+    test('near threshold not trending fires on second frame', () {
+      // First sample: assumes trending → defer
+      final v1 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.0,
+        currentFlow: 3.0,
+      );
+      expect(v1, StepExitVerdict.defer);
+
+      // Second sample: pressure dropped → not trending toward "over"
+      final v2 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 4.8,
+        currentFlow: 3.0,
+      );
+      expect(v2, StepExitVerdict.fire);
+    });
+
+    test('sensor past threshold defers then fires at max', () {
+      // Pressure 7.0 > exit 6.0 → distance -1.0 ≤ 0
+      final v1 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 7.0,
+        currentFlow: 3.0,
+      );
+      expect(v1, StepExitVerdict.defer);
+
+      final v2 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 7.0,
+        currentFlow: 3.0,
+      );
+      expect(v2, StepExitVerdict.defer);
+
+      // Third frame hits maxDeferralFrames
+      final v3 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 7.0,
+        currentFlow: 3.0,
+      );
+      expect(v3, StepExitVerdict.fire);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Flow / under
+  // ---------------------------------------------------------------
+
+  group('flow under exit', () {
+    const exit = StepExitCondition(
+      type: ExitType.flow,
+      condition: ExitCondition.under,
+      value: 2.0,
+    );
+
+    test('far from threshold fires immediately', () {
+      // Current flow 3.5, exit under 2.0 → distance 1.5 > 0.8
+      final verdict = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.0,
+        currentFlow: 3.5,
+      );
+      expect(verdict, StepExitVerdict.fire);
+    });
+
+    test('near threshold defers', () {
+      // Current flow 2.5, exit under 2.0 → distance 0.5 < 0.8
+      final verdict = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.0,
+        currentFlow: 2.5,
+      );
+      expect(verdict, StepExitVerdict.defer);
+    });
+
+    test('near threshold trending down defers, not trending fires', () {
+      // First: flow 2.5 → defer (assumes trending)
+      arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.0,
+        currentFlow: 2.5,
+      );
+
+      // Second: flow 2.3 (dropping toward "under 2.0") → trending → defer
+      final v2 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.0,
+        currentFlow: 2.3,
+      );
+      expect(v2, StepExitVerdict.defer);
+
+      // Third: max deferral → fire
+      final v3 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.0,
+        currentFlow: 2.1,
+      );
+      expect(v3, StepExitVerdict.fire);
+    });
+
+    test('near threshold flow rising fires on second frame', () {
+      // First: defer (assumes trending)
+      arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.0,
+        currentFlow: 2.5,
+      );
+
+      // Second: flow 2.8 — rising, not trending toward "under"
+      final v2 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.0,
+        currentFlow: 2.8,
+      );
+      expect(v2, StepExitVerdict.fire);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Edge cases
+  // ---------------------------------------------------------------
+
+  group('edge cases', () {
+    test('exit value <= 0 fires immediately', () {
+      const exit = StepExitCondition(
+        type: ExitType.pressure,
+        condition: ExitCondition.over,
+        value: 0.0,
+      );
+
+      final verdict = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 1.0,
+        currentFlow: 3.0,
+      );
+      expect(verdict, StepExitVerdict.fire);
+    });
+
+    test('negative exit value fires immediately', () {
+      const exit = StepExitCondition(
+        type: ExitType.flow,
+        condition: ExitCondition.under,
+        value: -1.0,
+      );
+
+      final verdict = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.0,
+        currentFlow: 2.0,
+      );
+      expect(verdict, StepExitVerdict.fire);
+    });
+
+    test('onFrameAdvanced clears stale deferral state', () {
+      const exit = StepExitCondition(
+        type: ExitType.pressure,
+        condition: ExitCondition.over,
+        value: 6.0,
+      );
+
+      // Start deferring on frame 0
+      arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.0,
+        currentFlow: 3.0,
+      );
+
+      // Firmware advances to frame 1
+      arbiter.onFrameAdvanced(1);
+
+      // Evaluate frame 0 again — fresh state, first sample assumes trending
+      final v = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.0,
+        currentFlow: 3.0,
+      );
+      expect(v, StepExitVerdict.defer, reason: 'deferral state was cleared');
+    });
+
+    test('reset clears all deferral state', () {
+      const exit = StepExitCondition(
+        type: ExitType.pressure,
+        condition: ExitCondition.over,
+        value: 6.0,
+      );
+
+      // Accumulate 2 deferrals
+      arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.0,
+        currentFlow: 3.0,
+      );
+      arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.2,
+        currentFlow: 3.0,
+      );
+
+      arbiter.reset();
+
+      // Same frame, same readings — should start fresh (first sample)
+      final v = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.0,
+        currentFlow: 3.0,
+      );
+      expect(v, StepExitVerdict.defer, reason: 'reset clears frame count');
+    });
+
+    test('independent deferral per frame', () {
+      const exit0 = StepExitCondition(
+        type: ExitType.pressure,
+        condition: ExitCondition.over,
+        value: 6.0,
+      );
+      const exit1 = StepExitCondition(
+        type: ExitType.pressure,
+        condition: ExitCondition.over,
+        value: 8.0,
+      );
+
+      // Defer on frame 0
+      final v0 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit0,
+        currentPressure: 5.0,
+        currentFlow: 3.0,
+      );
+      expect(v0, StepExitVerdict.defer);
+
+      // Frame 1 is far from its threshold → fire
+      final v1 = arbiter.evaluate(
+        profileFrame: 1,
+        exit: exit1,
+        currentPressure: 2.0,
+        currentFlow: 3.0,
+      );
+      expect(v1, StepExitVerdict.fire);
+    });
+
+    test('pressure exactly at proximity boundary fires', () {
+      const exit = StepExitCondition(
+        type: ExitType.pressure,
+        condition: ExitCondition.over,
+        value: 6.0,
+      );
+
+      // distance = 6.0 - 4.5 = 1.5, which is NOT > 1.5
+      final vAt = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 4.5,
+        currentFlow: 3.0,
+      );
+      expect(vAt, StepExitVerdict.defer,
+          reason: 'distance == proximity is "near", not "far"');
+
+      // distance = 6.0 - 4.4 = 1.6, which is > 1.5
+      arbiter.reset();
+      final vBeyond = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 4.4,
+        currentFlow: 3.0,
+      );
+      expect(vBeyond, StepExitVerdict.fire);
+    });
+  });
+}

--- a/test/controllers/step_exit_arbiter_test.dart
+++ b/test/controllers/step_exit_arbiter_test.dart
@@ -21,7 +21,7 @@ void main() {
     );
 
     test('far from threshold fires immediately', () {
-      // Current pressure 2.0, exit at 6.0 → distance 4.0 > 1.5
+      // Current pressure 2.0, exit at 6.0 → distance 4.0 > 1.2 (20% of 6.0)
       final verdict = arbiter.evaluate(
         profileFrame: 0,
         exit: exit,
@@ -32,7 +32,7 @@ void main() {
     });
 
     test('near threshold and trending defers', () {
-      // Current pressure 5.0, exit at 6.0 → distance 1.0 < 1.5
+      // Current pressure 5.0, exit at 6.0 → distance 1.0 < 1.2 (20% of 6.0)
       final v1 = arbiter.evaluate(
         profileFrame: 0,
         exit: exit,
@@ -134,7 +134,7 @@ void main() {
     );
 
     test('far from threshold fires immediately', () {
-      // Current flow 3.5, exit under 2.0 → distance 1.5 > 0.8
+      // Current flow 3.5, exit under 2.0 → distance 1.5 > 0.5 (25% of 2.0)
       final verdict = arbiter.evaluate(
         profileFrame: 0,
         exit: exit,
@@ -145,7 +145,7 @@ void main() {
     });
 
     test('near threshold defers', () {
-      // Current flow 2.5, exit under 2.0 → distance 0.5 < 0.8
+      // Current flow 2.5, exit under 2.0 → distance 0.5 ≦ 0.5 (25% of 2.0)
       final verdict = arbiter.evaluate(
         profileFrame: 0,
         exit: exit,
@@ -332,32 +332,280 @@ void main() {
       expect(v1, StepExitVerdict.fire);
     });
 
-    test('pressure exactly at proximity boundary fires', () {
+    test('pressure exactly at proximity boundary defers', () {
       const exit = StepExitCondition(
         type: ExitType.pressure,
         condition: ExitCondition.over,
         value: 6.0,
       );
 
-      // distance = 6.0 - 4.5 = 1.5, which is NOT > 1.5
+      // proximity = 6.0 * 0.20 = 1.2 bar
+      // distance = 6.0 - 4.8 = 1.2, which is NOT > 1.2 → near
       final vAt = arbiter.evaluate(
         profileFrame: 0,
         exit: exit,
-        currentPressure: 4.5,
+        currentPressure: 4.8,
         currentFlow: 3.0,
       );
       expect(vAt, StepExitVerdict.defer,
           reason: 'distance == proximity is "near", not "far"');
 
-      // distance = 6.0 - 4.4 = 1.6, which is > 1.5
+      // distance = 6.0 - 4.7 = 1.3 > 1.2 → far
       arbiter.reset();
       final vBeyond = arbiter.evaluate(
         profileFrame: 0,
         exit: exit,
-        currentPressure: 4.4,
+        currentPressure: 4.7,
         currentFlow: 3.0,
       );
       expect(vBeyond, StepExitVerdict.fire);
+    });
+
+    test('trend requires all pairwise comparisons to point toward exit', () {
+      const exit = StepExitCondition(
+        type: ExitType.pressure,
+        condition: ExitCondition.over,
+        value: 9.0,
+      );
+
+      // proximity = 9.0 * 0.20 = 1.8 bar.
+      // Feed a zigzag near threshold: up, then down.
+      // Frame 0: pressure 7.5 → distance 1.5 < 1.8, near, first → defer
+      final v1 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 7.5,
+        currentFlow: 3.0,
+      );
+      expect(v1, StepExitVerdict.defer);
+
+      // Frame 0: pressure 7.8 (up from 7.5) → trending → defer
+      final v2 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 7.8,
+        currentFlow: 3.0,
+      );
+      expect(v2, StepExitVerdict.defer);
+
+      // Frame 0: pressure 7.6 (down from 7.8).
+      // With 3 readings [7.5, 7.8, 7.6]: 7.8>7.5 ✓ but 7.6>7.8 ✗
+      // All comparisons must agree → not trending → fire.
+      // (maxDeferralFrames=3, so frameCount=3 ≥ max → max triggers first.
+      //  On read: fires because max reached, not because trend flipped.)
+      final v3 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 7.6,
+        currentFlow: 3.0,
+      );
+      expect(v3, StepExitVerdict.fire,
+          reason: 'max deferral reached before trend check on frame 3');
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Tight-margin — realistic DE1 firing behavior
+  //
+  // DE1 firmware is precise: when exit is {pressure over 5 bar},
+  // the machine crosses ~5.02 bar and advances the frame within
+  // milliseconds. The tablet snapshot sees pressure barely past or
+  // barely below the threshold. The arbiter's primary job is handling
+  // these sub-0.1 bar / sub-0.2 ml/s margins, not the wide gaps the
+  // logic-coverage tests above use.
+  // ---------------------------------------------------------------
+
+  group('tight-margin (real DE1 firing)', () {
+    // -- pressure over, barely past ---------------------------------
+
+    test('barely past pressure threshold defers', () {
+      // Exit over 5.0 bar. Snapshot shows pressure 5.02 →
+      // firmware very likely already advanced. Defer.
+      const exit = StepExitCondition(
+        type: ExitType.pressure,
+        condition: ExitCondition.over,
+        value: 5.0,
+      );
+
+      final v = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.02,
+        currentFlow: 3.0,
+      );
+      expect(v, StepExitVerdict.defer,
+          reason: 'Pressure 0.02 bar past threshold — firmware likely '
+              'already advanced. Defer to avoid double-skip.');
+    });
+
+    test('barely past pressure, firmware advances, race avoided', () {
+      // The primary race scenario: pressure crosses 5.0, firmware
+      // advances frame 0→1. Tablet snapshot still shows frame 0
+      // with pressure 5.02 and weight exit met. Arbiter defers.
+      // Next snapshot: firmware already on frame 1.
+      const exit = StepExitCondition(
+        type: ExitType.pressure,
+        condition: ExitCondition.over,
+        value: 5.0,
+      );
+
+      // Frame 0: pressure 5.02 → barely past → defer
+      final v0 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.02,
+        currentFlow: 3.0,
+      );
+      expect(v0, StepExitVerdict.defer);
+
+      // Firmware advances to frame 1 (it handled the exit).
+      arbiter.onFrameAdvanced(1);
+
+      // Frame 1 has its own step. No skipStep was sent for frame 0 —
+      // double-skip avoided.
+      // (Frame 0 deferral state was cleared by onFrameAdvanced.)
+      final v1 = arbiter.evaluate(
+        profileFrame: 1,
+        exit: const StepExitCondition(
+          type: ExitType.pressure,
+          condition: ExitCondition.over,
+          value: 9.0,
+        ),
+        currentPressure: 5.1,
+        currentFlow: 3.0,
+      );
+      // Frame 1: pressure 5.1, exit 9.0 → distance 3.9 > 1.8 (20% of 9.0)
+      // → far → fire (if its weight exit is met).
+      expect(v1, StepExitVerdict.fire,
+          reason: 'Frame 0 race avoided; frame 1 independent.');
+    });
+
+    test('barely past pressure, no firmware advance, max deferral fires',
+        () {
+      // Firmware DIDN'T fire its exit (unlikely but possible if
+      // communication glitch). After 3 frames of being past threshold,
+      // tablet fires skipStep so the shot doesn't stall.
+      const exit = StepExitCondition(
+        type: ExitType.pressure,
+        condition: ExitCondition.over,
+        value: 5.0,
+      );
+
+      for (var i = 0; i < StepExitArbiter.maxDeferralFrames - 1; i++) {
+        final v = arbiter.evaluate(
+          profileFrame: 0,
+          exit: exit,
+          currentPressure: 5.02,
+          currentFlow: 3.0,
+        );
+        expect(v, StepExitVerdict.defer, reason: 'frame $i: still past');
+      }
+
+      final vFire = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.02,
+        currentFlow: 3.0,
+      );
+      expect(vFire, StepExitVerdict.fire,
+          reason: 'Max deferral reached — fire as backstop.');
+    });
+
+    // -- pressure over, near but not yet past -----------------------
+
+    test('near pressure threshold, tiny margin, trending defers', () {
+      // Exit over 5.0 bar. Pressure at 4.96, inching toward 5.0.
+      // Firmware will fire within ~100ms. Defer.
+      const exit = StepExitCondition(
+        type: ExitType.pressure,
+        condition: ExitCondition.over,
+        value: 5.0,
+      );
+
+      final v1 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 4.96,
+        currentFlow: 3.0,
+      );
+      expect(v1, StepExitVerdict.defer,
+          reason: '4.96 at exit 5.0 → distance 0.04 < 1.0, first → defer');
+
+      final v2 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 4.98,
+        currentFlow: 3.0,
+      );
+      expect(v2, StepExitVerdict.defer,
+          reason: '4.96→4.98 trending toward 5.0 → defer');
+    });
+
+    test('near pressure threshold, tiny margin, not trending fires', () {
+      // Pressure was near threshold then drifted away.
+      // Firmware unlikely to fire. Fire skipStep.
+      const exit = StepExitCondition(
+        type: ExitType.pressure,
+        condition: ExitCondition.over,
+        value: 5.0,
+      );
+
+      arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 4.96,
+        currentFlow: 3.0,
+      );
+
+      final v2 = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 4.93,
+        currentFlow: 3.0,
+      );
+      expect(v2, StepExitVerdict.fire,
+          reason: '4.96→4.93 away from exit 5.0 → fire');
+    });
+
+    // -- flow under, tight margins ----------------------------------
+
+    test('barely past flow threshold defers', () {
+      // Exit under 2.0 ml/s. Snapshot shows flow 1.98 →
+      // barely below threshold. Firmware likely already advanced.
+      const exit = StepExitCondition(
+        type: ExitType.flow,
+        condition: ExitCondition.under,
+        value: 2.0,
+      );
+
+      final v = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.0,
+        currentFlow: 1.98,
+      );
+      expect(v, StepExitVerdict.defer,
+          reason: 'Flow 0.02 ml/s past under-2.0 — firmware likely '
+              'already advanced.');
+    });
+
+    test('near flow threshold, tiny margin defers', () {
+      // Exit under 2.0 ml/s. Flow at 2.02 → distance 0.02.
+      // Proximity = 2.0 * 0.25 = 0.5. 0.02 < 0.5 → near.
+      const exit = StepExitCondition(
+        type: ExitType.flow,
+        condition: ExitCondition.under,
+        value: 2.0,
+      );
+
+      final v = arbiter.evaluate(
+        profileFrame: 0,
+        exit: exit,
+        currentPressure: 5.0,
+        currentFlow: 2.02,
+      );
+      expect(v, StepExitVerdict.defer,
+          reason: 'Flow 0.02 above under-2.0 → near, first → defer');
     });
   });
 }

--- a/test/helpers/mock_settings_service.dart
+++ b/test/helpers/mock_settings_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:reaprime/src/settings/charging_mode.dart';
+import 'package:reaprime/src/settings/feature_flags.dart';
 import 'package:reaprime/src/settings/gateway_mode.dart';
 import 'package:reaprime/src/settings/scale_power_mode.dart';
 import 'package:reaprime/src/settings/settings_service.dart';
@@ -37,6 +38,8 @@ class MockSettingsService extends SettingsService {
   bool _accountStepSeen = true; // skip account step in tests
   bool _androidWarningDismissed = true; // skip android warning in tests
   bool _enableSimulatedWebViews = false;
+
+  final Map<String, bool> _featureFlags = {};
 
   @override
   Future<ThemeMode> themeMode() async => _themeMode;
@@ -174,4 +177,12 @@ class MockSettingsService extends SettingsService {
   @override
   Future<void> setEnableSimulatedWebViews(bool value) async =>
       _enableSimulatedWebViews = value;
+
+  // Feature flags
+  @override
+  Future<bool?> featureFlag(FeatureFlag flag) async =>
+      _featureFlags[flag.name];
+  @override
+  Future<void> setFeatureFlag(FeatureFlag flag, bool value) async =>
+      _featureFlags[flag.name] = value;
 }

--- a/test/unit/controllers/settings_controller_test.dart
+++ b/test/unit/controllers/settings_controller_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/settings/feature_flags.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/settings/settings_service.dart';
 
@@ -6,8 +7,10 @@ import 'package:reaprime/src/settings/settings_service.dart';
 class _SpySettingsService implements SettingsService {
   int setSimulatedDevicesCallCount = 0;
   int setEnableSimulatedWebViewsCallCount = 0;
+  int setFeatureFlagCallCount = 0;
   Set<SimulatedDevicesTypes> _simulatedDevices = {};
   bool _enableSimulatedWebViews = false;
+  final Map<String, bool?> _featureFlags = {};
   String? _preferredMachineId;
   String? _preferredScaleId;
 
@@ -24,6 +27,14 @@ class _SpySettingsService implements SettingsService {
   Future<void> setEnableSimulatedWebViews(bool value) async {
     setEnableSimulatedWebViewsCallCount++;
     _enableSimulatedWebViews = value;
+  }
+  // Feature flags
+  @override
+  Future<bool?> featureFlag(FeatureFlag flag) async => _featureFlags[flag.name];
+  @override
+  Future<void> setFeatureFlag(FeatureFlag flag, bool value) async {
+    setFeatureFlagCallCount++;
+    _featureFlags[flag.name] = value;
   }
   @override
   Future<String?> preferredMachineId() async => _preferredMachineId;
@@ -193,6 +204,61 @@ void main() {
       await controller.setEnableSimulatedWebViews(false);
 
       expect(spy.setEnableSimulatedWebViewsCallCount, 0);
+      expect(notified, isFalse);
+    });
+  });
+
+  group('SettingsController.setFeatureFlag', () {
+    test('returns default value when not yet stored', () {
+      final spy = _SpySettingsService();
+      final controller = SettingsController(spy);
+
+      // Without calling loadSettings, the in-memory map is empty.
+      // isFeatureFlagEnabled falls back to defaultFeatureFlagValues.
+      expect(
+        controller.isFeatureFlagEnabled(FeatureFlag.stepExitArbiter),
+        isTrue, // default is true
+      );
+    });
+
+    test('persists and updates the in-memory value', () async {
+      final spy = _SpySettingsService();
+      final controller = SettingsController(spy);
+
+      await controller.setFeatureFlag(FeatureFlag.stepExitArbiter, false);
+
+      expect(
+        controller.isFeatureFlagEnabled(FeatureFlag.stepExitArbiter),
+        isFalse,
+      );
+      expect(spy.setFeatureFlagCallCount, 1);
+    });
+
+    test('notifies listeners on change', () async {
+      final spy = _SpySettingsService();
+      final controller = SettingsController(spy);
+      var notified = false;
+      controller.addListener(() => notified = true);
+
+      await controller.setFeatureFlag(FeatureFlag.stepExitArbiter, false);
+
+      expect(notified, isTrue);
+    });
+
+    test('is a no-op when the value is unchanged', () async {
+      final spy = _SpySettingsService();
+      final controller = SettingsController(spy);
+
+      // Set to false first so the in-memory map has a value.
+      await controller.setFeatureFlag(FeatureFlag.stepExitArbiter, false);
+      spy.setFeatureFlagCallCount = 0; // reset counter
+      var notified = false;
+      controller.addListener(() => notified = true);
+
+      // Setting false again should be a no-op.
+      await controller.setFeatureFlag(FeatureFlag.stepExitArbiter, false);
+
+      expect(spy.setFeatureFlagCallCount, 0);
       expect(notified, isFalse);
     });
   });


### PR DESCRIPTION
Fixes #269

## Summary
- Prevent tablet-side `skipStep` from racing firmware-owned frame exits.
- Treat mixed `weight + exit` profile steps as firmware-owned so the machine remains self-sufficient.
- Keep weight-only step transitions unchanged.
- Document the mixed-exit behavior in `doc/Profiles.md`.

## Verification
- `flutter test --no-pub test/controllers/shot_sequencer_test.dart --reporter=compact`: passed (`+15`)
- `flutter analyze --no-pub lib/src/controllers/shot_sequencer.dart test/controllers/shot_sequencer_test.dart`: passed
- `flutter analyze --no-pub`: passed
- `flutter test --no-pub --reporter=compact`: passed (`+1719`)
- `git diff --check upstream/main --`: passed

## Windows Smoke
- Built Debug Windows binary via VS2022 CMake fallback.
- Started compiled app.
- Verified `MockDe1` and `Mock Scale` connected.
- Uploaded temporary mixed-exit profile.
- Started espresso via REST.
- Verified `/api/v1/machine/state` responded during pouring.
- No current `SEVERE`/`Unhandled` log entries.
- Stopped app and confirmed port `8080` closed.

Note: `MockDe1` does not simulate DE1 firmware pressure/flow exits, so the compiled smoke proves startup/profile/start-shot health. The double-skip prevention is covered by deterministic `ShotSequencer` controller tests.