### PR TITLE
fix(webui): offline skin server startup fails when WiFi IP unavailable

### DIFF
--- a/lib/src/webui_support/webui_service.dart
+++ b/lib/src/webui_support/webui_service.dart
@@ -61,6 +61,26 @@ class WebUIService {
   String _path = "";
   String? _localIP;
 
+  /// Test seam: override in tests to simulate offline/no-WiFi without
+  /// touching the real platform channel. Returns null when no WiFi IP is
+  /// available (null-collapsed by [_resolveLocalIP]).
+  @visibleForTesting
+  static Future<String?> Function() resolveWifiIP =
+      NetworkInfo().getWifiIP;
+
+  /// Resolves the device's WiFi IP for the browser-hero card and QR code.
+  /// Must not block the critical path — falls back to "localhost" when the
+  /// platform call throws or the device is offline (gh#337).
+  Future<String> _resolveLocalIP() async {
+    try {
+      final ip = await resolveWifiIP();
+      if (ip != null && ip.isNotEmpty) return ip;
+    } catch (e) {
+      _log.warning('Failed to resolve WiFi IP, falling back to localhost', e);
+    }
+    return 'localhost';
+  }
+
   /// Overrides the skin source for the initialization step. Set from CLI flags
   /// (--skin-path) before the onboarding flow starts. Defaults to [SkinSource.registry].
   SkinOverride skinOverride = const SkinOverride.registry();
@@ -74,7 +94,7 @@ class WebUIService {
 
   Future<void> serveFolderAtPath(String path, {int port = 3000}) async {
     await _server?.close(force: true);
-    _localIP ??= await NetworkInfo().getWifiIP();
+    _localIP ??= await _resolveLocalIP();
 
     // 1. Get system temp directory
     // final documents = await getApplicationDocumentsDirectory();

--- a/test/webui_support/webui_token_injection_test.dart
+++ b/test/webui_support/webui_token_injection_test.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:network_info_plus/network_info_plus.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
 
 void main() {
@@ -33,5 +36,56 @@ void main() {
   test('json-encodes the token (escapes quotes)', () {
     final out = injectProxyTokenScript('<head></head>', 'a"b');
     expect(out, contains(r'window.__REA_PROXY_TOKEN__="a\"b";'));
+  });
+
+  group('serveFolderAtPath offline', () {
+    late Directory tempDir;
+    late WebUIService service;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('webui_offline_test');
+      // Minimal content — shelf_io.serve needs something to serve.
+      await File('${tempDir.path}/index.html')
+          .writeAsString('<html><body>test</body></html>');
+      service = WebUIService();
+    });
+
+    tearDown(() async {
+      await service.stopServing();
+      if (tempDir.existsSync()) {
+        await tempDir.delete(recursive: true);
+      }
+      // Restore default behaviour so subsequent tests get real WiFi IP.
+      WebUIService.resolveWifiIP = NetworkInfo().getWifiIP;
+    });
+
+    test('falls back to localhost when getWifiIP throws (gh#337)', () async {
+      WebUIService.resolveWifiIP = () async =>
+          throw Exception('no wifi');
+
+      await service.serveFolderAtPath(tempDir.path);
+
+      expect(service.isServing, isTrue);
+      expect(service.deviceIp(), 'localhost');
+    });
+
+    test('falls back to localhost when getWifiIP returns null', () async {
+      WebUIService.resolveWifiIP = () async => null;
+
+      await service.serveFolderAtPath(tempDir.path);
+
+      expect(service.isServing, isTrue);
+      expect(service.deviceIp(), 'localhost');
+    });
+
+    test('falls back to localhost when getWifiIP returns empty string',
+        () async {
+      WebUIService.resolveWifiIP = () async => '';
+
+      await service.serveFolderAtPath(tempDir.path);
+
+      expect(service.isServing, isTrue);
+      expect(service.deviceIp(), 'localhost');
+    });
   });
 }


### PR DESCRIPTION
## Problem

When Decent.app launches on a tablet without internet/WiFi, `NetworkInfo().getWifiIP()` inside `serveFolderAtPath()` can throw or return null — and because it ran on the critical path inside the skin-server startup, the skin server never bound port 3000. The internal WebView uses `http://localhost:3000` regardless, so the WiFi IP is only needed for the browser-hero card and QR code (cosmetic).

Fixes #337.

## Root cause

`webui_service.dart:77` — `_localIP ??= await NetworkInfo().getWifiIP()` was unguarded inside `serveFolderAtPath()`. On Android SDK ≥31, `connectivityManager.activeNetwork` can be null when offline → `getLinkProperties(null)` throws → `serveFolderAtPath` fails → skin never starts.

## Fix

- Extract `_resolveLocalIP()` with try/catch + fallback to `"localhost"`
- Add `@visibleForTesting` seam `resolveWifiIP` for offline simulation
- 3 new tests: throw → localhost, null → localhost, empty → localhost

## Verification

- `flutter analyze` — clean
- `flutter test` — 1829/1829 pass
- 3 new unit tests cover throw/null/empty fallback paths