### PR TITLE
fix: refresh skins list after skin update check (#370)

### DIFF
--- a/lib/src/skin_selector/skin_selector_page.dart
+++ b/lib/src/skin_selector/skin_selector_page.dart
@@ -569,6 +569,11 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
 
       await widget.webUIStorage.downloadRemoteSkins();
 
+      // downloadRemoteSkins() re-scans the registry, so installedSkins now
+      // reflects any newly downloaded versions. Rebuild so the dropdown shows
+      // them without the user having to leave and re-enter the page (#370).
+      if (mounted) setState(() {});
+
       if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(

--- a/test/skin_selector_update_refresh_test.dart
+++ b/test/skin_selector_update_refresh_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/skin_selector/skin_selector_page.dart';
+import 'package:reaprime/src/webui_support/webui_service.dart';
+import 'package:reaprime/src/webui_support/webui_storage.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+import 'helpers/mock_settings_service.dart';
+
+/// Minimal stand-in: never serving, so the page renders the "Check for Skin
+/// Updates" control.
+class _FakeWebUIService extends Fake implements WebUIService {
+  @override
+  bool get isServing => false;
+}
+
+/// Stand-in storage whose single installed skin reports a newer version after
+/// [downloadRemoteSkins] runs — mirroring a real update check that bumps the
+/// on-disk skin from 0.2.2 to 0.2.3 and re-scans the registry.
+class _FakeWebUIStorage extends Fake implements WebUIStorage {
+  _FakeWebUIStorage(this._version);
+
+  String _version;
+  int downloadCount = 0;
+
+  WebUISkin get _skin => WebUISkin(
+        id: 'streamline.js',
+        name: 'Streamline',
+        path: '/tmp/streamline.js',
+        version: _version,
+        isBundled: true,
+      );
+
+  @override
+  List<WebUISkin> get installedSkins => [_skin];
+
+  @override
+  WebUISkin? get defaultSkin => _skin;
+
+  @override
+  WebUISkin? getSkin(String id) => id == _skin.id ? _skin : null;
+
+  @override
+  Future<void> downloadRemoteSkins() async {
+    downloadCount++;
+    _version = '0.2.3';
+  }
+}
+
+void main() {
+  testWidgets(
+    'skins list refreshes to the new version after "Check for Skin Updates" '
+    '(issue #370)',
+    (tester) async {
+      final storage = _FakeWebUIStorage('0.2.2');
+
+      await tester.pumpWidget(
+        ShadApp(
+          // The production app provides a ScaffoldMessenger above the page
+          // (app.dart); the page's update-check snackbars require one.
+          home: ScaffoldMessenger(
+            child: SkinSelectorPage(
+              settingsController: SettingsController(MockSettingsService()),
+              webUIService: _FakeWebUIService(),
+              webUIStorage: storage,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // The dropdown shows the currently-installed version up front.
+      expect(find.textContaining('0.2.2'), findsOneWidget);
+      expect(find.textContaining('0.2.3'), findsNothing);
+
+      final updateButton = find.text('Check for Skin Updates');
+      await tester.ensureVisible(updateButton);
+      await tester.tap(updateButton);
+      await tester.pump(); // run the async handler + its setState
+      await tester.pump(const Duration(milliseconds: 300)); // settle snackbar
+
+      // Storage actually ran the update...
+      expect(storage.downloadCount, 1);
+      // ...and the list now reflects the new version without leaving the page.
+      expect(find.textContaining('0.2.3'), findsOneWidget);
+      expect(find.textContaining('0.2.2'), findsNothing);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- **Problem:** On the Web Interface screen, tapping **Check for Skin Updates** downloaded the newer skin but the on-screen skin list kept showing the *old* version (e.g. stuck on 0.2.2 after 0.2.3 was installed). Leaving and re-entering the page showed the new version.
- **Why it matters:** The update looks like it did nothing — users can't tell it succeeded (#370).
- **What changed:** After `downloadRemoteSkins()` completes in `_checkForSkinUpdates()`, call `setState()` (mounted-guarded) so the skin dropdown rebuilds from the freshly re-scanned registry.
- **What did NOT change (scope boundary):** No change to download, version-check, or registry-scan logic, storage, or any skin behavior — purely a missing UI rebuild trigger.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] WebUI skins
- [x] UI / Flutter widgets

## Linked Issues

- Closes #370

## Root Cause (if bug fix)

- **Root cause:** `_checkForSkinUpdates()` awaited the async update but never called `setState()`. The dropdown is built synchronously from `widget.webUIStorage.installedSkins` in `build()`, so without a rebuild the stale version stayed on screen. `downloadRemoteSkins()` already calls `_scanInstalledSkins()`, so the in-memory registry *was* up to date — only the widget rebuild was missing (re-entering the page rebuilds it, which is exactly the reporter's workaround).
- **Missing detection or guardrail:** No widget test covered the post-update-check refresh.
- **Contributing context:** Every other mutating action in this page (`_restartServerWithSkin`, `_startSelectedSkin`, skin removal) calls `setState()`; this one path was missed.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test (widget test, runs under `flutter test`)
- **Target test or file:** `test/skin_selector_update_refresh_test.dart`
- **Scenario the test should lock in:** Tapping "Check for Skin Updates" updates the displayed version (0.2.2 → 0.2.3) *without leaving the page*. The test fails on the unpatched code (`Found 0 widgets with text containing 0.2.3`) and passes with the fix.

## Documentation Obligations (required)

- [x] N/A — no docs affected. `doc/Skins.md` documents the update *mechanism* (`downloadRemoteSkins()`), which is unchanged; this fix only makes the UI reflect it.

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `No`
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`

## User-Visible Changes

After tapping **Check for Skin Updates**, the skin dropdown now refreshes immediately to the newly downloaded version instead of requiring the user to leave and re-open the page.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass (ran `bundle_skins.sh` first to generate `assets/bundled_skins/`, the build-time prerequisite for `webui_storage_bundled_test.dart`)
- [ ] `(cd packages/dye2-plugin && npm run build)` — N/A, plugin untouched

### Manual verification (if applicable)

- OS / platform tested: macOS (host), via widget test
- Simulated devices? (`simulate=1`): `No` (widget test with fakes)
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: Wrote a widget test reproducing the bug (dropdown stuck on the old version after an update), confirmed it **fails before** the fix and **passes after**; `flutter analyze` clean; full `flutter test` green.
- Edge cases checked: `mounted` guard prevents `setState()` if the user leaves the page mid-download.
- What you did **not** verify: On-device run against live GitHub skin releases — no behavioral risk, the change only adds a rebuild trigger.

### Evidence

Test output (same test, before vs. after the fix):

```
# BEFORE (unpatched lib): regression test fails exactly at the refresh assertion
Expected: exactly one matching candidate
  Actual: _TextContainingWidgetFinder:<Found 0 widgets with text containing 0.2.3: []>
00:00 +0 -1: skins list refreshes ... (issue #370) [E]

# AFTER (with setState fix)
00:00 +1: All tests passed!
```

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`

## Risks & Mitigations

- Risk: `setState()` after an async gap if the widget was disposed.
  - Mitigation: guarded by `if (mounted)`.
