### PR TITLE
fix: return 400 when workflow PUT fails to parse instead of hanging

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -878,6 +878,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WorkflowRequest"
+        "400":
+          description: >
+            Invalid request body — the merged JSON failed to parse (e.g. an
+            invalid enum value, a missing required profile field, or an
+            unparseable number). The response body contains an `error` and
+            `message` field describing the validation failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error during DE1 side-effect writes
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   # REA Shot history API
   /api/v1/shots:

--- a/lib/src/services/webserver/workflow_handler.dart
+++ b/lib/src/services/webserver/workflow_handler.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/home_feature/forms/hot_water_form.dart';
@@ -13,6 +14,8 @@ import 'package:shelf_plus/shelf_plus.dart';
 class WorkflowHandler {
   final WorkflowController _controller;
   final De1Controller _de1controller;
+
+  static final _log = Logger('WorkflowHandler');
 
   Timer? _debounceTimer;
   Map<String, dynamic> _pendingMerge = {};
@@ -57,42 +60,72 @@ class WorkflowHandler {
     _pendingMerge = {};
     _pendingResponses.clear();
 
-    final oldWorkflow = _controller.currentWorkflow;
-    final currentJson = oldWorkflow.toJson();
-    final resultJson = deepMergeJson(currentJson, merge);
-    final updatedWorkflow = Workflow.fromJson(resultJson);
+    try {
+      final oldWorkflow = _controller.currentWorkflow;
+      final currentJson = oldWorkflow.toJson();
+      final resultJson = deepMergeJson(currentJson, merge);
+      final updatedWorkflow = Workflow.fromJson(resultJson);
 
-    _controller.setWorkflow(updatedWorkflow);
-    // Profile push is owned by WorkflowDeviceSync — it observes
-    // `setWorkflow` and uploads the profile if it changed. Keeping a
-    // second setProfile call here would race against that listener and
-    // write every BLE frame twice (see the profile-double-upload P0).
-    if (oldWorkflow.rinseData != updatedWorkflow.rinseData) {
-      await _de1controller.updateFlushSettings(updatedWorkflow.rinseData);
-    }
-    if (oldWorkflow.steamSettings != updatedWorkflow.steamSettings) {
-      await _de1controller.updateSteamSettings(
-        SteamFormSettings(
-          steamEnabled: updatedWorkflow.steamSettings.duration > 0,
-          targetTemp: updatedWorkflow.steamSettings.targetTemperature,
-          targetDuration: updatedWorkflow.steamSettings.duration,
-          targetFlow: updatedWorkflow.steamSettings.flow,
-        ),
-      );
-    }
-    if (oldWorkflow.hotWaterData != updatedWorkflow.hotWaterData) {
-      await _de1controller.updateHotWaterSettings(
-        HotWaterFormSettings(
-          targetTemperature: updatedWorkflow.hotWaterData.targetTemperature,
-          flow: updatedWorkflow.hotWaterData.flow,
-          volume: updatedWorkflow.hotWaterData.volume,
-          duration: updatedWorkflow.hotWaterData.duration,
-        ),
-      );
-    }
+      _controller.setWorkflow(updatedWorkflow);
+      // Profile push is owned by WorkflowDeviceSync — it observes
+      // `setWorkflow` and uploads the profile if it changed. Keeping a
+      // second setProfile call here would race against that listener and
+      // write every BLE frame twice (see the profile-double-upload P0).
+      if (oldWorkflow.rinseData != updatedWorkflow.rinseData) {
+        await _de1controller.updateFlushSettings(updatedWorkflow.rinseData);
+      }
+      if (oldWorkflow.steamSettings != updatedWorkflow.steamSettings) {
+        await _de1controller.updateSteamSettings(
+          SteamFormSettings(
+            steamEnabled: updatedWorkflow.steamSettings.duration > 0,
+            targetTemp: updatedWorkflow.steamSettings.targetTemperature,
+            targetDuration: updatedWorkflow.steamSettings.duration,
+            targetFlow: updatedWorkflow.steamSettings.flow,
+          ),
+        );
+      }
+      if (oldWorkflow.hotWaterData != updatedWorkflow.hotWaterData) {
+        await _de1controller.updateHotWaterSettings(
+          HotWaterFormSettings(
+            targetTemperature: updatedWorkflow.hotWaterData.targetTemperature,
+            flow: updatedWorkflow.hotWaterData.flow,
+            volume: updatedWorkflow.hotWaterData.volume,
+            duration: updatedWorkflow.hotWaterData.duration,
+          ),
+        );
+      }
 
-    for (final completer in responses) {
-      completer.complete(jsonOk(updatedWorkflow.toJson()));
+      for (final completer in responses) {
+        completer.complete(jsonOk(updatedWorkflow.toJson()));
+      }
+    } on ArgumentError catch (e) {
+      // Client sent a payload that fails validation (e.g. an invalid
+      // enum value like ExitType 'weight', or a missing required
+      // profile field). Return a clean 400 — matching the pattern in
+      // profile_handler.dart — so the HTTP request does not hang.
+      // _pendingMerge was already cleared above, so subsequent PUTs
+      // start from a clean slate.
+      for (final completer in responses) {
+        completer.complete(
+          jsonBadRequest({'error': 'Invalid request', 'message': '$e'}),
+        );
+      }
+    } on FormatException catch (e) {
+      for (final completer in responses) {
+        completer.complete(
+          jsonBadRequest({'error': 'Invalid request', 'message': '$e'}),
+        );
+      }
+    } catch (e, st) {
+      // Unexpected error — likely a server-side failure during DE1
+      // side-effects (BLE writes, controller updates). Log it and
+      // return 500 so the request still doesn't hang.
+      _log.severe('Error in _applyPendingUpdate', e, st);
+      for (final completer in responses) {
+        completer.complete(
+          jsonError({'error': 'Internal server error', 'message': '$e'}),
+        );
+      }
     }
   }
 }

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -368,6 +368,122 @@ void main() {
     );
   });
 
