### PR TITLE
fix: clear the BLE queue and fail fast on a GATT timeout

### DIFF
--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart' as device;
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/models/device/transport/ble_timeout_exception.dart';
 import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/services/ble/ble_exception_mapper.dart';
 import 'package:rxdart/subjects.dart';
@@ -290,9 +291,27 @@ class UniversalBleTransport implements BLETransport {
         characteristicUUID,
         timeout: timeout
       );
+    } on TimeoutException {
+      // Fail fast (see write() — a read-timeout reconnect mid profile-upload
+      // would wedge the firmware the same way). Clear the stuck queue entry and
+      // let the plain timeout propagate.
+      _onOperationTimeout('read', '$serviceUUID/$characteristicUUID');
+      rethrow;
     } on UniversalBleException catch (e) {
       _handleGattError(e, 'read', '$serviceUUID/$characteristicUUID');
     }
+  }
+
+  /// universal_ble's internal operation queue throws a bare [TimeoutException]
+  /// (not a [UniversalBleException]) when a GATT op never completes — e.g. the
+  /// DE1 stops servicing ops on a flaky link. Clear the stuck queue entry so it
+  /// doesn't block (and time out) every following operation, then let the plain
+  /// timeout propagate. Do NOT convert it to a [BleTimeoutException]: that would
+  /// trigger a disconnect/reconnect+single-write retry, which corrupts an
+  /// in-flight profile upload (a stateful multi-write sequence).
+  void _onOperationTimeout(String operation, String path) {
+    _log.warning('GATT $operation($path) timed out — clearing BLE queue');
+    UniversalBle.clearQueue(_device.deviceId);
   }
 
   final Map<String, StreamSubscription<Uint8List>> _subscriptions = {};
@@ -343,6 +362,17 @@ class UniversalBleTransport implements BLETransport {
         withoutResponse: !withResponse,
         timeout: timeout
       );
+    } on TimeoutException {
+      // Fail fast — do NOT map this to a BleTimeoutException. Doing so routes it
+      // into the DE1 transport's reconnect-and-retry-this-one-write recovery,
+      // which is catastrophic mid profile-upload: a profile is a stateful
+      // multi-write sequence (header declares N frames, then each indexed
+      // frame, then a tail), and a disconnect/reconnect resets the firmware's
+      // receive state machine — leaving the DE1 stuck "receiving" (GHC purple)
+      // until reaprime restarts. Surfacing it as a plain timeout fails the whole
+      // upload, which WorkflowDeviceSync then re-drives cleanly from the header.
+      _onOperationTimeout('write', '$serviceUUID/$characteristicUUID');
+      rethrow;
     } on UniversalBleException catch (e) {
       _handleGattError(e, 'write', '$serviceUUID/$characteristicUUID');
     }


### PR DESCRIPTION
## Summary

- **Problem:** a bare `TimeoutException` from universal_ble's command queue (on `write`/`read`) was mapped to `BleTimeoutException`, which routed it into the DE1 transport's disconnect/reconnect + retry-one-write recovery.
- **Why it matters:** mid profile-upload that recovery is catastrophic. A profile is a stateful multi-write sequence (header declares N frames → indexed frames → tail); a reconnect resets the firmware's receive state machine, leaving the DE1 wedged "receiving" (GHC stuck purple) until reaprime is restarted.
- **What changed:** on a `TimeoutException`, `write()`/`read()` now clear the stuck universal_ble queue entry and let the plain timeout propagate (no mapping to `BleTimeoutException`), so the whole upload fails and is re-driven cleanly from the header by `WorkflowDeviceSync`.
- **What did NOT change (scope boundary):** `UniversalBleException` (GATT error) handling, the reconnect path for genuine disconnects, and all other transport behavior.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] BLE transport / device comms

## Linked Issues

- None

## Root Cause (if bug fix)

- **Root cause:** write/read timeouts were funneled into a reconnect-and-retry-single-write recovery designed for connection loss, not for an in-flight multi-write sequence. A reconnect mid-upload desyncs the firmware's profile receive state.
- **Missing detection or guardrail:** no distinction between "connection lost" and "this GATT op timed out"; the stuck queue entry was also left in place, timing out every following operation.
- **Contributing context:** reproduced on real hardware — DE1 stuck "receiving" (GHC purple) until restart while uploading a profile on a flaky link.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Integration test (mock transport edge)
- **Target test or file:** none added in this PR (see below).
- **If no new test added, why not:** `UniversalBleTransport` calls universal_ble's static API directly (no injection seam), and reproducing the bug requires the library's *internal* command queue to throw a **bare** `TimeoutException` mid multi-write — a path the existing test doubles can't drive without refactoring the transport boundary. Verified instead on real hardware via device logs. A mock-transport-edge integration test is the right follow-up once that seam exists.

## Documentation Obligations (required)

- [x] N/A — no docs affected (no API/spec change)

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `Yes` — GATT timeout handling only. No new attack surface: clears a stuck queue entry and fails fast instead of reconnecting mid-op.
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`

## User-Visible Changes

On a flaky BLE link, a profile upload that times out now fails fast and is retried cleanly, instead of wedging the DE1 until a restart. No UI or API change.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass (1720 tests)
- [x] `(cd packages/dye2-plugin && npm run build)` — N/A, no plugin files touched

### Manual verification (if applicable)

- Real hardware? (DE1/Bengle/scale): `Yes` — DE1Pro, flaky BLE link.
- What you personally verified and how: before the fix, a write timeout mid profile-upload left the DE1 stuck "receiving" (GHC purple) until a reaprime restart; after, the upload fails fast and `WorkflowDeviceSync` re-drives it cleanly from the header.
- What you did **not** verify: an automated reproduction (see Regression Test Plan).

### Evidence

- [x] Log snippets (DE1 stuck "receiving" before; clean re-drive after)

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`

## Risks & Mitigations

- Risk: a genuine connection loss during a write now surfaces as a plain timeout rather than triggering an immediate reconnect-retry.
  - Mitigation: the connection-state stream and the next operation's reconnect path still handle real disconnects; clearing the queue entry prevents the stuck-entry cascade that previously timed out every following op.
