### PR TITLE
feat(skins): add "Go to skin" button and rework the Web Interface page

### DIFF
--- a/lib/src/skin_selector/skin_selector_page.dart
+++ b/lib/src/skin_selector/skin_selector_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/skin_feature/skin_view.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
 import 'package:reaprime/src/webui_support/webui_storage.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -68,261 +69,338 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
 
   @override
   Widget build(BuildContext context) {
+    // The storage-permission affordance only exists for Android sideload builds.
+    final showStorageRow = Platform.isAndroid && !BuildInfo.appStore;
+
     return Scaffold(
       appBar: AppBar(title: const Text('Web Interface')),
       body: SafeArea(
         top: false,
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            spacing: 16,
-            children: [
-              // Skin selector card
-              ShadCard(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        const Icon(Icons.web_outlined, size: 20),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: Text(
-                            'Active Skin',
-                            style: Theme.of(context)
-                                .textTheme
-                                .titleMedium
-                                ?.copyWith(fontWeight: FontWeight.bold),
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      'Choose and manage your skins',
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: Theme.of(context)
-                                .colorScheme
-                                .onSurface
-                                .withValues(alpha: 0.7),
-                          ),
-                    ),
-                    const SizedBox(height: 16),
-                    _buildSkinSelector(),
-                    const SizedBox(height: 16),
-                    _buildStoragePermissionRow(),
-                  ],
+          child: ShadCard(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _buildHeader(),
+                const SizedBox(height: 16),
+                _buildSkinSelector(),
+                const SizedBox(height: 12),
+                // Primary, per-skin action: open the selected skin. Linux has no
+                // in-app WebView, so there it opens the external browser instead.
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: _ActionButton(
+                    label: Platform.isLinux ? 'Open in Browser' : 'Go to skin',
+                    icon: Platform.isLinux ? Icons.open_in_browser : Icons.web,
+                    onPressed: _goToSkin,
+                  ),
                 ),
-              ),
-
-              // Server controls card
-              ShadCard(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        const Icon(Icons.cloud_outlined, size: 20),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: Text(
-                            'Skin Server',
-                            style: Theme.of(context)
-                                .textTheme
-                                .titleMedium
-                                ?.copyWith(fontWeight: FontWeight.bold),
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      widget.webUIService.isServing
-                          ? 'Skin server is running'
-                          : 'Skin server is stopped',
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: Theme.of(context)
-                                .colorScheme
-                                .onSurface
-                                .withValues(alpha: 0.7),
-                          ),
-                    ),
-                    const SizedBox(height: 16),
-                    if (!widget.webUIService.isServing)
-                      _ActionButton(
-                        label: 'Start Skin Server',
-                        icon: Icons.play_arrow,
-                        onPressed: _startSelectedSkin,
-                      )
-                    else
-                      Wrap(
-                        spacing: 12,
-                        runSpacing: 12,
-                        children: [
-                          _ActionButton(
-                            label: 'Open in Browser',
-                            icon: Icons.open_in_browser,
-                            onPressed: _openWebUIInBrowser,
-                          ),
-                          _ActionButton.destructive(
-                            label: 'Stop Skin Server',
-                            icon: Icons.stop,
-                            onPressed: () async {
-                              await widget.webUIService.stopServing();
-                              setState(() {});
-                            },
-                          ),
-                        ],
-                      ),
-                    if (!BuildInfo.appStore) ...[
-                      const SizedBox(height: 12),
-                      _ActionButton.outline(
-                        label: 'Check for Skin Updates',
-                        icon: Icons.update,
-                        onPressed: () => _checkForSkinUpdates(context),
-                      ),
-                    ],
-                  ],
-                ),
-              ),
-            ],
+                if (showStorageRow) ...[
+                  const SizedBox(height: 16),
+                  _buildStoragePermissionRow(),
+                ],
+                const SizedBox(height: 16),
+                const Divider(height: 1),
+                const SizedBox(height: 12),
+                _buildServerFooter(),
+              ],
+            ),
           ),
         ),
       ),
     );
   }
 