+  group('PUT /api/v1/workflow — parse errors (issue #338)', () {
+    test(
+      'invalid ExitType returns 400 instead of hanging forever',
+      () async {
+        await _settleHandler();
+
+        // Send a profile step with an invalid ExitType ('weight'
+        // is not a valid member of ExitType {pressure, flow}).
+        final future = put({
+          'profile': {
+            'steps': [
+              {
+                'name': 'p',
+                'pump': 'flow',
+                'transition': 'fast',
+                'flow': 2,
+                'temperature': 93,
+                'sensor': 'coffee',
+                'seconds': 10,
+                'volume': 0,
+                'exit': {
+                  'type': 'weight',
+                  'condition': 'over',
+                  'value': 36,
+                },
+              },
+            ],
+          },
+        });
+
+        // Wait for the debounce timer to fire and _applyPendingUpdate
+        // to run (or, pre-fix, to throw silently and hang).
+        await _settleHandler();
+
+        // With the fix, the completer is completed with a 400 response
+        // instead of never completing.
+        final response = await future;
+        expect(response.statusCode, equals(400));
+        final body = jsonDecode(await response.readAsString());
+        expect(body, isA<Map<String, dynamic>>());
+        expect(body['error'], equals('Invalid request'));
+        expect(body['message'], isNotNull);
+      },
+    );
+
+    test(
+      'after a failed parse, a subsequent valid PUT succeeds normally',
+      () async {
+        await _settleHandler();
+
+        // First: an invalid PUT that will fail to parse.
+        final badFuture = put({
+          'profile': {
+            'steps': [
+              {
+                'name': 'p',
+                'pump': 'flow',
+                'transition': 'fast',
+                'flow': 2,
+                'temperature': 93,
+                'sensor': 'coffee',
+                'seconds': 10,
+                'volume': 0,
+                'exit': {
+                  'type': 'weight',
+                  'condition': 'over',
+                  'value': 36,
+                },
+              },
+            ],
+          },
+        });
+        await _settleHandler();
+        final badResponse = await badFuture;
+        expect(badResponse.statusCode, equals(400));
+
+        // Second: a valid PUT that must work because _pendingMerge
+        // was cleared after the failure.
+        final goodFuture = put({
+          'steamSettings': {'duration': 25},
+        });
+        await _settleHandler();
+        final goodResponse = await goodFuture;
+        expect(goodResponse.statusCode, equals(200));
+        final goodBody = jsonDecode(await goodResponse.readAsString());
+        expect(
+          goodBody['steamSettings']['duration'],
+          equals(25),
+        );
+      },
+    );
+
+    test(
+      'empty profile title (Profile.fromJson ArgumentError) returns 400',
+      () async {
+        // Tests the interaction between the new Profile.fromJson
+        // validation (throws ArgumentError on empty title) and our
+        // catch block in _applyPendingUpdate. Without the catch,
+        // this ArgumentError would escape the fire-and-forget Timer
+        // callback and hang the request.
+        await _settleHandler();
+
+        final future = put({
+          'profile': {'title': ''},
+        });
+        await _settleHandler();
+
+        final response = await future;
+        expect(response.statusCode, equals(400));
+        final body = jsonDecode(await response.readAsString());
+        expect(body['error'], equals('Invalid request'));
+        expect(body['message'], isNotNull);
+      },
+    );
+  });
+
   group('PUT /api/v1/workflow — read-modify-write race', () {
     test(
       'multi-field PUT: final shot-settings write reflects BOTH changes',


### PR DESCRIPTION
## Summary

> **Naming:** The display name is **Decent.app**. The repo, package, and bundle ID use legacy `reaprime` / `streamline-bridge` — see the naming table in [`CLAUDE.md`](CLAUDE.md).

- **Problem:** `PUT /api/v1/workflow` hangs forever (until connection timeout) when the merged JSON fails to parse — e.g. an invalid enum value like `ExitType 'weight'`, or a missing required profile field. Subsequent PUTs also stall because `_pendingMerge` retains the bad payload.
- **Why it matters:** Any skin or client that sends a slightly-invalid profile through the workflow endpoint permanently wedges the API — the request never returns and all future updates are blocked.
- **What changed:** Wrapped `_applyPendingUpdate()` in try/catch. `ArgumentError` / `FormatException` (client errors) complete all queued completers with a `400 Bad Request` via `jsonBadRequest`, matching the pattern in `profile_handler.dart`. Unexpected errors (server-side DE1 failures) return `500` via `jsonError` with logging. `_pendingMerge` / `_pendingResponses` are cleared before the `try` block, so subsequent PUTs start clean.
- **What did NOT change (scope boundary):** No changes to `Profile.fromJson`, `profile_handler.dart`, or the `/api/v1/profiles` endpoints. No changes to the debounce logic, deep-merge semantics, or DE1 side-effect call sequence. The `ExitType` enum was not broadened (the DE1 hardware only supports `pressure` / `flow`).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [x] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [x] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #338
- Related: the `Profile.fromJson` validation commits (4f23b49c, f5184961, 3cb363f9) that landed on main — their `ArgumentError` throws would also hang the workflow endpoint without this fix.

## Root Cause (if bug fix)

- **Root cause:** `_applyPendingUpdate()` is a fire-and-forget `Timer` callback — its `Future` is never awaited and there was no `try/catch`. When `Workflow.fromJson` throws (which calls `Profile.fromJson` internally), the exception escapes silently into the zone. The `Completer<Response>` is never completed, so the HTTP request hangs until the connection times out.
- **Missing detection or guardrail:** No error handling around the fire-and-forget debounce callback. The method assumed `Workflow.fromJson` would always succeed on merged JSON.
- **Contributing context:** The recent `Profile.fromJson` validation commits (4f23b49c, f5184961, 3cb363f9) added `ArgumentError` throws for missing/invalid fields. Without this fix, any of those errors routed through `PUT /api/v1/workflow` would also hang — making this fix complementary, not redundant, with that work.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/webserver/workflow_handler_test.dart` — group `PUT /api/v1/workflow — parse errors (issue #338)`
- Scenario the test should lock in:
  1. `invalid ExitType returns 400 instead of hanging forever` — sends the exact reproduction payload from the issue (`exit.type: 'weight'`)
  2. `after a failed parse, a subsequent valid PUT succeeds normally` — verifies `_pendingMerge` was cleared, no stall
  3. `empty profile title (Profile.fromJson ArgumentError) returns 400` — tests the interaction with the new `Profile.fromJson` validation; without the catch, this `ArgumentError` would also hang

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` — added `400` and `500` responses to `PUT /api/v1/workflow`
- [ ] API docs updated: `doc/Api.md` — no change needed (endpoint table doesn't list response codes)
- [ ] Plugin docs updated: N/A
- [ ] Skin docs updated: N/A
- [ ] Profile docs updated: N/A
- [ ] Device docs updated: N/A
- [ ] N/A — no other docs affected

## Security Impact (required)

- New or changed REST endpoints? **No** (existing endpoint, new error response)
- New or changed WebSocket topics? **No**
- New or changed network calls? **No**
- BLE/USB surface changed? **No**
- File system access changed? **No**
- Plugin sandbox boundary changed? **No**
- If any `Yes`, explain risk and mitigation: N/A — the 400/500 responses return only the error message, not stack traces.

## User-Visible Changes

- `PUT /api/v1/workflow` now returns `400 Bad Request` (with `{"error":"Invalid request","message":"..."}`) instead of hanging when the payload contains invalid data (bad enum values, missing required fields, unparseable numbers).
- `PUT /api/v1/workflow` now returns `500` (with `{"error":"Internal server error","message":"..."}`) instead of hanging if a server-side error occurs during DE1 side-effect writes.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass (7/7 workflow handler tests, 111/111 webserver tests, 41/41 profile tests)
- [ ] `(cd packages/dye2-plugin && npm run build)` — N/A (no plugin changes)

### Manual verification (if applicable)

- OS / platform tested: macOS
- Simulated devices? (`simulate=1`): `No` (unit tests with mock DE1)
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: Unit tests covering the exact reproduction payload from the issue, plus a test for the `Profile.fromJson` validation interaction.
- Edge cases checked: (1) invalid enum value, (2) recovery after failed parse, (3) `ArgumentError` from new `Profile.fromJson` validation.
- What you did **not** verify: Real HTTP server with `curl` (covered by handler-level tests that exercise the full shelf pipeline).

### Evidence

Test output (all passing):
```
00:02 +2: PUT /api/v1/workflow — parse errors (issue #338) invalid ExitType returns 400 instead of hanging forever
00:03 +3: PUT /api/v1/workflow — parse errors (issue #338) after a failed parse, a subsequent valid PUT succeeds normally
00:05 +4: PUT /api/v1/workflow — parse errors (issue #338) empty profile title (Profile.fromJson ArgumentError) returns 400
00:06 +5: PUT /api/v1/workflow — read-modify-write race multi-field PUT: final shot-settings write reflects BOTH changes
00:07 +6: PUT /api/v1/workflow — read-modify-write race WebSocket-observable stream: final emit reflects BOTH changes
00:09 +7: All tests passed!
```

- [x] Test output (passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? **Yes** — previously these requests hung; now they return an error. No successful request behavior changed.
- Config / env changes needed? **No**
- Database migration needed? **No**

## Risks & Mitigations

- **Risk:** The catch-all `catch (e, st)` returns `500` for unexpected errors during DE1 side-effect writes. If a transient BLE failure occurs, the workflow state may have already been partially updated (`setWorkflow` succeeded but `updateFlushSettings` failed).
  - **Mitigation:** The workflow controller state is already updated, so the next successful PUT will re-apply all settings. The `500` response correctly signals the partial failure to the client. The error is logged via `Logger('WorkflowHandler')`.
- **Risk:** The error response format (`{"error":"Invalid request","message":"..."}`) differs from the issue's suggested format (`{"error":"<exception>"}`).
  - **Mitigation:** The format matches the established pattern in `profile_handler.dart` for consistency across the API. Stack traces are not leaked in the response body.