### PR TITLE
fix(profiles): keep user-hidden default profiles hidden across restarts

### DIFF
--- a/doc/Profiles.md
+++ b/doc/Profiles.md
@@ -80,7 +80,7 @@ The implementation follows REA's standard layered architecture with clear separa
 
 **ProfileController** (`lib/src/controllers/profile_controller.dart`)
 - Business logic and validation layer
-- Auto-loads default profiles from `assets/defaultProfiles/` on every startup (idempotent: seeds new ones, skips existing by content hash)
+- Auto-loads default profiles from `assets/defaultProfiles/` on every startup (idempotent: seeds new ones, skips existing by content hash). Seeding **preserves the stored visibility** of an existing default, so a default the user hid stays hidden across restarts (re-show it with `POST /api/v1/profiles/restore/{filename}`)
 - **Curation upkeep** (so edits to bundled defaults reach existing installs): refreshes a default's presentation fields (title/author/notes) when the bundled `metadataHash` changes but content is unchanged; and `_retireStaleDefaults` hides any default whose `metadata.filename` left the manifest, or whose stored id no longer matches the current bundled version (content changed). Retired defaults are hidden, never deleted
 - Enforces default profile protection (cannot be deleted, only hidden; cannot modify execution fields)
 - Validates parent profile existence before creating children

