### PR TITLE
Hot water stop-at-weight (tare scale + stop at target)

### DIFF
--- a/.agents/skills/decent-app/scenarios/hot-water-stop-at-weight.md
+++ b/.agents/skills/decent-app/scenarios/hot-water-stop-at-weight.md
@@ -1,0 +1,98 @@
+# Scenario: hot water stop-at-weight
+
+End-to-end check of native hot-water stop-at-weight: the `stopHotWaterAtWeight`
+REST setting, plus the behaviour — taring the scale and stopping the dispense
+once the scale reaches the configured hot-water volume target (treated as grams).
+
+When a scale is connected and `stopHotWaterAtWeight` is on (default), entering
+`hotWater` tares the scale, then the dispense is stopped (machine → `idle`) once
+the projected weight reaches the target. The machine's own volume/time stop
+stays as a backstop and is not modified.
+
+## Preconditions
+
+```bash
+scripts/sb-dev.sh start --connect-machine MockDe1 --connect-scale MockScale
+BASE=http://localhost:8080
+```
+
+## Setting surface (REST)
+
+```bash
+# Default is true.
+curl -sf "$BASE/api/v1/settings" | jq .stopHotWaterAtWeight   # true
+
+# Toggle off and back on; the response echoes the new value.
+curl -sf -X POST "$BASE/api/v1/settings" \
+  -H 'content-type: application/json' \
+  -d '{"stopHotWaterAtWeight": false}' >/dev/null
+curl -sf "$BASE/api/v1/settings" | jq .stopHotWaterAtWeight    # false
+
+curl -sf -X POST "$BASE/api/v1/settings" \
+  -H 'content-type: application/json' \
+  -d '{"stopHotWaterAtWeight": true}' >/dev/null
+curl -sf "$BASE/api/v1/settings" | jq .stopHotWaterAtWeight    # true
+```
+
+Bad type is rejected:
+
+```bash
+curl -s -o /tmp/sb-err -w '%{http_code}\n' -X POST "$BASE/api/v1/settings" \
+  -H 'content-type: application/json' -d '{"stopHotWaterAtWeight": "yes"}'
+cat /tmp/sb-err; echo   # 400 {"message":"stopHotWaterAtWeight must be a boolean"}
+```
+
+## Stop-at-weight behaviour
+
+Set a small hot-water volume target (treated as the gram target) so the
+simulated scale reaches it quickly:
+
+```bash
+# targetHotWaterVolume is part of shot settings; read the current ones,
+# then write back with a small volume. (MockDe1 defaults to 100.)
+curl -sf "$BASE/api/v1/machine/shotSettings" 2>/dev/null || true
+curl -sf -X POST "$BASE/api/v1/machine/shotSettings" \
+  -H 'content-type: application/json' \
+  -d '{"steamSetting":0,"targetSteamTemp":150,"targetSteamDuration":30,"targetHotWaterTemp":85,"targetHotWaterVolume":5,"targetHotWaterDuration":30,"targetShotVolume":0,"groupTemp":90}' >/dev/null
+```
+
+Start hot water (as a group-head controller / skin would) and watch the state
+channel return to `idle` once the scale passes the target:
+
+```bash
+# In one shell, follow machine state:
+websocat -n -t ws://localhost:8080/ws/v1/machine/snapshot &
+WS=$!
+
+# Trigger the dispense:
+curl -sf -X PUT "$BASE/api/v1/machine/state/hotWater" >/dev/null
+
+# Expect: state transitions to "hotWater", the scale is tared (weight ~0),
+# then within a couple of seconds the state returns to "idle" — the app
+# requested the stop at the target weight. Look for a log line:
+#   HotWaterSequencer - Arming hot water stop-at-weight: target 5 g
+#   HotWaterSequencer - Hot water target 5 g reached ... stopping
+kill $WS 2>/dev/null
+```
+
+Confirm via logs:
+
+```bash
+scripts/sb-dev.sh logs --filter HotWaterSequencer -n 20
+```
+
+With `stopHotWaterAtWeight` set to `false`, repeating the dispense leaves the
+stop to the machine's native volume/time target — no `HotWaterSequencer`
+arming line appears.
+
+## Postconditions
+
+```bash
+scripts/sb-dev.sh stop
+```
+
+> Note: the macOS desktop build does not stay resident in headless/CI sessions,
+> so this recipe is intended for the Android tablet or Linux builds. The same
+> flow is covered deterministically in-process by
+> `test/integration/hot_water_sequencer_integration_test.dart` and
+> `test/controllers/hot_water_sequencer_test.dart`.

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -4749,6 +4749,12 @@ components:
           format: double
           nullable: true
           example: 0.3
+        hotWaterFlowMultiplier:
+          description: Lookahead (in seconds) applied to scale weight flow when stopping hot water at weight (see stopHotWaterAtWeight). Separate from weightFlowMultiplier because hot water dispenses with a different pump/flow profile than espresso. Default is 0.3. Higher values stop earlier.
+          type: number
+          format: double
+          nullable: true
+          example: 0.3
         scalePowerMode:
           description: Automatic scale power management tied to machine state. Disabled means no automatic action. displayOff turns off scale display when machine sleeps (scales without display control will disconnect). disconnect disconnects scale completely when machine sleeps.
           type: string
@@ -4757,6 +4763,9 @@ components:
           example: "disabled"
         blockOnNoScale:
           description: When true, shots will be blocked from starting if no scale is connected.
+          type: boolean
+        stopHotWaterAtWeight:
+          description: When true (default) and a scale is connected, hot water dispensing tares the scale and stops at the configured hot-water volume target treated as grams. The machine's own volume/time stop remains a backstop. Ignored in full gateway mode (a skin owns the machine). Set false to use only the machine's native volume/time stop.
           type: boolean
         preferredMachineId:
           description: Device ID of the preferred machine for auto-connect on startup. When set, REA will automatically connect to this machine when it's discovered during device scan. Set to null to clear the preference.
@@ -4834,6 +4843,11 @@ components:
           type: number
           format: double
           example: 0.3
+        hotWaterFlowMultiplier:
+          description: Lookahead (in seconds) applied to scale weight flow when stopping hot water at weight (see stopHotWaterAtWeight). Separate from weightFlowMultiplier because hot water dispenses with a different pump/flow profile than espresso. Default is 0.3. Higher values stop earlier.
+          type: number
+          format: double
+          example: 0.3
         scalePowerMode:
           description: Automatic scale power management tied to machine state. Disabled means no automatic action. displayOff turns off scale display when machine sleeps (scales without display control will disconnect). disconnect disconnects scale completely when machine sleeps.
           type: string
@@ -4841,6 +4855,9 @@ components:
           example: "disabled"
         blockOnNoScale:
           description: When true, shots will be blocked from starting if no scale is connected.
+          type: boolean
+        stopHotWaterAtWeight:
+          description: When true (default) and a scale is connected, hot water dispensing tares the scale and stops at the configured hot-water volume target treated as grams. The machine's own volume/time stop remains a backstop. Ignored in full gateway mode (a skin owns the machine).
           type: boolean
         preferredMachineId:
           description: Device ID of the preferred machine for auto-connect on startup. Returns null if no preferred device is set.