+  /// Card header: title/subtitle on the left, plus the library-wide "Check for
+  /// updates" action on the right (it refreshes *all* installed skins, not the
+  /// selected one, so it lives at the section level rather than next to the
+  /// per-skin "Go to skin" button).
+  Widget _buildHeader() {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Icon(Icons.web_outlined, size: 20),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Active Skin',
+                style: Theme.of(
+                  context,
+                ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Choose and manage your skins',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.onSurface.withValues(alpha: 0.7),
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (!BuildInfo.appStore) ...[
+          const SizedBox(width: 8),
+          _ActionButton.outline(
+            label: 'Check for updates',
+            icon: Icons.refresh,
+            size: ShadButtonSize.sm,
+            onPressed: () => _checkForSkinUpdates(context),
+          ),
+        ],
+      ],
+    );
+  }
+
+  /// Quiet footer for the niche skin-server controls (start/stop, open in an
+  /// external browser). De-emphasised vs. the primary actions above.
+  Widget _buildServerFooter() {
+    final serving = widget.webUIService.isServing;
+    final muted = Theme.of(
+      context,
+    ).colorScheme.onSurface.withValues(alpha: 0.7);
+
+    final status = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 8,
+          height: 8,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: serving ? Colors.green : muted,
+          ),
+        ),
+        const SizedBox(width: 8),
+        Flexible(
+          child: Text(
+            serving ? 'Skin server running' : 'Skin server stopped',
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(
+              context,
+            ).textTheme.bodySmall?.copyWith(color: muted),
+          ),
+        ),
+      ],
+    );
+
+    final actions = <Widget>[];
+    if (serving) {
+      // On Linux the external browser is already the primary action above, so
+      // don't duplicate it here.
+      if (!Platform.isLinux) {
+        actions.add(
+          _ActionButton.ghost(
+            label: 'Open in browser',
+            icon: Icons.open_in_browser,
+            size: ShadButtonSize.sm,
+            foregroundColor: muted,
+            onPressed: () async {
+              await _openWebUIInBrowser();
+            },
+          ),
+        );
+      }
+      actions.add(
+        _ActionButton.ghost(
+          label: 'Stop server',
+          icon: Icons.stop,
+          size: ShadButtonSize.sm,
+          foregroundColor: ShadTheme.of(context).colorScheme.destructive,
+          onPressed: () async {
+            await widget.webUIService.stopServing();
+            if (mounted) setState(() {});
+          },
+        ),
+      );
+    } else {
+      actions.add(
+        _ActionButton.ghost(
+          label: 'Start server',
+          icon: Icons.play_arrow,
+          size: ShadButtonSize.sm,
+          foregroundColor: muted,
+          onPressed: _startSelectedSkin,
+        ),
+      );
+    }
+
+    // Status fills the left and pushes the niche controls flush to the right.
+    return Row(
+      children: [
+        Expanded(child: status),
+        const SizedBox(width: 12),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: actions,
+        ),
+      ],
+    );
+  }
+
   Widget _buildSkinSelector() {
     final installedSkins = widget.webUIStorage.installedSkins;
 
-    return DropdownButton<String>(
-      isExpanded: true,
-      value: _selectedSkinId,
-      onChanged: (value) async {
-        if (value == null) return;
+    // Left-aligned and sized to its content (the widest item) rather than
+    // stretching across the card.
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        decoration: BoxDecoration(
+          border: Border.all(color: ShadTheme.of(context).colorScheme.border),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: DropdownButtonHideUnderline(
+          child: DropdownButton<String>(
+            borderRadius: BorderRadius.circular(8),
+            value: _selectedSkinId,
+            onChanged: (value) async {
+              if (value == null) return;
 
-        setState(() => _selectedSkinId = value);
+              setState(() => _selectedSkinId = value);
 
-        if (value == _customSkinId) {
-          await _pickCustomSkinZip(context);
-        } else if (value == _liveEditSkinId) {
-          await _pickLiveEditFolder(context);
-        } else if (widget.webUIService.isServing) {
-          await _restartServerWithSkin(value);
-        }
-      },
-      items: [
-        ...installedSkins.map((skin) {
-          return DropdownMenuItem(
-            value: skin.id,
-            child: Row(
-              children: [
-                Icon(skin.isBundled ? Icons.verified : Icons.folder, size: 16),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(skin.name, overflow: TextOverflow.ellipsis),
-                ),
-                if (skin.version != null)
-                  Text(
-                    ' v${skin.version}',
-                    style: Theme.of(context).textTheme.bodySmall,
-                  ),
-                if (!skin.isBundled && !BuildInfo.appStore)
-                  SizedBox(
-                    width: 24,
-                    height: 24,
-                    child: IconButton(
-                      padding: EdgeInsets.zero,
-                      iconSize: 16,
-                      tooltip: 'Remove ${skin.name}',
-                      icon: const Icon(Icons.delete_outline),
-                      onPressed: () async {
-                        // Close the dropdown first
-                        Navigator.of(context).pop();
-
-                        final confirmed = await showDialog<bool>(
-                          context: context,
-                          builder: (dialogContext) => AlertDialog(
-                            title: const Text('Remove skin?'),
-                            content: Text(
-                              'Remove "${skin.name}"? This cannot be undone.',
-                            ),
-                            actions: [
-                              TextButton(
-                                onPressed: () =>
-                                    Navigator.of(dialogContext).pop(false),
-                                child: const Text('Cancel'),
-                              ),
-                              TextButton(
-                                onPressed: () =>
-                                    Navigator.of(dialogContext).pop(true),
-                                child: const Text('Remove'),
-                              ),
-                            ],
+              if (value == _customSkinId) {
+                await _pickCustomSkinZip(context);
+              } else if (value == _liveEditSkinId) {
+                await _pickLiveEditFolder(context);
+              } else if (widget.webUIService.isServing) {
+                await _restartServerWithSkin(value);
+              }
+            },
+            items: [
+              ...installedSkins.map((skin) {
+                return DropdownMenuItem(
+                  value: skin.id,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        skin.isBundled ? Icons.verified : Icons.folder,
+                        size: 16,
+                      ),
+                      const SizedBox(width: 8),
+                      Text(skin.name),
+                      if (skin.version != null) ...[
+                        const SizedBox(width: 6),
+                        Padding(
+                          // The smaller version text centres ~2px high next to the
+                          // name; nudge it down onto the name's baseline.
+                          padding: const EdgeInsets.only(top: 2),
+                          child: Text(
+                            'v${skin.version}',
+                            style: Theme.of(context).textTheme.bodySmall,
                           ),
-                        );
-                        if (confirmed != true) return;
+                        ),
+                      ],
+                      if (!skin.isBundled && !BuildInfo.appStore) ...[
+                        const SizedBox(width: 8),
+                        SizedBox(
+                          width: 24,
+                          height: 24,
+                          child: IconButton(
+                            padding: EdgeInsets.zero,
+                            iconSize: 16,
+                            tooltip: 'Remove ${skin.name}',
+                            icon: const Icon(Icons.delete_outline),
+                            onPressed: () async {
+                              // Close the dropdown first
+                              Navigator.of(context).pop();
 
-                        try {
-                          await widget.webUIStorage.removeSkin(skin.id);
+                              final confirmed = await showDialog<bool>(
+                                context: context,
+                                builder: (dialogContext) => AlertDialog(
+                                  title: const Text('Remove skin?'),
+                                  content: Text(
+                                    'Remove "${skin.name}"? This cannot be undone.',
+                                  ),
+                                  actions: [
+                                    TextButton(
+                                      onPressed: () => Navigator.of(
+                                        dialogContext,
+                                      ).pop(false),
+                                      child: const Text('Cancel'),
+                                    ),
+                                    TextButton(
+                                      onPressed: () =>
+                                          Navigator.of(dialogContext).pop(true),
+                                      child: const Text('Remove'),
+                                    ),
+                                  ],
+                                ),
+                              );
+                              if (confirmed != true) return;
 
-                          if (_selectedSkinId == skin.id) {
-                            _selectedSkinId =
-                                widget.webUIStorage.defaultSkin?.id;
-                            if (widget.webUIService.isServing) {
-                              await widget.webUIService.stopServing();
-                            }
-                          }
-                        } catch (e) {
-                          if (mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(
-                                content: Text('Failed to remove skin: $e'),
-                              ),
-                            );
-                          }
-                        }
+                              try {
+                                await widget.webUIStorage.removeSkin(skin.id);
 
-                        setState(() {});
-                      },
-                    ),
+                                if (_selectedSkinId == skin.id) {
+                                  _selectedSkinId =
+                                      widget.webUIStorage.defaultSkin?.id;
+                                  if (widget.webUIService.isServing) {
+                                    await widget.webUIService.stopServing();
+                                  }
+                                }
+                              } catch (e) {
+                                if (mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: Text(
+                                        'Failed to remove skin: $e',
+                                      ),
+                                    ),
+                                  );
+                                }
+                              }
+
+                              setState(() {});
+                            },
+                          ),
+                        ),
+                      ],
+                    ],
                   ),
-              ],
-            ),
-          );
-        }),
-        if (!BuildInfo.appStore)
-          const DropdownMenuItem(
-            value: _customSkinId,
-            child: Row(
-              children: [
-                Icon(Icons.archive_outlined, size: 16),
-                SizedBox(width: 8),
-                Text('Install from .zip...'),
-              ],
-            ),
+                );
+              }),
+              if (!BuildInfo.appStore)
+                const DropdownMenuItem(
+                  value: _customSkinId,
+                  child: Row(
+                    children: [
+                      Icon(Icons.archive_outlined, size: 16),
+                      SizedBox(width: 8),
+                      Text('Install from .zip...'),
+                    ],
+                  ),
+                ),
+              if (!BuildInfo.appStore &&
+                  (Platform.isMacOS ||
+                      Platform.isLinux ||
+                      Platform.isWindows ||
+                      (Platform.isAndroid &&
+                          (_storagePermissionGranted ||
+                              _selectedSkinId == _liveEditSkinId))))
+                const DropdownMenuItem(
+                  value: _liveEditSkinId,
+                  child: Row(
+                    children: [
+                      Icon(Icons.folder_open, size: 16),
+                      SizedBox(width: 8),
+                      Text('Live-edit from folder...'),
+                    ],
+                  ),
+                ),
+            ],
           ),
-        if (!BuildInfo.appStore &&
-            (Platform.isMacOS ||
-                Platform.isLinux ||
-                Platform.isWindows ||
-                (Platform.isAndroid &&
-                    (_storagePermissionGranted ||
-                        _selectedSkinId == _liveEditSkinId))))
-          const DropdownMenuItem(
-            value: _liveEditSkinId,
-            child: Row(
-              children: [
-                Icon(Icons.folder_open, size: 16),
-                SizedBox(width: 8),
-                Text('Live-edit from folder...'),
-              ],
-            ),
-          ),
-      ],
+        ),
+      ),
     );
   }
 
