### PR TITLE
Restart the sleep timer when an activity ends so the machine doesn't sleep right after a shot

### DIFF
--- a/lib/src/controllers/presence_controller.dart
+++ b/lib/src/controllers/presence_controller.dart
@@ -170,6 +170,22 @@ class PresenceController {
       _log.info('Machine went to sleep during keep-awake window, clearing');
       _keepAwakeUntil = null;
     }
+
+    // An activity (espresso/steam/hot water/flush/clean) just finished: restart
+    // the idle countdown so the machine gets a full sleep-timeout window from the
+    // END of the activity. Without this, the timer keeps running from the last
+    // heartbeat straight through a hands-off pull and can fire the instant the
+    // shot ends. The [_onSleepTimeout] active-state guard only covers the timer
+    // firing *during* the activity, not the seconds right after it returns to idle.
+    if (_settingsController.userPresenceEnabled &&
+        _isActiveState(_currentMachineState) &&
+        (newState == MachineState.idle || newState == MachineState.schedIdle)) {
+      _log.info(
+        'Activity ($_currentMachineState) ended, restarting sleep timer',
+      );
+      _resetSleepTimer();
+    }
+
     _currentMachineState = newState;
   }
 

--- a/test/controllers/presence_controller_test.dart
+++ b/test/controllers/presence_controller_test.dart
@@ -425,6 +425,49 @@ void main() {
         controller.dispose();
       });
     });
+
+    test('sleep countdown restarts when a shot ends, not from the last heartbeat', () {
+      fakeAsync((async) {
+        settingsController.setSleepTimeoutMinutes(5);
+        async.flushMicrotasks();
+
+        final controller = PresenceController(
+          de1Controller: de1Controller,
+          settingsController: settingsController,
+          clock: () => clock.now(),
+        );
+        controller.initialize();
+        de1Controller.setDe1(testDe1);
+        async.flushMicrotasks();
+
+        controller.heartbeat();
+        async.flushMicrotasks();
+
+        // A hands-off pull that begins and ends well within the timeout window,
+        // with no further heartbeats (the user never touches the screen).
+        async.elapse(const Duration(minutes: 1));
+        testDe1.emitState(MachineState.espresso);
+        async.flushMicrotasks();
+        async.elapse(const Duration(minutes: 1));
+        testDe1.emitState(MachineState.idle);
+        async.flushMicrotasks();
+
+        // Past the ORIGINAL heartbeat-anchored timeout (5m after the heartbeat):
+        // must NOT sleep, because the shot ending restarted the countdown.
+        async.elapse(const Duration(minutes: 3, seconds: 30));
+        expect(
+          testDe1.requestedStates.where((s) => s == MachineState.sleeping),
+          isEmpty,
+          reason: 'Shot end should have restarted the sleep countdown',
+        );
+
+        // A full timeout after the shot ended: now it sleeps.
+        async.elapse(const Duration(minutes: 2));
+        expect(testDe1.requestedStates, contains(MachineState.sleeping));
+
+        controller.dispose();
+      });
+    });
   });
 
   group('scheduled wake', () {


### PR DESCRIPTION
## Summary

- **Problem:** When a hands-off espresso/steam/hot-water/flush/clean activity finishes, the machine could go to sleep almost immediately after returning to idle.
- **Why it matters:** The idle sleep countdown kept running from the last presence heartbeat straight through the activity, so it could fire the instant the shot ended — sleeping the machine right after a pull.
- **What changed:** In `PresenceController`, when an active machine state transitions back to `idle`/`schedIdle` (and user-presence is enabled), restart the sleep timer so the machine gets a full sleep-timeout window measured from the *end* of the activity.
- **What did NOT change (scope boundary):** No change to the in-activity timer guard (`_onSleepTimeout` active-state check), presence heartbeat handling, or any other controller. Skins / iPhone 15 WebView work is intentionally excluded from this PR.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Machine state / shot logic

## Linked Issues

- N/A

## Root Cause (if bug fix)

- Root cause: The idle sleep countdown was anchored to the last presence heartbeat, not to the end of the activity. The `_onSleepTimeout` active-state guard only suppresses the timer firing *during* an activity, leaving the brief window right after return-to-idle unprotected.
- Missing detection or guardrail: No reset of the sleep timer on the active→idle transition.
- Contributing context (if known): Hands-off pulls produce no heartbeats, so the timer can elapse exactly as the activity ends.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `test/controllers/presence_controller_test.dart`
- Scenario the test should lock in: an active→idle transition restarts the sleep timer (full timeout window granted from the end of the activity).

## Documentation Obligations (required)

- [x] N/A — no docs affected

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `No`
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`

## User-Visible Changes

The machine no longer sleeps immediately after a hands-off activity ends; it waits the full configured sleep-timeout window measured from when the activity finished.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — relevant suite passes (`presence_controller_test.dart`)

### Manual verification (if applicable)

- What you personally verified and how: Ran the added/updated unit tests in `presence_controller_test.dart`.

### Evidence

- [x] Test output (passing after)

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`

## Risks & Mitigations

- None