--- a/lib/src/controllers/profile_controller.dart
+++ b/lib/src/controllers/profile_controller.dart
@@ -69,21 +69,23 @@ class ProfileController {
           // Check if this profile already exists (by hash)
           final existing = await _storage.get(record.id);
           if (existing != null) {
-            // Same execution content. Refresh presentation fields
-            // (title/author/notes) when the bundled metadata changed, and
-            // (re)assert default+visible — a user may have imported this
-            // profile before it became a bundled default. Refreshing metadata
-            // is what lets curation edits (issue #242) reach existing installs,
-            // since metadata-only changes leave the content hash (id) unchanged.
+            // Same execution content. Re-assert `isDefault` (a user may have
+            // imported this profile before it became a bundled default) and
+            // refresh presentation fields (title/author/notes) when the bundled
+            // metadata changed — that's what lets curation edits (issue #242)
+            // reach existing installs, since metadata-only changes leave the
+            // content hash (id) unchanged.
+            //
+            // Visibility is deliberately PRESERVED (omitted from copyWith): a
+            // default the user hid must stay hidden across restarts. Previously
+            // this forced Visibility.visible, silently un-hiding it on every
+            // launch. Use POST /profiles/restore/{filename} to un-hide.
             final needsMetadataRefresh =
                 existing.metadataHash != record.metadataHash;
-            if (!existing.isDefault ||
-                existing.visibility != Visibility.visible ||
-                needsMetadataRefresh) {
+            if (!existing.isDefault || needsMetadataRefresh) {
               await _storage.update(existing.copyWith(
                 profile: profile,
                 isDefault: true,
-                visibility: Visibility.visible,
                 metadata: {'source': 'bundled', 'filename': filename},
               ));
               if (needsMetadataRefresh) {

--- a/test/profiles/default_profiles_migration_test.dart
+++ b/test/profiles/default_profiles_migration_test.dart
@@ -131,4 +131,43 @@ void main() {
     expect(storage.records[userProfile.id]!.visibility, Visibility.visible);
     expect(storage.records[userProfile.id]!.isDefault, isFalse);
   });
+
+  test('M3: a default the user hid stays hidden across a reseed', () async {
+    final storage = InMemoryProfileStorage();
+    final current = Profile.fromJson(await _bundledJson(_milkyFile));
+    final hidden = ProfileRecord.create(
+      profile: current,
+      isDefault: true,
+      metadata: {'source': 'bundled', 'filename': _milkyFile},
+    ).copyWith(visibility: Visibility.hidden);
+    await storage.store(hidden);
+
+    await ProfileController(storage: storage).initialize();
+
+    expect(storage.records[hidden.id]!.visibility, Visibility.hidden,
+        reason: 'a user-hidden default must not be un-hidden by the reseed');
+    expect(storage.records[hidden.id]!.isDefault, isTrue);
+  });
+
+  test('M3: a hidden default still gets curated metadata refreshed but stays hidden',
+      () async {
+    final storage = InMemoryProfileStorage();
+    // Same content as current milky (same id) but a stale title, and hidden.
+    final json = await _bundledJson(_milkyFile);
+    json['title'] = 'OLD STALE TITLE';
+    final hiddenStale = ProfileRecord.create(
+      profile: Profile.fromJson(json),
+      isDefault: true,
+      metadata: {'source': 'bundled', 'filename': _milkyFile},
+    ).copyWith(visibility: Visibility.hidden);
+    await storage.store(hiddenStale);
+
+    await ProfileController(storage: storage).initialize();
+
+    final refreshed = storage.records[hiddenStale.id]!;
+    expect(refreshed.profile.title, 'Flow profile for milky drinks',
+        reason: 'curation metadata refresh still applies to hidden defaults');
+    expect(refreshed.visibility, Visibility.hidden,
+        reason: 'refreshing metadata must not un-hide the profile');
+  });
 }


### PR DESCRIPTION
## Summary

- **Problem:** On startup, the default-profile seeding pass re-asserted `visibility: visible` for every existing bundled default on *every* launch, silently un-hiding any default the user had hidden.
- **Why it matters:** Hiding a bundled default was effectively temporary — it reappeared after the next restart, so users couldn't durably declutter the bundled profile list. (This blocks a durable "Hide" control in the Beanie skin.)
- **What changed:** `_loadDefaultProfilesIfNeeded` now preserves the stored visibility (omits it from `copyWith`) and no longer rewrites a record merely because it isn't visible. It still re-asserts `isDefault: true` and refreshes curated metadata (title/author/notes) when the bundled metadata changed.
- **What did NOT change (scope boundary):** No API / endpoint / spec changes. `_retireStaleDefaults`, default-profile protection, content-hash dedup, and the restore endpoint are untouched. Un-hiding remains `POST /api/v1/profiles/restore/{filename}`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [x] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes # — N/A (no issue filed)
- Related #242 (curation-upkeep metadata refresh — preserved by this change)

## Root Cause (if bug fix)

- **Root cause:** The seeding update branch hard-coded `visibility: Visibility.visible` and treated "not visible" as a reason to rewrite the record, so every launch reset a user-hidden default back to visible.
- **Missing detection or guardrail:** No migration test exercised an *existing hidden* default through `initialize()` — coverage only checked retirement and metadata refresh on visible records.
- **Contributing context:** The force-visible was meant to (re)assert default+visible for a user-imported profile that later becomes a bundled default; it also clobbered deliberate hides.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
- **Target test / file:** `test/profiles/default_profiles_migration_test.dart`
- **Scenario locked in:** (1) a user-hidden default stays hidden across a reseed; (2) a hidden default whose bundled metadata changed still gets refreshed but stays hidden. Both fail on the pre-fix code.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` — N/A (no REST/WS change)
- [ ] API docs updated: `doc/Api.md` — N/A (no endpoint change)
- [ ] Plugin docs updated: `doc/Plugins.md` — N/A
- [ ] Skin docs updated: `doc/Skins.md` — N/A
- [x] Profile docs updated: `doc/Profiles.md` — clarified that seeding preserves stored visibility (user-hidden defaults persist across restarts)
- [ ] Device docs updated: `doc/DeviceManagement.md` — N/A

## Security Impact (required)

- New or changed REST endpoints? **No**
- New or changed WebSocket topics? **No**
- New or changed network calls? **No**
- BLE/USB surface changed? **No**
- File system access changed? **No**
- Plugin sandbox boundary changed? **No**

## User-Visible Changes

- A bundled default profile the user hides now **stays hidden after a restart** (previously it reappeared on the next launch). No changes to the API, default-profile content, or any other behavior.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean on the changed files (`lib/src/controllers/profile_controller.dart`, `test/profiles/`): *No issues found!*
- [x] `flutter test` — profile/migration/handler suites pass (44 tests, including the 2 new M3 cases). Full-suite run left to CI.
- [ ] `(cd packages/dye2-plugin && npm run build)` — N/A (plugin untouched)

### Manual verification (if applicable)

- Pure seeding-logic change, fully covered by unit tests — no hardware or manual path. `simulate=1` not required.

### Evidence

- [x] Test output (the two `M3` cases fail on the pre-fix code, pass after):

```
+0: M2: a default whose file was removed from the manifest is hidden
+1: M2: a stale prior version of a changed default is hidden, current stays visible
+2: M1: an existing default with stale metadata gets its title refreshed
+3: user profiles (not default) are never touched by retirement
+4: M3: a default the user hid stays hidden across a reseed
+5: M3: a hidden default still gets curated metadata refreshed but stays hidden
+6: All tests passed!
```

## Compatibility & Migration

- Backward compatible? **Yes**
- Config / env changes needed? **No**
- Database migration needed? **No**

## Risks & Mitigations

- **Risk:** A profile the user imported and then hid/soft-deleted, which *later* becomes a bundled default, now keeps its stored visibility (stays hidden) instead of being force-shown.
  - **Mitigation:** Recoverable via `POST /api/v1/profiles/restore/{filename}` or `PUT /api/v1/profiles/{id}/visibility`. This is the more intent-respecting behavior.
