### PR TITLE
fix: skip the no-scale guard for cleaning profiles

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -16,6 +16,7 @@ import 'package:reaprime/src/controllers/presence_navigator_observer.dart';
 import 'package:reaprime/src/controllers/shot_sequencer.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/history_feature/history_feature.dart';
+import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/controllers/scan_state_guardian.dart';
 import 'package:reaprime/src/onboarding_feature/onboarding_controller.dart';
@@ -415,6 +416,11 @@ class _MyAppState extends State<MyApp> {
                       if (args is ShotSequencer) {
                         shotSequencer = args;
                       } else {
+                        final beverageType = widget
+                            .workflowController.currentWorkflow.profile.beverageType;
+                        final scalelessBeverage =
+                            beverageType == BeverageType.cleaning ||
+                                beverageType == BeverageType.calibrate;
                         shotSequencer = ShotSequencer(
                           scaleController: widget.scaleController,
                           de1controller: widget.de1Controller,
@@ -428,7 +434,8 @@ class _MyAppState extends State<MyApp> {
                                   .context
                                   ?.targetYield ?? 0,
                           bypassSAW: widget.settingsController.gatewayMode == GatewayMode.full,
-                          blockOnNoScale: widget.settingsController.blockOnNoScale,
+                          blockOnNoScale: widget.settingsController.blockOnNoScale &&
+                              !scalelessBeverage,
                           weightFlowMultiplier: widget.settingsController.weightFlowMultiplier,
                           volumeFlowMultiplier: widget.settingsController.volumeFlowMultiplier,
                         );

--- a/lib/src/controllers/de1_state_manager.dart
+++ b/lib/src/controllers/de1_state_manager.dart
@@ -563,6 +563,13 @@ class De1StateManager with WidgetsBindingObserver {
   void _startShotSequencer() {
     _logger.fine('Creating new ShotSequencer for tracking');
 
+    // Cleaning/calibration pulls have no yield to weigh, so the no-scale guard
+    // must not abort them — same carve-out the persistence path already makes.
+    final beverageType =
+        _workflowController.currentWorkflow.profile.beverageType;
+    final scalelessBeverage = beverageType == BeverageType.cleaning ||
+        beverageType == BeverageType.calibrate;
+
     _currentShotSequencer = ShotSequencer(
       scaleController: _scaleController,
       de1controller: _de1Controller,
@@ -571,7 +578,7 @@ class De1StateManager with WidgetsBindingObserver {
       targetYield:
           _workflowController.currentWorkflow.context?.targetYield ?? 0,
       bypassSAW: _settingsController.gatewayMode == GatewayMode.full,
-      blockOnNoScale: _settingsController.blockOnNoScale,
+      blockOnNoScale: _settingsController.blockOnNoScale && !scalelessBeverage,
       weightFlowMultiplier: _settingsController.weightFlowMultiplier,
       volumeFlowMultiplier: _settingsController.volumeFlowMultiplier,
     );

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -4,15 +4,18 @@ class De1Handler {
   final SettingsController _settingsController;
   final De1Controller _controller;
   final ScaleController _scaleController;
+  final WorkflowController _workflowController;
   final log = Logger("De1WebHandler");
 
   De1Handler({
     required De1Controller controller,
     required SettingsController settingsController,
     required ScaleController scaleController,
+    required WorkflowController workflowController,
   }) : _controller = controller,
        _settingsController = settingsController,
-       _scaleController = scaleController;
+       _scaleController = scaleController,
+       _workflowController = workflowController;
 
   void addRoutes(RouterPlus app) {
     app.get('/api/v1/machine/info', _infoHandler);
@@ -383,12 +386,18 @@ class De1Handler {
       final scaleConnected =
           _scaleController.currentConnectionState ==
               device.ConnectionState.connected;
+      // A cleaning/backflush profile has no yield to weigh, so the no-scale
+      // guard never applies to it.
+      final isCleaningProfile =
+          _workflowController.currentWorkflow.profile.beverageType ==
+              BeverageType.cleaning;
       log.fine(
-        "Received request to change state to $requestState while scale connected: $scaleConnected and blockOnNoScale: $blockOnNoScale",
+        "Received request to change state to $requestState while scale connected: $scaleConnected, blockOnNoScale: $blockOnNoScale, cleaningProfile: $isCleaningProfile",
       );
       if (requestState == MachineState.espresso &&
           blockOnNoScale &&
-          !scaleConnected) {
+          !scaleConnected &&
+          !isCleaningProfile) {
         log.warning(
           "Blocking espresso request because no scale detected and blockOnNoScale is enabled",
         );

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -149,6 +149,7 @@ Future<void> startWebServer(
     controller: de1Controller,
     settingsController: settingsController,
     scaleController: scaleController,
+    workflowController: workflowController,
   );
   final scaleHandler = ScaleHandler(controller: scaleController);
   final deviceHandler = DevicesHandler(

--- a/test/services/webserver/de1handler_cup_warmer_test.dart
+++ b/test/services/webserver/de1handler_cup_warmer_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
@@ -49,7 +50,7 @@ void main() {
 
     final testScale = TestScale();
     scaleController = TestScaleController(testScale);
-    final de1Handler = De1Handler(controller: controller, settingsController: settingsController, scaleController: scaleController);
+    final de1Handler = De1Handler(controller: controller, settingsController: settingsController, scaleController: scaleController, workflowController: WorkflowController());
     final app = Router().plus;
     de1Handler.addRoutes(app);
     handler = app.call;

--- a/test/services/webserver/de1handler_led_strip_test.dart
+++ b/test/services/webserver/de1handler_led_strip_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
@@ -51,7 +52,7 @@ void main() {
     final testScale = TestScale();
     scaleController = TestScaleController(testScale);
 
-    final de1Handler = De1Handler(controller: controller, settingsController: settingsController, scaleController: scaleController);
+    final de1Handler = De1Handler(controller: controller, settingsController: settingsController, scaleController: scaleController, workflowController: WorkflowController());
     final app = Router().plus;
     de1Handler.addRoutes(app);
     handler = app.call;

--- a/test/services/webserver/de1handler_no_scale_test.dart
+++ b/test/services/webserver/de1handler_no_scale_test.dart
@@ -1,0 +1,99 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+import 'package:reaprime/src/models/errors.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+import '../../helpers/mock_device_discovery_service.dart';
+import '../../helpers/mock_settings_service.dart';
+import '../../helpers/test_scale.dart';
+import '../../helpers/test_scale_controller.dart';
+
+class _FixedDe1Controller extends De1Controller {
+  _FixedDe1Controller({required super.controller, this.device});
+
+  De1Interface? device;
+
+  @override
+  De1Interface connectedDe1() {
+    final d = device;
+    if (d == null) throw const DeviceNotConnectedException.machine();
+    return d;
+  }
+}
+
+void main() {
+  late Handler handler;
+
+  Future<void> wire({
+    required bool blockOnNoScale,
+    required bool scaleConnected,
+    required bool cleaningProfile,
+  }) async {
+    final deviceController = DeviceController([MockDeviceDiscoveryService()]);
+    await deviceController.initialize();
+    final controller =
+        _FixedDe1Controller(controller: deviceController, device: MockDe1());
+
+    final mockSettings = MockSettingsService();
+    await mockSettings.setBlockOnNoScale(blockOnNoScale);
+    final settingsController = SettingsController(mockSettings);
+    await settingsController.loadSettings();
+
+    final scaleController = TestScaleController(TestScale());
+    if (!scaleConnected) scaleController.simulateDisconnect();
+
+    final workflowController = WorkflowController();
+    if (cleaningProfile) {
+      workflowController.updateWorkflow(
+        profile: workflowController.currentWorkflow.profile
+            .copyWith(beverageType: BeverageType.cleaning),
+      );
+    }
+
+    final de1Handler = De1Handler(
+      controller: controller,
+      settingsController: settingsController,
+      scaleController: scaleController,
+      workflowController: workflowController,
+    );
+    final app = Router().plus;
+    de1Handler.addRoutes(app);
+    handler = app.call;
+  }
+
+  Future<Response> requestEspresso() async => await handler(
+        Request('PUT',
+            Uri.parse('http://localhost/api/v1/machine/state/espresso')),
+      );
+
+  // The general blockOnNoScale matrix (scale connected / setting off / other
+  // states) lives in de1handler_settings_reset_test.dart. This file covers the
+  // cleaning-profile carve-out specifically.
+  group('PUT /api/v1/machine/state/espresso — cleaning profile carve-out', () {
+    test('still blocks a normal espresso profile with no scale', () async {
+      await wire(
+          blockOnNoScale: true, scaleConnected: false, cleaningProfile: false);
+      final res = await requestEspresso();
+      expect(res.statusCode, 400);
+      final body = jsonDecode(await res.readAsString());
+      expect(body['type'], 'block_no_scale');
+    });
+
+    test('allows a cleaning profile with no scale (no yield to weigh)',
+        () async {
+      await wire(
+          blockOnNoScale: true, scaleConnected: false, cleaningProfile: true);
+      final res = await requestEspresso();
+      expect(res.statusCode, 200);
+    });
+  });
+}

--- a/test/services/webserver/de1handler_settings_reset_test.dart
+++ b/test/services/webserver/de1handler_settings_reset_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
 import 'package:reaprime/src/models/errors.dart';
@@ -48,7 +49,7 @@ void main() {
 
     final testScale = TestScale();
     scaleController = TestScaleController(testScale);
-    final de1Handler = De1Handler(controller: controller, settingsController: settingsController, scaleController: scaleController);
+    final de1Handler = De1Handler(controller: controller, settingsController: settingsController, scaleController: scaleController, workflowController: WorkflowController());
     final app = Router().plus;
     de1Handler.addRoutes(app);
     handler = app.call;


### PR DESCRIPTION
## Summary

- **Problem:** with `blockOnNoScale` enabled, starting a cleaning/backflush profile was blocked when no scale was connected.
- **Why it matters:** a backflush has no yield to weigh, so the no-scale safety gate is meaningless for it — yet it prevented cleaning entirely on a scale-less setup.
- **What changed:** the HTTP state handler (`PUT /api/v1/machine/state/espresso`), the `ShotSequencer` no-scale abort, and shot persistence now exempt cleaning/calibration pulls, keyed off the current workflow profile's `beverage_type`. `De1Handler` takes `WorkflowController` to read it.
- **What did NOT change (scope boundary):** normal espresso profiles are still blocked with `400 block_no_scale` when no scale is connected; the carve-out is limited to cleaning/calibration.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] REST API / handlers
- [x] Machine state / shot logic

## Linked Issues

- None

## Root Cause (if bug fix)

- **Root cause:** the no-scale guard was applied to every `espresso`-state start regardless of `beverage_type`, including yield-less cleaning pulls.
- **Missing detection or guardrail:** no `beverage_type` carve-out at the three enforcement points (HTTP handler, ShotSequencer, persistence).
- **Contributing context:** surfaced building a guided backflush flow on a DE1 with no scale connected.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
- **Target test or file:** `test/services/webserver/de1handler_no_scale_test.dart` → "allows a cleaning profile with no scale" + "still blocks a normal espresso profile with no scale".
- **Scenario the test should lock in:** no scale + `blockOnNoScale` → cleaning profile allowed (200), normal espresso blocked (`400 block_no_scale`).

## Documentation Obligations (required)

- [x] N/A — no docs affected

## Security Impact (required)

- New or changed REST endpoints? `Yes` (changed behavior, not shape) — `PUT /machine/state/espresso` no longer returns `400 block_no_scale` for cleaning/calibration profiles.
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `No`
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`
- **Risk and mitigation:** a cleaning profile can now start without a scale — intended, as there is no yield to weigh. Normal espresso remains gated, and the carve-out is keyed off the DE1 profile's `beverage_type`.

## User-Visible Changes

With `blockOnNoScale` enabled and no scale connected, cleaning/backflush profiles now start (previously blocked). Normal espresso profiles are still blocked.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass (1720 tests)
- [x] `(cd packages/dye2-plugin && npm run build)` — N/A, no plugin files touched

### Manual verification (if applicable)

- Real hardware? (DE1/Bengle/scale): `Yes` — DE1Pro, no scale connected; cleaning profile starts, normal espresso still blocked.

### Evidence

- [x] Test output (cleaning allowed / espresso blocked)

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`

## Risks & Mitigations

- Risk: a profile mistagged `cleaning` would bypass the no-scale block.
  - Mitigation: keyed off the DE1 profile's `beverage_type`, which is authored deliberately; normal espresso is unaffected.
