### PR TITLE
Serve /api/v1/logs and /api/v1/webview/logs newest-first

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3797,6 +3797,13 @@ paths:
             type: integer
           description: |
           Number of kilobytes to return (default: 16)
+        - name: order
+          in: query
+          schema:
+            type: string
+            enum: [desc, asc]
+            default: desc
+          description: Line order — desc (newest first, default) or asc (original chronological order).
       responses:
         "200":
           description: Recent log entries as plain text
@@ -3809,6 +3816,14 @@ paths:
       summary: Get WebView console logs
       description: Returns console log messages forwarded from in-app WebViews, newest entries first.
       tags: [System]
+      parameters:
+        - name: order
+          in: query
+          schema:
+            type: string
+            enum: [desc, asc]
+            default: desc
+          description: Line order — desc (newest first, default) or asc (original chronological order).
       responses:
         "200":
           description: WebView console log entries

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3788,7 +3788,7 @@ paths:
     get:
       summary: Get recent log entries
       description: |
-      Returns the last N kilobytes of the app log file. Query parameter `kb` controls the size (default: 16).
+      Returns the last N kilobytes of the app log file, newest entries first. Query parameter `kb` controls the size (default: 16).
       tags: [System]
       parameters:
         - name: kb
@@ -3807,7 +3807,7 @@ paths:
   /api/v1/webview/logs:
     get:
       summary: Get WebView console logs
-      description: Returns console log messages forwarded from in-app WebViews.
+      description: Returns console log messages forwarded from in-app WebViews, newest entries first.
       tags: [System]
       responses:
         "200":

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -288,8 +288,8 @@ The **proxy** lets clients *use* the account without ever seeing the credentials
 | GET | `/api/v1/info` | Build metadata (version, commit, branch) + gateway LAN IP (`localIp`) | `info_handler.dart` |
 | GET | `/api/v1/update` | App-update state snapshot (`phase`, `latestVersion`, `releaseNotes`, `releaseUrl`, `installable`). Pure read — no network call; force a re-check via `/ws/v1/update`. | `update_handler.dart` |
 | POST | `/api/v1/feedback` | Submit feedback (creates GitHub issue) | `feedback_handler.dart` |
-| GET | `/api/v1/logs` | Recent log entries, newest first (optional `?kb=N` for last N KB) | `logs_handler.dart` |
-| GET | `/api/v1/webview/logs` | WebView console log forwarding, newest first | `webview_logs_handler.dart` |
+| GET | `/api/v1/logs` | Recent log entries, newest first (optional `?kb=N` for last N KB; `?order=asc` for original chronological order) | `logs_handler.dart` |
+| GET | `/api/v1/webview/logs` | WebView console log forwarding, newest first (`?order=asc` for original chronological order) | `webview_logs_handler.dart` |
 
 ### Debug (simulate mode only)
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -288,8 +288,8 @@ The **proxy** lets clients *use* the account without ever seeing the credentials
 | GET | `/api/v1/info` | Build metadata (version, commit, branch) + gateway LAN IP (`localIp`) | `info_handler.dart` |
 | GET | `/api/v1/update` | App-update state snapshot (`phase`, `latestVersion`, `releaseNotes`, `releaseUrl`, `installable`). Pure read — no network call; force a re-check via `/ws/v1/update`. | `update_handler.dart` |
 | POST | `/api/v1/feedback` | Submit feedback (creates GitHub issue) | `feedback_handler.dart` |
-| GET | `/api/v1/logs` | Recent log entries | `logs_handler.dart` |
-| GET | `/api/v1/webview/logs` | WebView console log forwarding | `webview_logs_handler.dart` |
+| GET | `/api/v1/logs` | Recent log entries, newest first (optional `?kb=N` for last N KB) | `logs_handler.dart` |
+| GET | `/api/v1/webview/logs` | WebView console log forwarding, newest first | `webview_logs_handler.dart` |
 
 ### Debug (simulate mode only)
 