@@ -560,6 +638,24 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
     );
   }
 
+  /// Opens the selected skin inside the app, starting the skin server first if
+  /// it isn't already running so the button works in a single tap. Linux has no
+  /// in-app WebView (the plugin is a no-op there), so it falls back to the
+  /// external browser — same policy as the home screen's "Open" button.
+  Future<void> _goToSkin() async {
+    if (!widget.webUIService.isServing) {
+      await _startSelectedSkin();
+    }
+    if (!widget.webUIService.isServing) return;
+    if (!mounted) return;
+
+    if (Platform.isLinux) {
+      await _openWebUIInBrowser();
+    } else {
+      await Navigator.of(context).pushNamed(SkinView.routeName);
+    }
+  }
+
   Future<void> _checkForSkinUpdates(BuildContext context) async {
     try {
       if (!context.mounted) return;
@@ -591,65 +687,89 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
   }
 }
 
+enum _ActionButtonVariant { primary, outline, ghost }
+
 /// Small helper for consistent action buttons in the skin selector.
 class _ActionButton extends StatelessWidget {
   final String label;
   final IconData icon;
   final VoidCallback onPressed;
-  final bool isDestructive;
-  final bool isOutline;
+  final _ActionButtonVariant variant;
+  final ShadButtonSize? size;
+
+  /// Overrides the icon/text color — used to tint a ghost button (e.g. the
+  /// destructive "Stop server") without giving it a filled destructive style.
+  final Color? foregroundColor;
 
   const _ActionButton({
     required this.label,
     required this.icon,
     required this.onPressed,
-    this.isDestructive = false,
-    this.isOutline = false,
+    this.variant = _ActionButtonVariant.primary,
+    this.size,
+    this.foregroundColor,
   });
 
-  factory _ActionButton.destructive(
-      {required String label,
-      required IconData icon,
-      required VoidCallback onPressed}) {
+  factory _ActionButton.outline({
+    required String label,
+    required IconData icon,
+    required VoidCallback onPressed,
+    ShadButtonSize? size,
+  }) {
     return _ActionButton(
       label: label,
       icon: icon,
       onPressed: onPressed,
-      isDestructive: true,
+      variant: _ActionButtonVariant.outline,
+      size: size,
     );
   }
 
-  factory _ActionButton.outline(
-      {required String label,
-      required IconData icon,
-      required VoidCallback onPressed}) {
+  factory _ActionButton.ghost({
+    required String label,
+    required IconData icon,
+    required VoidCallback onPressed,
+    ShadButtonSize? size,
+    Color? foregroundColor,
+  }) {
     return _ActionButton(
       label: label,
       icon: icon,
       onPressed: onPressed,
-      isOutline: true,
+      variant: _ActionButtonVariant.ghost,
+      size: size,
+      foregroundColor: foregroundColor,
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    final button = isDestructive
-        ? ShadButton.destructive(
-            leading: Icon(icon, size: 16),
-            onPressed: onPressed,
-            child: Text(label),
-          )
-        : isOutline
-            ? ShadButton.outline(
-                leading: Icon(icon, size: 16),
-                onPressed: onPressed,
-                child: Text(label),
-              )
-            : ShadButton(
-                leading: Icon(icon, size: 16),
-                onPressed: onPressed,
-                child: Text(label),
-              );
+    final leading = Icon(icon, size: 16, color: foregroundColor);
+    final child = Text(
+      label,
+      style: foregroundColor != null ? TextStyle(color: foregroundColor) : null,
+    );
+
+    final ShadButton button = switch (variant) {
+      _ActionButtonVariant.outline => ShadButton.outline(
+        leading: leading,
+        onPressed: onPressed,
+        size: size,
+        child: child,
+      ),
+      _ActionButtonVariant.ghost => ShadButton.ghost(
+        leading: leading,
+        onPressed: onPressed,
+        size: size,
+        child: child,
+      ),
+      _ActionButtonVariant.primary => ShadButton(
+        leading: leading,
+        onPressed: onPressed,
+        size: size,
+        child: child,
+      ),
+    };
 
     return Semantics(
       button: true,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1194,7 +1194,7 @@ packages:
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
@@ -1752,7 +1752,7 @@ packages:
     source: hosted
     version: "3.2.5"
   url_launcher_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: url_launcher_platform_interface
       sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -151,6 +151,10 @@ dev_dependencies:
   clock: ^1.1.1
   fake_async: ^1.3.1
   flutter_lints: ^6.0.0
+  # Test-only: mock url_launcher for the skin "Go to skin" button. Already
+  # present transitively via url_launcher; declared so the test imports resolve.
+  plugin_platform_interface: ^2.1.8
+  url_launcher_platform_interface: ^2.3.2
   hive_ce_generator: ^1.10.0
   drift_dev: ^2.24.0
   build_runner: ^2.4.0

--- a/test/skin_selector_go_to_skin_test.dart
+++ b/test/skin_selector_go_to_skin_test.dart
@@ -1,0 +1,201 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/skin_feature/skin_view.dart';
+import 'package:reaprime/src/skin_selector/skin_selector_page.dart';
+import 'package:reaprime/src/webui_support/webui_service.dart';
+import 'package:reaprime/src/webui_support/webui_storage.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+import 'helpers/mock_settings_service.dart';
+
+/// Sentinel page wired to [SkinView.routeName] so tests can assert the in-app
+/// skin route was pushed without constructing the real (webview-backed) view.
+const String _skinViewSentinel = 'SKIN VIEW SENTINEL';
+
+/// Records launched URLs so the Linux fallback path can be asserted without
+/// hitting a real platform channel.
+class _RecordingUrlLauncher extends Fake
+    with MockPlatformInterfaceMixin
+    implements UrlLauncherPlatform {
+  final List<String> launched = [];
+
+  @override
+  Future<bool> canLaunch(String url) async => true;
+
+  @override
+  Future<bool> launchUrl(String url, LaunchOptions options) async {
+    launched.add(url);
+    return true;
+  }
+
+  @override
+  Future<bool> supportsMode(PreferredLaunchMode mode) async => true;
+
+  @override
+  Future<bool> supportsCloseForMode(PreferredLaunchMode mode) async => false;
+}
+
+/// Stand-in service whose [isServing] flips to true once a folder is served,
+/// mirroring the real lifecycle so we can exercise the start-then-open path.
+class _FakeWebUIService extends Fake implements WebUIService {
+  _FakeWebUIService({this.serving = false});
+
+  bool serving;
+  final List<String> servedPaths = [];
+
+  @override
+  bool get isServing => serving;
+
+  @override
+  Future<void> serveFolderAtPath(String path, {int port = 3000}) async {
+    servedPaths.add(path);
+    serving = true;
+  }
+
+  @override
+  Future<void> stopServing() async {
+    serving = false;
+  }
+}
+
+class _FakeWebUIStorage extends Fake implements WebUIStorage {
+  final WebUISkin _skin = WebUISkin(
+    id: 'streamline.js',
+    name: 'Streamline',
+    path: '/tmp/streamline.js',
+    version: '0.2.2',
+    isBundled: true,
+  );
+
+  String? defaultSkinSet;
+
+  @override
+  List<WebUISkin> get installedSkins => [_skin];
+
+  @override
+  WebUISkin? get defaultSkin => _skin;
+
+  @override
+  WebUISkin? getSkin(String id) => id == _skin.id ? _skin : null;
+
+  @override
+  Future<void> setDefaultSkin(String skinId) async {
+    defaultSkinSet = skinId;
+  }
+}
+
+Future<void> _pumpPage(WidgetTester tester, WebUIService service) async {
+  await tester.pumpWidget(
+    ShadApp(
+      onGenerateRoute: (settings) {
+        if (settings.name == SkinView.routeName) {
+          return MaterialPageRoute<void>(
+            settings: settings,
+            builder: (_) => const Scaffold(body: Text(_skinViewSentinel)),
+          );
+        }
+        return null;
+      },
+      home: ScaffoldMessenger(
+        child: SkinSelectorPage(
+          settingsController: SettingsController(MockSettingsService()),
+          webUIService: service,
+          webUIStorage: _FakeWebUIStorage(),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  late _RecordingUrlLauncher launcher;
+  late UrlLauncherPlatform original;
+
+  setUp(() {
+    original = UrlLauncherPlatform.instance;
+    launcher = _RecordingUrlLauncher();
+    UrlLauncherPlatform.instance = launcher;
+  });
+
+  tearDown(() {
+    UrlLauncherPlatform.instance = original;
+  });
+
+  testWidgets('renders a "Go to skin" button below the skin selector',
+      (tester) async {
+    await _pumpPage(tester, _FakeWebUIService(serving: false));
+
+    expect(find.text('Go to skin'), findsOneWidget);
+  });
+
+  testWidgets('server controls are the quiet footer, not the primary action',
+      (tester) async {
+    await _pumpPage(tester, _FakeWebUIService(serving: true));
+
+    // Niche controls live in the footer when serving.
+    expect(find.text('Stop server'), findsOneWidget);
+    if (!Platform.isLinux) {
+      expect(find.text('Open in browser'), findsOneWidget);
+    }
+    expect(find.text('Start server'), findsNothing);
+    // Library-wide refresh sits in the header.
+    expect(find.text('Check for updates'), findsOneWidget);
+  });
+
+  testWidgets('server footer offers "Start server" when stopped',
+      (tester) async {
+    await _pumpPage(tester, _FakeWebUIService(serving: false));
+
+    expect(find.text('Start server'), findsOneWidget);
+    expect(find.text('Stop server'), findsNothing);
+  });
+
+  testWidgets(
+      'tapping "Go to skin" while serving opens the skin in-app '
+      '(external browser on Linux)', (tester) async {
+    await _pumpPage(tester, _FakeWebUIService(serving: true));
+
+    final button = find.text('Go to skin');
+    await tester.ensureVisible(button);
+    await tester.tap(button);
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    if (Platform.isLinux) {
+      expect(launcher.launched, hasLength(1));
+      expect(launcher.launched.single, contains('localhost:3000'));
+      expect(find.text(_skinViewSentinel), findsNothing);
+    } else {
+      expect(find.text(_skinViewSentinel), findsOneWidget);
+      expect(launcher.launched, isEmpty);
+    }
+  });
+
+  testWidgets(
+      'tapping "Go to skin" while stopped starts the selected skin then opens it',
+      (tester) async {
+    final service = _FakeWebUIService(serving: false);
+    await _pumpPage(tester, service);
+
+    final button = find.text('Go to skin');
+    await tester.ensureVisible(button);
+    await tester.tap(button);
+    await tester.pump(); // run async handler + setState
+    await tester.pumpAndSettle();
+
+    // Server was started with the selected skin before opening it.
+    expect(service.servedPaths, ['/tmp/streamline.js']);
+
+    if (Platform.isLinux) {
+      expect(launcher.launched, hasLength(1));
+    } else {
+      expect(find.text(_skinViewSentinel), findsOneWidget);
+    }
+  });
+}

--- a/test/skin_selector_go_to_skin_test.dart
+++ b/test/skin_selector_go_to_skin_test.dart
@@ -17,6 +17,12 @@ import 'helpers/mock_settings_service.dart';
 /// skin route was pushed without constructing the real (webview-backed) view.
 const String _skinViewSentinel = 'SKIN VIEW SENTINEL';
 
+/// The primary button is "Go to skin" everywhere except Linux, which has no
+/// in-app WebView and so opens the external browser instead. CI runs on Linux,
+/// so the finder must follow the platform rather than assume "Go to skin".
+final String _primaryActionLabel =
+    Platform.isLinux ? 'Open in Browser' : 'Go to skin';
+
 /// Records launched URLs so the Linux fallback path can be asserted without
 /// hitting a real platform channel.
 class _RecordingUrlLauncher extends Fake
@@ -131,7 +137,7 @@ void main() {
       (tester) async {
     await _pumpPage(tester, _FakeWebUIService(serving: false));
 
-    expect(find.text('Go to skin'), findsOneWidget);
+    expect(find.text(_primaryActionLabel), findsOneWidget);
   });
 
   testWidgets('server controls are the quiet footer, not the primary action',
@@ -161,7 +167,7 @@ void main() {
       '(external browser on Linux)', (tester) async {
     await _pumpPage(tester, _FakeWebUIService(serving: true));
 
-    final button = find.text('Go to skin');
+    final button = find.text(_primaryActionLabel);
     await tester.ensureVisible(button);
     await tester.tap(button);
     await tester.pump();
@@ -183,7 +189,7 @@ void main() {
     final service = _FakeWebUIService(serving: false);
     await _pumpPage(tester, service);
 
-    final button = find.text('Go to skin');
+    final button = find.text(_primaryActionLabel);
     await tester.ensureVisible(button);
     await tester.tap(button);
     await tester.pump(); // run async handler + setState

--- a/test/skin_selector_update_refresh_test.dart
+++ b/test/skin_selector_update_refresh_test.dart
@@ -50,7 +50,7 @@ class _FakeWebUIStorage extends Fake implements WebUIStorage {
 
 void main() {
   testWidgets(
-    'skins list refreshes to the new version after "Check for Skin Updates" '
+    'skins list refreshes to the new version after "Check for updates" '
     '(issue #370)',
     (tester) async {
       final storage = _FakeWebUIStorage('0.2.2');
@@ -74,7 +74,7 @@ void main() {
       expect(find.textContaining('0.2.2'), findsOneWidget);
       expect(find.textContaining('0.2.3'), findsNothing);
 
-      final updateButton = find.text('Check for Skin Updates');
+      final updateButton = find.text('Check for updates');
       await tester.ensureVisible(updateButton);
       await tester.tap(updateButton);
       await tester.pump(); // run the async handler + its setState


### PR DESCRIPTION
## Summary

- **Problem:** The Web Interface (Skins) page had no quick way to open the active skin, and its two equal-weight cards gave niche server controls (stop server, open in browser) the same prominence as the actions users reach for most.
- **Why it matters:** The common actions — open the skin and check for updates — weren't the visual priority.
- **What changed:** Added a "Go to skin" action (opens the selected skin in the in-app WebView; external browser on Linux), reorganised the page into one focused card with a clear hierarchy, and restyled the skin dropdown to match the card.
- **What did NOT change (scope boundary):** Skin install / live-edit / delete flows, the `WebUIService`/`WebUIStorage` behaviour, and all REST/WebSocket APIs are untouched.

## Change Type (select all)

- [x] Feature
- [x] UI / Flutter widgets (also a small local refactor of the page's `_ActionButton` helper)

## Scope (select all touched areas)

- [x] WebUI skins
- [x] UI / Flutter widgets

## Linked Issues

- N/A

## Root Cause (if bug fix)

N/A — not a bug fix.

## Regression Test Plan (if bug fix or refactor)

- Coverage level:
  - [x] Unit test (widget tests)
- Target test or file: `test/skin_selector_go_to_skin_test.dart`, `test/skin_selector_update_refresh_test.dart`
- Scenario locked in: "Go to skin" opens the skin in-app on non-Linux and falls back to the external browser on Linux; it starts the server first when stopped; the skin-server controls live in the footer (Stop/Open when serving, Start when stopped) while "Check for updates" sits in the header.

## Documentation Obligations (required)

- [x] N/A — no docs affected. This is a UI rework of the existing Skins page; skin behaviour and the skin API are unchanged (`doc/Skins.md` covers skin *development*).

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `No`
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`

## User-Visible Changes

- New "Go to skin" button on the Web Interface page that opens the selected skin in the app (external browser on Linux), starting the skin server first if needed.
- The page is now a single card: per-skin "Go to skin" action up top, library-wide "Check for updates" in the header, and the skin-server controls (start/stop, open in browser) as a quiet footer. "Stop server" is the only accent-coloured (red) footer control; the others are muted.
- The skin selector is now a bordered, content-width dropdown matching the rest of the card.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean
- [x] `flutter test` — all pass (1828)
- [ ] `(cd packages/dye2-plugin && npm run build)` — N/A (no plugin changes)

### Manual verification (if applicable)

- OS / platform tested: macOS
- Simulated devices? (`simulate=1`): `Yes`
- Real hardware? (DE1/Bengle/scale): `No`
- What was verified: hot-reloaded the running app and visually confirmed the layout, button placement/alignment, dropdown styling, and the footer right-alignment across server running/stopped states.
- What was not verified: Linux in-app-WebView fallback path on real Linux (logic mirrors the existing home-screen "Open" button); Android storage-permission row.

### Evidence

- [x] Test output (red before / green after the new widget tests)
- [x] Screenshot / recording (UI change verified live during review)

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`

## Risks & Mitigations

- Risk: On Linux, "Go to skin" is replaced by "Open in Browser" (no in-app WebView). Mitigation: mirrors the existing home-screen "Open" behaviour; covered by a platform-branched test.
- Risk: Two test-only dev dependencies (`plugin_platform_interface`, `url_launcher_platform_interface`) added to mock `url_launcher`. Mitigation: pinned to the already-resolved transitive versions, so resolution is unchanged.