--- a/assets/plugins/settings.reaplugin/manifest.json
+++ b/assets/plugins/settings.reaplugin/manifest.json
@@ -3,7 +3,7 @@
   "author": "Decent Espresso",
   "name": "Settings Viewer",
   "description": "Displays Decent application and machine settings in an embeddable HTML page. http://localhost:8080/api/v1/plugins/settings.reaplugin/ui",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "apiVersion": 1,
   "permissions": [
     "log",

--- a/assets/plugins/settings.reaplugin/plugin.js
+++ b/assets/plugins/settings.reaplugin/plugin.js
@@ -480,6 +480,25 @@ function createPlugin(host) {
                         </div>
                     </div>
                     <div class="setting-item">
+                        <label class="setting-label" for="stopHotWaterAtWeight">Stop Hot Water at Weight</label>
+                        <div class="setting-control">
+                            <select id="stopHotWaterAtWeight" aria-describedby="stopHotWaterAtWeight-desc">
+                                <option value="true" ${reaSettings.stopHotWaterAtWeight ? 'selected' : ''}>Enabled</option>
+                                <option value="false" ${!reaSettings.stopHotWaterAtWeight ? 'selected' : ''}>Disabled</option>
+                            </select>
+                            <span id="stopHotWaterAtWeight-desc" class="visually-hidden">When enabled and a scale is connected, hot water dispensing tares the scale and stops at the configured hot-water volume target (treated as grams). Ignored in full gateway mode.</span>
+                            <button class="btn btn-primary" onclick="updateReaSetting('stopHotWaterAtWeight', document.getElementById('stopHotWaterAtWeight').value === 'true')" aria-label="Save stop hot water at weight setting">Save</button>
+                        </div>
+                    </div>
+                    <div class="setting-item">
+                        <label class="setting-label" for="hotWaterFlowMultiplier">Hot Water Flow Multiplier (s)</label>
+                        <div class="setting-control">
+                            <input type="number" id="hotWaterFlowMultiplier" value="${reaSettings.hotWaterFlowMultiplier !== undefined ? reaSettings.hotWaterFlowMultiplier : 0.3}" step="0.05" min="0" max="2" aria-describedby="hotWaterFlowMultiplier-desc">
+                            <span id="hotWaterFlowMultiplier-desc" class="visually-hidden">Look-ahead time in seconds for projected weight calculation when stopping hot water at weight. Separate from the espresso weight flow multiplier because hot water dispenses with a different pump/flow profile.</span>
+                            <button class="btn btn-primary" onclick="updateReaSetting('hotWaterFlowMultiplier', parseFloat(document.getElementById('hotWaterFlowMultiplier').value))" aria-label="Save hot water flow multiplier setting">Save</button>
+                        </div>
+                    </div>
+                    <div class="setting-item">
                         <label class="setting-label" for="preferredMachineId">Auto-Connect Device ID</label>
                         <div class="setting-control">
                             <input type="text" id="preferredMachineId" value="${escapeHtml(reaSettings.preferredMachineId)}" placeholder="None set" aria-describedby="preferredMachineId-desc" style="width: 200px;">

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -185,7 +185,9 @@ in-app stop will trigger on.
 | GET | `/api/v1/settings` | All app settings (gateway, theme, charging, devices, etc.) | `settings_handler.dart` |
 | POST | `/api/v1/settings` | Update settings (partial, key-by-key) | |
 
-Settings fields include: `gatewayMode`, `themeMode`, `logLevel`, `weightFlowMultiplier`, `volumeFlowMultiplier`, `scalePowerMode`, `preferredMachineId`, `preferredScaleId`, `defaultSkinId`, `automaticUpdateCheck`, `chargingMode`, `nightModeEnabled`, `nightModeSleepTime`, `nightModeMorningTime`, `lowBatteryBrightnessLimit`, `simulatedDevices`.
+Settings fields include: `gatewayMode`, `themeMode`, `logLevel`, `weightFlowMultiplier`, `volumeFlowMultiplier`, `hotWaterFlowMultiplier`, `scalePowerMode`, `blockOnNoScale`, `stopHotWaterAtWeight`, `preferredMachineId`, `preferredScaleId`, `defaultSkinId`, `automaticUpdateCheck`, `chargingMode`, `nightModeEnabled`, `nightModeSleepTime`, `nightModeMorningTime`, `lowBatteryBrightnessLimit`, `simulatedDevices`.
+
+`stopHotWaterAtWeight` (boolean, default `true`): when on and a scale is connected, hot-water dispensing tares the scale and stops at the configured hot-water `volume` target treated as grams (mirrors the espresso stop-at-weight). The machine's own volume/time stop remains a backstop, and the value is ignored in `full` gateway mode (a skin owns the machine). `hotWaterFlowMultiplier` (number, default `0.3`) is the seconds-of-lookahead applied to scale weight flow for that stop — separate from `weightFlowMultiplier` because hot water dispenses with a different pump/flow profile than espresso. See [DeviceManagement.md](DeviceManagement.md#hot-water-stop-at-weight).
 
 ### WebUI & Skins
 

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -582,6 +582,44 @@ De1StateManager({
 - `_handleScalePowerManagement(MachineState)`: Manages scale sleep/wake/scan
 - `_triggerScaleScan()`: Initiates device scan with 30s timeout
 
+### Hot water stop-at-weight
+
+**Files:** `lib/src/controllers/hot_water_sequencer.dart` (wiring),
+`lib/src/controllers/hot_water_stop.dart` (pure decision logic).
+
+`HotWaterSequencer` is a long-lived service (created once in `main.dart`,
+alongside `SteamSequencer`) that brings the espresso stop-at-weight behaviour to
+hot water.
+
+Hot water is always started **externally** here (group-head controller, physical
+button, REST `PUT /api/v1/machine/state/hotWater`, or a skin) — the native UI
+never calls `requestState(MachineState.hotWater)`. So the sequencer *reacts* to
+the machine entering `hotWater`:
+
+1. **Arm + tare.** If `stopHotWaterAtWeight` is on, a scale is connected, the
+   gateway mode is not `full`, and the configured hot-water `volume` (treated as
+   grams) is positive, the scale is tared via `ScaleController.tare()` and the
+   monitor arms.
+2. **Monitor.** The tare is trusted only once the scale has actually been
+   *observed* to drop near zero (proof the tare applied) — guarding against a
+   stale pre-tare reading (e.g. a mug still on the platter) causing a false
+   early stop. If the tare never lands, the monitor simply never arms and the
+   machine's native stop takes over (fail-safe). Once confirmed and past the
+   settle window, the weight is projected a short time ahead
+   (`weight + weightFlow * hotWaterFlowMultiplier`, default 0.3 s lookahead) —
+   the same shape as `ShotSequencer`'s espresso stop-at-weight, but with its own
+   multiplier because hot water dispenses with a different pump/flow profile than
+   espresso.
+3. **Stop.** When the projection reaches the target, `requestState(idle)` is sent
+   once. The machine's own volume/time stop is left **unmodified** as a backstop
+   (so the no-scale and weight-never-climbs cases still end normally).
+4. **Disarm** when the machine leaves `hotWater`, disconnects, or the scale drops.
+
+In `full` gateway mode the sequencer stays inert — a skin owns the machine and
+would otherwise double-stop (mirrors `ShotSequencer`'s `bypassSAW`). Controlled
+by the `stopHotWaterAtWeight` setting (default `true`, exposed on
+`/api/v1/settings`).
+
 ---
 
 ## Connection Policy

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -1204,7 +1204,10 @@ GET /api/v1/settings
   "logLevel": "INFO",
   "weightFlowMultiplier": 1.0,
   "volumeFlowMultiplier": 0.3,
+  "hotWaterFlowMultiplier": 0.3,
   "scalePowerMode": "disabled",
+  "blockOnNoScale": false,
+  "stopHotWaterAtWeight": true,
   "preferredMachineId": "F4:12:FA:5C:3D:8E"
 }
 ```
@@ -1215,7 +1218,10 @@ GET /api/v1/settings
 - `logLevel`: Log verbosity level
 - `weightFlowMultiplier`: Multiplier for projected weight calculation (default: 1.0)
 - `volumeFlowMultiplier`: Multiplier for projected volume calculation (default: 0.3)
+- `hotWaterFlowMultiplier`: Look-ahead seconds for projected weight when stopping hot water at weight (default: 0.3). Separate from `weightFlowMultiplier` because hot water dispenses with a different pump/flow profile
 - `scalePowerMode`: Automatic scale power management (`disabled`, `displayOff`, `disconnect`)
+- `blockOnNoScale`: When true, shots are blocked from starting if no scale is connected (default: false)
+- `stopHotWaterAtWeight`: When true and a scale is connected, hot water dispensing tares the scale and stops at the configured hot-water volume target treated as grams (default: true). Ignored in full gateway mode
 - `preferredMachineId`: Device ID for auto-connect on startup
 - `lowBatteryBrightnessLimit` (boolean): When enabled, caps brightness at 20 when battery drops below 30%
 

--- a/doc/plans/archive/hot-water-stop-at-weight/design.md
+++ b/doc/plans/archive/hot-water-stop-at-weight/design.md
@@ -1,0 +1,76 @@
+# Native hot-water stop-at-weight (scale tare)
+
+## Goal
+
+Bring the espresso stop-at-weight behaviour to hot water: when hot water is
+dispensed and a scale is connected, tare the scale and stop the dispense once
+the (flow-projected) scale weight reaches the configured target.
+
+The target is the configured hot-water `volume` (ml treated as g) — i.e.
+`HotWaterData.volume` is reused as the gram target.
+
+## Native design
+
+Hot water is **always started externally** here (GHC / physical button / REST /
+skin) — `requestState(MachineState.hotWater)` is never called from native UI. So
+the feature must detect *externally-started* hot water and stop it at weight,
+reacting to the machine entering `hotWater` rather than initiating the pour.
+
+### Pieces
+
+1. **`lib/src/controllers/hot_water_stop.dart`** — pure decision logic.
+   `HotWaterStopState` + `nextHotWaterStop(state, input)` → wait | clear | stop.
+   The per-frame rule: once the machine is seen pouring hot water and the
+   post-tare reading has settled, project `weight + flow * lookahead` and stop
+   when it reaches the target. No I/O, fully unit-tested.
+
+2. **`lib/src/controllers/hot_water_sequencer.dart`** — long-lived service (like
+   `SteamSequencer`, created in `main.dart`). Wires `De1Controller` +
+   `ScaleController` + `SettingsController`:
+   - On the machine entering `hotWater`, if eligible (setting on, scale
+     connected, `gatewayMode != full`, target volume > 0): **tare the scale**
+     and arm.
+   - On each scale weight frame, run `nextHotWaterStop`; on `stop`,
+     `requestState(idle)`.
+   - Disarm when the machine leaves `hotWater` or disconnects.
+
+3. **`stopHotWaterAtWeight` setting** (default **true**) and
+   **`hotWaterFlowMultiplier`** (default 0.3 s lookahead) — across
+   `SettingsService` (+keys), `SettingsController`, `MockSettingsService`,
+   `settings_handler` GET/POST, `rest_v1.yml`, and settings export/import.
+
+### Authority / safety
+
+We do **not** mutate the DE1's hot-water volume/duration (we can't anyway — the
+pour is externally started and the FW latches its targets at entry). The scale
+stop projects the weight a short time ahead so it fires just before the target;
+the DE1's own volume/time stop stays as a **safe backstop** for the no-scale /
+weight-never-climbs cases.
+
+The tare is trusted only once the scale is *observed* to settle near zero — so a
+stale pre-tare reading (e.g. a mug still on the platter) can't false-stop; if the
+tare never lands, the monitor never arms and the DE1's native stop takes over.
+
+### Projection multiplier
+
+The stop projects `weight + weightFlow * hotWaterFlowMultiplier`, the same shape
+as the espresso stop-at-weight in `ShotSequencer` (`weight + weightFlow *
+weightFlowMultiplier`), but with its **own** multiplier: hot water dispenses with
+a different pump/flow profile than espresso, so the stop-latency lookahead is a
+separate, independently-tunable setting (default 0.3 s).
+
+### Gateway mode
+
+In `full` gateway mode a skin owns the machine, so the native sequencer stays
+inert to avoid a double-stop. In `tracking`/`disabled` it arms. This mirrors
+`ShotSequencer`'s `bypassSAW = gatewayMode == full`.
+
+## Test tiers
+
+- **Unit**: `hot_water_stop_test.dart` (decision table), `hot_water_sequencer_test.dart`
+  (arm/tare/stop wiring, tare confirmation, consecutive dispenses), settings
+  round-trip + export/import.
+- **Integration**: `hot_water_sequencer_integration_test.dart` — real
+  controllers + MockDe1/MockScale through to a stop.
+- **End-to-end**: `.agents/skills/decent-app/scenarios/hot-water-stop-at-weight.md`
+  — simulate machine+scale, PUT state/hotWater, observe return to idle.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:reaprime/src/controllers/battery_controller.dart';
 import 'package:reaprime/src/controllers/bengle_probe_bridge.dart';
 import 'package:reaprime/src/controllers/bengle_saw_bridge.dart';
 import 'package:reaprime/src/controllers/bengle_steam_stop_bridge.dart';
+import 'package:reaprime/src/controllers/hot_water_sequencer.dart';
 import 'package:reaprime/src/controllers/steam_sequencer.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
@@ -404,6 +405,16 @@ void main(List<String> args) async {
     sensorController: sensorController,
     workflowController: workflowController,
     persistenceController: persistenceController,
+  );
+
+  // Tares the scale and stops hot-water dispensing at the configured volume
+  // target (treated as grams) when a scale is connected — the hot-water
+  // counterpart of the espresso stop-at-weight. See [[hot_water_sequencer]].
+  // ignore: unused_local_variable
+  final hotWaterSequencer = HotWaterSequencer(
+    de1Controller: de1Controller,
+    scaleController: scaleController,
+    settingsController: settingsController,
   );
   final WebUIService webUIService = WebUIService();
   final WebUIStorage webUIStorage = WebUIStorage(settingsController);

--- a/lib/src/controllers/hot_water_sequencer.dart
+++ b/lib/src/controllers/hot_water_sequencer.dart
@@ -1,0 +1,222 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/hot_water_stop.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/models/data/workflow.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart' as device;
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/settings/gateway_mode.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+
+/// Long-lived service that stops a hot-water dispense once the scale reaches the
+/// configured target weight — the hot-water counterpart of the espresso
+/// stop-at-weight in [ShotSequencer].
+///
+/// Hot water is always started externally on this platform (group-head
+/// controller, physical button, REST, or a skin), so this service *reacts* to
+/// the machine entering `hotWater`: it tares the scale and then monitors the
+/// weight, asking the machine to stop the moment the (flow-projected) weight
+/// reaches the target. It mirrors the shape of [SteamSequencer] — created once
+/// in `main.dart`, lives across the app lifetime.
+///
+/// The target weight is the configured hot-water `volume` (ml ≈ g). We never
+/// mutate the machine's own volume/time targets, so the DE1's native stop stays
+/// as a safe backstop when there's no scale or the weight never climbs.
+class HotWaterSequencer {
+  HotWaterSequencer({
+    required De1Controller de1Controller,
+    required ScaleController scaleController,
+    required SettingsController settingsController,
+    DateTime Function()? now,
+  })  : _de1 = de1Controller,
+        _scale = scaleController,
+        _settings = settingsController,
+        _now = now ?? DateTime.now {
+    _scaleConnected =
+        _scale.currentConnectionState == device.ConnectionState.connected;
+    _hotWaterSub = _de1.hotWaterData.listen((hw) => _latestHotWater = hw);
+    _connectionSub = _scale.connectionState.listen(_onScaleConnection);
+    _weightSub = _scale.weightSnapshot.listen(_onWeight);
+    _de1Sub = _de1.de1.listen(_onMachineChange);
+  }
+
+  final De1Controller _de1;
+  final ScaleController _scale;
+  final SettingsController _settings;
+  final DateTime Function() _now;
+  final Logger _log = Logger('HotWaterSequencer');
+
+  /// Window after a tare during which the scale reading is not yet trustworthy
+  /// (matches [ScaleController.smoothingWindowDuration]).
+  static const Duration _tareSettleWindow =
+      ScaleController.smoothingWindowDuration;
+
+  /// A scale frame older than this is considered stale.
+  static const Duration _scaleFreshWindow = Duration(seconds: 2);
+
+  /// The tare is trusted only once the scale has actually been *observed* to
+  /// drop to/below this many grams — proof the tare applied. A meaningful
+  /// pre-tare load (e.g. the cup still on the platter) could otherwise trigger
+  /// a false early stop if the physical tare lags the time window. If the tare
+  /// never lands, the stop simply never arms and the machine's own volume/time
+  /// stop takes over — failing safe.
+  static const double _tareConfirmGrams = 3.0;
+
+  /// Lookahead used when the configured `hotWaterFlowMultiplier` is non-positive.
+  /// Matches that setting's default so a misconfig still behaves sanely.
+  static const double _defaultLookaheadSeconds = 0.3;
+
+  StreamSubscription<De1Interface?>? _de1Sub;
+  StreamSubscription<MachineSnapshot>? _snapshotSub;
+  StreamSubscription<WeightSnapshot>? _weightSub;
+  StreamSubscription<device.ConnectionState>? _connectionSub;
+  StreamSubscription<HotWaterData>? _hotWaterSub;
+
+  De1Interface? _machine;
+  HotWaterData? _latestHotWater;
+  MachineState? _latestMachineState;
+  WeightSnapshot? _latestWeight;
+  DateTime? _lastWeightAt;
+  bool _scaleConnected = false;
+
+  /// Whether the post-tare zero has actually been observed for the armed pour.
+  bool _tareConfirmed = false;
+
+  // Active stop monitor (null when not armed).
+  HotWaterStopState? _state;
+  DateTime? _armedAt;
+  DateTime? _tareRequestedAt;
+
+  bool get isArmed => _state != null;
+
+  void _onScaleConnection(device.ConnectionState state) {
+    _scaleConnected = state == device.ConnectionState.connected;
+    if (!_scaleConnected) _disarm();
+  }
+
+  void _onMachineChange(De1Interface? machine) {
+    if (identical(_machine, machine)) return;
+    _snapshotSub?.cancel();
+    _snapshotSub = null;
+    _disarm();
+    _machine = machine;
+    _latestMachineState = null;
+    if (machine != null) {
+      _snapshotSub = machine.currentSnapshot.listen(_onMachineSnapshot);
+    }
+  }
+
+  void _onMachineSnapshot(MachineSnapshot snapshot) {
+    _latestMachineState = snapshot.state.state;
+    if (_state == null) {
+      if (snapshot.state.state == MachineState.hotWater) _maybeArm();
+    }
+    _evaluate();
+  }
+
+  void _onWeight(WeightSnapshot weight) {
+    _latestWeight = weight;
+    _lastWeightAt = _now();
+    if (_state == null) return;
+    if (!_tareConfirmed && weight.weight <= _tareConfirmGrams) {
+      _tareConfirmed = true;
+    }
+    _evaluate();
+  }
+
+  void _maybeArm() {
+    if (_machine == null) return;
+    // In full gateway mode a skin owns the machine — stay inert to avoid a
+    // double-stop (mirrors ShotSequencer's bypassSAW).
+    if (_settings.gatewayMode == GatewayMode.full) return;
+    if (!_settings.stopHotWaterAtWeight) return;
+    if (!_scaleConnected) return;
+    final hotWater = _latestHotWater;
+    if (hotWater == null) return;
+    final target = hotWater.volume.toDouble();
+    if (target <= 0) return;
+
+    final at = _now();
+    _state = HotWaterStopState(
+      targetWeight: target,
+      configuredFlow: hotWater.flow,
+      // Projects `weight + weightFlow * hotWaterFlowMultiplier` to compensate
+      // for the stop-command → flow-off latency, exactly like the espresso
+      // stop-at-weight in ShotSequencer — but with its own multiplier, because
+      // hot water dispenses with a different pump/flow profile than espresso.
+      lookaheadSeconds: _settings.hotWaterFlowMultiplier > 0
+          ? _settings.hotWaterFlowMultiplier
+          : _defaultLookaheadSeconds,
+    );
+    _armedAt = at;
+    _tareRequestedAt = at;
+    _tareConfirmed = false;
+    _log.info(
+      'Arming hot water stop-at-weight: target ${target.toStringAsFixed(0)} g',
+    );
+    _scale.tare().catchError(
+      (e) => _log.warning('Failed to tare scale for hot water', e),
+    );
+  }
+
+  void _evaluate() {
+    final state = _state;
+    if (state == null) return;
+    final now = _now();
+    final input = HotWaterStopInput(
+      machineState: _latestMachineState,
+      sinceArmed: _armedAt == null ? Duration.zero : now.difference(_armedAt!),
+      tareSettled: _tareConfirmed &&
+          _tareRequestedAt != null &&
+          now.difference(_tareRequestedAt!) >= _tareSettleWindow,
+      freshScale: _scaleConnected &&
+          _lastWeightAt != null &&
+          now.difference(_lastWeightAt!) < _scaleFreshWindow,
+      weight: _latestWeight?.weight,
+      weightFlow: _latestWeight?.weightFlow,
+    );
+
+    final decision = nextHotWaterStop(state, input);
+    if (decision.action == HotWaterStopAction.clear) {
+      _disarm();
+      return;
+    }
+    _state = decision.state;
+    if (decision.action == HotWaterStopAction.stop) {
+      _log.info(
+        'Hot water target ${state.targetWeight.toStringAsFixed(0)} g reached '
+        '(weight ${decision.weight.toStringAsFixed(1)} g, '
+        'projected ${decision.projectedWeight.toStringAsFixed(1)} g) — stopping',
+      );
+      final machine = _machine;
+      if (machine != null) {
+        machine.requestState(MachineState.idle).catchError(
+              (e) => _log.warning('Failed to stop hot water at weight', e),
+            );
+      }
+    }
+  }
+
+  void _disarm() {
+    _state = null;
+    _armedAt = null;
+    _tareRequestedAt = null;
+    _tareConfirmed = false;
+  }
+
+  Future<void> dispose() async {
+    await _de1Sub?.cancel();
+    _de1Sub = null;
+    await _snapshotSub?.cancel();
+    _snapshotSub = null;
+    await _weightSub?.cancel();
+    _weightSub = null;
+    await _connectionSub?.cancel();
+    _connectionSub = null;
+    await _hotWaterSub?.cancel();
+    _hotWaterSub = null;
+  }
+}

--- a/lib/src/controllers/hot_water_stop.dart
+++ b/lib/src/controllers/hot_water_stop.dart
@@ -1,0 +1,162 @@
+import 'package:reaprime/src/models/device/machine.dart';
+
+/// Pure decision logic for stopping a hot-water dispense at a target weight.
+///
+/// It is deliberately free of any I/O — the [HotWaterSequencer] feeds it
+/// observations and acts on the resulting [HotWaterStopDecision]. Keeping the
+/// rule pure makes the stop table exhaustively unit-testable.
+///
+/// The model: once the machine is actually seen pouring hot water and the
+/// post-tare reading has settled, project the weight a short time ahead
+/// (`weight + flow * lookahead`) and request a stop the moment that projection
+/// reaches the target. The lookahead compensates for the latency between
+/// asking the machine to stop and the pump actually closing.
+
+/// How long to wait for the machine to actually enter `hotWater` after arming
+/// before giving up and clearing. Guards an arm that never turns into a pour.
+const Duration kHotWaterArmTimeout = Duration(seconds: 10);
+
+class HotWaterStopState {
+  /// Target beverage weight in grams (the configured hot-water volume).
+  final double targetWeight;
+
+  /// Configured hot-water flow (ml/s ≈ g/s), used as the lookahead flow before
+  /// the scale's own derived flow becomes trustworthy.
+  final double configuredFlow;
+
+  /// Seconds of flow to project ahead when deciding to stop.
+  final double lookaheadSeconds;
+
+  /// Whether the machine has been observed in the `hotWater` state at least
+  /// once since arming.
+  final bool activeSeen;
+
+  /// Whether a stop has already been requested (latched to avoid double-stop).
+  final bool stopRequested;
+
+  const HotWaterStopState({
+    required this.targetWeight,
+    required this.configuredFlow,
+    required this.lookaheadSeconds,
+    this.activeSeen = false,
+    this.stopRequested = false,
+  });
+
+  HotWaterStopState copyWith({bool? activeSeen, bool? stopRequested}) {
+    return HotWaterStopState(
+      targetWeight: targetWeight,
+      configuredFlow: configuredFlow,
+      lookaheadSeconds: lookaheadSeconds,
+      activeSeen: activeSeen ?? this.activeSeen,
+      stopRequested: stopRequested ?? this.stopRequested,
+    );
+  }
+}
+
+class HotWaterStopInput {
+  /// Latest machine state, if known.
+  final MachineState? machineState;
+
+  /// Time elapsed since the controller armed (tared) for this pour.
+  final Duration sinceArmed;
+
+  /// Whether the post-tare settle window has elapsed, so the scale reading now
+  /// reflects the tared zero rather than the pre-tare discontinuity.
+  final bool tareSettled;
+
+  /// Whether the scale is connected and emitting recent frames.
+  final bool freshScale;
+
+  /// Latest scale weight in grams (may be null before the first frame).
+  final double? weight;
+
+  /// Latest scale-derived flow in g/s (may be null/zero early in the pour).
+  final double? weightFlow;
+
+  const HotWaterStopInput({
+    required this.machineState,
+    required this.sinceArmed,
+    required this.tareSettled,
+    required this.freshScale,
+    required this.weight,
+    required this.weightFlow,
+  });
+}
+
+enum HotWaterStopAction { wait, clear, stop }
+
+class HotWaterStopDecision {
+  final HotWaterStopAction action;
+
+  /// Next controller state. Null only when [action] is [HotWaterStopAction.clear].
+  final HotWaterStopState? state;
+
+  /// Weight and projected weight at the moment of a stop decision (0 otherwise).
+  final double weight;
+  final double projectedWeight;
+
+  const HotWaterStopDecision._(
+    this.action,
+    this.state, {
+    this.weight = 0,
+    this.projectedWeight = 0,
+  });
+
+  factory HotWaterStopDecision.wait(HotWaterStopState state) =>
+      HotWaterStopDecision._(HotWaterStopAction.wait, state);
+
+  factory HotWaterStopDecision.clear() =>
+      const HotWaterStopDecision._(HotWaterStopAction.clear, null);
+
+  factory HotWaterStopDecision.stop(
+    HotWaterStopState state, {
+    required double weight,
+    required double projectedWeight,
+  }) =>
+      HotWaterStopDecision._(
+        HotWaterStopAction.stop,
+        state,
+        weight: weight,
+        projectedWeight: projectedWeight,
+      );
+}
+
+HotWaterStopDecision nextHotWaterStop(
+  HotWaterStopState state,
+  HotWaterStopInput input,
+) {
+  var next = state;
+  if (input.machineState == MachineState.hotWater) {
+    next = next.copyWith(activeSeen: true);
+  } else if (next.activeSeen || input.sinceArmed > kHotWaterArmTimeout) {
+    // Either we left hot water after pouring, or we armed but the pour never
+    // started — disarm.
+    return HotWaterStopDecision.clear();
+  }
+
+  if (!next.activeSeen || next.stopRequested) {
+    return HotWaterStopDecision.wait(next);
+  }
+  if (!input.freshScale) return HotWaterStopDecision.wait(next);
+  if (!input.tareSettled) return HotWaterStopDecision.wait(next);
+
+  final weight = _finite(input.weight) ?? 0.0;
+  final flow = _positive(input.weightFlow) ?? next.configuredFlow;
+  final projectedWeight = weight + flow * next.lookaheadSeconds;
+  if (projectedWeight < next.targetWeight) {
+    return HotWaterStopDecision.wait(next);
+  }
+
+  next = next.copyWith(stopRequested: true);
+  return HotWaterStopDecision.stop(
+    next,
+    weight: weight,
+    projectedWeight: projectedWeight,
+  );
+}
+
+double? _finite(double? value) =>
+    (value != null && value.isFinite) ? value : null;
+
+double? _positive(double? value) =>
+    (value != null && value.isFinite && value > 0) ? value : null;

--- a/lib/src/services/webserver/data_export/settings_export_section.dart
+++ b/lib/src/services/webserver/data_export/settings_export_section.dart
@@ -22,8 +22,10 @@ class SettingsExportSection implements DataExportSection {
         'themeMode': _controller.themeMode.name,
         'weightFlowMultiplier': _controller.weightFlowMultiplier,
         'volumeFlowMultiplier': _controller.volumeFlowMultiplier,
+        'hotWaterFlowMultiplier': _controller.hotWaterFlowMultiplier,
         'scalePowerMode': _controller.scalePowerMode.name,
         'blockOnNoScale': _controller.blockOnNoScale,
+        'stopHotWaterAtWeight': _controller.stopHotWaterAtWeight,
         'defaultSkinId': _controller.defaultSkinId,
         'automaticUpdateCheck': _controller.automaticUpdateCheck,
         'chargingMode': _controller.chargingMode.name,
@@ -92,6 +94,16 @@ class SettingsExportSection implements DataExportSection {
           }
         }
 
+        if (settings.containsKey('hotWaterFlowMultiplier')) {
+          final value = settings['hotWaterFlowMultiplier'];
+          if (value is num) {
+            await _controller.setHotWaterFlowMultiplier(value.toDouble());
+            imported++;
+          } else {
+            errors.add('Invalid hotWaterFlowMultiplier: $value');
+          }
+        }
+
         if (settings.containsKey('scalePowerMode')) {
           final mode = ScalePowerModeFromString.fromString(
               settings['scalePowerMode']);
@@ -107,6 +119,12 @@ class SettingsExportSection implements DataExportSection {
         if (settings.containsKey('blockOnNoScale')) {
           await _controller
               .setBlockOnNoScale(settings['blockOnNoScale'] as bool);
+          imported++;
+        }
+
+        if (settings.containsKey('stopHotWaterAtWeight')) {
+          await _controller
+              .setStopHotWaterAtWeight(settings['stopHotWaterAtWeight'] as bool);
           imported++;
         }
 

--- a/lib/src/services/webserver/settings_handler.dart
+++ b/lib/src/services/webserver/settings_handler.dart
@@ -24,8 +24,10 @@ class SettingsHandler {
       final logLevel = _controller.logLevel;
       final weightFlowMultiplier = _controller.weightFlowMultiplier;
       final volumeFlowMultiplier = _controller.volumeFlowMultiplier;
+      final hotWaterFlowMultiplier = _controller.hotWaterFlowMultiplier;
       final scalePowerMode = _controller.scalePowerMode.name;
       final blockOnNoScale = _controller.blockOnNoScale;
+      final stopHotWaterAtWeight = _controller.stopHotWaterAtWeight;
       final preferredMachineId = _controller.preferredMachineId;
       final preferredScaleId = _controller.preferredScaleId;
       final defaultSkinId = _controller.defaultSkinId;
@@ -36,8 +38,10 @@ class SettingsHandler {
         'logLevel': logLevel,
         'weightFlowMultiplier': weightFlowMultiplier,
         'volumeFlowMultiplier': volumeFlowMultiplier,
+        'hotWaterFlowMultiplier': hotWaterFlowMultiplier,
         'scalePowerMode': scalePowerMode,
         'blockOnNoScale': blockOnNoScale,
+        'stopHotWaterAtWeight': stopHotWaterAtWeight,
         'preferredMachineId': preferredMachineId,
         'preferredScaleId': preferredScaleId,
         'defaultSkinId': defaultSkinId,
@@ -98,6 +102,16 @@ class SettingsHandler {
           );
         }
       }
+      if (json.containsKey('hotWaterFlowMultiplier')) {
+        final value = json['hotWaterFlowMultiplier'];
+        if (value is num) {
+          await _controller.setHotWaterFlowMultiplier(value.toDouble());
+        } else {
+          return jsonBadRequest(
+            {'message': 'hotWaterFlowMultiplier must be a number'},
+          );
+        }
+      }
       if (json.containsKey('scalePowerMode')) {
         final ScalePowerMode? mode = ScalePowerModeFromString.fromString(
           json['scalePowerMode'],
@@ -117,6 +131,16 @@ class SettingsHandler {
         } else {
           return jsonBadRequest(
             {'message': 'blockOnNoScale must be a boolean'},
+          );
+        }
+      }
+      if (json.containsKey('stopHotWaterAtWeight')) {
+        final value = json['stopHotWaterAtWeight'];
+        if (value is bool) {
+          await _controller.setStopHotWaterAtWeight(value);
+        } else {
+          return jsonBadRequest(
+            {'message': 'stopHotWaterAtWeight must be a boolean'},
           );
         }
       }

--- a/lib/src/settings/settings_controller.dart
+++ b/lib/src/settings/settings_controller.dart
@@ -33,9 +33,13 @@ class SettingsController with ChangeNotifier {
 
   double _volumeFlowMultiplier = 0.3;
 
+  double _hotWaterFlowMultiplier = 0.3;
+
   ScalePowerMode _scalePowerMode = ScalePowerMode.disconnect;
 
   bool _blockOnNoScale = false;
+
+  bool _stopHotWaterAtWeight = true;
 
   String? _preferredMachineId;
 
@@ -74,8 +78,10 @@ class SettingsController with ChangeNotifier {
   Set<SimulatedDevicesTypes> get simulatedDevices => _simulatedDevices;
   double get weightFlowMultiplier => _weightFlowMultiplier;
   double get volumeFlowMultiplier => _volumeFlowMultiplier;
+  double get hotWaterFlowMultiplier => _hotWaterFlowMultiplier;
   ScalePowerMode get scalePowerMode => _scalePowerMode;
   bool get blockOnNoScale => _blockOnNoScale;
+  bool get stopHotWaterAtWeight => _stopHotWaterAtWeight;
   String? get preferredMachineId => _preferredMachineId;
   String? get preferredScaleId => _preferredScaleId;
   String get defaultSkinId => _defaultSkinId;
@@ -108,8 +114,10 @@ class SettingsController with ChangeNotifier {
     _simulatedDevices = await _settingsService.simulateDevices();
     _weightFlowMultiplier = await _settingsService.weightFlowMultiplier();
     _volumeFlowMultiplier = await _settingsService.volumeFlowMultiplier();
+    _hotWaterFlowMultiplier = await _settingsService.hotWaterFlowMultiplier();
     _scalePowerMode = await _settingsService.scalePowerMode();
     _blockOnNoScale = await _settingsService.blockOnNoScale();
+    _stopHotWaterAtWeight = await _settingsService.stopHotWaterAtWeight();
     _preferredMachineId = await _settingsService.preferredMachineId();
     _preferredScaleId = await _settingsService.preferredScaleId();
     _defaultSkinId = await _settingsService.defaultSkinId();
@@ -239,6 +247,15 @@ class SettingsController with ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> setHotWaterFlowMultiplier(double value) async {
+    if (value == _hotWaterFlowMultiplier) {
+      return;
+    }
+    _hotWaterFlowMultiplier = value;
+    await _settingsService.setHotWaterFlowMultiplier(value);
+    notifyListeners();
+  }
+
   Future<void> setScalePowerMode(ScalePowerMode mode) async {
     if (mode == _scalePowerMode) {
       return;
@@ -254,6 +271,15 @@ class SettingsController with ChangeNotifier {
     }
     _blockOnNoScale = value;
     await _settingsService.setBlockOnNoScale(value);
+    notifyListeners();
+  }
+
+  Future<void> setStopHotWaterAtWeight(bool value) async {
+    if (value == _stopHotWaterAtWeight) {
+      return;
+    }
+    _stopHotWaterAtWeight = value;
+    await _settingsService.setStopHotWaterAtWeight(value);
     notifyListeners();
   }
 

--- a/lib/src/settings/settings_service.dart
+++ b/lib/src/settings/settings_service.dart
@@ -22,10 +22,14 @@ abstract class SettingsService {
   Future<void> setWeightFlowMultiplier(double value);
   Future<double> volumeFlowMultiplier();
   Future<void> setVolumeFlowMultiplier(double value);
+  Future<double> hotWaterFlowMultiplier();
+  Future<void> setHotWaterFlowMultiplier(double value);
   Future<ScalePowerMode> scalePowerMode();
   Future<void> setScalePowerMode(ScalePowerMode mode);
   Future<bool> blockOnNoScale();
   Future<void> setBlockOnNoScale(bool value);
+  Future<bool> stopHotWaterAtWeight();
+  Future<void> setStopHotWaterAtWeight(bool value);
   Future<String?> preferredMachineId();
   Future<void> setPreferredMachineId(String? machineId);
   Future<String?> preferredScaleId();
@@ -159,6 +163,17 @@ class SharedPreferencesSettingsService extends SettingsService {
   }
 
   @override
+  Future<double> hotWaterFlowMultiplier() async {
+    return await prefs.getDouble(SettingsKeys.hotWaterFlowMultiplier.name) ??
+        0.3;
+  }
+
+  @override
+  Future<void> setHotWaterFlowMultiplier(double value) async {
+    await prefs.setDouble(SettingsKeys.hotWaterFlowMultiplier.name, value);
+  }
+
+  @override
   Future<ScalePowerMode> scalePowerMode() async {
     return ScalePowerModeFromString.fromString(
           await prefs.getString(SettingsKeys.scalePowerMode.name) ??
@@ -175,6 +190,16 @@ class SharedPreferencesSettingsService extends SettingsService {
   @override
   Future<void> setBlockOnNoScale(bool value) async {
     return await prefs.setBool(SettingsKeys.blockOnNoScale.name, value);
+  }
+
+  @override
+  Future<bool> stopHotWaterAtWeight() async {
+    return await prefs.getBool(SettingsKeys.stopHotWaterAtWeight.name) ?? true;
+  }
+
+  @override
+  Future<void> setStopHotWaterAtWeight(bool value) async {
+    return await prefs.setBool(SettingsKeys.stopHotWaterAtWeight.name, value);
   }
 
   @override
@@ -447,8 +472,10 @@ enum SettingsKeys {
   simulateDevices,
   weightFlowMultiplier,
   volumeFlowMultiplier,
+  hotWaterFlowMultiplier,
   scalePowerMode,
   blockOnNoScale,
+  stopHotWaterAtWeight,
   preferredMachineId,
   preferredScaleId,
   defaultSkinId,

--- a/test/controllers/hot_water_sequencer_test.dart
+++ b/test/controllers/hot_water_sequencer_test.dart
@@ -1,0 +1,390 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/hot_water_sequencer.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/models/data/workflow.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
+import 'package:reaprime/src/settings/gateway_mode.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:rxdart/rxdart.dart';
+
+import '../helpers/mock_settings_service.dart';
+
+class _EmptyDiscovery extends DeviceDiscoveryService {
+  @override
+  Stream<List<Device>> get devices => const Stream.empty();
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
+}
+
+class _StubDe1Controller extends De1Controller {
+  _StubDe1Controller({HotWaterData? hotWater})
+      : _de1subj = BehaviorSubject.seeded(null),
+        _hw = BehaviorSubject.seeded(
+          hotWater ??
+              HotWaterData(
+                  targetTemperature: 85, duration: 35, volume: 30, flow: 2.0),
+        ),
+        super(controller: DeviceController([_EmptyDiscovery()]));
+
+  final BehaviorSubject<De1Interface?> _de1subj;
+  final BehaviorSubject<HotWaterData> _hw;
+
+  @override
+  Stream<De1Interface?> get de1 => _de1subj.stream;
+  @override
+  Stream<HotWaterData> get hotWaterData => _hw.stream;
+
+  void emitMachine(De1Interface? d) => _de1subj.add(d);
+  void setHotWater(HotWaterData hw) => _hw.add(hw);
+}
+
+class _StubScaleController extends ScaleController {
+  _StubScaleController({ConnectionState initial = ConnectionState.connected})
+      : _conn = BehaviorSubject.seeded(initial);
+
+  final BehaviorSubject<WeightSnapshot> _weights = BehaviorSubject();
+  final BehaviorSubject<ConnectionState> _conn;
+  int tareCount = 0;
+
+  @override
+  Stream<WeightSnapshot> get weightSnapshot => _weights.stream;
+  @override
+  Stream<ConnectionState> get connectionState => _conn.stream;
+  @override
+  ConnectionState get currentConnectionState => _conn.value;
+  @override
+  Future<void> tare() async {
+    tareCount++;
+  }
+
+  void emitWeight(double weight, {double flow = 0, DateTime? at}) {
+    _weights.add(WeightSnapshot(
+      timestamp: at ?? DateTime.now(),
+      weight: weight,
+      weightFlow: flow,
+    ));
+  }
+
+  void setConnection(ConnectionState s) => _conn.add(s);
+
+  @override
+  void dispose() {
+    _weights.close();
+    _conn.close();
+  }
+}
+
+class _TestMachine implements De1Interface {
+  @override
+  String get deviceId => 'test-machine';
+  @override
+  String get name => 'TestMachine';
+  @override
+  DeviceType get type => DeviceType.machine;
+
+  final BehaviorSubject<MachineSnapshot> _snap = BehaviorSubject();
+  @override
+  Stream<MachineSnapshot> get currentSnapshot => _snap.stream;
+
+  final List<MachineState> requested = [];
+  @override
+  Future<void> requestState(MachineState state) async {
+    requested.add(state);
+  }
+
+  void emit(MachineSnapshot s) => _snap.add(s);
+
+  @override
+  Future<void> dispose() async => _snap.close();
+  @override
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.connected);
+  @override
+  Future<void> onConnect() async {}
+  @override
+  Future<void> disconnect() async {}
+  @override
+  Stream<bool> get ready => Stream<bool>.value(false);
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+MachineSnapshot _snap(MachineState state,
+    {MachineSubstate substate = MachineSubstate.pouring}) {
+  return MachineSnapshot(
+    timestamp: DateTime.now(),
+    state: MachineStateSnapshot(state: state, substate: substate),
+    flow: 0,
+    pressure: 0,
+    targetFlow: 0,
+    targetPressure: 0,
+    mixTemperature: 90,
+    groupTemperature: 90,
+    targetMixTemperature: 93,
+    targetGroupTemperature: 93,
+    profileFrame: 0,
+    steamTemperature: 0,
+  );
+}
+
+void main() {
+  late _StubDe1Controller de1;
+  late _StubScaleController scale;
+  late SettingsController settings;
+  late MockSettingsService settingsService;
+  late HotWaterSequencer sequencer;
+  late DateTime clock;
+
+  Future<void> settle() => Future<void>.delayed(Duration.zero);
+
+  Future<void> build() async {
+    sequencer = HotWaterSequencer(
+      de1Controller: de1,
+      scaleController: scale,
+      settingsController: settings,
+      now: () => clock,
+    );
+    await settle();
+  }
+
+  setUp(() async {
+    clock = DateTime(2024, 1, 1, 12, 0, 0);
+    de1 = _StubDe1Controller();
+    scale = _StubScaleController();
+    settingsService = MockSettingsService();
+    settings = SettingsController(settingsService);
+    await settings.loadSettings();
+  });
+
+  tearDown(() async {
+    await sequencer.dispose();
+    scale.dispose();
+  });
+
+  group('arming', () {
+    test('tares the scale and arms on entering hotWater when eligible',
+        () async {
+      await build();
+      final m = _TestMachine();
+      de1.emitMachine(m);
+      await settle();
+      m.emit(_snap(MachineState.hotWater));
+      await settle();
+
+      expect(scale.tareCount, 1);
+      expect(sequencer.isArmed, isTrue);
+      m.dispose();
+    });
+
+    test('does not arm when the setting is off', () async {
+      await settings.setStopHotWaterAtWeight(false);
+      await build();
+      final m = _TestMachine();
+      de1.emitMachine(m);
+      await settle();
+      m.emit(_snap(MachineState.hotWater));
+      await settle();
+
+      expect(scale.tareCount, 0);
+      expect(sequencer.isArmed, isFalse);
+    });
+
+    test('does not arm when no scale is connected', () async {
+      scale.setConnection(ConnectionState.disconnected);
+      await build();
+      final m = _TestMachine();
+      de1.emitMachine(m);
+      await settle();
+      m.emit(_snap(MachineState.hotWater));
+      await settle();
+
+      expect(scale.tareCount, 0);
+      expect(sequencer.isArmed, isFalse);
+    });
+
+    test('does not arm in full gateway mode (skin owns the machine)', () async {
+      await settings.updateGatewayMode(GatewayMode.full);
+      await build();
+      final m = _TestMachine();
+      de1.emitMachine(m);
+      await settle();
+      m.emit(_snap(MachineState.hotWater));
+      await settle();
+
+      expect(scale.tareCount, 0);
+      expect(sequencer.isArmed, isFalse);
+    });
+
+    test('does not arm when the target volume is zero', () async {
+      de1 = _StubDe1Controller(
+        hotWater:
+            HotWaterData(targetTemperature: 85, duration: 35, volume: 0, flow: 2),
+      );
+      await build();
+      final m = _TestMachine();
+      de1.emitMachine(m);
+      await settle();
+      m.emit(_snap(MachineState.hotWater));
+      await settle();
+
+      expect(scale.tareCount, 0);
+      expect(sequencer.isArmed, isFalse);
+    });
+  });
+
+  group('stopping', () {
+    // Drives a machine into hotWater and emits the post-tare zero frame so the
+    // monitor confirms the tare applied (mirrors a scale reporting ~0 after the
+    // tare command lands).
+    Future<_TestMachine> armAndConfirmTare() async {
+      final m = _TestMachine();
+      de1.emitMachine(m);
+      await settle();
+      m.emit(_snap(MachineState.hotWater));
+      await settle();
+      scale.emitWeight(0, flow: 0, at: clock); // post-tare zero observed
+      await settle();
+      return m;
+    }
+
+    test('requests idle once the weight reaches the target', () async {
+      await build();
+      final m = await armAndConfirmTare();
+
+      // Past the tare-settle window.
+      clock = clock.add(const Duration(seconds: 1));
+      scale.emitWeight(30, flow: 0, at: clock);
+      await settle();
+
+      expect(m.requested, contains(MachineState.idle));
+      m.dispose();
+    });
+
+    test('does not stop before the tare-settle window elapses', () async {
+      await build();
+      final m = await armAndConfirmTare();
+
+      // Still inside the settle window.
+      clock = clock.add(const Duration(milliseconds: 100));
+      scale.emitWeight(50, flow: 0, at: clock);
+      await settle();
+
+      expect(m.requested, isEmpty);
+      m.dispose();
+    });
+
+    test('waits for the post-tare zero before stopping (stale pre-tare weight)',
+        () async {
+      // The cup is still on the platter and the physical tare lags: the scale
+      // keeps reporting the pre-tare weight (>= target) past the time window.
+      // The monitor must NOT false-stop until it has seen the weight settle low.
+      await build();
+      final m = _TestMachine();
+      de1.emitMachine(m);
+      await settle();
+      m.emit(_snap(MachineState.hotWater));
+      await settle();
+
+      clock = clock.add(const Duration(seconds: 1)); // window elapsed
+      scale.emitWeight(50, flow: 0, at: clock); // stale pre-tare cup weight
+      await settle();
+      expect(m.requested, isEmpty,
+          reason: 'must not stop on an unconfirmed (pre-tare) reading');
+
+      // Tare finally lands — scale drops to zero, then water climbs to target.
+      scale.emitWeight(0, flow: 0, at: clock);
+      await settle();
+      clock = clock.add(const Duration(milliseconds: 200));
+      scale.emitWeight(30, flow: 0, at: clock);
+      await settle();
+      expect(m.requested, contains(MachineState.idle));
+      m.dispose();
+    });
+
+    test('only requests idle once', () async {
+      await build();
+      final m = await armAndConfirmTare();
+
+      clock = clock.add(const Duration(seconds: 1));
+      scale.emitWeight(40, flow: 1, at: clock);
+      await settle();
+      scale.emitWeight(45, flow: 1, at: clock);
+      await settle();
+
+      expect(
+        m.requested.where((s) => s == MachineState.idle).length,
+        1,
+      );
+      m.dispose();
+    });
+
+    test('re-arms and stops again on a second consecutive dispense', () async {
+      await build();
+      final m = await armAndConfirmTare();
+
+      // First dispense reaches target and stops.
+      clock = clock.add(const Duration(seconds: 1));
+      scale.emitWeight(30, flow: 0, at: clock);
+      await settle();
+      expect(m.requested.where((s) => s == MachineState.idle).length, 1);
+
+      // Machine returns to idle → disarm.
+      m.emit(_snap(MachineState.idle, substate: MachineSubstate.idle));
+      await settle();
+      expect(sequencer.isArmed, isFalse);
+
+      // Second dispense: re-arm, re-tare, confirm, reach target, stop again.
+      m.emit(_snap(MachineState.hotWater));
+      await settle();
+      expect(sequencer.isArmed, isTrue);
+      expect(scale.tareCount, 2, reason: 'a fresh tare per dispense');
+      scale.emitWeight(0, flow: 0, at: clock);
+      await settle();
+      clock = clock.add(const Duration(seconds: 1));
+      scale.emitWeight(30, flow: 0, at: clock);
+      await settle();
+      expect(m.requested.where((s) => s == MachineState.idle).length, 2);
+      m.dispose();
+    });
+  });
+
+  group('disarming', () {
+    test('disarms when the machine leaves hotWater', () async {
+      await build();
+      final m = _TestMachine();
+      de1.emitMachine(m);
+      await settle();
+      m.emit(_snap(MachineState.hotWater));
+      await settle();
+      expect(sequencer.isArmed, isTrue);
+
+      m.emit(_snap(MachineState.idle, substate: MachineSubstate.idle));
+      await settle();
+      expect(sequencer.isArmed, isFalse);
+      m.dispose();
+    });
+
+    test('disarms when the machine disconnects', () async {
+      await build();
+      final m = _TestMachine();
+      de1.emitMachine(m);
+      await settle();
+      m.emit(_snap(MachineState.hotWater));
+      await settle();
+      expect(sequencer.isArmed, isTrue);
+
+      de1.emitMachine(null);
+      await settle();
+      expect(sequencer.isArmed, isFalse);
+    });
+  });
+}

--- a/test/data_export/settings_export_section_test.dart
+++ b/test/data_export/settings_export_section_test.dart
@@ -45,7 +45,9 @@ void main() {
       expect(settings['logLevel'], equals('INFO'));
       expect(settings['weightFlowMultiplier'], equals(1.0));
       expect(settings['volumeFlowMultiplier'], equals(0.3));
+      expect(settings['hotWaterFlowMultiplier'], equals(0.3));
       expect(settings['scalePowerMode'], equals('disabled'));
+      expect(settings['stopHotWaterAtWeight'], isTrue);
       expect(settings['automaticUpdateCheck'], isTrue);
       expect(settings['chargingMode'], equals('disabled'));
       expect(settings['nightModeEnabled'], isFalse);
@@ -85,12 +87,16 @@ void main() {
       await controller.updateGatewayMode(GatewayMode.full);
       await controller.setWeightFlowMultiplier(2.5);
       await controller.setNightModeEnabled(true);
+      await controller.setStopHotWaterAtWeight(false);
+      await controller.setHotWaterFlowMultiplier(0.5);
       final exported = await section.export();
 
       // Reset to defaults
       await controller.updateGatewayMode(GatewayMode.disabled);
       await controller.setWeightFlowMultiplier(1.0);
       await controller.setNightModeEnabled(false);
+      await controller.setStopHotWaterAtWeight(true);
+      await controller.setHotWaterFlowMultiplier(0.3);
 
       final result =
           await section.import(exported, ConflictStrategy.overwrite);
@@ -100,6 +106,8 @@ void main() {
       expect(controller.gatewayMode, equals(GatewayMode.full));
       expect(controller.weightFlowMultiplier, equals(2.5));
       expect(controller.nightModeEnabled, isTrue);
+      expect(controller.stopHotWaterAtWeight, isFalse);
+      expect(controller.hotWaterFlowMultiplier, equals(0.5));
     });
 
     test('imports device preferences', () async {

--- a/test/helpers/mock_settings_service.dart
+++ b/test/helpers/mock_settings_service.dart
@@ -13,8 +13,10 @@ class MockSettingsService extends SettingsService {
   Set<SimulatedDevicesTypes> _simulateDevices = {};
   double _weightFlowMultiplier = 1.0;
   double _volumeFlowMultiplier = 0.3;
+  double _hotWaterFlowMultiplier = 0.3;
   ScalePowerMode _scalePowerMode = ScalePowerMode.disabled;
   bool _blockOnNoScale = false;
+  bool _stopHotWaterAtWeight = true;
   String? _preferredMachineId;
   String? _preferredScaleId;
   String _defaultSkinId = 'streamline.js';
@@ -63,6 +65,11 @@ class MockSettingsService extends SettingsService {
   @override
   Future<void> setVolumeFlowMultiplier(double value) async => _volumeFlowMultiplier = value;
   @override
+  Future<double> hotWaterFlowMultiplier() async => _hotWaterFlowMultiplier;
+  @override
+  Future<void> setHotWaterFlowMultiplier(double value) async =>
+      _hotWaterFlowMultiplier = value;
+  @override
   Future<ScalePowerMode> scalePowerMode() async => _scalePowerMode;
   @override
   Future<void> setScalePowerMode(ScalePowerMode mode) async => _scalePowerMode = mode;
@@ -70,6 +77,11 @@ class MockSettingsService extends SettingsService {
   Future<bool> blockOnNoScale() async => _blockOnNoScale;
   @override
   Future<void> setBlockOnNoScale(bool value) async => _blockOnNoScale = value;
+  @override
+  Future<bool> stopHotWaterAtWeight() async => _stopHotWaterAtWeight;
+  @override
+  Future<void> setStopHotWaterAtWeight(bool value) async =>
+      _stopHotWaterAtWeight = value;
   @override
   Future<String?> preferredMachineId() async => _preferredMachineId;
   @override

--- a/test/integration/hot_water_sequencer_integration_test.dart
+++ b/test/integration/hot_water_sequencer_integration_test.dart
@@ -1,0 +1,119 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/hot_water_sequencer.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/home_feature/forms/hot_water_form.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+import 'package:reaprime/src/models/device/impl/mock_scale/mock_scale.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/settings/gateway_mode.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+
+import '../helpers/mock_settings_service.dart';
+
+/// Integration tier: wires the real [De1Controller], [ScaleController],
+/// [SettingsController] and [HotWaterSequencer] with the simulated MockDe1 +
+/// MockScale — the same objects `main.dart` constructs. MockDe1 has no
+/// autonomous hot-water stop, so a `hotWater → idle` transition can only have
+/// been driven by the sequencer requesting idle.
+class _EmptyDiscovery extends DeviceDiscoveryService {
+  @override
+  Stream<List<Device>> get devices => const Stream.empty();
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
+}
+
+void main() {
+  late De1Controller de1Controller;
+  late ScaleController scaleController;
+  late SettingsController settings;
+  late HotWaterSequencer sequencer;
+
+  setUp(() async {
+    de1Controller = De1Controller(controller: DeviceController([_EmptyDiscovery()]));
+    scaleController = ScaleController();
+    settings = SettingsController(MockSettingsService());
+    await settings.loadSettings();
+    sequencer = HotWaterSequencer(
+      de1Controller: de1Controller,
+      scaleController: scaleController,
+      settingsController: settings,
+    );
+  });
+
+  tearDown(() async {
+    await sequencer.dispose();
+    scaleController.dispose();
+  });
+
+  /// Waits for the machine to reach [state], failing after [within].
+  Future<void> waitForState(
+    MockDe1 machine,
+    MachineState state, {
+    Duration within = const Duration(seconds: 12),
+  }) async {
+    await machine.currentSnapshot
+        .firstWhere((s) => s.state.state == state)
+        .timeout(within);
+  }
+
+  test('tares the scale and stops hot water at the target weight', () async {
+    final machine = MockDe1();
+    await de1Controller.connectToDe1(machine);
+    final scale = MockScale();
+    await scaleController.connectToScale(scale);
+
+    // Small target so the ramping MockScale reaches it quickly.
+    await de1Controller.updateHotWaterSettings(HotWaterFormSettings(
+      targetTemperature: 85,
+      flow: 2.0,
+      volume: 5,
+      duration: 30,
+    ));
+    // Let the hot-water target propagate to the sequencer.
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+
+    // Externally-started hot water (as a GHC / REST / skin would).
+    await machine.requestState(MachineState.hotWater);
+    await waitForState(machine, MachineState.hotWater);
+    expect(sequencer.isArmed, isTrue,
+        reason: 'sequencer should arm on hotWater entry');
+
+    // The scale weight ramps past 5 g; the sequencer must request idle.
+    await waitForState(machine, MachineState.idle);
+    expect(sequencer.isArmed, isFalse,
+        reason: 'sequencer should disarm once hot water ends');
+
+    await machine.disconnect();
+  });
+
+  test('does not arm in full gateway mode', () async {
+    await settings.updateGatewayMode(GatewayMode.full);
+    final machine = MockDe1();
+    await de1Controller.connectToDe1(machine);
+    final scale = MockScale();
+    await scaleController.connectToScale(scale);
+    await de1Controller.updateHotWaterSettings(HotWaterFormSettings(
+      targetTemperature: 85,
+      flow: 2.0,
+      volume: 5,
+      duration: 30,
+    ));
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+
+    await machine.requestState(MachineState.hotWater);
+    await waitForState(machine, MachineState.hotWater);
+    // Give the sequencer a few snapshots' worth of time to (not) arm.
+    await Future<void>.delayed(const Duration(seconds: 2));
+
+    expect(sequencer.isArmed, isFalse);
+    await machine.disconnect();
+  });
+}

--- a/test/unit/controllers/hot_water_stop_test.dart
+++ b/test/unit/controllers/hot_water_stop_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/hot_water_stop.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+
+void main() {
+  HotWaterStopState armed({
+    double target = 30,
+    double configuredFlow = 2.0,
+    double lookahead = 0.3,
+    bool activeSeen = false,
+    bool stopRequested = false,
+  }) =>
+      HotWaterStopState(
+        targetWeight: target,
+        configuredFlow: configuredFlow,
+        lookaheadSeconds: lookahead,
+        activeSeen: activeSeen,
+        stopRequested: stopRequested,
+      );
+
+  HotWaterStopInput input({
+    MachineState? machineState = MachineState.hotWater,
+    Duration sinceArmed = const Duration(seconds: 1),
+    bool tareSettled = true,
+    bool freshScale = true,
+    double? weight = 0,
+    double? weightFlow = 0,
+  }) =>
+      HotWaterStopInput(
+        machineState: machineState,
+        sinceArmed: sinceArmed,
+        tareSettled: tareSettled,
+        freshScale: freshScale,
+        weight: weight,
+        weightFlow: weightFlow,
+      );
+
+  group('nextHotWaterStop', () {
+    test('marks activeSeen once the machine is seen in hotWater', () {
+      final d = nextHotWaterStop(armed(), input(weight: 5));
+      expect(d.action, HotWaterStopAction.wait);
+      expect(d.state!.activeSeen, isTrue);
+    });
+
+    test('waits (does not clear) before hotWater is seen, within timeout', () {
+      final d = nextHotWaterStop(
+        armed(),
+        input(machineState: MachineState.heating, sinceArmed: const Duration(seconds: 2)),
+      );
+      expect(d.action, HotWaterStopAction.wait);
+      expect(d.state!.activeSeen, isFalse);
+    });
+
+    test('clears if hotWater is never seen within the arm timeout', () {
+      final d = nextHotWaterStop(
+        armed(),
+        input(machineState: MachineState.idle, sinceArmed: const Duration(seconds: 11)),
+      );
+      expect(d.action, HotWaterStopAction.clear);
+      expect(d.state, isNull);
+    });
+
+    test('clears once the machine leaves hotWater after being active', () {
+      final d = nextHotWaterStop(
+        armed(activeSeen: true),
+        input(machineState: MachineState.idle),
+      );
+      expect(d.action, HotWaterStopAction.clear);
+    });
+
+    test('waits while the tare has not settled, even above target', () {
+      final d = nextHotWaterStop(
+        armed(activeSeen: true),
+        input(weight: 50, tareSettled: false),
+      );
+      expect(d.action, HotWaterStopAction.wait);
+    });
+
+    test('waits while the scale is not fresh', () {
+      final d = nextHotWaterStop(
+        armed(activeSeen: true),
+        input(weight: 50, freshScale: false),
+      );
+      expect(d.action, HotWaterStopAction.wait);
+    });
+
+    test('waits while projected weight is below target', () {
+      final d = nextHotWaterStop(
+        armed(activeSeen: true, target: 30),
+        input(weight: 20, weightFlow: 2),
+      );
+      expect(d.action, HotWaterStopAction.wait);
+    });
+
+    test('stops when actual weight reaches target', () {
+      final d = nextHotWaterStop(
+        armed(activeSeen: true, target: 30),
+        input(weight: 30, weightFlow: 0),
+      );
+      expect(d.action, HotWaterStopAction.stop);
+      expect(d.state!.stopRequested, isTrue);
+      expect(d.weight, 30);
+    });
+
+    test('stops early via flow lookahead before actual weight reaches target', () {
+      // 29 + 4 g/s * 0.3 s = 30.2 >= 30
+      final d = nextHotWaterStop(
+        armed(activeSeen: true, target: 30, lookahead: 0.3),
+        input(weight: 29, weightFlow: 4),
+      );
+      expect(d.action, HotWaterStopAction.stop);
+      expect(d.projectedWeight, closeTo(30.2, 1e-9));
+    });
+
+    test('falls back to configured flow when scale flow is not positive', () {
+      // 29.9 + 2.0 (configured) * 0.3 = 30.5 >= 30
+      final d = nextHotWaterStop(
+        armed(activeSeen: true, target: 30, configuredFlow: 2.0, lookahead: 0.3),
+        input(weight: 29.9, weightFlow: 0),
+      );
+      expect(d.action, HotWaterStopAction.stop);
+    });
+
+    test('does not stop twice once a stop is already requested', () {
+      final d = nextHotWaterStop(
+        armed(activeSeen: true, target: 30, stopRequested: true),
+        input(weight: 50, weightFlow: 5),
+      );
+      expect(d.action, HotWaterStopAction.wait);
+    });
+
+    test('treats null weight as zero', () {
+      final d = nextHotWaterStop(
+        armed(activeSeen: true, target: 30, configuredFlow: 0),
+        input(weight: null, weightFlow: null),
+      );
+      expect(d.action, HotWaterStopAction.wait);
+    });
+  });
+}

--- a/test/webserver/settings_handler_test.dart
+++ b/test/webserver/settings_handler_test.dart
@@ -76,6 +76,34 @@ void main() {
     });
   });
 
+  group('stopHotWaterAtWeight', () {
+    test('defaults to true', () {
+      expect(controller.stopHotWaterAtWeight, isTrue);
+    });
+
+    test('can be toggled off and persists', () async {
+      await controller.setStopHotWaterAtWeight(false);
+      expect(controller.stopHotWaterAtWeight, isFalse);
+      expect(await mockService.stopHotWaterAtWeight(), isFalse);
+    });
+  });
+
+  group('hotWaterFlowMultiplier', () {
+    test('defaults to 0.3, separate from weightFlowMultiplier (1.0)', () {
+      expect(controller.hotWaterFlowMultiplier, 0.3);
+      expect(controller.weightFlowMultiplier, 1.0);
+    });
+
+    test('can be set independently of the shot multiplier and persists',
+        () async {
+      await controller.setHotWaterFlowMultiplier(0.5);
+      expect(controller.hotWaterFlowMultiplier, 0.5);
+      expect(controller.weightFlowMultiplier, 1.0,
+          reason: 'shot multiplier is untouched');
+      expect(await mockService.hotWaterFlowMultiplier(), 0.5);
+    });
+  });
+
   group('themeMode', () {
     test('defaults to system', () {
       expect(controller.themeMode, ThemeMode.system);


### PR DESCRIPTION
## Summary

- **Problem:** Hot water pours don't track weight — on many scales (e.g. the Skale 2 called out in #342) the scale isn't even tared during a hot water pour, so its reading is meaningless and you can't pour to a target weight.
- **Why it matters:** Pouring hot water to a known weight (tea, Americano, pre-filling) is a common need, and espresso already stops at weight — hot water should too.
- **What changed:** A new `HotWaterSequencer` tares the scale when the machine enters `hotWater` and stops the pour at the configured hot-water `volume` target (treated as grams), using the same scale-weight projection as the espresso stop-at-weight. Two new settings: `stopHotWaterAtWeight` (default `true`) and `hotWaterFlowMultiplier` (default `0.3` s lookahead).
- **What did NOT change (scope boundary):** The DE1's own volume/time stop is left untouched as a safe backstop (no machine-settings mutation). No native settings-UI toggle was added — the settings are REST-only, matching the existing `weightFlowMultiplier` / `blockOnNoScale`. In `full` gateway mode the sequencer stays inert so a skin in control isn't double-stopped.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [x] REST API / handlers
- [ ] WebSocket API
- [x] Machine state / shot logic
- [x] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #342
- Related #287

## Root Cause (if bug fix)

N/A — feature.

## Regression Test Plan (if bug fix or refactor)

N/A — feature. Test coverage is listed under Verification.

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` (added `stopHotWaterAtWeight`, `hotWaterFlowMultiplier` to `ReaSettings` + `ReaSettingsRequest`)
- [x] API docs updated: `doc/Api.md` (settings field list + descriptions)
- [ ] Plugin docs updated: `doc/Plugins.md`
- [ ] Skin docs updated: `doc/Skins.md`
- [ ] Profile docs updated: `doc/Profiles.md`
- [x] Device docs updated: `doc/DeviceManagement.md` (new "Hot water stop-at-weight" section)

## Security Impact (required)

- New or changed REST endpoints? **Yes** — `/api/v1/settings` GET/POST gained two fields (`stopHotWaterAtWeight` bool, `hotWaterFlowMultiplier` number). No new routes.
- New or changed WebSocket topics? **No**
- New or changed network calls? **No**
- BLE/USB surface changed? **No** — uses the existing `ScaleController.tare()` and `machine.requestState(idle)`.
- File system access changed? **No**
- Plugin sandbox boundary changed? **No**
- Risk/mitigation: the two new settings are validated server-side (type checks → 400 on bad type), same pattern as the existing settings. Additive, no new attack surface.

## User-Visible Changes

- With a scale connected, hot water now **tares the scale and stops at the configured hot-water volume target (treated as grams)**. On by default (`stopHotWaterAtWeight = true`).
- New settings via `/api/v1/settings`: `stopHotWaterAtWeight` (bool, default `true`) and `hotWaterFlowMultiplier` (number, seconds of lookahead, default `0.3`).
- The DE1's native volume/time stop remains a backstop; the feature is ignored in `full` gateway mode.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (`flutter analyze lib test` → No issues found)
- [x] `flutter test` — all pass (1747)
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds

### Manual verification (if applicable)

- OS / platform tested: macOS (`simulate=1`)
- Simulated devices? (`simulate=1`): **Yes** (MockDe1 + MockScale, in-process via the integration test)
- Real hardware? (DE1/Bengle/scale): **No**
- What you personally verified and how: pure decision table (unit), sequencer wiring — arm/tare/stop/disarm, tare-confirmation, consecutive dispenses (unit), and the full native stack (real `De1Controller` + `ScaleController` + `SettingsController` + `HotWaterSequencer` + MockDe1/MockScale) driving hot water → tare → stop → idle (integration). Settings round-trip + export/import.
- Edge cases checked: stale pre-tare reading (mug on platter), tare never lands, scale/machine disconnect mid-pour, target volume 0, `full` gateway mode, no scale connected.
- What you did **not** verify: real DE1 + scale hardware. The `0.3 s` lookahead default is **not** hardware-tuned (it carries over the value the gateway already used for this) — see Risks.

### Evidence

- [x] Test output (failing before + passing after) — `flutter test` for the feature files (62+ feature tests green; full suite 1747 green).
- The headless macOS desktop build does not stay resident in this CI-like session, so the GUI sb-dev e2e is replaced by the in-process integration test; the `curl`/`websocat` recipe ships in `.agents/skills/decent-app/scenarios/hot-water-stop-at-weight.md` for an on-device run.

## Compatibility & Migration

- Backward compatible? **Yes at the API level** (additive settings fields). Default *behavior* for hot water changes when a scale is connected (it now tares + stops at weight) — that is the requested feature, and it can be turned off with `stopHotWaterAtWeight = false`. The stop point (configured volume in grams) is very close to the prior DE1 volumetric stop (volume in ml).
- Config / env changes needed? **No**
- Database migration needed? **No**

## Risks & Mitigations

- **Risk:** the `0.3 s` `hotWaterFlowMultiplier` default isn't hardware-validated, so it could slightly over/under-pour.
  - **Mitigation:** now an independently tunable setting; the DE1 native stop is a backstop; the small lookahead errs toward a slight *over*-pour (the more forgiving direction when filling a cup).
- **Risk:** a stale pre-tare reading (e.g. a mug still on the platter) could trigger a false early stop.
  - **Mitigation:** the tare is trusted only once the scale is *observed* to settle near zero; if it never lands the monitor never arms and the DE1's native stop takes over (fail-safe).
- **Risk:** default-on changes hot-water behavior for existing scale users.
  - **Mitigation:** matches the #342 request; opt-out via the setting; volume(ml) ≈ weight(g) so the stop point barely moves.