--- a/lib/src/services/webserver/logs_handler.dart
+++ b/lib/src/services/webserver/logs_handler.dart
@@ -4,6 +4,8 @@ part of '../webserver_service.dart';
 ///
 /// GET /api/v1/logs?kb=N — returns last N kilobytes of the log file.
 /// Without `kb`, returns the entire file.
+///
+/// Lines are served newest-first (reverse of the on-disk chronological order).
 class LogsHandler {
   final String _logFilePath;
 
@@ -33,7 +35,7 @@ class LogsHandler {
         await raf.setPosition(start);
         final data = await raf.read(bytes);
         return Response.ok(
-          String.fromCharCodes(data),
+          _reverseLogLines(String.fromCharCodes(data)),
           headers: {'content-type': 'text/plain'},
         );
       } finally {
@@ -43,8 +45,22 @@ class LogsHandler {
 
     final contents = await file.readAsString();
     return Response.ok(
-      contents,
+      _reverseLogLines(contents),
       headers: {'content-type': 'text/plain'},
     );
   }
+}
+
+/// Reverse the line order of [contents] so the newest log entries appear first.
+///
+/// Log files are written oldest-first; the REST log endpoints serve them
+/// newest-first for readability. Shared by [LogsHandler] and
+/// [WebViewLogsHandler], which are both `part of` the webserver library.
+///
+/// Uses [LineSplitter] so `\n`, `\r\n`, and `\r` terminators are handled and a
+/// trailing newline doesn't produce a leading blank line after reversal.
+String _reverseLogLines(String contents) {
+  final lines = const LineSplitter().convert(contents);
+  if (lines.isEmpty) return contents;
+  return '${lines.reversed.join('\n')}\n';
 }

--- a/lib/src/services/webserver/logs_handler.dart
+++ b/lib/src/services/webserver/logs_handler.dart
@@ -5,7 +5,9 @@ part of '../webserver_service.dart';
 /// GET /api/v1/logs?kb=N — returns last N kilobytes of the log file.
 /// Without `kb`, returns the entire file.
 ///
-/// Lines are served newest-first (reverse of the on-disk chronological order).
+/// Lines are served newest-first by default. Pass `order=asc` to get the
+/// original on-disk chronological order (oldest first); `order=desc` is the
+/// explicit form of the default.
 class LogsHandler {
   final String _logFilePath;
 
@@ -19,6 +21,11 @@ class LogsHandler {
     final file = File(_logFilePath);
     if (!await file.exists()) {
       return Response.notFound('Log file not found');
+    }
+
+    final order = _parseLogOrder(request);
+    if (order == null) {
+      return Response.badRequest(body: "order must be 'asc' or 'desc'");
     }
 
     final kbParam = request.url.queryParameters['kb'];
@@ -35,7 +42,7 @@ class LogsHandler {
         await raf.setPosition(start);
         final data = await raf.read(bytes);
         return Response.ok(
-          _reverseLogLines(String.fromCharCodes(data)),
+          _orderLogLines(String.fromCharCodes(data), order),
           headers: {'content-type': 'text/plain'},
         );
       } finally {
@@ -45,17 +52,52 @@ class LogsHandler {
 
     final contents = await file.readAsString();
     return Response.ok(
-      _reverseLogLines(contents),
+      _orderLogLines(contents, order),
       headers: {'content-type': 'text/plain'},
     );
   }
 }
 
+/// Output line order for the log endpoints.
+enum _LogOrder {
+  /// Original on-disk order: oldest entries first.
+  ascending,
+
+  /// Newest entries first (the default).
+  descending,
+}
+
+/// Parse the optional `order` query parameter shared by the log endpoints.
+///
+/// Accepts `desc` (newest-first, the default when absent) or `asc`
+/// (oldest-first, the original on-disk order), case-insensitive. Returns `null`
+/// for an unrecognized value so the caller can reject it with `400`.
+_LogOrder? _parseLogOrder(Request request) {
+  final raw = request.url.queryParameters['order'];
+  if (raw == null) return _LogOrder.descending;
+  switch (raw.toLowerCase()) {
+    case 'asc':
+      return _LogOrder.ascending;
+    case 'desc':
+      return _LogOrder.descending;
+    default:
+      return null;
+  }
+}
+
+/// Apply [order] to raw, chronological log [contents].
+///
+/// [_LogOrder.ascending] returns the text unchanged; [_LogOrder.descending]
+/// reverses it to newest-first via [_reverseLogLines]. Shared by [LogsHandler]
+/// and [WebViewLogsHandler], which are both `part of` the webserver library.
+String _orderLogLines(String contents, _LogOrder order) {
+  return order == _LogOrder.ascending ? contents : _reverseLogLines(contents);
+}
+
 /// Reverse the line order of [contents] so the newest log entries appear first.
 ///
 /// Log files are written oldest-first; the REST log endpoints serve them
-/// newest-first for readability. Shared by [LogsHandler] and
-/// [WebViewLogsHandler], which are both `part of` the webserver library.
+/// newest-first by default for readability.
 ///
 /// Uses [LineSplitter] so `\n`, `\r\n`, and `\r` terminators are handled and a
 /// trailing newline doesn't produce a leading blank line after reversal.

--- a/lib/src/services/webserver/webview_logs_handler.dart
+++ b/lib/src/services/webserver/webview_logs_handler.dart
@@ -20,12 +20,17 @@ class WebViewLogsHandler {
 
   /// GET /api/v1/webview/logs
   /// Returns the current webview_console.log contents as plain text,
-  /// newest entries first.
+  /// newest entries first by default. Pass `order=asc` for the original
+  /// chronological order (`order=desc` is the explicit default).
   /// Mirrors the existing LogsHandler pattern for app logs.
   Future<Response> _handleGetLogs(Request request) async {
+    final order = _parseLogOrder(request);
+    if (order == null) {
+      return Response.badRequest(body: "order must be 'asc' or 'desc'");
+    }
     final contents = _webViewLogService.getContents();
     return Response.ok(
-      _reverseLogLines(contents),
+      _orderLogLines(contents, order),
       headers: {'content-type': 'text/plain'},
     );
   }

--- a/lib/src/services/webserver/webview_logs_handler.dart
+++ b/lib/src/services/webserver/webview_logs_handler.dart
@@ -19,12 +19,13 @@ class WebViewLogsHandler {
   }
 
   /// GET /api/v1/webview/logs
-  /// Returns the current webview_console.log contents as plain text.
+  /// Returns the current webview_console.log contents as plain text,
+  /// newest entries first.
   /// Mirrors the existing LogsHandler pattern for app logs.
   Future<Response> _handleGetLogs(Request request) async {
     final contents = _webViewLogService.getContents();
     return Response.ok(
-      contents,
+      _reverseLogLines(contents),
       headers: {'content-type': 'text/plain'},
     );
   }

--- a/test/webserver/logs_handler_test.dart
+++ b/test/webserver/logs_handler_test.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:reaprime/src/services/webview_log_service.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+/// Stub that returns fixed contents, bypassing the IOSink-buffered file the
+/// real [WebViewLogService] writes to (which would race a synchronous read).
+class _StubWebViewLogService extends WebViewLogService {
+  final String _contents;
+  _StubWebViewLogService(this._contents) : super(logDirectoryPath: '/unused');
+
+  @override
+  String getContents() => _contents;
+}
+
+void main() {
+  Future<Response> get(Handler handler, String path) async {
+    return await handler(Request('GET', Uri.parse('http://localhost$path')));
+  }
+
+  group('LogsHandler GET /api/v1/logs', () {
+    late Directory tmpDir;
+    late File logFile;
+
+    setUp(() {
+      tmpDir = Directory.systemTemp.createTempSync('logs_handler_test');
+      logFile = File('${tmpDir.path}/log.txt');
+    });
+
+    tearDown(() {
+      if (tmpDir.existsSync()) tmpDir.deleteSync(recursive: true);
+    });
+
+    Handler handlerFor(String path) {
+      final app = Router().plus;
+      LogsHandler(logFilePath: path).addRoutes(app);
+      return app.call;
+    }
+
+    test('returns the whole file with lines newest-first', () async {
+      // Written oldest-first, as the app writes them.
+      const lines = ['oldest', 'middle', 'newest'];
+      logFile.writeAsStringSync('${lines.join('\n')}\n');
+
+      final res = await get(handlerFor(logFile.path), '/api/v1/logs');
+
+      expect(res.statusCode, 200);
+      expect(res.headers['content-type'], 'text/plain');
+      expect(await res.readAsString(), 'newest\nmiddle\noldest\n');
+    });
+
+    test('does not produce a leading blank line from a trailing newline',
+        () async {
+      logFile.writeAsStringSync('a\nb\nc\n');
+      final res = await get(handlerFor(logFile.path), '/api/v1/logs');
+      final body = await res.readAsString();
+      expect(body, 'c\nb\na\n');
+      expect(body.startsWith('\n'), isFalse);
+    });
+
+    test('empty file yields an empty body (not a blank line)', () async {
+      logFile.writeAsStringSync('');
+      final res = await get(handlerFor(logFile.path), '/api/v1/logs');
+      expect(res.statusCode, 200);
+      expect(await res.readAsString(), '');
+    });
+
+    test('missing file returns 404', () async {
+      final res =
+          await get(handlerFor('${tmpDir.path}/nope.txt'), '/api/v1/logs');
+      expect(res.statusCode, 404);
+    });
+
+    test('?kb=N returns the most recent window, newest-first', () async {
+      // 200 lines of 9 bytes each ("lineNNNN\n") = 1800 bytes, so a 1KB
+      // window drops the oldest lines.
+      final lines = [
+        for (var i = 0; i < 200; i++) 'line${i.toString().padLeft(4, '0')}',
+      ];
+      logFile.writeAsStringSync('${lines.join('\n')}\n');
+
+      final res = await get(handlerFor(logFile.path), '/api/v1/logs?kb=1');
+      final body = await res.readAsString();
+
+      expect(res.statusCode, 200);
+      // Newest line first.
+      expect(body.startsWith('line0199'), isTrue);
+      // Oldest line dropped by the 1KB window.
+      expect(body.contains('line0000'), isFalse);
+      // A recent line is present, and ordering is descending.
+      expect(body.contains('line0150'), isTrue);
+      expect(body.indexOf('line0199'), lessThan(body.indexOf('line0150')));
+    });
+
+    test('?kb=0 is rejected', () async {
+      logFile.writeAsStringSync('x\n');
+      final res = await get(handlerFor(logFile.path), '/api/v1/logs?kb=0');
+      expect(res.statusCode, 400);
+    });
+  });
+
+  group('WebViewLogsHandler GET /api/v1/webview/logs', () {
+    Handler handlerFor(WebViewLogService service) {
+      final app = Router().plus;
+      WebViewLogsHandler(webViewLogService: service).addRoutes(app);
+      return app.call;
+    }
+
+    test('returns console entries newest-first', () async {
+      final service = _StubWebViewLogService(
+        '[t1] [skin] [INFO] one\n'
+        '[t2] [skin] [INFO] two\n'
+        '[t3] [skin] [WARN] three\n',
+      );
+
+      final res =
+          await get(handlerFor(service), '/api/v1/webview/logs');
+
+      expect(res.statusCode, 200);
+      expect(res.headers['content-type'], 'text/plain');
+      expect(
+        await res.readAsString(),
+        '[t3] [skin] [WARN] three\n'
+        '[t2] [skin] [INFO] two\n'
+        '[t1] [skin] [INFO] one\n',
+      );
+    });
+
+    test('empty log yields an empty body', () async {
+      final res = await get(handlerFor(_StubWebViewLogService('')),
+          '/api/v1/webview/logs');
+      expect(res.statusCode, 200);
+      expect(await res.readAsString(), '');
+    });
+  });
+}

--- a/test/webserver/logs_handler_test.dart
+++ b/test/webserver/logs_handler_test.dart
@@ -99,6 +99,55 @@ void main() {
       final res = await get(handlerFor(logFile.path), '/api/v1/logs?kb=0');
       expect(res.statusCode, 400);
     });
+
+    test('?order=asc returns the original chronological order', () async {
+      logFile.writeAsStringSync('oldest\nmiddle\nnewest\n');
+      final res =
+          await get(handlerFor(logFile.path), '/api/v1/logs?order=asc');
+      expect(res.statusCode, 200);
+      expect(await res.readAsString(), 'oldest\nmiddle\nnewest\n');
+    });
+
+    test('?order=desc is the explicit default (newest-first)', () async {
+      logFile.writeAsStringSync('oldest\nmiddle\nnewest\n');
+      final res =
+          await get(handlerFor(logFile.path), '/api/v1/logs?order=desc');
+      expect(res.statusCode, 200);
+      expect(await res.readAsString(), 'newest\nmiddle\noldest\n');
+    });
+
+    test('?order is case-insensitive', () async {
+      logFile.writeAsStringSync('oldest\nnewest\n');
+      final res =
+          await get(handlerFor(logFile.path), '/api/v1/logs?order=ASC');
+      expect(res.statusCode, 200);
+      expect(await res.readAsString(), 'oldest\nnewest\n');
+    });
+
+    test('an unrecognized ?order value is rejected', () async {
+      logFile.writeAsStringSync('x\n');
+      final res =
+          await get(handlerFor(logFile.path), '/api/v1/logs?order=sideways');
+      expect(res.statusCode, 400);
+    });
+
+    test('?kb=N&order=asc returns the window in chronological order', () async {
+      final lines = [
+        for (var i = 0; i < 200; i++) 'line${i.toString().padLeft(4, '0')}',
+      ];
+      logFile.writeAsStringSync('${lines.join('\n')}\n');
+
+      final res =
+          await get(handlerFor(logFile.path), '/api/v1/logs?kb=1&order=asc');
+      final body = await res.readAsString();
+
+      expect(res.statusCode, 200);
+      // Newest line last (chronological), oldest dropped by the 1KB window.
+      expect(body.endsWith('line0199\n'), isTrue);
+      expect(body.contains('line0000'), isFalse);
+      expect(body.contains('line0150'), isTrue);
+      expect(body.indexOf('line0150'), lessThan(body.indexOf('line0199')));
+    });
   });
 
   group('WebViewLogsHandler GET /api/v1/webview/logs', () {
@@ -133,6 +182,31 @@ void main() {
           '/api/v1/webview/logs');
       expect(res.statusCode, 200);
       expect(await res.readAsString(), '');
+    });
+
+    test('?order=asc returns the original chronological order', () async {
+      final service = _StubWebViewLogService(
+        '[t1] [skin] [INFO] one\n'
+        '[t2] [skin] [INFO] two\n'
+        '[t3] [skin] [WARN] three\n',
+      );
+
+      final res =
+          await get(handlerFor(service), '/api/v1/webview/logs?order=asc');
+
+      expect(res.statusCode, 200);
+      expect(
+        await res.readAsString(),
+        '[t1] [skin] [INFO] one\n'
+        '[t2] [skin] [INFO] two\n'
+        '[t3] [skin] [WARN] three\n',
+      );
+    });
+
+    test('an unrecognized ?order value is rejected', () async {
+      final res = await get(handlerFor(_StubWebViewLogService('x\n')),
+          '/api/v1/webview/logs?order=sideways');
+      expect(res.statusCode, 400);
     });
   });
 }


