### PR TITLE
fix: retry a failed profile upload instead of marking it pushed

### DIFF
--- a/lib/src/controllers/workflow_device_sync.dart
+++ b/lib/src/controllers/workflow_device_sync.dart
@@ -35,24 +35,35 @@ class WorkflowDeviceSync {
   final Logger _log = Logger('WorkflowDeviceSync');
 
   Profile? _lastPushedProfile;
+  Profile? _pushingProfile;
 
   void _onChange() {
     final profile = _workflow.currentWorkflow.profile;
-    if (profile == _lastPushedProfile) return;
-    _lastPushedProfile = profile;
+    if (profile == _lastPushedProfile) return; // already on the device
+    if (profile == _pushingProfile) return; // already uploading this profile
+    _pushingProfile = profile;
     _push(profile);
   }
 
   Future<void> _push(Profile profile) async {
     try {
       await _de1.connectedDe1().setProfile(profile);
+      // Mark pushed ONLY after the upload lands. The old behaviour marked it
+      // before the write, so a failed upload (e.g. a BLE write timeout on a
+      // flaky link) was still recorded as pushed — re-applying the same profile
+      // then short-circuited and the DE1 never received it.
+      _lastPushedProfile = profile;
     } on DeviceNotConnectedException {
       _log.fine(
         'DE1 not connected; skipping profile push — will sync via '
         'defaultWorkflow on next connect',
       );
     } catch (e, st) {
-      _log.warning('setProfile failed', e, st);
+      _log.warning('setProfile failed; will retry on next workflow change', e, st);
+    } finally {
+      // Clear the in-flight guard so the next change (including a retry of this
+      // same profile after a failure) can push again.
+      if (_pushingProfile == profile) _pushingProfile = null;
     }
   }
 

--- a/test/controllers/workflow_device_sync_test.dart
+++ b/test/controllers/workflow_device_sync_test.dart
@@ -29,6 +29,23 @@ class _RecordingDe1 extends TestDe1 {
   }
 }
 
+/// Fails the first [failures] setProfile calls (simulating a BLE write timeout),
+/// then records subsequent ones.
+class _FlakyDe1 extends TestDe1 {
+  _FlakyDe1({this.failures = 1});
+  int failures;
+  final List<Profile> setProfileCalls = [];
+
+  @override
+  Future<void> setProfile(Profile profile) async {
+    if (failures > 0) {
+      failures--;
+      throw Exception('simulated BLE write timeout');
+    }
+    setProfileCalls.add(profile);
+  }
+}
+
 void main() {
   late WorkflowController workflow;
   late DeviceController deviceController;
@@ -105,6 +122,49 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 10));
 
       expect(de1.setProfileCalls, isEmpty);
+    },
+  );
+
+  test(
+    'a failed setProfile is retried on the next workflow change',
+    () async {
+      // Build an isolated sync wired to a DE1 whose first upload fails.
+      final wf = WorkflowController();
+      final dc = DeviceController([MockDeviceDiscoveryService()]);
+      await dc.initialize();
+      final controller = De1Controller(controller: dc);
+      final flaky = _FlakyDe1(failures: 1);
+      await controller.connectToDe1(flaky);
+      flaky.emitShotSettings(De1ShotSettings(
+        steamSetting: 0,
+        targetSteamTemp: 150,
+        targetSteamDuration: 30,
+        targetHotWaterTemp: 75,
+        targetHotWaterVolume: 50,
+        targetHotWaterDuration: 30,
+        targetShotVolume: 36,
+        groupTemp: 94.0,
+      ));
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      final flakySync = WorkflowDeviceSync(
+        workflowController: wf,
+        de1Controller: controller,
+      );
+
+      // First push of the cleaning profile fails (timeout) — nothing recorded,
+      // and the profile is NOT marked pushed.
+      wf.setWorkflow(wf.currentWorkflow.copyWith(profile: _profile('Cleaning')));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(flaky.setProfileCalls, isEmpty);
+
+      // Re-applying the SAME profile must RETRY (not skip as already-pushed),
+      // since the first upload never landed on the device.
+      wf.setWorkflow(wf.currentWorkflow.copyWith(profile: _profile('Cleaning')));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(flaky.setProfileCalls.length, equals(1));
+      expect(flaky.setProfileCalls.single.title, equals('Cleaning'));
+
+      flakySync.dispose();
     },
   );
 


### PR DESCRIPTION
## Summary

- **Problem:** `WorkflowDeviceSync` marked a profile as "pushed" *before* the BLE `setProfile` completed, so an upload that failed (e.g. a write timeout on a flaky link) was still recorded as done.
- **Why it matters:** re-applying the same profile then short-circuited on the equality guard, so the DE1 never received it — and no retry happened until a *different* profile was set or the app restarted.
- **What changed:** mark `_lastPushedProfile` only after `setProfile` succeeds, plus a small `_pushingProfile` in-flight guard so mark-on-success doesn't reintroduce the double-upload `WorkflowDeviceSync` exists to prevent.
- **What did NOT change (scope boundary):** the single-writer design, Equatable-based dedup, disconnect-skip behavior, and the public API are all unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [x] Profiles / beans / grinders / workflows

## Linked Issues

- None

## Root Cause (if bug fix)

- **Root cause:** `_lastPushedProfile` was assigned synchronously in `_onChange`, before the async `setProfile` ran — so a failed upload was indistinguishable from a successful one.
- **Missing detection or guardrail:** no in-flight tracking and no post-success confirmation of the upload.
- **Contributing context:** surfaced while debugging cleaning-profile uploads over a flaky BLE link.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
- **Target test or file:** `test/controllers/workflow_device_sync_test.dart` → "a failed setProfile is retried on the next workflow change"
- **Scenario the test should lock in:** first upload throws (simulated timeout) → nothing recorded; re-applying the same profile retries and succeeds.

## Documentation Obligations (required)

- [x] N/A — no docs affected (internal behavior, no API/spec change)

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `No` — profile-push bookkeeping only; no change to the BLE wire surface.
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`

## User-Visible Changes

A profile that failed to upload now retries on the next workflow change instead of being silently skipped. No UI or API change.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass (1720 tests)
- [x] `(cd packages/dye2-plugin && npm run build)` — N/A, no plugin files touched

### Manual verification (if applicable)

- What you personally verified and how: the new unit test fails on the old mark-before-success code and passes after the fix.

### Evidence

- [x] Test output (failing before + passing after)

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`

## Risks & Mitigations

- Risk: mark-on-success could re-introduce the double-upload `WorkflowDeviceSync` was built to prevent.
  - Mitigation: the `_pushingProfile` in-flight guard rejects a second push of the same profile while one is in flight; covered by the existing "identical profile does not push again" test.