### PR DESCRIPTION
## Summary

- **Problem:** `GET /api/v1/logs` and `GET /api/v1/webview/logs` returned lines in on-disk chronological order (oldest first), so the most recent entries were at the very bottom.
- **Why it matters:** When debugging, the newest lines are what you want first; oldest-first is awkward for a log viewer.
- **What changed:** Both REST endpoints now return lines **newest-first by default** via a shared `_reverseLogLines` helper. For `/api/v1/logs?kb=N`, the most-recent-N-KB window is reversed (newest on top). An **`order` query param** lets clients opt back into the original order: `order=asc` (oldest-first / original), `order=desc` (newest-first, the explicit default); unrecognized values return `400`.
- **What did NOT change (scope boundary):** Which bytes/window are returned is unchanged — only line order. WebSocket log streams (`/ws/v1/logs`, `/ws/v1/webview/logs`) are untouched: they push entries live as they occur, so there is no stored order to reverse.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] REST API / handlers
- [x] Docs / specs

## Linked Issues

- N/A

## Root Cause (if bug fix)

- N/A (not a bug fix)

## Regression Test Plan (if bug fix or refactor)

N/A (feature). Added unit coverage regardless:

- Coverage level:
  - [x] Unit test
- Target test: `test/webserver/logs_handler_test.dart`
- Scenario locked in: newest-first default for both endpoints; `order=asc` restores chronological order; `order=desc` explicit default; case-insensitive; unrecognized `order` → 400; `?kb=N` window reversal and `?kb=N&order=asc`; trailing-newline handling (no leading blank line); empty file; missing file → 404; `?kb=0` → 400.

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` (added `order` param to both endpoints)
- [x] API docs updated: `doc/Api.md`
- [ ] Plugin docs updated
- [ ] Skin docs updated
- [ ] Profile docs updated
- [ ] Device docs updated

## Security Impact (required)

- New or changed REST endpoints? **Yes (changed)** — output line order of two existing GET endpoints reversed by default; added an `order` query param. No new routes.
- New or changed WebSocket topics? **No**
- New or changed network calls? **No**
- BLE/USB surface changed? **No**
- File system access changed? **No** (reads the same log files as before)
- Plugin sandbox boundary changed? **No**
- Explanation: The change only reorders already-exposed log content and adds a read-only ordering toggle. No new data, endpoints, auth, or access — same local-only surface.

## User-Visible Changes

- API consumers of `GET /api/v1/logs` and `GET /api/v1/webview/logs` now receive log lines **newest-first by default**.
- New optional **`?order=asc`** query param returns the original chronological order; `?order=desc` is the explicit default.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (changed files: no issues)
- [x] `flutter test` — all pass (1732)
- [ ] `(cd packages/dye2-plugin && npm run build)` — N/A, plugin not touched

### Manual verification (if applicable)

- OS / platform tested: macOS (unit level)
- Simulated devices? (`simulate=1`): No
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: Unit tests exercise both handlers' real code paths for default order, `order=asc`/`desc`, case-insensitivity, invalid `order` → 400, `?kb=N` (+`order=asc`), trailing-newline handling, empty file, missing file → 404, `?kb=0` → 400.
- Edge cases checked: trailing newline (no leading blank line), empty content, kb window with partial leading line, missing file, invalid query values.
- What you did **not** verify: a live end-to-end smoke test against a running app was blocked by a separate Decent instance occupying port 8080 (hardcoded, not overridable); unit tests were used instead.

### Evidence

- [x] Test output:
  - `flutter test test/webserver/logs_handler_test.dart` → **15/15 pass**
  - full `flutter test` → **+1732: All tests passed!**

## Compatibility & Migration

- Backward compatible? **Mostly** — same schema, content-type, and bytes. The *default* order flips to newest-first; clients needing the old order can pass `?order=asc`.
- Config / env changes needed? **No**
- Database migration needed? **No**

## Risks & Mitigations

- Risk: A client that relied on oldest-first ordering would now see newest-first by default.
  - Mitigation: `?order=asc` restores the original order; documented in `doc/Api.md` and `rest_v1.yml`; content/format unchanged.
