### PR TITLE
feat(shots): add /ws/v1/machine/shotState feed and persist stop reason

### DIFF
--- a/.agents/skills/decent-app/scenarios/shot-state-ws.md
+++ b/.agents/skills/decent-app/scenarios/shot-state-ws.md
@@ -1,0 +1,74 @@
+# Scenario: shot state WebSocket + persisted stop reason
+
+End-to-end check of `/ws/v1/machine/shotState` — the shot sequencer's state +
+decision feed (why a step advanced, why the shot stopped) — and of the
+`stopReason` field persisted onto the resulting shot record.
+
+Requires gateway mode `tracking` or `disabled` (the sequencer only runs
+app-side SAW then). The feed itself is available regardless — it just stays
+`idle` when nothing is sequenced.
+
+## Preconditions
+
+```bash
+scripts/sb-dev.sh start --connect-machine MockDe1 --connect-scale MockScale
+BASE=http://localhost:8080
+WS=ws://localhost:8080
+```
+
+## Feed idles and replays on connect
+
+```bash
+# First frame arrives immediately (BehaviorSubject replay): an idle state frame.
+websocat -n1 "$WS/ws/v1/machine/shotState" | jq '{event, state, shotId}'
+# {"event":"state","state":"idle","shotId":null}
+```
+
+## A full shot produces state frames, decisions, and a stop reason
+
+Open the stream in the background, pull a simulated shot, stop it via the API:
+
+```bash
+websocat "$WS/ws/v1/machine/shotState" > /tmp/shotstate.jsonl &
+WS_PID=$!
+
+curl -sf -X PUT "$BASE/api/v1/machine/state/espresso" >/dev/null
+sleep 6   # let the mock shot preheat and start pouring
+
+# Stop via REST — this stop must be attributed to apiStop, not machineEnded.
+curl -sf -X PUT "$BASE/api/v1/machine/state/idle" >/dev/null
+sleep 6   # post-stop settling window + finalization
+
+kill $WS_PID
+jq -c '{event, state, reason: .decision.reason}' /tmp/shotstate.jsonl
+```
+
+Expected output hints (exact frames vary with the mock's pacing):
+
+- `{"event":"state","state":"preheating",...}` then `"pouring"` — shot phases.
+- Possibly `{"event":"decision",...,"reason":"profileAdvance"}` /
+  `"profileSkip"` — step transitions during the pour.
+- `{"event":"decision","state":"pouring","reason":"apiStop"}` — the REST stop,
+  attributed to its source.
+- `{"event":"state","state":"finished",...}` then a final
+  `{"event":"state","state":"idle","shotId":null}` re-seed.
+- Every mid-shot frame carries the same non-null `shotId`.
+
+## The stop reason is persisted onto the shot record
+
+```bash
+# The latest shot's id matches the shotId seen on the stream, and stopReason
+# records why it ended.
+curl -sf "$BASE/api/v1/shots/latest" | jq '{id, stopReason}'
+# {"id":"<same as the stream's shotId>","stopReason":"apiStop"}
+```
+
+Letting the shot run to the mock profile's natural end (no API stop) persists
+`"machineEnded"` instead; an app-side stop-at-weight ends it with
+`"targetWeight"`.
+
+## Postconditions
+
+```bash
+scripts/sb-dev.sh stop
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,9 +121,8 @@ All three steps are required, not optional.
 
 - **`DeviceController`:** Coordinates multiple `DeviceDiscoveryService` implementations → unified device stream
 - **`ConnectionManager`:** Centralized connection orchestrator. Scans for devices, applies preferred-device policy, handles machine→scale connection sequencing. Exposes `ConnectionStatus` stream with phases: `idle`, `scanning`, `connectingMachine`, `connectingScale`, `ready`.
-- **`De1Controller`:** Machine operations (state, settings, profiles)
+- **`De1Controller`:** Machine operations (state, settings, profiles). Also hosts the long-lived `shotState` feed backing `/ws/v1/machine/shotState` (`De1StateManager` publishes into it) and the stop-intent stamp (`recordStopIntent`/`consumeStopIntent`) used to attribute machine-reported stops to their source (REST vs in-app UI).
 - **`ScaleController`:** Scale connection lifecycle, weight/flow data processing
-- **`ShotController`:** Orchestrates shot execution, stops at target weight. Timer lifecycle: reset on first tare (preparingForShot), start on second tare (preinfusion/pouring), stop when shot ends.
 - **`ProfileController`:** Profile library with content-based hash IDs for deduplication
 - **`WorkflowController`:** Multi-step espresso workflows
 - **`PersistenceController`:** Thin persistence layer — delegates to `StorageService`, emits `shotsChanged` stream for UI/handler invalidation
@@ -133,7 +132,7 @@ All three steps are required, not optional.
 - **`DisplayController`:** Display/screen management
 - **`FeedbackController`:** Feedback submission orchestration
 - **`De1StateManager`:** Central state→behavior orchestrator. Listens to machine state transitions, manages scale power (sleep/wake on machine state), handles gateway mode logic (full/tracking/disabled), triggers scale re-scans, manages shot/steam sequencing via `ShotSequencer` and `SteamSequencer`, navigates to realtime features in disabled mode.
-- **`ShotSequencer`:** Owned by `De1StateManager` — manages shot lifecycle (timer start/stop, measurement recording, persistence) for a single shot. Recreated per shot.
+- **`ShotSequencer`:** Owned by `De1StateManager` — manages shot lifecycle (timer start/stop at target weight, measurement recording, persistence) for a single shot. Recreated per shot. Emits structured `ShotDecision`s (why a step advanced, why the shot stopped — vocabulary in `lib/src/models/data/shot_state_event.dart`) with a single consolidated log line per decision under `Logger('ShotState')`; the final stop reason persists as `ShotRecord.stopReason`.
 - **`SteamSequencer`:** Owned by `De1StateManager` — manages steam session lifecycle (start on steam entry, finalize on exit, record `SteamSnapshot`).
 - **`RememberedDevicesController`:** Persists devices the user connected to (machine + scale) across restarts. Feeds the `available` field in device list — remembered but offline devices show as `state: "disconnected"`.
 - **`ScanStateGuardian`:** Guards against overlapping BLE scans and tracks adapter state across scan attempts.

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -5198,6 +5198,19 @@ components:
             $ref: "#/components/schemas/ShotSnapshot"
         workflow:
           $ref: "#/components/schemas/WorkflowRequest"
+        stopReason:
+          type: string
+          nullable: true
+          description: |
+            Why the shot ended, as decided by the app's shot sequencer.
+            OPEN SET — clients must tolerate unknown values from newer builds.
+            Known persisted values: targetWeight, targetVolume, apiStop,
+            appStop, machineEnded, error. (Aborted shots — no scale, or a stop
+            before the pour began — and mid-shot disconnects are not persisted
+            at all; their reasons appear only on the /ws/v1/machine/shotState
+            feed.) Null for legacy shots and shots the app did not sequence
+            (e.g. full gateway mode while backgrounded).
+          example: targetWeight
         shotNotes:
           type: string
           nullable: true
@@ -5259,6 +5272,13 @@ components:
               type: object
               nullable: true
               additionalProperties: true
+        stopReason:
+          type: string
+          nullable: true
+          description: |
+            Why the shot ended (open set — tolerate unknown values).
+            See ShotRecord.stopReason.
+          example: targetWeight
         shotNotes:
           type: string
           nullable: true

--- a/assets/api/websocket_v1.yml
+++ b/assets/api/websocket_v1.yml
@@ -58,6 +58,22 @@ channels:
     messages:
       machineRawMessage:
         $ref: '#/components/messages/MachineRawMessage'
+  ShotState:
+    description: >
+      Shot state + decision feed from the app's shot sequencer: state
+      transitions (idle/preheating/pouring/stopping/finished), why a profile
+      step advanced (app-issued weight skip vs firmware-natural), and why the
+      shot stopped (target weight/volume, API/app command, machine-reported
+      end, error, disconnect). One event type multiplexes all frames,
+      discriminated by `event`. On connect the server replays the latest
+      frame (an idle frame between shots), so clients can attach once and
+      wait — the socket is not gated on a connected machine. Note the feed
+      reflects app-side sequencing only: in full gateway mode (backgrounded)
+      no sequencer runs and the feed stays idle.
+    address: ws/v1/machine/shotState
+    messages:
+      shotStateEvent:
+        $ref: '#/components/messages/ShotStateEvent'
   SensorSnapshot:
     description: Real-time sensor snapshot updates for a specific sensor.
     address: ws/v1/sensors/{id}/snapshot
@@ -148,6 +164,10 @@ operations:
     action: receive
     channel:
       $ref: '#/channels/WaterLevels'
+  shotState:
+    action: receive
+    channel:
+      $ref: '#/channels/ShotState'
   scaleSnapshot:
     action: receive
     channel:
@@ -246,6 +266,11 @@ components:
       title: Machine Raw BLE Message
       payload:
         $ref: '#/components/schemas/De1RawMessage'
+    ShotStateEvent:
+      name: ShotStateEvent
+      title: Shot state / decision event
+      payload:
+        $ref: '#/components/schemas/ShotStateEvent'
     SensorSnapshot:
       name: SensorSnapshot
       title: Sensor Snapshot
@@ -413,6 +438,94 @@ components:
         status:
           type: string
           enum: [connected, disconnected]
+    ShotStateEvent:
+      type: object
+      description: >
+        One frame on ws/v1/machine/shotState. Every frame carries the current
+        shot phase and machine context so any single frame gives a coherent
+        view; `decision` is non-null only for decision/terminal frames.
+      required:
+        [event, timestamp, state, scaleConnected, scaleLost,
+         machineHasAutonomousSAW]
+      properties:
+        event:
+          type: string
+          enum: [state, decision, terminal]
+        timestamp:
+          type: string
+          description: >
+            ISO8601 timestamp of the machine snapshot that drove the event
+            (matching the timestamps on ws/v1/machine/snapshot, so decisions
+            can be time-aligned with telemetry). Wall clock only when no
+            snapshot context exists (e.g. the idle re-seed after a
+            disconnect).
+        shotId:
+          type: string
+          nullable: true
+          description: >
+            Stable id for the shot, equal to the persisted ShotRecord id when
+            the shot is saved. Null between shots.
+        state:
+          type: string
+          enum: [idle, preheating, pouring, stopping, finished]
+          description: Current shot phase as tracked by the sequencer.
+        machineState:
+          type: string
+          nullable: true
+          description: MachineState name from the latest machine snapshot.
+        machineSubstate:
+          type: string
+          nullable: true
+        profileFrame:
+          type: integer
+          nullable: true
+          description: 0-based profile frame index from the latest snapshot.
+        scaleConnected:
+          type: boolean
+        scaleLost:
+          type: boolean
+          description: >
+            True once the scale dropped mid-shot. Sticky for the remainder of
+            the shot — stop-at-weight stays disabled even if scaleConnected
+            flips back.
+        machineHasAutonomousSAW:
+          type: boolean
+          description: >
+            True when the machine firmware runs its own stop-at-weight
+            (Bengle) — the final target-yield stop is then firmware-side and
+            reported as machineEnded.
+        decision:
+          type: object
+          nullable: true
+          description: Present on decision/terminal frames only.
+          properties:
+            kind:
+              type: string
+              enum: [advance, stop, abort, terminal, finalize]
+              description: >
+                advance = profile moved to the next step; stop = pour ended;
+                abort = shot blocked before it ran; terminal = abnormal end
+                (error/disconnect); finalize = post-stop settling window
+                closed (not why the shot stopped).
+            reason:
+              type: string
+              description: >
+                OPEN SET — tolerate unknown values from newer builds. Known:
+                targetWeight, targetVolume, apiStop, appStop, machineEnded,
+                profileAdvance, profileSkip, noScale, error, disconnected,
+                stoppingBackstop.
+            details:
+              type: string
+              nullable: true
+              description: Human-readable explanation.
+            data:
+              type: object
+              nullable: true
+              additionalProperties: true
+              description: >
+                Reason-specific numeric context (e.g. targetYield /
+                projectedWeight for targetWeight, frame / stepExitWeight for
+                profileSkip).
     MachineSnapshot:
       type: object
       properties:

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -319,6 +319,7 @@ All WebSocket endpoints are on port 8080 at `/ws/v1/...`. See [`assets/api/webso
 | `/ws/v1/machine/shotSettings` | Shot settings changes | Target temp, volume, weight |
 | `/ws/v1/machine/waterLevels` | Water level changes | Current/limit levels |
 | `/ws/v1/machine/raw` | Raw BLE characteristic data | Hex-encoded bytes |
+| `/ws/v1/machine/shotState` | Shot sequencer state + decision feed: why a step advanced, why the shot stopped. Replays the latest frame on connect; idle between shots; not gated on a connected machine. | `event` (`state`\|`decision`\|`terminal`), `shotId`, shot phase, machine context, `decision {kind, reason, details, data}` |
 | `/ws/v1/devices` | Device discovery + `ConnectionManager` status (phase, found devices, ambiguity, errors). Also accepts `scan`/`connect`/`disconnect` commands. | Device list, `connectionStatus` |
 | `/ws/v1/sensors/:id/snapshot` | Sensor data stream | Sensor-specific |
 | `/ws/v1/plugins/:id/:endpoint` | Plugin WebSocket proxy | Plugin-specific |
@@ -326,6 +327,47 @@ All WebSocket endpoints are on port 8080 at `/ws/v1/...`. See [`assets/api/webso
 | `/ws/v1/webview/logs` | WebView console log stream | WebView console messages |
 | `/ws/v1/display` | Display state changes | Brightness, wakelock |
 | `/ws/v1/update` | App-update state stream. Also accepts `{"command":"check"}` and `{"command":"install"}` (Android installs; other platforms reply `{"error","url"}`). | `phase`, `progress`, `latestVersion`, `installable` |
+
+### `shotState` events
+
+`/ws/v1/machine/shotState` streams the app's shot-sequencer decisions as a single event type
+discriminated by `event`. Every frame carries the current shot phase (`state`) and machine context,
+so a late joiner gets a coherent view from any single frame; `decision` is non-null only on
+`decision`/`terminal` frames.
+
+```json
+{
+  "event": "decision",
+  "timestamp": "2026-06-17T10:32:18.903Z",
+  "shotId": "a1b2c3d4-...",
+  "state": "pouring",
+  "machineState": "espresso",
+  "machineSubstate": "pouring",
+  "profileFrame": 2,
+  "scaleConnected": true,
+  "scaleLost": false,
+  "machineHasAutonomousSAW": false,
+  "decision": {
+    "kind": "stop",
+    "reason": "targetWeight",
+    "details": "Target weight 36.0g reached (projected: 36.4). Stopping shot.",
+    "data": {"targetYield": 36.0, "projectedWeight": 36.4}
+  }
+}
+```
+
+- `shotId` equals the persisted `ShotRecord.id`, so the stream can be correlated to the saved shot.
+  The final stop reason is also persisted on the record as `stopReason`.
+- `decision.reason` is an **open set** — tolerate unknown values. Known reasons: `targetWeight`,
+  `targetVolume` (app-side targets), `profileSkip` (app-issued weight skip), `profileAdvance`
+  (firmware-natural step exit), `apiStop` / `appStop` (stop command attributed to a REST client /
+  the in-app Stop button), `machineEnded` (GHC stop or natural profile completion —
+  indistinguishable), `noScale` (blocked by `blockOnNoScale`), `error` / `disconnected` (abnormal
+  endings, `event: "terminal"`), `stoppingBackstop` (post-stop settling window closed by the safety
+  timer; never the stop reason itself).
+- Coverage: the feed reflects app-side sequencing only. In full gateway mode with the app
+  backgrounded no sequencer runs (the feed stays `idle`), and on machines with autonomous
+  stop-at-weight (Bengle) the final yield stop is firmware-side and reported as `machineEnded`.
 
 ### `connectionStatus.error`
 

--- a/doc/plans/archive/shot-state-ws/2026-06-16-shot-state-ws-findings.md
+++ b/doc/plans/archive/shot-state-ws/2026-06-16-shot-state-ws-findings.md
@@ -1,0 +1,136 @@
+# Shot State WS + Stop Reason — Thread Findings
+
+_As of 2026-06-17. Companion to the design doc
+[`2026-06-16-shot-state-ws-and-stop-reason-design.md`](2026-06-16-shot-state-ws-and-stop-reason-design.md)._
+_This captures what the investigation found and the decisions reached in discussion, including
+refinements that post-date the design doc's last revision (flagged at the end)._
+
+## The ask
+
+- Maintainer's request: a "ShotState websocket", a stream of `ShotSequencer` decisions about the
+  state of a shot (why a step advanced, why a shot stopped: weight, volume, machine, etc.), and get
+  some of that into the logs too.
+- Discussion [#343](https://github.com/tadelv/reaprime/discussions/343) broadens it to three
+  objectives: (1) persist the final stop reason on `ShotRecord`, (2) a `/ws/v1/shotState` stream,
+  (3) mid-shot scale-loss handling.
+- Prior art: **#34** (the original block-no-scale request), **PR #230** (added the
+  `ShotSequencer.decisions` stream as groundwork, explicitly "the natural home for the planned
+  `/ws/v1/shotState` decision feed"; motivated by unifying the two code paths, app SAW vs
+  GHC/REST-initiated shots).
+
+## Key code findings
+
+- `ShotSequencer` already has `ShotDecision` + a `decisions` BehaviorSubject, but the enum has only
+  `noScale` and only the no-scale abort is ever emitted. Every other reason is logged inline and
+  dropped (`shot_sequencer.dart`).
+- `ShotSequencer` is recreated per shot and disposed (all three streams `close()`d) at shot end
+  (`de1_state_manager.dart:566` / `:673`). A WS handler cannot subscribe to it directly.
+- `De1StateManager` lives in the widget layer (`app.dart:226`), is built after `startWebServer`
+  (`main.dart:475`), and is **not** passed to the webserver.
+- `De1Controller` **is** passed to both the webserver and `De1StateManager`, and is already a
+  BehaviorSubject hub (`de1_controller.dart:24-59`). This makes it the natural home for the stream.
+- The firmware never reports **why** a shot ended; all reasons are app-inferred from substate
+  transitions and threshold math.
+- Volume-based stopping already exists when the profile has a `targetVolume` (`shot_sequencer.dart:382`;
+  guard `!_bypassSAW && !_machineHasAutonomousSAW && (scale == null || _scaleLost) && targetVolume > 0`).
+- `_scaleLost` is sticky (set once, never cleared; `shot_sequencer.dart:151-160`).
+- Flow estimation (`getFlowEstimation`/`setFlowEstimation`, `de1_interface.dart:49-56`) is a
+  **multiplier** (default 1.0) the machine applies to its own flow output; cached as
+  `cachedFlowEstimation`, snapshotted onto shots as `WorkflowMachine.flowCalibration`
+  (`de1_state_manager.dart:632`). It makes `_accumulatedVolume` accurate ml. It is **not** a
+  grams-to-ml factor.
+- Auth: LAN-trust. Only `/api/v1/account/proxy/*` is gated (`proxy_auth_middleware.dart`); all
+  `/ws/v1/*` is open. `shotState` inherits the open posture, no work.
+- No `ShotController` class exists (CLAUDE.md is stale on this); `De1StateManager` + `ShotSequencer`
+  are the real orchestration.
+- `SteamSequencer` is a long-lived fire-and-forget singleton (`main.dart:427`,
+  `// ignore: unused_local_variable`), not threaded anywhere; CLAUDE.md "owned by De1StateManager" is
+  stale.
+- Coverage gaps: in **full gateway mode backgrounded** no sequencer is created
+  (`de1_state_manager.dart:396`); on **Bengle** the FW stops the shot (autonomous SAW) so the app makes
+  no decision. Both land in `machineEnded`/null.
+- **Error states and mid-shot disconnect** currently leave the sequencer stuck or silent: there is no
+  `error` arm, and `_handleSnapshot` routes only `espresso`/`steam` (error hits `default: break`).
+
+## Three-agent review outcome
+
+No architecture-breaking errors in the first design. Findings converged on:
+
+- Host the stream on `De1Controller`, not a new object threaded through the widget tree (the
+  `SteamSequencer` precedent argues against threading, it is self-wired and threaded nowhere).
+- `stopReason` should be a first-class field, not a `ShotAnnotations` entry (annotations are
+  user/tasting metadata).
+- Terminal handling for error/disconnect is a real hole (clients would hang in `pouring`).
+- `manual` is unreliable from the substate stream alone.
+- `profileAdvance`/`profileSkip` detection was off by one (test the **vacated** frame against
+  `skippedSteps`, not the new frame; make it delta-tolerant since `profileFrame` is a 10 Hz byte with
+  no monotonicity guarantee).
+- One unified event type over two frame kinds; single-source logging; re-slice the phases; expose the
+  reason as an open string (not a closed enum); mint `shotId` once so it equals `ShotRecord.id`.
+
+## Decisions as they stand now
+
+- **Host:** `De1Controller.shotState` (seeded BehaviorSubject) + `publishShotEvent`. `De1StateManager`
+  forwards from its existing per-shot `.state`/`.decisions` taps; the WS handler just listens. No new
+  widget-tree wiring.
+- **Wire format:** one `ShotStateEvent` = `{ event: state|decision|terminal, timestamp, shotId,
+  state, machineState, machineSubstate, profileFrame, scaleConnected, scaleLost,
+  machineHasAutonomousSAW, decision?: { kind, reason, details, data } }`. Seeded stream replays the
+  current state to late joiners.
+- **Persist:** first-class `ShotRecord.stopReason`, exposed as an **open string** in `rest_v1.yml`
+  (not a closed enum), null for old shots; schema version bumped 3 to 4 with a real migration branch.
+- **Granularity:** stream everything on the WS (advance/skip/stop/terminal); persist only the final
+  reason.
+- **Vocabulary:** `targetWeight`, `targetVolume`, `apiStop`, `appStop`, `machineEnded`, `noScaleBlock`
+  (canonical name TBD), plus terminal `error` and `disconnected`. Step changes: `profileAdvance`
+  (firmware-natural) vs `profileSkip` (app-issued weight skip).
+- **`manual` (attribute by source, not deferred):** stamp the REST stop (`de1handler`) and the in-app
+  Stop button (`realtime_shot_feature.dart:218`); with app-side SAW that covers everything
+  software-initiated. The remaining bare-signal case is GHC or natural completion, distinguishable
+  only by heuristic (ended before the last frame likely means GHC). Note REST means external client,
+  not necessarily a human, hence `apiStop` rather than `manual`.
+- **Terminal handling:** add an `error` arm to the sequencer and emit an explicit terminal event on
+  error and on mid-shot disconnect (owned by `De1StateManager`, published before teardown), so clients
+  never hang in `pouring`.
+- **Scale-loss ladder:** (1) fire `scaleLost` immediately so the skin/UI warns the user; (2) bounded,
+  platform-aware reconnect (reuse `ConnectionManager.connect(scaleOnly: true)`), resume SAW if the
+  scale kept its zero (no re-tare, that would zero the espresso already in the cup); (3) flood guard,
+  cap the shot at `targetYield * 1.1` ml against the flow-calibrated `_accumulatedVolume` (authored
+  `targetVolume` wins if the profile has one). Do **not** convert weight to volume to hit the yield.
+  `_scaleLost` changes from sticky to recoverable.
+- **Logging:** single source. Human string goes in `ShotDecision.details`; the forwarder logs each
+  event once via `Logger('ShotState')` at INFO (FINE for finalize), which auto-flows to `log.txt` and
+  `/ws/v1/logs`. Delete the now-redundant inline `_log.info` lines. Never WARNING+ for normal
+  decisions (auto-forwards to telemetry).
+- **Auth:** no work; inherits LAN-trust.
+- **Plan order:** A) reasons + emission + terminal arms, B) persist on `ShotRecord`, C) `De1Controller`
+  stream + WS topic + logging, D) scale-loss (event + reconnect + overfill cap), E) reconnect tuning
+  and fail policy.
+
+## Still the maintainer's call
+
+- Canonical name for `noScale` / `block_no_scale` / `noScaleBlock`.
+- `profileAdvance` vs `profileSkip` granularity (emit both or collapse to "step changed").
+- Reconnect aggressiveness / platform tuning and the fail-to-reconnect behavior.
+- Whether to also dispatch decisions as a JS plugin event (extra sink), or WS-only.
+- Topic path: `/ws/v1/machine/shotState` vs `/ws/v1/shotState`.
+- Whether persisting `stopReason` earns the schema bump given how often it will be `null` (full
+  gateway) or the ambiguous bucket (GHC/Bengle).
+- Steam (`/ws/v1/machine/steamState`) deferred; reuse this event/terminal contract when it lands.
+
+## Artifacts
+
+- Design doc:
+  [`2026-06-16-shot-state-ws-and-stop-reason-design.md`](2026-06-16-shot-state-ws-and-stop-reason-design.md).
+- A reply for discussion #343 was drafted (not posted).
+
+### Design-doc sync needed
+
+Two spots in the design doc predate the final refinements in this thread and should be reconciled:
+
+1. Open decision #1 in the doc recommends **deferring `manual`**; the thread landed on
+   **attribute-by-source** (`apiStop`/`appStop` + heuristic for GHC vs completion).
+2. The doc's scale-loss tier 3 says "authored `targetVolume`, else let it run"; the thread added the
+   **`targetYield * 1.1` ml overfill cap** as the flood guard.
+
+No code has been written; everything so far is investigation plus these design docs.

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/connection/connection_timings.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/home_feature/forms/hot_water_form.dart';
 import 'package:reaprime/src/home_feature/forms/steam_form.dart';
+import 'package:reaprime/src/models/data/shot_state_event.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart';
@@ -57,6 +59,69 @@ class De1Controller {
   );
 
   Stream<RinseData> get rinseData => _rinseStream.stream;
+
+  /// Live shot state + decision feed, backing `/ws/v1/machine/shotState`.
+  ///
+  /// De1StateManager forwards each per-shot ShotSequencer's state transitions
+  /// and decisions into here via [publishShotEvent] — the sequencer itself is
+  /// recreated every shot and its streams close on dispose, so this long-lived
+  /// subject is what WebSocket clients subscribe to. Seeded with an idle frame
+  /// so a late joiner never replays a stale mid-shot frame from a previous
+  /// shot.
+  final BehaviorSubject<ShotStateEvent> _shotStateSubject =
+      BehaviorSubject.seeded(ShotStateEvent.idle());
+
+  Stream<ShotStateEvent> get shotState => _shotStateSubject.stream;
+  ShotStateEvent get currentShotState => _shotStateSubject.value;
+
+  /// WS-frame trail at FINE; the per-decision INFO/WARNING line is emitted
+  /// once by ShotSequencer under the same logger name — don't log it twice.
+  static final Logger _shotStateLog = Logger('ShotState');
+
+  void publishShotEvent(ShotStateEvent event) {
+    _shotStateLog.fine(
+      '[shot ${event.shotId ?? '-'}] ${event.event}: ${event.state.name}'
+      '${event.decision != null ? ' (${event.decision!.reason.name})' : ''}',
+    );
+    if (!_shotStateSubject.isClosed) {
+      _shotStateSubject.add(event);
+    }
+  }
+
+  /// Pre-declared stop intent, so the sequencer can attribute a
+  /// machine-reported shot end to the command that caused it. The REST state
+  /// handler and the in-app Stop button record intent just before issuing
+  /// `requestState(idle)`; when the resulting `pouringDone` arrives the
+  /// sequencer consumes it. Anything older than [_stopIntentWindow] is stale —
+  /// a leftover stamp from an unrelated request must not label a later,
+  /// natural shot end.
+  static const Duration _stopIntentWindow = Duration(seconds: 5);
+  ShotDecisionReason? _pendingStopIntent;
+  DateTime? _pendingStopIntentAt;
+
+  void recordStopIntent(ShotDecisionReason reason) {
+    assert(
+      reason == ShotDecisionReason.apiStop ||
+          reason == ShotDecisionReason.appStop,
+      'stop intent must name a command source (apiStop/appStop)',
+    );
+    _pendingStopIntent = reason;
+    _pendingStopIntentAt = clock.now();
+  }
+
+  /// Returns the pending intent if one was recorded within [window], and
+  /// clears it either way — an intent is attributed at most once.
+  ShotDecisionReason? consumeStopIntent({
+    Duration window = _stopIntentWindow,
+  }) {
+    final intent = _pendingStopIntent;
+    final at = _pendingStopIntentAt;
+    _pendingStopIntent = null;
+    _pendingStopIntentAt = null;
+    if (intent == null || at == null) return null;
+    if (clock.now().difference(at) > window) return null;
+    return intent;
+  }
 
   final List<StreamSubscription<dynamic>> _subscriptions = [];
   bool _dataInitialized = false;
@@ -368,6 +433,7 @@ class De1Controller {
     if (!_steamDataController.isClosed) _steamDataController.close();
     if (!_hotWaterDataController.isClosed) _hotWaterDataController.close();
     if (!_rinseStream.isClosed) _rinseStream.close();
+    if (!_shotStateSubject.isClosed) _shotStateSubject.close();
   }
 }
 

--- a/lib/src/controllers/de1_state_manager.dart
+++ b/lib/src/controllers/de1_state_manager.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'dart:async';
+import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';
@@ -12,7 +13,10 @@ import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/data/shot_annotations.dart';
 import 'package:reaprime/src/models/data/shot_record.dart';
 import 'package:reaprime/src/models/data/shot_snapshot.dart';
+import 'package:reaprime/src/models/data/shot_state_event.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
+import 'package:reaprime/src/models/device/bengle_interface.dart';
+import 'package:reaprime/src/models/device/device.dart' as device;
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/realtime_shot_feature/realtime_shot_feature.dart';
 import 'package:reaprime/src/realtime_steam_feature/realtime_steam_feature.dart';
@@ -49,6 +53,14 @@ class De1StateManager with WidgetsBindingObserver {
   StreamSubscription<ShotState>? _shotStateSubscription;
   StreamSubscription<ShotSnapshot>? _shotSnapshotsSubscription;
   StreamSubscription<ShotDecision>? _shotDecisionSubscription;
+
+  /// Stable id for the tracked shot, minted when the sequencer is created so
+  /// the live `/ws/v1/machine/shotState` frames and the eventually persisted
+  /// ShotRecord.id match — clients can correlate the stream to the saved shot.
+  String? _currentShotId;
+
+  /// Latest machine snapshot, kept so shotState frames carry machine context.
+  MachineSnapshot? _latestSnapshot;
 
   bool _isRealtimeFeatureActive = false;
   final List<ShotSnapshot> _currentShotSnapshots = [];
@@ -250,6 +262,7 @@ class De1StateManager with WidgetsBindingObserver {
   /// Handles machine snapshot updates and triggers appropriate actions
   /// based on the machine state and gateway mode.
   void _handleSnapshot(MachineSnapshot snapshot) {
+    _latestSnapshot = snapshot;
     final gatewayMode = _settingsController.gatewayMode;
     final currentState = snapshot.state.state;
     final currentSubstate = snapshot.state.substate;
@@ -587,6 +600,7 @@ class De1StateManager with WidgetsBindingObserver {
     );
 
     _currentShotSnapshots.clear();
+    _currentShotId = Uuid().v4();
 
     // Listen to shot snapshots
     _shotSnapshotsSubscription = _currentShotSequencer!.shotData.listen((
@@ -595,8 +609,17 @@ class De1StateManager with WidgetsBindingObserver {
       _currentShotSnapshots.add(snapshot);
     });
 
-    // Listen to shot state changes
+    // Listen to shot state changes. Every transition is forwarded onto the
+    // long-lived De1Controller.shotState feed (the sequencer itself is
+    // per-shot; its streams close on dispose).
     _shotStateSubscription = _currentShotSequencer!.state.listen((state) {
+      // The sequencer's state stream is seeded `idle` and replays it on
+      // subscribe (pre-start). The wire contract is "idle ⇒ between shots,
+      // shotId null", and the between-shots idle frame is published by
+      // _cleanupShotSequencer with a null shotId — so skip idle here.
+      if (state != ShotState.idle) {
+        _publishShotStateFrame(state);
+      }
       if (state == ShotState.finished) {
         _logger.fine('Shot finished, cleaning up ShotSequencer');
         _persistShotIfNeeded();
@@ -604,19 +627,76 @@ class De1StateManager with WidgetsBindingObserver {
       }
     });
 
-    // A blocking decision (e.g. blockOnNoScale) means no shot ran — tear down
-    // without persisting so the next shot can start tracking.
+    // Forward every decision to the shotState feed. An abort decision
+    // (blockOnNoScale, or a stop before the pour began) means no real shot
+    // ran — tear down without persisting so the next shot can start tracking.
+    // The abort decision is itself the terminal signal, so suppress the
+    // teardown terminal frame to avoid a duplicate.
     _shotDecisionSubscription = _currentShotSequencer!.decisions.listen((
       decision,
     ) {
-      if (decision.reason == ShotDecisionReason.noScale) {
+      _publishShotDecisionFrame(decision);
+      if (decision.kind == ShotDecisionKind.abort) {
         _logger.info(
-          'Shot blocked (${decision.reason.name}), cleaning up '
+          'Shot aborted (${decision.reason.name}), cleaning up '
           'ShotSequencer without persisting',
         );
-        _cleanupShotSequencer();
+        _cleanupShotSequencer(emitTerminal: false);
       }
     });
+  }
+
+  bool get _isScaleConnected =>
+      _scaleController.currentConnectionState ==
+      device.ConnectionState.connected;
+
+  /// Publishes a state frame for the tracked shot onto
+  /// De1Controller.shotState.
+  ///
+  /// Frames are stamped with the triggering machine snapshot's timestamp (not
+  /// publish time) so clients can align them with `/ws/v1/machine/snapshot`
+  /// telemetry — the event describes that snapshot's moment, and publish time
+  /// lags it by a variable processing delay.
+  void _publishShotStateFrame(ShotState state) {
+    final sequencer = _currentShotSequencer;
+    _de1Controller.publishShotEvent(
+      ShotStateEvent(
+        event: 'state',
+        timestamp: _latestSnapshot?.timestamp ?? clock.now(),
+        shotId: _currentShotId,
+        state: state,
+        machineState: _latestSnapshot?.state.state,
+        machineSubstate: _latestSnapshot?.state.substate,
+        profileFrame: _latestSnapshot?.profileFrame,
+        scaleConnected: _isScaleConnected,
+        scaleLost: sequencer?.scaleLost ?? false,
+        machineHasAutonomousSAW: sequencer?.machineHasAutonomousSAW ?? false,
+      ),
+    );
+  }
+
+  /// Publishes a decision (or terminal) frame for the tracked shot onto
+  /// De1Controller.shotState. Stamped with the triggering snapshot's
+  /// timestamp — see [_publishShotStateFrame].
+  void _publishShotDecisionFrame(ShotDecision decision) {
+    final sequencer = _currentShotSequencer;
+    _de1Controller.publishShotEvent(
+      ShotStateEvent(
+        event: decision.kind == ShotDecisionKind.terminal
+            ? 'terminal'
+            : 'decision',
+        timestamp: _latestSnapshot?.timestamp ?? clock.now(),
+        shotId: _currentShotId,
+        state: sequencer?.currentState ?? ShotState.idle,
+        machineState: _latestSnapshot?.state.state,
+        machineSubstate: _latestSnapshot?.state.substate,
+        profileFrame: _latestSnapshot?.profileFrame,
+        scaleConnected: _isScaleConnected,
+        scaleLost: sequencer?.scaleLost ?? false,
+        machineHasAutonomousSAW: sequencer?.machineHasAutonomousSAW ?? false,
+        decision: decision,
+      ),
+    );
   }
 
   /// Persists the shot if it's not a cleaning or calibration shot.
@@ -652,10 +732,13 @@ class De1StateManager with WidgetsBindingObserver {
 
     _persistenceController.persistShot(
       ShotRecord(
-        id: Uuid().v4(),
+        // Same id the live shotState frames carried, so clients can correlate
+        // the stream they watched to the saved record.
+        id: _currentShotId ?? Uuid().v4(),
         timestamp: startTime,
         measurements: measurements,
         workflow: workflow,
+        stopReason: _currentShotSequencer!.finalStopReason?.name,
         // Pre-fill what a fresh shot can know: actual yield from the scale
         // trace and actual dose defaulted to the planned dose (de1app parity).
         annotations: ShotAnnotations.deriveForFinishedShot(
@@ -668,8 +751,36 @@ class De1StateManager with WidgetsBindingObserver {
   }
 
   /// Cleans up the current ShotSequencer and all associated subscriptions.
-  void _cleanupShotSequencer() {
+  ///
+  /// Terminal-frame contract: when the sequencer is torn down mid-shot with no
+  /// decision of its own (machine disconnect, manager dispose) and
+  /// [emitTerminal] is true, a `terminal/disconnected` frame is published
+  /// first — the sequencer's own streams close silently on dispose, and
+  /// without this shotState clients would hang on a stale `pouring` frame.
+  /// The abort path passes `emitTerminal: false` because the abort decision it
+  /// already emitted is the terminal signal. The feed is re-seeded with an
+  /// idle frame either way.
+  void _cleanupShotSequencer({bool emitTerminal = true}) {
     _logger.fine('Cleaning up ShotSequencer');
+
+    final sequencer = _currentShotSequencer;
+    final midShot = emitTerminal &&
+        sequencer != null &&
+        sequencer.currentState != ShotState.idle &&
+        sequencer.currentState != ShotState.finished;
+    if (midShot) {
+      _logger.warning(
+        'ShotSequencer torn down mid-shot '
+        '(${sequencer.currentState.name}) — publishing terminal frame',
+      );
+      _publishShotDecisionFrame(
+        const ShotDecision(
+          kind: ShotDecisionKind.terminal,
+          reason: ShotDecisionReason.disconnected,
+          details: 'Shot tracking torn down mid-shot',
+        ),
+      );
+    }
 
     _shotStateSubscription?.cancel();
     _shotStateSubscription = null;
@@ -684,6 +795,39 @@ class De1StateManager with WidgetsBindingObserver {
     _currentShotSequencer = null;
 
     _currentShotSnapshots.clear();
+
+    if (_currentShotId != null) {
+      _currentShotId = null;
+      _publishIdleFrame();
+    }
+  }
+
+  /// Re-seeds the shotState feed with an idle (between-shots) frame carrying
+  /// the real resting scale/machine context, so a client attaching between
+  /// shots sees accurate `scaleConnected`/`machineHasAutonomousSAW` rather
+  /// than the bare `ShotStateEvent.idle()` defaults.
+  void _publishIdleFrame() {
+    _de1Controller.publishShotEvent(
+      ShotStateEvent(
+        event: 'state',
+        timestamp: clock.now(),
+        state: ShotState.idle,
+        machineState: _latestSnapshot?.state.state,
+        machineSubstate: _latestSnapshot?.state.substate,
+        scaleConnected: _isScaleConnected,
+        machineHasAutonomousSAW: _machineHasAutonomousSAW,
+      ),
+    );
+  }
+
+  /// Whether the connected machine runs its own stop-at-weight (Bengle).
+  /// Static capability, so it holds between shots too.
+  bool get _machineHasAutonomousSAW {
+    try {
+      return _de1Controller.connectedDe1() is BengleInterface;
+    } catch (_) {
+      return false;
+    }
   }
 
   /// Disposes all subscriptions and cleans up resources.

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -7,10 +7,16 @@ import 'package:reaprime/src/controllers/scale_controller.dart';
 import 'package:reaprime/src/controllers/step_exit_arbiter.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/data/shot_snapshot.dart';
+import 'package:reaprime/src/models/data/shot_state_event.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/device/device.dart' as device;
 import 'package:rxdart/rxdart.dart';
+
+// The shot-state vocabulary lived here before it gained wire serialization;
+// re-export so existing importers keep working.
+export 'package:reaprime/src/models/data/shot_state_event.dart'
+    show ShotState, ShotDecision, ShotDecisionKind, ShotDecisionReason;
 
 class ShotSequencer {
   final De1Controller de1controller;
@@ -48,6 +54,11 @@ class ShotSequencer {
   List<int> skippedSteps = [];
   final StepExitArbiter _stepExitArbiter = StepExitArbiter();
   int _lastProfileFrame = -1;
+
+  /// Highest profile frame reported so far this shot, for one-shot
+  /// `profileAdvance` emission that survives BLE frame reordering. See
+  /// [_trackFrameAdvance].
+  int _maxFrameSeen = -1;
 
   // Volume counting state
   double _accumulatedVolume = 0.0;
@@ -112,14 +123,10 @@ class ShotSequencer {
       // The sequencer is created reactively, after the machine has already
       // entered espresso (incl. GHC / physical starts), so "block" means abort
       // the shot in progress and publish the reason rather than prevent it.
-      _log.warning(
-        "blockOnNoScale enabled and no scale connected — aborting shot",
-      );
-      _decisionStream.add(
-        const ShotDecision(
-          reason: ShotDecisionReason.noScale,
-          details: 'No scale connected, blocking shot',
-        ),
+      _emitDecision(
+        ShotDecisionKind.abort,
+        ShotDecisionReason.noScale,
+        details: 'No scale connected, blocking shot',
       );
       de1controller
           .connectedDe1()
@@ -209,6 +216,55 @@ class ShotSequencer {
   /// constructor (e.g. the blockOnNoScale abort).
   final BehaviorSubject<ShotDecision> _decisionStream = BehaviorSubject();
   Stream<ShotDecision> get decisions => _decisionStream.stream;
+
+  /// Dedicated logger for the decision trail: one consistent, greppable line
+  /// per decision, regardless of who owns this sequencer (De1StateManager or
+  /// a route-constructed instance). The per-site `_log.info` lines this
+  /// replaces were deleted — do not re-add them, or every decision double-logs.
+  static final Logger _decisionLog = Logger('ShotState');
+
+  /// The reason the shot stopped, retained for persistence onto the
+  /// ShotRecord. Set by the stop/abort/terminal decision sites; `finalize`
+  /// decisions (e.g. the stopping backstop) never overwrite it — they close
+  /// the settling window, they are not why the shot stopped.
+  ShotDecisionReason? _finalStopReason;
+  ShotDecisionReason? get finalStopReason => _finalStopReason;
+
+  /// Current shot phase — lets the owner distinguish a natural finish from a
+  /// mid-shot teardown (disconnect) without subscribing to [state].
+  ShotState get currentState => _state;
+
+  bool get scaleLost => _scaleLost;
+  bool get machineHasAutonomousSAW => _machineHasAutonomousSAW;
+
+  /// Emits a decision on [decisions] and writes the single consolidated log
+  /// line. Abort/terminal log at WARNING (abnormal endings, telemetry-worthy
+  /// and rare); finalize at FINE (window bookkeeping); the rest at INFO.
+  void _emitDecision(
+    ShotDecisionKind kind,
+    ShotDecisionReason reason, {
+    String? details,
+    Map<String, dynamic>? data,
+  }) {
+    final message =
+        '${kind.name}/${reason.name}: ${details ?? ''}'
+        '${data != null ? ' $data' : ''}';
+    switch (kind) {
+      case ShotDecisionKind.abort:
+      case ShotDecisionKind.terminal:
+        _decisionLog.warning(message);
+      case ShotDecisionKind.finalize:
+        _decisionLog.fine(message);
+      case ShotDecisionKind.advance:
+      case ShotDecisionKind.stop:
+        _decisionLog.info(message);
+    }
+    if (!_decisionStream.isClosed) {
+      _decisionStream.add(
+        ShotDecision(kind: kind, reason: reason, details: details, data: data),
+      );
+    }
+  }
 
   DateTime _shotStartTime = DateTime.now();
   DateTime get shotStartTime => _shotStartTime;
@@ -304,6 +360,29 @@ class ShotSequencer {
     );
 
     _log.finest("State in: ${_state.name}");
+
+    // Terminal arm: a machine fault ends the shot from any active phase.
+    // Without this the sequencer would sit in `pouring` forever — the DE1
+    // reports MachineState.error, not espresso/pouringDone, so the regular
+    // stop detection below never fires.
+    if (machine.state.state == MachineState.error &&
+        _state != ShotState.idle &&
+        _state != ShotState.finished) {
+      _finalStopReason ??= ShotDecisionReason.error;
+      _emitDecision(
+        ShotDecisionKind.terminal,
+        ShotDecisionReason.error,
+        details:
+            'Machine entered error state (${machine.state.substate.name})',
+        data: {'substate': machine.state.substate.name},
+      );
+      _volumeCountingActive = false;
+      dataCollectionEnabled = false;
+      _state = ShotState.finished;
+      _stateStream.add(_state);
+      return;
+    }
+
     switch (_state) {
       case ShotState.idle:
         if (machine.state.state == MachineState.espresso &&
@@ -322,6 +401,8 @@ class ShotSequencer {
           skippedSteps.clear();
           _stepExitArbiter.reset();
           _lastProfileFrame = -1;
+          _maxFrameSeen = -1;
+          _finalStopReason = null;
 
           if (_bypassSAW == false && scale != null && !_scaleLost) {
             _log.info(
@@ -339,6 +420,25 @@ class ShotSequencer {
         break;
 
       case ShotState.preheating:
+        // Abort arm: the machine left espresso before the pour began (GHC /
+        // app / REST stop during preheat, or a mode change). End the shot as
+        // an abort so De1StateManager tears the sequencer down — otherwise it
+        // sits in `preheating` forever, hangs the shotState feed on a stale
+        // frame, and gets recycled into the next espresso/steam/hot-water
+        // session. A steam session (De1SubState.steaming also maps to the
+        // `pouring` substate) is caught here by the state check, not the
+        // substate check below.
+        if (machine.state.state != MachineState.espresso) {
+          final intent = de1controller.consumeStopIntent();
+          // No _finalStopReason: an aborted shot is never persisted — the
+          // abort decision itself carries the reason to the feed.
+          _emitDecision(
+            ShotDecisionKind.abort,
+            intent ?? ShotDecisionReason.machineEnded,
+            details: 'Shot aborted during preheat, before the pour began',
+          );
+          break;
+        }
         if (machine.state.substate == MachineSubstate.preinfusion ||
             machine.state.substate == MachineSubstate.pouring) {
           if (_bypassSAW == false && scale != null && !_scaleLost) {
@@ -364,24 +464,32 @@ class ShotSequencer {
         break;
 
       case ShotState.pouring:
+        _trackFrameAdvance(machine.profileFrame);
         if (_bypassSAW == false && scale != null && !_scaleLost) {
           double currentWeight = scale.weight;
           double weightFlow = scale.weightFlow;
           double projectedWeight =
               currentWeight + (weightFlow * _weightFlowMultiplier);
-          final int profileFrame = machine.profileFrame;
 
-          if (profileFrame != _lastProfileFrame) {
-            _stepExitArbiter.onFrameAdvanced(profileFrame);
-            _lastProfileFrame = profileFrame;
-          }
-
-          _handleStepWeightExit(profileFrame, projectedWeight, machine);
+          _handleStepWeightExit(
+            machine.profileFrame,
+            projectedWeight,
+            machine,
+          );
           if (!_machineHasAutonomousSAW &&
               targetYield > 0 &&
               projectedWeight >= targetYield) {
-            _log.info(
-              "Target weight ${targetYield}g reached (projected: $projectedWeight). Stopping shot.",
+            _finalStopReason = ShotDecisionReason.targetWeight;
+            _emitDecision(
+              ShotDecisionKind.stop,
+              ShotDecisionReason.targetWeight,
+              details:
+                  'Target weight ${targetYield}g reached '
+                  '(projected: $projectedWeight). Stopping shot.',
+              data: {
+                'targetYield': targetYield,
+                'projectedWeight': projectedWeight,
+              },
             );
             de1controller.connectedDe1().requestState(
               MachineState.idle,
@@ -398,8 +506,17 @@ class ShotSequencer {
           final projectedVolume =
               _accumulatedVolume + (machine.flow * _volumeFlowMultiplier);
           if (projectedVolume > targetProfile.targetVolume!) {
-            _log.info(
-              "Target volume ${targetProfile.targetVolume}ml reached (projected: $projectedVolume). Stopping shot.",
+            _finalStopReason = ShotDecisionReason.targetVolume;
+            _emitDecision(
+              ShotDecisionKind.stop,
+              ShotDecisionReason.targetVolume,
+              details:
+                  'Target volume ${targetProfile.targetVolume}ml reached '
+                  '(projected: $projectedVolume). Stopping shot.',
+              data: {
+                'targetVolume': targetProfile.targetVolume,
+                'projectedVolume': projectedVolume,
+              },
             );
             de1controller.connectedDe1().requestState(
               MachineState.idle,
@@ -410,6 +527,27 @@ class ShotSequencer {
         }
         if (machine.state.substate == MachineSubstate.pouringDone ||
             machine.state.substate == MachineSubstate.idle) {
+          // The machine reported the end without an app-side target firing.
+          // If a stop command recently passed through this app (REST client
+          // or the in-app Stop button), attribute it to that source; the
+          // unmarked remainder is the GHC or natural profile completion,
+          // indistinguishable from the substate stream alone.
+          final intent = de1controller.consumeStopIntent();
+          final reason = intent ?? ShotDecisionReason.machineEnded;
+          _finalStopReason ??= reason;
+          _emitDecision(
+            ShotDecisionKind.stop,
+            reason,
+            details: switch (reason) {
+              ShotDecisionReason.apiStop =>
+                'Shot stopped via REST API request',
+              ShotDecisionReason.appStop =>
+                'Shot stopped from the app UI',
+              _ =>
+                'Machine reported shot end '
+                    '(${machine.state.substate.name})',
+            },
+          );
           _enterStopping(scale);
         }
         break;
@@ -435,8 +573,13 @@ class ShotSequencer {
         // / spike event. Guarantee the shot still finalizes.
         _stoppingStateFuture ??= Future.delayed(_stoppingBackstop, () {
           if (_state == ShotState.stopping) {
-            _log.info(
-              "Stopping backstop fired. Final volume: ${_accumulatedVolume}ml",
+            _emitDecision(
+              ShotDecisionKind.finalize,
+              ShotDecisionReason.stoppingBackstop,
+              details:
+                  'Stopping backstop fired. '
+                  'Final volume: ${_accumulatedVolume}ml',
+              data: {'finalVolume': _accumulatedVolume},
             );
             _finishStopping();
           }
@@ -452,6 +595,43 @@ class ShotSequencer {
         break;
     }
     _log.finest("State out: ${_state.name}");
+  }
+
+  /// Tracks profile-frame changes during pouring and reports firmware-natural
+  /// advances (frames the app did NOT skip) as `profileAdvance` decisions.
+  ///
+  /// `skippedSteps` records the *vacated* frame at the moment the app
+  /// requests a skip, so an increment whose previous frame is in that set is
+  /// the firmware acknowledging our skip — already reported as `profileSkip`.
+  /// The frame index is a raw byte off the BLE shot sample with no
+  /// monotonicity guarantee, so advances are emitted against a high-water
+  /// mark ([_maxFrameSeen]): a jump >1 reports each vacated frame once, and a
+  /// regression followed by recovery does not re-report frames already
+  /// emitted. The arbiter still tracks the true current frame separately.
+  void _trackFrameAdvance(int profileFrame) {
+    if (profileFrame != _lastProfileFrame) {
+      _stepExitArbiter.onFrameAdvanced(profileFrame);
+      _lastProfileFrame = profileFrame;
+    }
+    if (_maxFrameSeen < 0) {
+      _maxFrameSeen = profileFrame;
+      return;
+    }
+    if (profileFrame <= _maxFrameSeen) {
+      return;
+    }
+    for (var frame = _maxFrameSeen; frame < profileFrame; frame++) {
+      if (skippedSteps.contains(frame)) {
+        continue;
+      }
+      _emitDecision(
+        ShotDecisionKind.advance,
+        ShotDecisionReason.profileAdvance,
+        details: 'Firmware advanced from frame $frame to ${frame + 1}',
+        data: {'fromFrame': frame, 'toFrame': frame + 1},
+      );
+    }
+    _maxFrameSeen = profileFrame;
   }
 
   void _handleStepWeightExit(
@@ -490,7 +670,18 @@ class ShotSequencer {
       }
     }
 
-    _log.info("Step weight reached, moving on");
+    _emitDecision(
+      ShotDecisionKind.advance,
+      ShotDecisionReason.profileSkip,
+      details:
+          'Step weight ${stepExitWeight}g reached '
+          '(projected: $projectedWeight), skipping frame $profileFrame',
+      data: {
+        'frame': profileFrame,
+        'stepExitWeight': stepExitWeight,
+        'projectedWeight': projectedWeight,
+      },
+    );
     skippedSteps.add(profileFrame);
     de1controller.connectedDe1().requestState(MachineState.skipStep);
   }
@@ -572,19 +763,9 @@ class ShotSequencer {
   }
 }
 
-enum ShotState { idle, preheating, pouring, stopping, finished }
-
-/// Why the sequencer made a decision (currently only shot-stop reasons).
-/// [noScale] corresponds to the REST `block_no_scale` error type; keep the two
-/// vocabularies aligned when this gains wire serialization for `/ws/v1/shotState`.
-enum ShotDecisionReason { noScale }
-
-class ShotDecision {
-  final ShotDecisionReason reason;
-  final String? details;
-
-  const ShotDecision({required this.reason, this.details});
-}
+// ShotState, ShotDecision, ShotDecisionKind and ShotDecisionReason moved to
+// lib/src/models/data/shot_state_event.dart (re-exported above) when the
+// decision stream gained wire serialization for /ws/v1/machine/shotState.
 
 
 

--- a/lib/src/models/data/shot_record.dart
+++ b/lib/src/models/data/shot_record.dart
@@ -10,6 +10,15 @@ class ShotRecord {
   final Workflow workflow;
   final ShotAnnotations? annotations;
 
+  /// Why the shot ended, as decided by the ShotSequencer
+  /// (`ShotDecisionReason.name`, e.g. `targetWeight`, `machineEnded`).
+  /// Machine-derived and immutable — deliberately NOT part of
+  /// [ShotAnnotations], which holds user-entered tasting metadata. Stored as
+  /// an open string: newer builds may persist reasons this build doesn't
+  /// know, and they must survive round-trips. Null for legacy shots and for
+  /// shots the app didn't sequence (e.g. full gateway mode, backgrounded).
+  final String? stopReason;
+
   // Legacy fields kept for backward compatibility during migration.
   final String? _shotNotes;
   final Map<String, dynamic>? _metadata;
@@ -20,6 +29,7 @@ class ShotRecord {
     required this.measurements,
     required this.workflow,
     this.annotations,
+    this.stopReason,
     String? shotNotes,
     Map<String, dynamic>? metadata,
   })  : _shotNotes = shotNotes ?? annotations?.espressoNotes,
@@ -39,6 +49,7 @@ class ShotRecord {
       "measurements": measurements.map((e) => e.toJson()).toList(),
       "workflow": workflow.toJson(),
       if (annotations != null) "annotations": annotations!.toJson(),
+      if (stopReason != null) "stopReason": stopReason,
       // Write legacy fields too for backward compat with older app versions
       if (_shotNotes != null) "shotNotes": _shotNotes,
       if (_metadata != null) "metadata": _metadata,
@@ -52,6 +63,7 @@ class ShotRecord {
       "timestamp": timestamp.toIso8601String(),
       "workflow": workflow.toJson(),
       if (annotations != null) "annotations": annotations!.toJson(),
+      if (stopReason != null) "stopReason": stopReason,
       if (_shotNotes != null) "shotNotes": _shotNotes,
       if (_metadata != null) "metadata": _metadata,
     };
@@ -74,6 +86,7 @@ class ShotRecord {
           .toList(),
       workflow: Workflow.fromJson(json["workflow"]),
       annotations: ann,
+      stopReason: json["stopReason"] as String?,
       // Still parse legacy fields for backward compat with old callers
       shotNotes: json["shotNotes"] as String?,
       metadata: json["metadata"] as Map<String, dynamic>?,
@@ -92,6 +105,7 @@ class ShotRecord {
     List<ShotSnapshot>? measurements,
     Workflow? workflow,
     ShotAnnotations? annotations,
+    String? stopReason,
     String? shotNotes,
     Map<String, dynamic>? metadata,
   }) {
@@ -101,6 +115,7 @@ class ShotRecord {
       measurements: measurements ?? this.measurements,
       workflow: workflow ?? this.workflow,
       annotations: annotations ?? this.annotations,
+      stopReason: stopReason ?? this.stopReason,
       shotNotes: shotNotes ?? _shotNotes,
       metadata: metadata ?? _metadata,
     );

--- a/lib/src/models/data/shot_state_event.dart
+++ b/lib/src/models/data/shot_state_event.dart
@@ -1,0 +1,153 @@
+import 'package:clock/clock.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+
+/// Shot lifecycle phases as tracked by `ShotSequencer`.
+enum ShotState { idle, preheating, pouring, stopping, finished }
+
+/// What a [ShotDecision] did to the shot.
+///
+/// * [advance] — moved the profile to the next step (app-issued skip or
+///   firmware-natural frame exit).
+/// * [stop] — ended the pour (target reached, machine reported done, or a
+///   client/user commanded it).
+/// * [abort] — the shot never ran (e.g. blocked because no scale connected).
+/// * [terminal] — the shot ended abnormally (machine error, disconnect).
+/// * [finalize] — closed the post-stop settling window; not why the shot
+///   stopped, so it never overrides the persisted stop reason.
+enum ShotDecisionKind { advance, stop, abort, terminal, finalize }
+
+/// Why the sequencer made a decision.
+///
+/// Serialized by `.name` onto the wire (`/ws/v1/machine/shotState`) and into
+/// the persisted `ShotRecord.stopReason`. The wire vocabulary is an OPEN set —
+/// consumers must tolerate unknown values from newer builds.
+///
+/// [noScale] corresponds to the REST `block_no_scale` error type; keep the two
+/// vocabularies aligned.
+enum ShotDecisionReason {
+  /// Shot blocked/aborted: blockOnNoScale enabled and no scale connected.
+  noScale,
+
+  /// App-side stop-at-weight hit the target yield.
+  targetWeight,
+
+  /// App-side stop-at-volume hit the profile's target volume.
+  targetVolume,
+
+  /// Stop commanded by an external client via the REST API.
+  apiStop,
+
+  /// Stop commanded from the in-app UI (Stop Shot button).
+  appStop,
+
+  /// The machine reported the shot end with no app/client command on record —
+  /// GHC stop or natural profile completion (indistinguishable from the
+  /// substate stream alone).
+  machineEnded,
+
+  /// Firmware advanced to the next profile frame on its own.
+  profileAdvance,
+
+  /// The app skipped the current frame (per-step weight exit).
+  profileSkip,
+
+  /// The machine entered an error state mid-shot.
+  error,
+
+  /// The machine disconnected mid-shot (sequencer torn down).
+  disconnected,
+
+  /// The 4s post-stop safety backstop closed the settling window.
+  stoppingBackstop,
+}
+
+/// A single sequencer decision: what happened ([kind]), why ([reason]),
+/// a human-readable [details] string, and optional numeric context ([data]).
+class ShotDecision {
+  final ShotDecisionKind kind;
+  final ShotDecisionReason reason;
+  final String? details;
+  final Map<String, dynamic>? data;
+
+  const ShotDecision({
+    required this.kind,
+    required this.reason,
+    this.details,
+    this.data,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'kind': kind.name,
+        'reason': reason.name,
+        'details': details,
+        'data': data,
+      };
+}
+
+/// One frame on the `/ws/v1/machine/shotState` topic.
+///
+/// A single event type multiplexes shot-state transitions and decisions,
+/// discriminated by [event] (`state` | `decision` | `terminal`). Every frame
+/// carries the current shot phase and machine context so late joiners get a
+/// coherent view from any single frame; [decision] is non-null only for
+/// `decision`/`terminal` frames.
+class ShotStateEvent {
+  final String event;
+
+  /// When the event happened: the timestamp of the machine snapshot that
+  /// drove it, so clients can align frames with `/ws/v1/machine/snapshot`
+  /// telemetry. Falls back to wall clock only when no snapshot context
+  /// exists (e.g. the between-shots idle re-seed after a disconnect).
+  final DateTime timestamp;
+
+  /// Stable id for the shot, equal to the persisted `ShotRecord.id` when the
+  /// shot is saved. Null between shots.
+  final String? shotId;
+  final ShotState state;
+  final MachineState? machineState;
+  final MachineSubstate? machineSubstate;
+  final int? profileFrame;
+  final bool scaleConnected;
+
+  /// Sticky for the remainder of the shot once the scale drops mid-pour —
+  /// stop-at-weight stays disabled even if [scaleConnected] flips back.
+  final bool scaleLost;
+  final bool machineHasAutonomousSAW;
+  final ShotDecision? decision;
+
+  ShotStateEvent({
+    required this.event,
+    required this.timestamp,
+    required this.state,
+    this.shotId,
+    this.machineState,
+    this.machineSubstate,
+    this.profileFrame,
+    this.scaleConnected = false,
+    this.scaleLost = false,
+    this.machineHasAutonomousSAW = false,
+    this.decision,
+  });
+
+  /// The between-shots resting frame — seeds the topic so late joiners never
+  /// replay a stale mid-shot frame from a previous shot.
+  factory ShotStateEvent.idle() => ShotStateEvent(
+        event: 'state',
+        timestamp: clock.now(),
+        state: ShotState.idle,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'event': event,
+        'timestamp': timestamp.toIso8601String(),
+        'shotId': shotId,
+        'state': state.name,
+        'machineState': machineState?.name,
+        'machineSubstate': machineSubstate?.name,
+        'profileFrame': profileFrame,
+        'scaleConnected': scaleConnected,
+        'scaleLost': scaleLost,
+        'machineHasAutonomousSAW': machineHasAutonomousSAW,
+        'decision': decision?.toJson(),
+      };
+}

--- a/lib/src/realtime_shot_feature/realtime_shot_feature.dart
+++ b/lib/src/realtime_shot_feature/realtime_shot_feature.dart
@@ -213,6 +213,10 @@ class _RealtimeShotFeatureState extends State<RealtimeShotFeature> {
         ShadButton.destructive(
           enabled: !backEnabled,
           onPressed: () {
+            // Pre-declare intent so the stop is attributed to the app UI
+            // (stopReason: appStop) rather than the ambiguous machineEnded.
+            widget.shotSequencer.de1controller
+                .recordStopIntent(ShotDecisionReason.appStop);
             widget.shotSequencer.de1controller
                 .connectedDe1()
                 .requestState(MachineState.idle);

--- a/lib/src/services/database/database.dart
+++ b/lib/src/services/database/database.dart
@@ -44,7 +44,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 3;
+  int get schemaVersion => 4;
 
   @override
   MigrationStrategy get migration {
@@ -61,6 +61,9 @@ class AppDatabase extends _$AppDatabase {
         if (from < 3) {
           await m.createTable(steamRecords);
           await _createSteamIndices();
+        }
+        if (from < 4) {
+          await m.addColumn(shotRecords, shotRecords.stopReason);
         }
       },
       beforeOpen: (details) async {

--- a/lib/src/services/database/database.g.dart
+++ b/lib/src/services/database/database.g.dart
@@ -322,30 +322,26 @@ class $BeansTable extends Beans with TableInfo<$BeansTable, Bean> {
   Bean map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return Bean(
-      id:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}id'],
-          )!,
-      roaster:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}roaster'],
-          )!,
-      name:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}name'],
-          )!,
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      roaster: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}roaster'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      )!,
       species: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}species'],
       ),
-      decaf:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.bool,
-            data['${effectivePrefix}decaf'],
-          )!,
+      decaf: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}decaf'],
+      )!,
       decafProcess: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}decaf_process'],
@@ -382,21 +378,18 @@ class $BeansTable extends Beans with TableInfo<$BeansTable, Bean> {
         DriftSqlType.string,
         data['${effectivePrefix}notes'],
       ),
-      archived:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.bool,
-            data['${effectivePrefix}archived'],
-          )!,
-      createdAt:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.dateTime,
-            data['${effectivePrefix}created_at'],
-          )!,
-      updatedAt:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.dateTime,
-            data['${effectivePrefix}updated_at'],
-          )!,
+      archived: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}archived'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      )!,
       extras: $BeansTable.$converterextras.fromSql(
         attachedDatabase.typeMapping.read(
           DriftSqlType.string,
@@ -510,44 +503,40 @@ class Bean extends DataClass implements Insertable<Bean> {
       id: Value(id),
       roaster: Value(roaster),
       name: Value(name),
-      species:
-          species == null && nullToAbsent
-              ? const Value.absent()
-              : Value(species),
+      species: species == null && nullToAbsent
+          ? const Value.absent()
+          : Value(species),
       decaf: Value(decaf),
-      decafProcess:
-          decafProcess == null && nullToAbsent
-              ? const Value.absent()
-              : Value(decafProcess),
-      country:
-          country == null && nullToAbsent
-              ? const Value.absent()
-              : Value(country),
-      region:
-          region == null && nullToAbsent ? const Value.absent() : Value(region),
-      producer:
-          producer == null && nullToAbsent
-              ? const Value.absent()
-              : Value(producer),
-      variety:
-          variety == null && nullToAbsent
-              ? const Value.absent()
-              : Value(variety),
-      altitude:
-          altitude == null && nullToAbsent
-              ? const Value.absent()
-              : Value(altitude),
-      processing:
-          processing == null && nullToAbsent
-              ? const Value.absent()
-              : Value(processing),
-      notes:
-          notes == null && nullToAbsent ? const Value.absent() : Value(notes),
+      decafProcess: decafProcess == null && nullToAbsent
+          ? const Value.absent()
+          : Value(decafProcess),
+      country: country == null && nullToAbsent
+          ? const Value.absent()
+          : Value(country),
+      region: region == null && nullToAbsent
+          ? const Value.absent()
+          : Value(region),
+      producer: producer == null && nullToAbsent
+          ? const Value.absent()
+          : Value(producer),
+      variety: variety == null && nullToAbsent
+          ? const Value.absent()
+          : Value(variety),
+      altitude: altitude == null && nullToAbsent
+          ? const Value.absent()
+          : Value(altitude),
+      processing: processing == null && nullToAbsent
+          ? const Value.absent()
+          : Value(processing),
+      notes: notes == null && nullToAbsent
+          ? const Value.absent()
+          : Value(notes),
       archived: Value(archived),
       createdAt: Value(createdAt),
       updatedAt: Value(updatedAt),
-      extras:
-          extras == null && nullToAbsent ? const Value.absent() : Value(extras),
+      extras: extras == null && nullToAbsent
+          ? const Value.absent()
+          : Value(extras),
     );
   }
 
@@ -644,17 +633,17 @@ class Bean extends DataClass implements Insertable<Bean> {
       name: data.name.present ? data.name.value : this.name,
       species: data.species.present ? data.species.value : this.species,
       decaf: data.decaf.present ? data.decaf.value : this.decaf,
-      decafProcess:
-          data.decafProcess.present
-              ? data.decafProcess.value
-              : this.decafProcess,
+      decafProcess: data.decafProcess.present
+          ? data.decafProcess.value
+          : this.decafProcess,
       country: data.country.present ? data.country.value : this.country,
       region: data.region.present ? data.region.value : this.region,
       producer: data.producer.present ? data.producer.value : this.producer,
       variety: data.variety.present ? data.variety.value : this.variety,
       altitude: data.altitude.present ? data.altitude.value : this.altitude,
-      processing:
-          data.processing.present ? data.processing.value : this.processing,
+      processing: data.processing.present
+          ? data.processing.value
+          : this.processing,
       notes: data.notes.present ? data.notes.value : this.notes,
       archived: data.archived.present ? data.archived.value : this.archived,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
@@ -1389,16 +1378,14 @@ class $BeanBatchesTable extends BeanBatches
   BeanBatche map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return BeanBatche(
-      id:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}id'],
-          )!,
-      beanId:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}bean_id'],
-          )!,
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      beanId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}bean_id'],
+      )!,
       roastDate: attachedDatabase.typeMapping.read(
         DriftSqlType.dateTime,
         data['${effectivePrefix}roast_date'],
@@ -1451,30 +1438,26 @@ class $BeanBatchesTable extends BeanBatches
         DriftSqlType.dateTime,
         data['${effectivePrefix}unfreeze_date'],
       ),
-      frozen:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.bool,
-            data['${effectivePrefix}frozen'],
-          )!,
-      archived:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.bool,
-            data['${effectivePrefix}archived'],
-          )!,
+      frozen: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}frozen'],
+      )!,
+      archived: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}archived'],
+      )!,
       notes: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}notes'],
       ),
-      createdAt:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.dateTime,
-            data['${effectivePrefix}created_at'],
-          )!,
-      updatedAt:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.dateTime,
-            data['${effectivePrefix}updated_at'],
-          )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      )!,
       extras: $BeanBatchesTable.$converterextras.fromSql(
         attachedDatabase.typeMapping.read(
           DriftSqlType.string,
@@ -1601,62 +1584,55 @@ class BeanBatche extends DataClass implements Insertable<BeanBatche> {
     return BeanBatchesCompanion(
       id: Value(id),
       beanId: Value(beanId),
-      roastDate:
-          roastDate == null && nullToAbsent
-              ? const Value.absent()
-              : Value(roastDate),
-      roastLevel:
-          roastLevel == null && nullToAbsent
-              ? const Value.absent()
-              : Value(roastLevel),
-      harvestDate:
-          harvestDate == null && nullToAbsent
-              ? const Value.absent()
-              : Value(harvestDate),
-      qualityScore:
-          qualityScore == null && nullToAbsent
-              ? const Value.absent()
-              : Value(qualityScore),
-      price:
-          price == null && nullToAbsent ? const Value.absent() : Value(price),
-      currency:
-          currency == null && nullToAbsent
-              ? const Value.absent()
-              : Value(currency),
-      weight:
-          weight == null && nullToAbsent ? const Value.absent() : Value(weight),
-      weightRemaining:
-          weightRemaining == null && nullToAbsent
-              ? const Value.absent()
-              : Value(weightRemaining),
-      buyDate:
-          buyDate == null && nullToAbsent
-              ? const Value.absent()
-              : Value(buyDate),
-      openDate:
-          openDate == null && nullToAbsent
-              ? const Value.absent()
-              : Value(openDate),
-      bestBeforeDate:
-          bestBeforeDate == null && nullToAbsent
-              ? const Value.absent()
-              : Value(bestBeforeDate),
-      freezeDate:
-          freezeDate == null && nullToAbsent
-              ? const Value.absent()
-              : Value(freezeDate),
-      unfreezeDate:
-          unfreezeDate == null && nullToAbsent
-              ? const Value.absent()
-              : Value(unfreezeDate),
+      roastDate: roastDate == null && nullToAbsent
+          ? const Value.absent()
+          : Value(roastDate),
+      roastLevel: roastLevel == null && nullToAbsent
+          ? const Value.absent()
+          : Value(roastLevel),
+      harvestDate: harvestDate == null && nullToAbsent
+          ? const Value.absent()
+          : Value(harvestDate),
+      qualityScore: qualityScore == null && nullToAbsent
+          ? const Value.absent()
+          : Value(qualityScore),
+      price: price == null && nullToAbsent
+          ? const Value.absent()
+          : Value(price),
+      currency: currency == null && nullToAbsent
+          ? const Value.absent()
+          : Value(currency),
+      weight: weight == null && nullToAbsent
+          ? const Value.absent()
+          : Value(weight),
+      weightRemaining: weightRemaining == null && nullToAbsent
+          ? const Value.absent()
+          : Value(weightRemaining),
+      buyDate: buyDate == null && nullToAbsent
+          ? const Value.absent()
+          : Value(buyDate),
+      openDate: openDate == null && nullToAbsent
+          ? const Value.absent()
+          : Value(openDate),
+      bestBeforeDate: bestBeforeDate == null && nullToAbsent
+          ? const Value.absent()
+          : Value(bestBeforeDate),
+      freezeDate: freezeDate == null && nullToAbsent
+          ? const Value.absent()
+          : Value(freezeDate),
+      unfreezeDate: unfreezeDate == null && nullToAbsent
+          ? const Value.absent()
+          : Value(unfreezeDate),
       frozen: Value(frozen),
       archived: Value(archived),
-      notes:
-          notes == null && nullToAbsent ? const Value.absent() : Value(notes),
+      notes: notes == null && nullToAbsent
+          ? const Value.absent()
+          : Value(notes),
       createdAt: Value(createdAt),
       updatedAt: Value(updatedAt),
-      extras:
-          extras == null && nullToAbsent ? const Value.absent() : Value(extras),
+      extras: extras == null && nullToAbsent
+          ? const Value.absent()
+          : Value(extras),
     );
   }
 
@@ -1749,12 +1725,14 @@ class BeanBatche extends DataClass implements Insertable<BeanBatche> {
     price: price.present ? price.value : this.price,
     currency: currency.present ? currency.value : this.currency,
     weight: weight.present ? weight.value : this.weight,
-    weightRemaining:
-        weightRemaining.present ? weightRemaining.value : this.weightRemaining,
+    weightRemaining: weightRemaining.present
+        ? weightRemaining.value
+        : this.weightRemaining,
     buyDate: buyDate.present ? buyDate.value : this.buyDate,
     openDate: openDate.present ? openDate.value : this.openDate,
-    bestBeforeDate:
-        bestBeforeDate.present ? bestBeforeDate.value : this.bestBeforeDate,
+    bestBeforeDate: bestBeforeDate.present
+        ? bestBeforeDate.value
+        : this.bestBeforeDate,
     freezeDate: freezeDate.present ? freezeDate.value : this.freezeDate,
     unfreezeDate: unfreezeDate.present ? unfreezeDate.value : this.unfreezeDate,
     frozen: frozen ?? this.frozen,
@@ -1769,33 +1747,32 @@ class BeanBatche extends DataClass implements Insertable<BeanBatche> {
       id: data.id.present ? data.id.value : this.id,
       beanId: data.beanId.present ? data.beanId.value : this.beanId,
       roastDate: data.roastDate.present ? data.roastDate.value : this.roastDate,
-      roastLevel:
-          data.roastLevel.present ? data.roastLevel.value : this.roastLevel,
-      harvestDate:
-          data.harvestDate.present ? data.harvestDate.value : this.harvestDate,
-      qualityScore:
-          data.qualityScore.present
-              ? data.qualityScore.value
-              : this.qualityScore,
+      roastLevel: data.roastLevel.present
+          ? data.roastLevel.value
+          : this.roastLevel,
+      harvestDate: data.harvestDate.present
+          ? data.harvestDate.value
+          : this.harvestDate,
+      qualityScore: data.qualityScore.present
+          ? data.qualityScore.value
+          : this.qualityScore,
       price: data.price.present ? data.price.value : this.price,
       currency: data.currency.present ? data.currency.value : this.currency,
       weight: data.weight.present ? data.weight.value : this.weight,
-      weightRemaining:
-          data.weightRemaining.present
-              ? data.weightRemaining.value
-              : this.weightRemaining,
+      weightRemaining: data.weightRemaining.present
+          ? data.weightRemaining.value
+          : this.weightRemaining,
       buyDate: data.buyDate.present ? data.buyDate.value : this.buyDate,
       openDate: data.openDate.present ? data.openDate.value : this.openDate,
-      bestBeforeDate:
-          data.bestBeforeDate.present
-              ? data.bestBeforeDate.value
-              : this.bestBeforeDate,
-      freezeDate:
-          data.freezeDate.present ? data.freezeDate.value : this.freezeDate,
-      unfreezeDate:
-          data.unfreezeDate.present
-              ? data.unfreezeDate.value
-              : this.unfreezeDate,
+      bestBeforeDate: data.bestBeforeDate.present
+          ? data.bestBeforeDate.value
+          : this.bestBeforeDate,
+      freezeDate: data.freezeDate.present
+          ? data.freezeDate.value
+          : this.freezeDate,
+      unfreezeDate: data.unfreezeDate.present
+          ? data.unfreezeDate.value
+          : this.unfreezeDate,
       frozen: data.frozen.present ? data.frozen.value : this.frozen,
       archived: data.archived.present ? data.archived.value : this.archived,
       notes: data.notes.present ? data.notes.value : this.notes,
@@ -2480,16 +2457,14 @@ class $GrindersTable extends Grinders with TableInfo<$GrindersTable, Grinder> {
   Grinder map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return Grinder(
-      id:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}id'],
-          )!,
-      model:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}model'],
-          )!,
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      model: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}model'],
+      )!,
       burrs: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}burrs'],
@@ -2506,16 +2481,14 @@ class $GrindersTable extends Grinders with TableInfo<$GrindersTable, Grinder> {
         DriftSqlType.string,
         data['${effectivePrefix}notes'],
       ),
-      archived:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.bool,
-            data['${effectivePrefix}archived'],
-          )!,
-      settingType:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}setting_type'],
-          )!,
+      archived: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}archived'],
+      )!,
+      settingType: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}setting_type'],
+      )!,
       settingValues: $GrindersTable.$convertersettingValues.fromSql(
         attachedDatabase.typeMapping.read(
           DriftSqlType.string,
@@ -2538,16 +2511,14 @@ class $GrindersTable extends Grinders with TableInfo<$GrindersTable, Grinder> {
         DriftSqlType.double,
         data['${effectivePrefix}rpm_big_step'],
       ),
-      createdAt:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.dateTime,
-            data['${effectivePrefix}created_at'],
-          )!,
-      updatedAt:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.dateTime,
-            data['${effectivePrefix}updated_at'],
-          )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      )!,
       extras: $GrindersTable.$converterextras.fromSql(
         attachedDatabase.typeMapping.read(
           DriftSqlType.string,
@@ -2653,44 +2624,40 @@ class Grinder extends DataClass implements Insertable<Grinder> {
     return GrindersCompanion(
       id: Value(id),
       model: Value(model),
-      burrs:
-          burrs == null && nullToAbsent ? const Value.absent() : Value(burrs),
-      burrSize:
-          burrSize == null && nullToAbsent
-              ? const Value.absent()
-              : Value(burrSize),
-      burrType:
-          burrType == null && nullToAbsent
-              ? const Value.absent()
-              : Value(burrType),
-      notes:
-          notes == null && nullToAbsent ? const Value.absent() : Value(notes),
+      burrs: burrs == null && nullToAbsent
+          ? const Value.absent()
+          : Value(burrs),
+      burrSize: burrSize == null && nullToAbsent
+          ? const Value.absent()
+          : Value(burrSize),
+      burrType: burrType == null && nullToAbsent
+          ? const Value.absent()
+          : Value(burrType),
+      notes: notes == null && nullToAbsent
+          ? const Value.absent()
+          : Value(notes),
       archived: Value(archived),
       settingType: Value(settingType),
-      settingValues:
-          settingValues == null && nullToAbsent
-              ? const Value.absent()
-              : Value(settingValues),
-      settingSmallStep:
-          settingSmallStep == null && nullToAbsent
-              ? const Value.absent()
-              : Value(settingSmallStep),
-      settingBigStep:
-          settingBigStep == null && nullToAbsent
-              ? const Value.absent()
-              : Value(settingBigStep),
-      rpmSmallStep:
-          rpmSmallStep == null && nullToAbsent
-              ? const Value.absent()
-              : Value(rpmSmallStep),
-      rpmBigStep:
-          rpmBigStep == null && nullToAbsent
-              ? const Value.absent()
-              : Value(rpmBigStep),
+      settingValues: settingValues == null && nullToAbsent
+          ? const Value.absent()
+          : Value(settingValues),
+      settingSmallStep: settingSmallStep == null && nullToAbsent
+          ? const Value.absent()
+          : Value(settingSmallStep),
+      settingBigStep: settingBigStep == null && nullToAbsent
+          ? const Value.absent()
+          : Value(settingBigStep),
+      rpmSmallStep: rpmSmallStep == null && nullToAbsent
+          ? const Value.absent()
+          : Value(rpmSmallStep),
+      rpmBigStep: rpmBigStep == null && nullToAbsent
+          ? const Value.absent()
+          : Value(rpmBigStep),
       createdAt: Value(createdAt),
       updatedAt: Value(updatedAt),
-      extras:
-          extras == null && nullToAbsent ? const Value.absent() : Value(extras),
+      extras: extras == null && nullToAbsent
+          ? const Value.absent()
+          : Value(extras),
     );
   }
 
@@ -2767,14 +2734,15 @@ class Grinder extends DataClass implements Insertable<Grinder> {
     notes: notes.present ? notes.value : this.notes,
     archived: archived ?? this.archived,
     settingType: settingType ?? this.settingType,
-    settingValues:
-        settingValues.present ? settingValues.value : this.settingValues,
-    settingSmallStep:
-        settingSmallStep.present
-            ? settingSmallStep.value
-            : this.settingSmallStep,
-    settingBigStep:
-        settingBigStep.present ? settingBigStep.value : this.settingBigStep,
+    settingValues: settingValues.present
+        ? settingValues.value
+        : this.settingValues,
+    settingSmallStep: settingSmallStep.present
+        ? settingSmallStep.value
+        : this.settingSmallStep,
+    settingBigStep: settingBigStep.present
+        ? settingBigStep.value
+        : this.settingBigStep,
     rpmSmallStep: rpmSmallStep.present ? rpmSmallStep.value : this.rpmSmallStep,
     rpmBigStep: rpmBigStep.present ? rpmBigStep.value : this.rpmBigStep,
     createdAt: createdAt ?? this.createdAt,
@@ -2790,26 +2758,24 @@ class Grinder extends DataClass implements Insertable<Grinder> {
       burrType: data.burrType.present ? data.burrType.value : this.burrType,
       notes: data.notes.present ? data.notes.value : this.notes,
       archived: data.archived.present ? data.archived.value : this.archived,
-      settingType:
-          data.settingType.present ? data.settingType.value : this.settingType,
-      settingValues:
-          data.settingValues.present
-              ? data.settingValues.value
-              : this.settingValues,
-      settingSmallStep:
-          data.settingSmallStep.present
-              ? data.settingSmallStep.value
-              : this.settingSmallStep,
-      settingBigStep:
-          data.settingBigStep.present
-              ? data.settingBigStep.value
-              : this.settingBigStep,
-      rpmSmallStep:
-          data.rpmSmallStep.present
-              ? data.rpmSmallStep.value
-              : this.rpmSmallStep,
-      rpmBigStep:
-          data.rpmBigStep.present ? data.rpmBigStep.value : this.rpmBigStep,
+      settingType: data.settingType.present
+          ? data.settingType.value
+          : this.settingType,
+      settingValues: data.settingValues.present
+          ? data.settingValues.value
+          : this.settingValues,
+      settingSmallStep: data.settingSmallStep.present
+          ? data.settingSmallStep.value
+          : this.settingSmallStep,
+      settingBigStep: data.settingBigStep.present
+          ? data.settingBigStep.value
+          : this.settingBigStep,
+      rpmSmallStep: data.rpmSmallStep.present
+          ? data.rpmSmallStep.value
+          : this.rpmSmallStep,
+      rpmBigStep: data.rpmBigStep.present
+          ? data.rpmBigStep.value
+          : this.rpmBigStep,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
       extras: data.extras.present ? data.extras.value : this.extras,
@@ -3252,28 +3218,41 @@ class $ShotRecordsTable extends ShotRecords
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
-  @override
-  late final GeneratedColumnWithTypeConverter<Map<String, dynamic>, String>
-  workflowJson = GeneratedColumn<String>(
-    'workflow_json',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  ).withConverter<Map<String, dynamic>>(
-    $ShotRecordsTable.$converterworkflowJson,
+  static const VerificationMeta _stopReasonMeta = const VerificationMeta(
+    'stopReason',
   );
   @override
-  late final GeneratedColumnWithTypeConverter<Map<String, dynamic>?, String>
-  annotationsJson = GeneratedColumn<String>(
-    'annotations_json',
+  late final GeneratedColumn<String> stopReason = GeneratedColumn<String>(
+    'stop_reason',
     aliasedName,
     true,
     type: DriftSqlType.string,
     requiredDuringInsert: false,
-  ).withConverter<Map<String, dynamic>?>(
-    $ShotRecordsTable.$converterannotationsJson,
   );
+  @override
+  late final GeneratedColumnWithTypeConverter<Map<String, dynamic>, String>
+  workflowJson =
+      GeneratedColumn<String>(
+        'workflow_json',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      ).withConverter<Map<String, dynamic>>(
+        $ShotRecordsTable.$converterworkflowJson,
+      );
+  @override
+  late final GeneratedColumnWithTypeConverter<Map<String, dynamic>?, String>
+  annotationsJson =
+      GeneratedColumn<String>(
+        'annotations_json',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      ).withConverter<Map<String, dynamic>?>(
+        $ShotRecordsTable.$converterannotationsJson,
+      );
   static const VerificationMeta _measurementsJsonMeta = const VerificationMeta(
     'measurementsJson',
   );
@@ -3300,6 +3279,7 @@ class $ShotRecordsTable extends ShotRecords
     targetYield,
     enjoyment,
     espressoNotes,
+    stopReason,
     workflowJson,
     annotationsJson,
     measurementsJson,
@@ -3419,6 +3399,12 @@ class $ShotRecordsTable extends ShotRecords
         ),
       );
     }
+    if (data.containsKey('stop_reason')) {
+      context.handle(
+        _stopReasonMeta,
+        stopReason.isAcceptableOrUnknown(data['stop_reason']!, _stopReasonMeta),
+      );
+    }
     if (data.containsKey('measurements_json')) {
       context.handle(
         _measurementsJsonMeta,
@@ -3439,16 +3425,14 @@ class $ShotRecordsTable extends ShotRecords
   ShotRecord map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return ShotRecord(
-      id:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}id'],
-          )!,
-      timestamp:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.dateTime,
-            data['${effectivePrefix}timestamp'],
-          )!,
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      timestamp: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}timestamp'],
+      )!,
       profileTitle: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}profile_title'],
@@ -3493,6 +3477,10 @@ class $ShotRecordsTable extends ShotRecords
         DriftSqlType.string,
         data['${effectivePrefix}espresso_notes'],
       ),
+      stopReason: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}stop_reason'],
+      ),
       workflowJson: $ShotRecordsTable.$converterworkflowJson.fromSql(
         attachedDatabase.typeMapping.read(
           DriftSqlType.string,
@@ -3505,11 +3493,10 @@ class $ShotRecordsTable extends ShotRecords
           data['${effectivePrefix}annotations_json'],
         ),
       ),
-      measurementsJson:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}measurements_json'],
-          )!,
+      measurementsJson: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}measurements_json'],
+      )!,
     );
   }
 
@@ -3538,6 +3525,10 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
   final double? targetYield;
   final double? enjoyment;
   final String? espressoNotes;
+
+  /// Why the shot ended (ShotDecisionReason.name, open set). Added in schema
+  /// v4; null for shots recorded before then or not sequenced by the app.
+  final String? stopReason;
   final Map<String, dynamic> workflowJson;
   final Map<String, dynamic>? annotationsJson;
   final String measurementsJson;
@@ -3555,6 +3546,7 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
     this.targetYield,
     this.enjoyment,
     this.espressoNotes,
+    this.stopReason,
     required this.workflowJson,
     this.annotationsJson,
     required this.measurementsJson,
@@ -3597,6 +3589,9 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
     if (!nullToAbsent || espressoNotes != null) {
       map['espresso_notes'] = Variable<String>(espressoNotes);
     }
+    if (!nullToAbsent || stopReason != null) {
+      map['stop_reason'] = Variable<String>(stopReason);
+    }
     {
       map['workflow_json'] = Variable<String>(
         $ShotRecordsTable.$converterworkflowJson.toSql(workflowJson),
@@ -3615,55 +3610,46 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
     return ShotRecordsCompanion(
       id: Value(id),
       timestamp: Value(timestamp),
-      profileTitle:
-          profileTitle == null && nullToAbsent
-              ? const Value.absent()
-              : Value(profileTitle),
-      grinderId:
-          grinderId == null && nullToAbsent
-              ? const Value.absent()
-              : Value(grinderId),
-      grinderModel:
-          grinderModel == null && nullToAbsent
-              ? const Value.absent()
-              : Value(grinderModel),
-      grinderSetting:
-          grinderSetting == null && nullToAbsent
-              ? const Value.absent()
-              : Value(grinderSetting),
-      beanBatchId:
-          beanBatchId == null && nullToAbsent
-              ? const Value.absent()
-              : Value(beanBatchId),
-      coffeeName:
-          coffeeName == null && nullToAbsent
-              ? const Value.absent()
-              : Value(coffeeName),
-      coffeeRoaster:
-          coffeeRoaster == null && nullToAbsent
-              ? const Value.absent()
-              : Value(coffeeRoaster),
-      targetDoseWeight:
-          targetDoseWeight == null && nullToAbsent
-              ? const Value.absent()
-              : Value(targetDoseWeight),
-      targetYield:
-          targetYield == null && nullToAbsent
-              ? const Value.absent()
-              : Value(targetYield),
-      enjoyment:
-          enjoyment == null && nullToAbsent
-              ? const Value.absent()
-              : Value(enjoyment),
-      espressoNotes:
-          espressoNotes == null && nullToAbsent
-              ? const Value.absent()
-              : Value(espressoNotes),
+      profileTitle: profileTitle == null && nullToAbsent
+          ? const Value.absent()
+          : Value(profileTitle),
+      grinderId: grinderId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(grinderId),
+      grinderModel: grinderModel == null && nullToAbsent
+          ? const Value.absent()
+          : Value(grinderModel),
+      grinderSetting: grinderSetting == null && nullToAbsent
+          ? const Value.absent()
+          : Value(grinderSetting),
+      beanBatchId: beanBatchId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(beanBatchId),
+      coffeeName: coffeeName == null && nullToAbsent
+          ? const Value.absent()
+          : Value(coffeeName),
+      coffeeRoaster: coffeeRoaster == null && nullToAbsent
+          ? const Value.absent()
+          : Value(coffeeRoaster),
+      targetDoseWeight: targetDoseWeight == null && nullToAbsent
+          ? const Value.absent()
+          : Value(targetDoseWeight),
+      targetYield: targetYield == null && nullToAbsent
+          ? const Value.absent()
+          : Value(targetYield),
+      enjoyment: enjoyment == null && nullToAbsent
+          ? const Value.absent()
+          : Value(enjoyment),
+      espressoNotes: espressoNotes == null && nullToAbsent
+          ? const Value.absent()
+          : Value(espressoNotes),
+      stopReason: stopReason == null && nullToAbsent
+          ? const Value.absent()
+          : Value(stopReason),
       workflowJson: Value(workflowJson),
-      annotationsJson:
-          annotationsJson == null && nullToAbsent
-              ? const Value.absent()
-              : Value(annotationsJson),
+      annotationsJson: annotationsJson == null && nullToAbsent
+          ? const Value.absent()
+          : Value(annotationsJson),
       measurementsJson: Value(measurementsJson),
     );
   }
@@ -3687,6 +3673,7 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
       targetYield: serializer.fromJson<double?>(json['targetYield']),
       enjoyment: serializer.fromJson<double?>(json['enjoyment']),
       espressoNotes: serializer.fromJson<String?>(json['espressoNotes']),
+      stopReason: serializer.fromJson<String?>(json['stopReason']),
       workflowJson: serializer.fromJson<Map<String, dynamic>>(
         json['workflowJson'],
       ),
@@ -3713,6 +3700,7 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
       'targetYield': serializer.toJson<double?>(targetYield),
       'enjoyment': serializer.toJson<double?>(enjoyment),
       'espressoNotes': serializer.toJson<String?>(espressoNotes),
+      'stopReason': serializer.toJson<String?>(stopReason),
       'workflowJson': serializer.toJson<Map<String, dynamic>>(workflowJson),
       'annotationsJson': serializer.toJson<Map<String, dynamic>?>(
         annotationsJson,
@@ -3735,6 +3723,7 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
     Value<double?> targetYield = const Value.absent(),
     Value<double?> enjoyment = const Value.absent(),
     Value<String?> espressoNotes = const Value.absent(),
+    Value<String?> stopReason = const Value.absent(),
     Map<String, dynamic>? workflowJson,
     Value<Map<String, dynamic>?> annotationsJson = const Value.absent(),
     String? measurementsJson,
@@ -3744,73 +3733,74 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
     profileTitle: profileTitle.present ? profileTitle.value : this.profileTitle,
     grinderId: grinderId.present ? grinderId.value : this.grinderId,
     grinderModel: grinderModel.present ? grinderModel.value : this.grinderModel,
-    grinderSetting:
-        grinderSetting.present ? grinderSetting.value : this.grinderSetting,
+    grinderSetting: grinderSetting.present
+        ? grinderSetting.value
+        : this.grinderSetting,
     beanBatchId: beanBatchId.present ? beanBatchId.value : this.beanBatchId,
     coffeeName: coffeeName.present ? coffeeName.value : this.coffeeName,
-    coffeeRoaster:
-        coffeeRoaster.present ? coffeeRoaster.value : this.coffeeRoaster,
-    targetDoseWeight:
-        targetDoseWeight.present
-            ? targetDoseWeight.value
-            : this.targetDoseWeight,
+    coffeeRoaster: coffeeRoaster.present
+        ? coffeeRoaster.value
+        : this.coffeeRoaster,
+    targetDoseWeight: targetDoseWeight.present
+        ? targetDoseWeight.value
+        : this.targetDoseWeight,
     targetYield: targetYield.present ? targetYield.value : this.targetYield,
     enjoyment: enjoyment.present ? enjoyment.value : this.enjoyment,
-    espressoNotes:
-        espressoNotes.present ? espressoNotes.value : this.espressoNotes,
+    espressoNotes: espressoNotes.present
+        ? espressoNotes.value
+        : this.espressoNotes,
+    stopReason: stopReason.present ? stopReason.value : this.stopReason,
     workflowJson: workflowJson ?? this.workflowJson,
-    annotationsJson:
-        annotationsJson.present ? annotationsJson.value : this.annotationsJson,
+    annotationsJson: annotationsJson.present
+        ? annotationsJson.value
+        : this.annotationsJson,
     measurementsJson: measurementsJson ?? this.measurementsJson,
   );
   ShotRecord copyWithCompanion(ShotRecordsCompanion data) {
     return ShotRecord(
       id: data.id.present ? data.id.value : this.id,
       timestamp: data.timestamp.present ? data.timestamp.value : this.timestamp,
-      profileTitle:
-          data.profileTitle.present
-              ? data.profileTitle.value
-              : this.profileTitle,
+      profileTitle: data.profileTitle.present
+          ? data.profileTitle.value
+          : this.profileTitle,
       grinderId: data.grinderId.present ? data.grinderId.value : this.grinderId,
-      grinderModel:
-          data.grinderModel.present
-              ? data.grinderModel.value
-              : this.grinderModel,
-      grinderSetting:
-          data.grinderSetting.present
-              ? data.grinderSetting.value
-              : this.grinderSetting,
-      beanBatchId:
-          data.beanBatchId.present ? data.beanBatchId.value : this.beanBatchId,
-      coffeeName:
-          data.coffeeName.present ? data.coffeeName.value : this.coffeeName,
-      coffeeRoaster:
-          data.coffeeRoaster.present
-              ? data.coffeeRoaster.value
-              : this.coffeeRoaster,
-      targetDoseWeight:
-          data.targetDoseWeight.present
-              ? data.targetDoseWeight.value
-              : this.targetDoseWeight,
-      targetYield:
-          data.targetYield.present ? data.targetYield.value : this.targetYield,
+      grinderModel: data.grinderModel.present
+          ? data.grinderModel.value
+          : this.grinderModel,
+      grinderSetting: data.grinderSetting.present
+          ? data.grinderSetting.value
+          : this.grinderSetting,
+      beanBatchId: data.beanBatchId.present
+          ? data.beanBatchId.value
+          : this.beanBatchId,
+      coffeeName: data.coffeeName.present
+          ? data.coffeeName.value
+          : this.coffeeName,
+      coffeeRoaster: data.coffeeRoaster.present
+          ? data.coffeeRoaster.value
+          : this.coffeeRoaster,
+      targetDoseWeight: data.targetDoseWeight.present
+          ? data.targetDoseWeight.value
+          : this.targetDoseWeight,
+      targetYield: data.targetYield.present
+          ? data.targetYield.value
+          : this.targetYield,
       enjoyment: data.enjoyment.present ? data.enjoyment.value : this.enjoyment,
-      espressoNotes:
-          data.espressoNotes.present
-              ? data.espressoNotes.value
-              : this.espressoNotes,
-      workflowJson:
-          data.workflowJson.present
-              ? data.workflowJson.value
-              : this.workflowJson,
-      annotationsJson:
-          data.annotationsJson.present
-              ? data.annotationsJson.value
-              : this.annotationsJson,
-      measurementsJson:
-          data.measurementsJson.present
-              ? data.measurementsJson.value
-              : this.measurementsJson,
+      espressoNotes: data.espressoNotes.present
+          ? data.espressoNotes.value
+          : this.espressoNotes,
+      stopReason: data.stopReason.present
+          ? data.stopReason.value
+          : this.stopReason,
+      workflowJson: data.workflowJson.present
+          ? data.workflowJson.value
+          : this.workflowJson,
+      annotationsJson: data.annotationsJson.present
+          ? data.annotationsJson.value
+          : this.annotationsJson,
+      measurementsJson: data.measurementsJson.present
+          ? data.measurementsJson.value
+          : this.measurementsJson,
     );
   }
 
@@ -3830,6 +3820,7 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
           ..write('targetYield: $targetYield, ')
           ..write('enjoyment: $enjoyment, ')
           ..write('espressoNotes: $espressoNotes, ')
+          ..write('stopReason: $stopReason, ')
           ..write('workflowJson: $workflowJson, ')
           ..write('annotationsJson: $annotationsJson, ')
           ..write('measurementsJson: $measurementsJson')
@@ -3852,6 +3843,7 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
     targetYield,
     enjoyment,
     espressoNotes,
+    stopReason,
     workflowJson,
     annotationsJson,
     measurementsJson,
@@ -3873,6 +3865,7 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
           other.targetYield == this.targetYield &&
           other.enjoyment == this.enjoyment &&
           other.espressoNotes == this.espressoNotes &&
+          other.stopReason == this.stopReason &&
           other.workflowJson == this.workflowJson &&
           other.annotationsJson == this.annotationsJson &&
           other.measurementsJson == this.measurementsJson);
@@ -3892,6 +3885,7 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
   final Value<double?> targetYield;
   final Value<double?> enjoyment;
   final Value<String?> espressoNotes;
+  final Value<String?> stopReason;
   final Value<Map<String, dynamic>> workflowJson;
   final Value<Map<String, dynamic>?> annotationsJson;
   final Value<String> measurementsJson;
@@ -3910,6 +3904,7 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
     this.targetYield = const Value.absent(),
     this.enjoyment = const Value.absent(),
     this.espressoNotes = const Value.absent(),
+    this.stopReason = const Value.absent(),
     this.workflowJson = const Value.absent(),
     this.annotationsJson = const Value.absent(),
     this.measurementsJson = const Value.absent(),
@@ -3929,6 +3924,7 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
     this.targetYield = const Value.absent(),
     this.enjoyment = const Value.absent(),
     this.espressoNotes = const Value.absent(),
+    this.stopReason = const Value.absent(),
     required Map<String, dynamic> workflowJson,
     this.annotationsJson = const Value.absent(),
     required String measurementsJson,
@@ -3951,6 +3947,7 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
     Expression<double>? targetYield,
     Expression<double>? enjoyment,
     Expression<String>? espressoNotes,
+    Expression<String>? stopReason,
     Expression<String>? workflowJson,
     Expression<String>? annotationsJson,
     Expression<String>? measurementsJson,
@@ -3970,6 +3967,7 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
       if (targetYield != null) 'target_yield': targetYield,
       if (enjoyment != null) 'enjoyment': enjoyment,
       if (espressoNotes != null) 'espresso_notes': espressoNotes,
+      if (stopReason != null) 'stop_reason': stopReason,
       if (workflowJson != null) 'workflow_json': workflowJson,
       if (annotationsJson != null) 'annotations_json': annotationsJson,
       if (measurementsJson != null) 'measurements_json': measurementsJson,
@@ -3991,6 +3989,7 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
     Value<double?>? targetYield,
     Value<double?>? enjoyment,
     Value<String?>? espressoNotes,
+    Value<String?>? stopReason,
     Value<Map<String, dynamic>>? workflowJson,
     Value<Map<String, dynamic>?>? annotationsJson,
     Value<String>? measurementsJson,
@@ -4010,6 +4009,7 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
       targetYield: targetYield ?? this.targetYield,
       enjoyment: enjoyment ?? this.enjoyment,
       espressoNotes: espressoNotes ?? this.espressoNotes,
+      stopReason: stopReason ?? this.stopReason,
       workflowJson: workflowJson ?? this.workflowJson,
       annotationsJson: annotationsJson ?? this.annotationsJson,
       measurementsJson: measurementsJson ?? this.measurementsJson,
@@ -4059,6 +4059,9 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
     if (espressoNotes.present) {
       map['espresso_notes'] = Variable<String>(espressoNotes.value);
     }
+    if (stopReason.present) {
+      map['stop_reason'] = Variable<String>(stopReason.value);
+    }
     if (workflowJson.present) {
       map['workflow_json'] = Variable<String>(
         $ShotRecordsTable.$converterworkflowJson.toSql(workflowJson.value),
@@ -4096,6 +4099,7 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
           ..write('targetYield: $targetYield, ')
           ..write('enjoyment: $enjoyment, ')
           ..write('espressoNotes: $espressoNotes, ')
+          ..write('stopReason: $stopReason, ')
           ..write('workflowJson: $workflowJson, ')
           ..write('annotationsJson: $annotationsJson, ')
           ..write('measurementsJson: $measurementsJson, ')
@@ -4133,26 +4137,28 @@ class $SteamRecordsTable extends SteamRecords
   );
   @override
   late final GeneratedColumnWithTypeConverter<Map<String, dynamic>, String>
-  workflowJson = GeneratedColumn<String>(
-    'workflow_json',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  ).withConverter<Map<String, dynamic>>(
-    $SteamRecordsTable.$converterworkflowJson,
-  );
+  workflowJson =
+      GeneratedColumn<String>(
+        'workflow_json',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      ).withConverter<Map<String, dynamic>>(
+        $SteamRecordsTable.$converterworkflowJson,
+      );
   @override
   late final GeneratedColumnWithTypeConverter<Map<String, dynamic>?, String>
-  annotationsJson = GeneratedColumn<String>(
-    'annotations_json',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  ).withConverter<Map<String, dynamic>?>(
-    $SteamRecordsTable.$converterannotationsJson,
-  );
+  annotationsJson =
+      GeneratedColumn<String>(
+        'annotations_json',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      ).withConverter<Map<String, dynamic>?>(
+        $SteamRecordsTable.$converterannotationsJson,
+      );
   static const VerificationMeta _measurementsJsonMeta = const VerificationMeta(
     'measurementsJson',
   );
@@ -4217,16 +4223,14 @@ class $SteamRecordsTable extends SteamRecords
   SteamRecord map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return SteamRecord(
-      id:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}id'],
-          )!,
-      timestamp:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.dateTime,
-            data['${effectivePrefix}timestamp'],
-          )!,
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      timestamp: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}timestamp'],
+      )!,
       workflowJson: $SteamRecordsTable.$converterworkflowJson.fromSql(
         attachedDatabase.typeMapping.read(
           DriftSqlType.string,
@@ -4239,11 +4243,10 @@ class $SteamRecordsTable extends SteamRecords
           data['${effectivePrefix}annotations_json'],
         ),
       ),
-      measurementsJson:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}measurements_json'],
-          )!,
+      measurementsJson: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}measurements_json'],
+      )!,
     );
   }
 
@@ -4295,10 +4298,9 @@ class SteamRecord extends DataClass implements Insertable<SteamRecord> {
       id: Value(id),
       timestamp: Value(timestamp),
       workflowJson: Value(workflowJson),
-      annotationsJson:
-          annotationsJson == null && nullToAbsent
-              ? const Value.absent()
-              : Value(annotationsJson),
+      annotationsJson: annotationsJson == null && nullToAbsent
+          ? const Value.absent()
+          : Value(annotationsJson),
       measurementsJson: Value(measurementsJson),
     );
   }
@@ -4344,26 +4346,24 @@ class SteamRecord extends DataClass implements Insertable<SteamRecord> {
     id: id ?? this.id,
     timestamp: timestamp ?? this.timestamp,
     workflowJson: workflowJson ?? this.workflowJson,
-    annotationsJson:
-        annotationsJson.present ? annotationsJson.value : this.annotationsJson,
+    annotationsJson: annotationsJson.present
+        ? annotationsJson.value
+        : this.annotationsJson,
     measurementsJson: measurementsJson ?? this.measurementsJson,
   );
   SteamRecord copyWithCompanion(SteamRecordsCompanion data) {
     return SteamRecord(
       id: data.id.present ? data.id.value : this.id,
       timestamp: data.timestamp.present ? data.timestamp.value : this.timestamp,
-      workflowJson:
-          data.workflowJson.present
-              ? data.workflowJson.value
-              : this.workflowJson,
-      annotationsJson:
-          data.annotationsJson.present
-              ? data.annotationsJson.value
-              : this.annotationsJson,
-      measurementsJson:
-          data.measurementsJson.present
-              ? data.measurementsJson.value
-              : this.measurementsJson,
+      workflowJson: data.workflowJson.present
+          ? data.workflowJson.value
+          : this.workflowJson,
+      annotationsJson: data.annotationsJson.present
+          ? data.annotationsJson.value
+          : this.annotationsJson,
+      measurementsJson: data.measurementsJson.present
+          ? data.measurementsJson.value
+          : this.measurementsJson,
     );
   }
 
@@ -4575,22 +4575,20 @@ class $WorkflowsTable extends Workflows
   Workflow map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return Workflow(
-      id:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}id'],
-          )!,
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
       workflowJson: $WorkflowsTable.$converterworkflowJson.fromSql(
         attachedDatabase.typeMapping.read(
           DriftSqlType.string,
           data['${effectivePrefix}workflow_json'],
         )!,
       ),
-      updatedAt:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.dateTime,
-            data['${effectivePrefix}updated_at'],
-          )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      )!,
     );
   }
 
@@ -4668,10 +4666,9 @@ class Workflow extends DataClass implements Insertable<Workflow> {
   Workflow copyWithCompanion(WorkflowsCompanion data) {
     return Workflow(
       id: data.id.present ? data.id.value : this.id,
-      workflowJson:
-          data.workflowJson.present
-              ? data.workflowJson.value
-              : this.workflowJson,
+      workflowJson: data.workflowJson.present
+          ? data.workflowJson.value
+          : this.workflowJson,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
   }
@@ -4875,26 +4872,28 @@ class $ProfileRecordsTable extends ProfileRecords
   );
   @override
   late final GeneratedColumnWithTypeConverter<Map<String, dynamic>, String>
-  profileJson = GeneratedColumn<String>(
-    'profile_json',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  ).withConverter<Map<String, dynamic>>(
-    $ProfileRecordsTable.$converterprofileJson,
-  );
+  profileJson =
+      GeneratedColumn<String>(
+        'profile_json',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      ).withConverter<Map<String, dynamic>>(
+        $ProfileRecordsTable.$converterprofileJson,
+      );
   @override
   late final GeneratedColumnWithTypeConverter<Map<String, dynamic>?, String>
-  metadata = GeneratedColumn<String>(
-    'metadata',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  ).withConverter<Map<String, dynamic>?>(
-    $ProfileRecordsTable.$convertermetadata,
-  );
+  metadata =
+      GeneratedColumn<String>(
+        'metadata',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      ).withConverter<Map<String, dynamic>?>(
+        $ProfileRecordsTable.$convertermetadata,
+      );
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -4990,45 +4989,38 @@ class $ProfileRecordsTable extends ProfileRecords
   ProfileRecord map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return ProfileRecord(
-      id:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}id'],
-          )!,
-      metadataHash:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}metadata_hash'],
-          )!,
-      compoundHash:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}compound_hash'],
-          )!,
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      metadataHash: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}metadata_hash'],
+      )!,
+      compoundHash: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}compound_hash'],
+      )!,
       parentId: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}parent_id'],
       ),
-      visibility:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.string,
-            data['${effectivePrefix}visibility'],
-          )!,
-      isDefault:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.bool,
-            data['${effectivePrefix}is_default'],
-          )!,
-      createdAt:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.dateTime,
-            data['${effectivePrefix}created_at'],
-          )!,
-      updatedAt:
-          attachedDatabase.typeMapping.read(
-            DriftSqlType.dateTime,
-            data['${effectivePrefix}updated_at'],
-          )!,
+      visibility: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}visibility'],
+      )!,
+      isDefault: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}is_default'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      )!,
       profileJson: $ProfileRecordsTable.$converterprofileJson.fromSql(
         attachedDatabase.typeMapping.read(
           DriftSqlType.string,
@@ -5109,19 +5101,17 @@ class ProfileRecord extends DataClass implements Insertable<ProfileRecord> {
       id: Value(id),
       metadataHash: Value(metadataHash),
       compoundHash: Value(compoundHash),
-      parentId:
-          parentId == null && nullToAbsent
-              ? const Value.absent()
-              : Value(parentId),
+      parentId: parentId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(parentId),
       visibility: Value(visibility),
       isDefault: Value(isDefault),
       createdAt: Value(createdAt),
       updatedAt: Value(updatedAt),
       profileJson: Value(profileJson),
-      metadata:
-          metadata == null && nullToAbsent
-              ? const Value.absent()
-              : Value(metadata),
+      metadata: metadata == null && nullToAbsent
+          ? const Value.absent()
+          : Value(metadata),
     );
   }
 
@@ -5188,22 +5178,22 @@ class ProfileRecord extends DataClass implements Insertable<ProfileRecord> {
   ProfileRecord copyWithCompanion(ProfileRecordsCompanion data) {
     return ProfileRecord(
       id: data.id.present ? data.id.value : this.id,
-      metadataHash:
-          data.metadataHash.present
-              ? data.metadataHash.value
-              : this.metadataHash,
-      compoundHash:
-          data.compoundHash.present
-              ? data.compoundHash.value
-              : this.compoundHash,
+      metadataHash: data.metadataHash.present
+          ? data.metadataHash.value
+          : this.metadataHash,
+      compoundHash: data.compoundHash.present
+          ? data.compoundHash.value
+          : this.compoundHash,
       parentId: data.parentId.present ? data.parentId.value : this.parentId,
-      visibility:
-          data.visibility.present ? data.visibility.value : this.visibility,
+      visibility: data.visibility.present
+          ? data.visibility.value
+          : this.visibility,
       isDefault: data.isDefault.present ? data.isDefault.value : this.isDefault,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
-      profileJson:
-          data.profileJson.present ? data.profileJson.value : this.profileJson,
+      profileJson: data.profileJson.present
+          ? data.profileJson.value
+          : this.profileJson,
       metadata: data.metadata.present ? data.metadata.value : this.metadata,
     );
   }
@@ -5499,7 +5489,7 @@ final class $$BeansTableReferences
   static MultiTypedResultKey<$BeanBatchesTable, List<BeanBatche>>
   _beanBatchesRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
     db.beanBatches,
-    aliasName: $_aliasNameGenerator(db.beans.id, db.beanBatches.beanId),
+    aliasName: 'beans__id__bean_batches__bean_id',
   );
 
   $$BeanBatchesTableProcessedTableManager get beanBatchesRefs {
@@ -5846,12 +5836,12 @@ class $$BeansTableTableManager
         TableManagerState(
           db: db,
           table: table,
-          createFilteringComposer:
-              () => $$BeansTableFilterComposer($db: db, $table: table),
-          createOrderingComposer:
-              () => $$BeansTableOrderingComposer($db: db, $table: table),
-          createComputedFieldComposer:
-              () => $$BeansTableAnnotationComposer($db: db, $table: table),
+          createFilteringComposer: () =>
+              $$BeansTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$BeansTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$BeansTableAnnotationComposer($db: db, $table: table),
           updateCompanionCallback:
               ({
                 Value<String> id = const Value.absent(),
@@ -5932,16 +5922,12 @@ class $$BeansTableTableManager
                 extras: extras,
                 rowid: rowid,
               ),
-          withReferenceMapper:
-              (p0) =>
-                  p0
-                      .map(
-                        (e) => (
-                          e.readTable(table),
-                          $$BeansTableReferences(db, table, e),
-                        ),
-                      )
-                      .toList(),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) =>
+                    (e.readTable(table), $$BeansTableReferences(db, table, e)),
+              )
+              .toList(),
           prefetchHooksCallback: ({beanBatchesRefs = false}) {
             return PrefetchHooks(
               db: db,
@@ -5954,16 +5940,10 @@ class $$BeansTableTableManager
                       currentTable: table,
                       referencedTable: $$BeansTableReferences
                           ._beanBatchesRefsTable(db),
-                      managerFromTypedResult:
-                          (p0) =>
-                              $$BeansTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).beanBatchesRefs,
-                      referencedItemsForCurrentItem:
-                          (item, referencedItems) =>
-                              referencedItems.where((e) => e.beanId == item.id),
+                      managerFromTypedResult: (p0) =>
+                          $$BeansTableReferences(db, table, p0).beanBatchesRefs,
+                      referencedItemsForCurrentItem: (item, referencedItems) =>
+                          referencedItems.where((e) => e.beanId == item.id),
                       typedResults: items,
                     ),
                 ];
@@ -6043,9 +6023,8 @@ final class $$BeanBatchesTableReferences
     extends BaseReferences<_$AppDatabase, $BeanBatchesTable, BeanBatche> {
   $$BeanBatchesTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
-  static $BeansTable _beanIdTable(_$AppDatabase db) => db.beans.createAlias(
-    $_aliasNameGenerator(db.beanBatches.beanId, db.beans.id),
-  );
+  static $BeansTable _beanIdTable(_$AppDatabase db) =>
+      db.beans.createAlias('bean_batches__bean_id__beans__id');
 
   $$BeansTableProcessedTableManager get beanId {
     final $_column = $_itemColumn<String>('bean_id')!;
@@ -6460,13 +6439,12 @@ class $$BeanBatchesTableTableManager
         TableManagerState(
           db: db,
           table: table,
-          createFilteringComposer:
-              () => $$BeanBatchesTableFilterComposer($db: db, $table: table),
-          createOrderingComposer:
-              () => $$BeanBatchesTableOrderingComposer($db: db, $table: table),
-          createComputedFieldComposer:
-              () =>
-                  $$BeanBatchesTableAnnotationComposer($db: db, $table: table),
+          createFilteringComposer: () =>
+              $$BeanBatchesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$BeanBatchesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$BeanBatchesTableAnnotationComposer($db: db, $table: table),
           updateCompanionCallback:
               ({
                 Value<String> id = const Value.absent(),
@@ -6563,52 +6541,50 @@ class $$BeanBatchesTableTableManager
                 extras: extras,
                 rowid: rowid,
               ),
-          withReferenceMapper:
-              (p0) =>
-                  p0
-                      .map(
-                        (e) => (
-                          e.readTable(table),
-                          $$BeanBatchesTableReferences(db, table, e),
-                        ),
-                      )
-                      .toList(),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$BeanBatchesTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
           prefetchHooksCallback: ({beanId = false}) {
             return PrefetchHooks(
               db: db,
               explicitlyWatchedTables: [],
-              addJoins: <
-                T extends TableManagerState<
-                  dynamic,
-                  dynamic,
-                  dynamic,
-                  dynamic,
-                  dynamic,
-                  dynamic,
-                  dynamic,
-                  dynamic,
-                  dynamic,
-                  dynamic,
-                  dynamic
-                >
-              >(state) {
-                if (beanId) {
-                  state =
-                      state.withJoin(
-                            currentTable: table,
-                            currentColumn: table.beanId,
-                            referencedTable: $$BeanBatchesTableReferences
-                                ._beanIdTable(db),
-                            referencedColumn:
-                                $$BeanBatchesTableReferences
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (beanId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.beanId,
+                                referencedTable: $$BeanBatchesTableReferences
+                                    ._beanIdTable(db),
+                                referencedColumn: $$BeanBatchesTableReferences
                                     ._beanIdTable(db)
                                     .id,
-                          )
-                          as T;
-                }
+                              )
+                              as T;
+                    }
 
-                return state;
-              },
+                    return state;
+                  },
               getPrefetchedDataCallback: (items) async {
                 return [];
               },
@@ -6950,12 +6926,12 @@ class $$GrindersTableTableManager
         TableManagerState(
           db: db,
           table: table,
-          createFilteringComposer:
-              () => $$GrindersTableFilterComposer($db: db, $table: table),
-          createOrderingComposer:
-              () => $$GrindersTableOrderingComposer($db: db, $table: table),
-          createComputedFieldComposer:
-              () => $$GrindersTableAnnotationComposer($db: db, $table: table),
+          createFilteringComposer: () =>
+              $$GrindersTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$GrindersTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$GrindersTableAnnotationComposer($db: db, $table: table),
           updateCompanionCallback:
               ({
                 Value<String> id = const Value.absent(),
@@ -7032,16 +7008,9 @@ class $$GrindersTableTableManager
                 extras: extras,
                 rowid: rowid,
               ),
-          withReferenceMapper:
-              (p0) =>
-                  p0
-                      .map(
-                        (e) => (
-                          e.readTable(table),
-                          BaseReferences(db, table, e),
-                        ),
-                      )
-                      .toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
           prefetchHooksCallback: null,
         ),
       );
@@ -7076,6 +7045,7 @@ typedef $$ShotRecordsTableCreateCompanionBuilder =
       Value<double?> targetYield,
       Value<double?> enjoyment,
       Value<String?> espressoNotes,
+      Value<String?> stopReason,
       required Map<String, dynamic> workflowJson,
       Value<Map<String, dynamic>?> annotationsJson,
       required String measurementsJson,
@@ -7096,6 +7066,7 @@ typedef $$ShotRecordsTableUpdateCompanionBuilder =
       Value<double?> targetYield,
       Value<double?> enjoyment,
       Value<String?> espressoNotes,
+      Value<String?> stopReason,
       Value<Map<String, dynamic>> workflowJson,
       Value<Map<String, dynamic>?> annotationsJson,
       Value<String> measurementsJson,
@@ -7173,6 +7144,11 @@ class $$ShotRecordsTableFilterComposer
 
   ColumnFilters<String> get espressoNotes => $composableBuilder(
     column: $table.espressoNotes,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get stopReason => $composableBuilder(
+    column: $table.stopReason,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -7276,6 +7252,11 @@ class $$ShotRecordsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get stopReason => $composableBuilder(
+    column: $table.stopReason,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get workflowJson => $composableBuilder(
     column: $table.workflowJson,
     builder: (column) => ColumnOrderings(column),
@@ -7358,6 +7339,11 @@ class $$ShotRecordsTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<String> get stopReason => $composableBuilder(
+    column: $table.stopReason,
+    builder: (column) => column,
+  );
+
   GeneratedColumnWithTypeConverter<Map<String, dynamic>, String>
   get workflowJson => $composableBuilder(
     column: $table.workflowJson,
@@ -7399,13 +7385,12 @@ class $$ShotRecordsTableTableManager
         TableManagerState(
           db: db,
           table: table,
-          createFilteringComposer:
-              () => $$ShotRecordsTableFilterComposer($db: db, $table: table),
-          createOrderingComposer:
-              () => $$ShotRecordsTableOrderingComposer($db: db, $table: table),
-          createComputedFieldComposer:
-              () =>
-                  $$ShotRecordsTableAnnotationComposer($db: db, $table: table),
+          createFilteringComposer: () =>
+              $$ShotRecordsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$ShotRecordsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$ShotRecordsTableAnnotationComposer($db: db, $table: table),
           updateCompanionCallback:
               ({
                 Value<String> id = const Value.absent(),
@@ -7421,6 +7406,7 @@ class $$ShotRecordsTableTableManager
                 Value<double?> targetYield = const Value.absent(),
                 Value<double?> enjoyment = const Value.absent(),
                 Value<String?> espressoNotes = const Value.absent(),
+                Value<String?> stopReason = const Value.absent(),
                 Value<Map<String, dynamic>> workflowJson = const Value.absent(),
                 Value<Map<String, dynamic>?> annotationsJson =
                     const Value.absent(),
@@ -7440,6 +7426,7 @@ class $$ShotRecordsTableTableManager
                 targetYield: targetYield,
                 enjoyment: enjoyment,
                 espressoNotes: espressoNotes,
+                stopReason: stopReason,
                 workflowJson: workflowJson,
                 annotationsJson: annotationsJson,
                 measurementsJson: measurementsJson,
@@ -7460,6 +7447,7 @@ class $$ShotRecordsTableTableManager
                 Value<double?> targetYield = const Value.absent(),
                 Value<double?> enjoyment = const Value.absent(),
                 Value<String?> espressoNotes = const Value.absent(),
+                Value<String?> stopReason = const Value.absent(),
                 required Map<String, dynamic> workflowJson,
                 Value<Map<String, dynamic>?> annotationsJson =
                     const Value.absent(),
@@ -7479,21 +7467,15 @@ class $$ShotRecordsTableTableManager
                 targetYield: targetYield,
                 enjoyment: enjoyment,
                 espressoNotes: espressoNotes,
+                stopReason: stopReason,
                 workflowJson: workflowJson,
                 annotationsJson: annotationsJson,
                 measurementsJson: measurementsJson,
                 rowid: rowid,
               ),
-          withReferenceMapper:
-              (p0) =>
-                  p0
-                      .map(
-                        (e) => (
-                          e.readTable(table),
-                          BaseReferences(db, table, e),
-                        ),
-                      )
-                      .toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
           prefetchHooksCallback: null,
         ),
       );
@@ -7671,13 +7653,12 @@ class $$SteamRecordsTableTableManager
         TableManagerState(
           db: db,
           table: table,
-          createFilteringComposer:
-              () => $$SteamRecordsTableFilterComposer($db: db, $table: table),
-          createOrderingComposer:
-              () => $$SteamRecordsTableOrderingComposer($db: db, $table: table),
-          createComputedFieldComposer:
-              () =>
-                  $$SteamRecordsTableAnnotationComposer($db: db, $table: table),
+          createFilteringComposer: () =>
+              $$SteamRecordsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$SteamRecordsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$SteamRecordsTableAnnotationComposer($db: db, $table: table),
           updateCompanionCallback:
               ({
                 Value<String> id = const Value.absent(),
@@ -7712,16 +7693,9 @@ class $$SteamRecordsTableTableManager
                 measurementsJson: measurementsJson,
                 rowid: rowid,
               ),
-          withReferenceMapper:
-              (p0) =>
-                  p0
-                      .map(
-                        (e) => (
-                          e.readTable(table),
-                          BaseReferences(db, table, e),
-                        ),
-                      )
-                      .toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
           prefetchHooksCallback: null,
         ),
       );
@@ -7856,12 +7830,12 @@ class $$WorkflowsTableTableManager
         TableManagerState(
           db: db,
           table: table,
-          createFilteringComposer:
-              () => $$WorkflowsTableFilterComposer($db: db, $table: table),
-          createOrderingComposer:
-              () => $$WorkflowsTableOrderingComposer($db: db, $table: table),
-          createComputedFieldComposer:
-              () => $$WorkflowsTableAnnotationComposer($db: db, $table: table),
+          createFilteringComposer: () =>
+              $$WorkflowsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$WorkflowsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$WorkflowsTableAnnotationComposer($db: db, $table: table),
           updateCompanionCallback:
               ({
                 Value<String> id = const Value.absent(),
@@ -7886,16 +7860,9 @@ class $$WorkflowsTableTableManager
                 updatedAt: updatedAt,
                 rowid: rowid,
               ),
-          withReferenceMapper:
-              (p0) =>
-                  p0
-                      .map(
-                        (e) => (
-                          e.readTable(table),
-                          BaseReferences(db, table, e),
-                        ),
-                      )
-                      .toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
           prefetchHooksCallback: null,
         ),
       );
@@ -8149,16 +8116,12 @@ class $$ProfileRecordsTableTableManager
         TableManagerState(
           db: db,
           table: table,
-          createFilteringComposer:
-              () => $$ProfileRecordsTableFilterComposer($db: db, $table: table),
-          createOrderingComposer:
-              () =>
-                  $$ProfileRecordsTableOrderingComposer($db: db, $table: table),
-          createComputedFieldComposer:
-              () => $$ProfileRecordsTableAnnotationComposer(
-                $db: db,
-                $table: table,
-              ),
+          createFilteringComposer: () =>
+              $$ProfileRecordsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$ProfileRecordsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$ProfileRecordsTableAnnotationComposer($db: db, $table: table),
           updateCompanionCallback:
               ({
                 Value<String> id = const Value.absent(),
@@ -8211,16 +8174,9 @@ class $$ProfileRecordsTableTableManager
                 metadata: metadata,
                 rowid: rowid,
               ),
-          withReferenceMapper:
-              (p0) =>
-                  p0
-                      .map(
-                        (e) => (
-                          e.readTable(table),
-                          BaseReferences(db, table, e),
-                        ),
-                      )
-                      .toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
           prefetchHooksCallback: null,
         ),
       );

--- a/lib/src/services/database/mappers/shot_mapper.dart
+++ b/lib/src/services/database/mappers/shot_mapper.dart
@@ -28,6 +28,7 @@ class ShotMapper {
       measurements: measurements,
       workflow: workflow,
       annotations: annotations,
+      stopReason: row.stopReason,
     );
   }
 
@@ -50,6 +51,7 @@ class ShotMapper {
       targetYield: Value(ctx?.targetYield),
       enjoyment: Value(record.annotations?.enjoyment),
       espressoNotes: Value(record.annotations?.espressoNotes),
+      stopReason: Value(record.stopReason),
 
       // Full JSON blobs
       workflowJson: Value(record.workflow.toJson()),

--- a/lib/src/services/database/tables/shot_tables.dart
+++ b/lib/src/services/database/tables/shot_tables.dart
@@ -19,6 +19,10 @@ class ShotRecords extends Table {
   RealColumn get enjoyment => real().nullable()();
   TextColumn get espressoNotes => text().nullable()();
 
+  /// Why the shot ended (ShotDecisionReason.name, open set). Added in schema
+  /// v4; null for shots recorded before then or not sequenced by the app.
+  TextColumn get stopReason => text().nullable()();
+
   // Full JSON blobs for complex nested data
   TextColumn get workflowJson =>
       text().map(const JsonMapConverter())();

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -94,6 +94,10 @@ class De1Handler {
       sws.webSocketHandler(_handleWaterLevels),
     );
     app.get('/ws/v1/machine/raw', sws.webSocketHandler(_handleRawSocket));
+    app.get(
+      '/ws/v1/machine/shotState',
+      sws.webSocketHandler(_handleShotState),
+    );
 
     app.get('/api/v1/machine/ledStrip', (Request _) async {
       return withDe1((de1) async {
@@ -406,7 +410,18 @@ class De1Handler {
           'type': 'block_no_scale',
         });
       }
+      // Record the intent only for an idle request that (a) targets an
+      // active tracked shot — shotState is non-idle only during an espresso
+      // shot, never during steam/hot-water/flush — and (b) whose BLE write
+      // actually succeeded, so a failed stop can't mislabel a later natural
+      // end. This lets the ShotSequencer attribute the stop to apiStop
+      // instead of the ambiguous machineEnded bucket.
+      final stoppingActiveShot = requestState == MachineState.idle &&
+          _controller.currentShotState.state != ShotState.idle;
       await de1.requestState(requestState);
+      if (stoppingActiveShot) {
+        _controller.recordStopIntent(ShotDecisionReason.apiStop);
+      }
       return jsonOk(null);
     });
   }
@@ -431,6 +446,29 @@ class De1Handler {
       await de1.updateShotSettings(settings);
       return jsonOk(null);
     });
+  }
+
+  /// Streams the shot state + decision feed (see ShotStateEvent). Unlike the
+  /// machine-gated sockets this one is NOT behind a connected DE1 — the feed
+  /// lives on De1Controller and idles between shots, so clients can attach
+  /// once and wait.
+  Future<void> _handleShotState(
+    WebSocketChannel socket,
+    String? protocol,
+  ) async {
+    log.fine("handling shotState websocket connection");
+    var sub = _controller.shotState.listen((event) {
+      try {
+        socket.sink.add(jsonEncode(event.toJson()));
+      } catch (e, st) {
+        log.severe("failed to send shotState event: ", e, st);
+      }
+    });
+    socket.stream.listen(
+      (e) {},
+      onDone: () => sub.cancel(),
+      onError: (e, st) => sub.cancel(),
+    );
   }
 
   Future<void> _handleSnapshot(

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -15,6 +15,7 @@ import 'package:reaprime/src/controllers/scale_controller.dart';
 import 'package:reaprime/src/controllers/sensor_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/models/data/profile_record.dart';
+import 'package:reaprime/src/models/data/shot_state_event.dart';
 import 'package:reaprime/src/models/data/utils.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/scale.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -234,7 +234,7 @@ packages:
     source: hosted
     version: "0.4.2"
   clock:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: clock
       sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,8 @@ dependencies:
     sdk: flutter
   logging: ^1.3.0
   logging_appenders: ^2.0.0
+  # Injectable clock (fake_async-aware) for the stop-intent attribution window.
+  clock: ^1.1.1
   flutter_foreground_task: ^9.2.2
   permission_handler: ^12.0.0+1
   rxdart: ^0.28.0
@@ -148,7 +150,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  clock: ^1.1.1
   fake_async: ^1.3.1
   flutter_lints: ^6.0.0
   # Test-only: mock url_launcher for the skin "Go to skin" button. Already

--- a/test/controllers/de1_controller_shot_state_test.dart
+++ b/test/controllers/de1_controller_shot_state_test.dart
@@ -1,0 +1,119 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/models/data/shot_state_event.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
+
+/// Minimal DeviceDiscoveryService that does nothing.
+class _FakeDiscoveryService extends DeviceDiscoveryService {
+  @override
+  Stream<List<Device>> get devices => const Stream.empty();
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
+}
+
+De1Controller _makeController() {
+  return De1Controller(controller: DeviceController([_FakeDiscoveryService()]));
+}
+
+ShotStateEvent _pouringEvent() {
+  return ShotStateEvent(
+    event: 'state',
+    timestamp: DateTime.now(),
+    shotId: 'shot-1',
+    state: ShotState.pouring,
+    machineState: MachineState.espresso,
+    machineSubstate: MachineSubstate.pouring,
+    profileFrame: 0,
+    scaleConnected: true,
+    scaleLost: false,
+    machineHasAutonomousSAW: false,
+  );
+}
+
+void main() {
+  group('De1Controller.shotState', () {
+    test('is seeded with an idle state frame', () async {
+      final controller = _makeController();
+
+      final first = await controller.shotState.first;
+
+      expect(first.event, 'state');
+      expect(first.state, ShotState.idle);
+      expect(first.shotId, isNull);
+    });
+
+    test('replays the latest event to late subscribers', () async {
+      final controller = _makeController();
+      final published = _pouringEvent();
+
+      controller.publishShotEvent(published);
+
+      final first = await controller.shotState.first;
+      expect(first.state, ShotState.pouring);
+      expect(first.shotId, 'shot-1');
+    });
+
+    test('currentShotState exposes the latest event synchronously', () {
+      final controller = _makeController();
+      expect(controller.currentShotState.state, ShotState.idle);
+
+      controller.publishShotEvent(_pouringEvent());
+      expect(controller.currentShotState.state, ShotState.pouring);
+    });
+  });
+
+  group('De1Controller stop intent', () {
+    test('records and consumes an intent exactly once', () {
+      final controller = _makeController();
+
+      controller.recordStopIntent(ShotDecisionReason.apiStop);
+
+      expect(controller.consumeStopIntent(), ShotDecisionReason.apiStop);
+      expect(
+        controller.consumeStopIntent(),
+        isNull,
+        reason: 'a consumed intent must not be attributed twice',
+      );
+    });
+
+    test('returns null when no intent was recorded', () {
+      final controller = _makeController();
+      expect(controller.consumeStopIntent(), isNull);
+    });
+
+    test('expires stale intents beyond the attribution window', () {
+      fakeAsync((async) {
+        final controller = _makeController();
+
+        controller.recordStopIntent(ShotDecisionReason.appStop);
+        async.elapse(const Duration(seconds: 6));
+
+        expect(
+          controller.consumeStopIntent(),
+          isNull,
+          reason: 'a stop intent older than the window must not be '
+              'attributed to a later, unrelated shot end',
+        );
+      });
+    });
+
+    test('a fresh intent within the window is attributed', () {
+      fakeAsync((async) {
+        final controller = _makeController();
+
+        controller.recordStopIntent(ShotDecisionReason.appStop);
+        async.elapse(const Duration(seconds: 2));
+
+        expect(controller.consumeStopIntent(), ShotDecisionReason.appStop);
+      });
+    });
+  });
+}

--- a/test/controllers/de1_state_manager_shot_state_test.dart
+++ b/test/controllers/de1_state_manager_shot_state_test.dart
@@ -1,0 +1,331 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/de1_state_manager.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/persistence_controller.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/shot_record.dart';
+import 'package:reaprime/src/models/data/shot_state_event.dart';
+import 'package:reaprime/src/models/data/steam_record.dart';
+import 'package:reaprime/src/models/data/workflow.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/services/storage/storage_service.dart';
+import 'package:reaprime/src/settings/gateway_mode.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:rxdart/rxdart.dart';
+
+import '../helpers/mock_device_discovery_service.dart';
+import '../helpers/mock_settings_service.dart';
+import '../helpers/test_de1.dart';
+
+/// De1Controller whose `de1` stream and `connectedDe1()` are test-driven.
+class _TestDe1Controller extends De1Controller {
+  final BehaviorSubject<De1Interface?> de1Subject = BehaviorSubject.seeded(
+    null,
+  );
+  De1Interface? current;
+
+  _TestDe1Controller({required super.controller});
+
+  @override
+  Stream<De1Interface?> get de1 => de1Subject.stream;
+
+  @override
+  De1Interface connectedDe1() {
+    final de1 = current;
+    if (de1 == null) throw 'no de1 connected';
+    return de1;
+  }
+
+  void connect(De1Interface de1) {
+    current = de1;
+    de1Subject.add(de1);
+  }
+
+  void disconnect() {
+    current = null;
+    de1Subject.add(null);
+  }
+}
+
+/// StorageService that records persisted shots and stores nothing else.
+class _CapturingStorageService implements StorageService {
+  final List<ShotRecord> storedShots = [];
+
+  @override
+  Future<void> storeShot(ShotRecord record) async => storedShots.add(record);
+  @override
+  Future<void> updateShot(ShotRecord record) async {}
+  @override
+  Future<void> deleteShot(String id) async {}
+  @override
+  Future<List<String>> getShotIds() async => [];
+  @override
+  Future<List<ShotRecord>> getAllShots() async => [];
+  @override
+  Future<ShotRecord?> getShot(String id) async => null;
+  @override
+  Future<void> storeCurrentWorkflow(Workflow workflow) async {}
+  @override
+  Future<Workflow?> loadCurrentWorkflow() async => null;
+  @override
+  Future<List<ShotRecord>> getShotsPaginated({
+    int limit = 20,
+    int offset = 0,
+    String? grinderId,
+    String? grinderModel,
+    String? beanBatchId,
+    List<String>? beanBatchIds,
+    String? coffeeName,
+    String? coffeeRoaster,
+    String? profileTitle,
+    String? search,
+    bool ascending = false,
+  }) async => [];
+  @override
+  Future<int> countShots({
+    String? grinderId,
+    String? grinderModel,
+    String? beanBatchId,
+    List<String>? beanBatchIds,
+    String? coffeeName,
+    String? coffeeRoaster,
+    String? profileTitle,
+    String? search,
+  }) async => 0;
+  @override
+  Future<ShotRecord?> getLatestShot() async => null;
+  @override
+  Future<ShotRecord?> getLatestShotMeta() async => null;
+  @override
+  Future<void> storeSteam(SteamRecord record) async {}
+  @override
+  Future<void> updateSteam(SteamRecord record) async {}
+  @override
+  Future<void> deleteSteam(String id) async {}
+  @override
+  Future<List<String>> getSteamIds() async => [];
+  @override
+  Future<List<SteamRecord>> getAllSteams() async => [];
+  @override
+  Future<SteamRecord?> getSteam(String id) async => null;
+  @override
+  Future<SteamRecord?> getLatestSteam() async => null;
+  @override
+  Future<SteamRecord?> getLatestSteamMeta() async => null;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late TestDe1 testDe1;
+  late _TestDe1Controller de1Controller;
+  late ScaleController scaleController;
+  late _CapturingStorageService storage;
+  late De1StateManager manager;
+  late List<ShotStateEvent> events;
+  late StreamSubscription<ShotStateEvent> eventsSub;
+
+  Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+  setUp(() async {
+    testDe1 = TestDe1();
+    final deviceController = DeviceController([MockDeviceDiscoveryService()]);
+    await deviceController.initialize();
+    de1Controller = _TestDe1Controller(controller: deviceController);
+    scaleController = ScaleController();
+    storage = _CapturingStorageService();
+
+    final settingsService = MockSettingsService();
+    await settingsService.updateGatewayMode(GatewayMode.tracking);
+    final settingsController = SettingsController(settingsService);
+    await settingsController.loadSettings();
+
+    final connectionManager = ConnectionManager(
+      deviceScanner: deviceController,
+      de1Controller: de1Controller,
+      scaleController: scaleController,
+      settingsController: settingsController,
+    );
+
+    manager = De1StateManager(
+      de1Controller: de1Controller,
+      scaleController: scaleController,
+      workflowController: WorkflowController(),
+      persistenceController: PersistenceController(storageService: storage),
+      settingsController: settingsController,
+      connectionManager: connectionManager,
+      navigatorKey: GlobalKey<NavigatorState>(),
+    );
+
+    events = [];
+    eventsSub = de1Controller.shotState.listen(events.add);
+
+    de1Controller.connect(testDe1);
+    await pump();
+  });
+
+  tearDown(() async {
+    await eventsSub.cancel();
+    manager.dispose();
+    await testDe1.dispose();
+  });
+
+  Future<void> driveShot() async {
+    testDe1.emitStateAndSubstate(
+      MachineState.espresso,
+      MachineSubstate.preparingForShot,
+    );
+    await pump();
+    testDe1.emitStateAndSubstate(
+      MachineState.espresso,
+      MachineSubstate.pouring,
+    );
+    await pump();
+    testDe1.emitStateAndSubstate(
+      MachineState.espresso,
+      MachineSubstate.pouringDone,
+    );
+    await pump();
+  }
+
+  test('forwards a full shot lifecycle onto De1Controller.shotState and '
+      'persists a matching record', () async {
+    await driveShot();
+
+    final states = events
+        .where((e) => e.event == 'state')
+        .map((e) => e.state)
+        .toList();
+    expect(states, contains(ShotState.preheating));
+    expect(states, contains(ShotState.pouring));
+    expect(states, contains(ShotState.finished));
+    expect(
+      states.last,
+      ShotState.idle,
+      reason: 'the feed re-seeds idle after cleanup',
+    );
+
+    final decision = events.singleWhere((e) => e.event == 'decision');
+    expect(decision.decision?.kind, ShotDecisionKind.stop);
+    expect(decision.decision?.reason, ShotDecisionReason.machineEnded);
+    expect(decision.shotId, isNotNull);
+    expect(
+      decision.timestamp,
+      DateTime(2026, 1, 15, 8, 0),
+      reason: 'frames carry the triggering snapshot timestamp (TestDe1 stamps '
+          'all snapshots with this fixed time), not publish wall clock, so '
+          'clients can align decisions with snapshot telemetry',
+    );
+
+    expect(storage.storedShots, hasLength(1));
+    final record = storage.storedShots.single;
+    expect(record.stopReason, 'machineEnded');
+    expect(
+      record.id,
+      decision.shotId,
+      reason: 'the persisted record id must match the live shotId so '
+          'clients can correlate the stream to the saved shot',
+    );
+  });
+
+  test('keeps forwarding across consecutive shots (per-shot sequencer '
+      'recreation)', () async {
+    await driveShot();
+    final firstShotId = events
+        .singleWhere((e) => e.event == 'decision')
+        .shotId;
+
+    // Machine returns to idle between shots.
+    testDe1.emitStateAndSubstate(MachineState.idle, MachineSubstate.idle);
+    await pump();
+
+    events.clear();
+    await driveShot();
+
+    final decision = events.singleWhere((e) => e.event == 'decision');
+    expect(decision.decision?.reason, ShotDecisionReason.machineEnded);
+    expect(
+      decision.shotId,
+      isNot(firstShotId),
+      reason: 'each shot gets its own id',
+    );
+    expect(storage.storedShots, hasLength(2));
+  });
+
+  test('aborting during preheat tears the sequencer down without persisting, '
+      'and the next shot gets a fresh id', () async {
+    // Stop the shot before first drops: machine leaves espresso for idle.
+    testDe1.emitStateAndSubstate(
+      MachineState.espresso,
+      MachineSubstate.preparingForShot,
+    );
+    await pump();
+    testDe1.emitStateAndSubstate(MachineState.idle, MachineSubstate.idle);
+    await pump();
+
+    expect(
+      events.any(
+        (e) => e.event == 'decision' && e.decision?.kind == ShotDecisionKind.abort,
+      ),
+      isTrue,
+      reason: 'the aborted preheat emits an abort decision, not a stuck '
+          'preheating frame',
+    );
+    expect(
+      events.where((e) => e.event == 'terminal'),
+      isEmpty,
+      reason: 'the abort decision is the terminal signal; no duplicate '
+          'disconnected frame',
+    );
+    expect(events.last.state, ShotState.idle);
+    expect(events.last.shotId, isNull, reason: 'feed re-seeds idle');
+    expect(storage.storedShots, isEmpty);
+
+    // A real shot afterwards must not inherit the aborted attempt's id.
+    events.clear();
+    await driveShot();
+
+    expect(storage.storedShots, hasLength(1));
+    final decision = events.singleWhere((e) => e.event == 'decision');
+    expect(storage.storedShots.single.id, decision.shotId);
+    expect(storage.storedShots.single.stopReason, 'machineEnded');
+  });
+
+  test('publishes a terminal frame when the machine disconnects mid-shot',
+      () async {
+    testDe1.emitStateAndSubstate(
+      MachineState.espresso,
+      MachineSubstate.preparingForShot,
+    );
+    await pump();
+    testDe1.emitStateAndSubstate(
+      MachineState.espresso,
+      MachineSubstate.pouring,
+    );
+    await pump();
+
+    de1Controller.disconnect();
+    await pump();
+
+    final terminal = events.singleWhere((e) => e.event == 'terminal');
+    expect(terminal.decision?.reason, ShotDecisionReason.disconnected);
+    expect(
+      events.last.state,
+      ShotState.idle,
+      reason: 'the feed re-seeds idle so late joiners never see a stale '
+          'pouring frame',
+    );
+    expect(
+      storage.storedShots,
+      isEmpty,
+      reason: 'a disconnected shot is torn down, not persisted',
+    );
+  });
+}

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -1503,4 +1503,597 @@ void main() {
       });
     });
   });
+
+  group('ShotSequencer — decision stream', () {
+    late TestDe1 testDe1;
+    late TestScale testScale;
+    late _TestDe1Controller de1Controller;
+    late _TestScaleController scaleController;
+    late PersistenceController persistenceController;
+
+    setUp(() {
+      testDe1 = TestDe1();
+      testScale = TestScale();
+      de1Controller = _TestDe1Controller(testDe1);
+      scaleController = _TestScaleController(testScale);
+      persistenceController = PersistenceController(
+        storageService: _NullStorageService(),
+      );
+    });
+
+    tearDown(() {
+      testDe1.dispose();
+      testScale.dispose();
+      scaleController.dispose();
+      persistenceController.dispose();
+    });
+
+    ShotSequencer makeSequencer({
+      Profile? profile,
+      double targetYield = 36.0,
+      double volumeFlowMultiplier = 0.0,
+    }) {
+      return ShotSequencer(
+        scaleController: scaleController,
+        de1controller: de1Controller,
+        persistenceController: persistenceController,
+        targetProfile: profile ?? _simpleProfile(),
+        targetYield: targetYield,
+        bypassSAW: false,
+        blockOnNoScale: false,
+        weightFlowMultiplier: 0.0,
+        volumeFlowMultiplier: volumeFlowMultiplier,
+        stepExitArbiterEnabled: true,
+      );
+    }
+
+    void driveToPouring() {
+      testDe1.emitStateAndSubstate(
+        MachineState.espresso,
+        MachineSubstate.preparingForShot,
+      );
+      testDe1.emitStateAndSubstate(
+        MachineState.espresso,
+        MachineSubstate.pouring,
+      );
+    }
+
+    void emitPouringFrame(int profileFrame, {double flow = 0}) {
+      final current = testDe1.snapshotSubject.value;
+      testDe1.emitSnapshot(
+        current.copyWith(
+          state: const MachineStateSnapshot(
+            state: MachineState.espresso,
+            substate: MachineSubstate.pouring,
+          ),
+          profileFrame: profileFrame,
+          flow: flow,
+        ),
+      );
+    }
+
+    test('target weight stop emits stop/targetWeight and latches it as the '
+        'final stop reason', () {
+      fakeAsync((async) {
+        scaleController.emitWeight(0.0);
+        final sequencer = makeSequencer();
+        final decisions = <ShotDecision>[];
+        sequencer.decisions.listen(decisions.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring();
+        async.elapse(Duration(milliseconds: 10));
+
+        scaleController.emitWeight(40.0);
+        testDe1.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.pouring,
+        );
+        async.elapse(Duration(milliseconds: 10));
+
+        final stop = decisions.singleWhere(
+          (d) => d.reason == ShotDecisionReason.targetWeight,
+        );
+        expect(stop.kind, ShotDecisionKind.stop);
+        expect(stop.data?['targetYield'], 36.0);
+        expect(sequencer.finalStopReason, ShotDecisionReason.targetWeight);
+        expect(testDe1.requestedStates, contains(MachineState.idle));
+
+        sequencer.dispose();
+      });
+    });
+
+    test('target volume stop emits stop/targetVolume when no scale weighs '
+        'the shot', () {
+      fakeAsync((async) {
+        scaleController.simulateDisconnect();
+        final profile = Profile(
+          version: '2',
+          title: 'Volume Profile',
+          notes: '',
+          author: 'test',
+          beverageType: BeverageType.espresso,
+          targetVolumeCountStart: 0,
+          tankTemperature: 0,
+          targetWeight: 0,
+          targetVolume: 50,
+          steps: [
+            ProfileStepPressure(
+              name: 'step1',
+              transition: TransitionType.fast,
+              volume: 0,
+              seconds: 30,
+              temperature: 93,
+              sensor: TemperatureSensor.coffee,
+              pressure: 9,
+            ),
+          ],
+        );
+        final sequencer = makeSequencer(
+          profile: profile,
+          volumeFlowMultiplier: 1.0,
+        );
+        final decisions = <ShotDecision>[];
+        sequencer.decisions.listen(decisions.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring();
+        async.elapse(Duration(milliseconds: 10));
+
+        // Projected volume = accumulated (0) + flow (60) * multiplier (1.0)
+        // = 60ml > 50ml target.
+        emitPouringFrame(0, flow: 60);
+        async.elapse(Duration(milliseconds: 10));
+
+        final stop = decisions.singleWhere(
+          (d) => d.reason == ShotDecisionReason.targetVolume,
+        );
+        expect(stop.kind, ShotDecisionKind.stop);
+        expect(sequencer.finalStopReason, ShotDecisionReason.targetVolume);
+        expect(testDe1.requestedStates, contains(MachineState.idle));
+
+        sequencer.dispose();
+      });
+    });
+
+    test('machine-reported end without any recorded intent emits '
+        'stop/machineEnded', () {
+      fakeAsync((async) {
+        scaleController.emitWeight(0.0);
+        final sequencer = makeSequencer();
+        final decisions = <ShotDecision>[];
+        sequencer.decisions.listen(decisions.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring();
+        async.elapse(Duration(milliseconds: 10));
+
+        testDe1.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.pouringDone,
+        );
+        async.elapse(Duration(milliseconds: 10));
+
+        final stop = decisions.singleWhere(
+          (d) => d.kind == ShotDecisionKind.stop,
+        );
+        expect(stop.reason, ShotDecisionReason.machineEnded);
+        expect(sequencer.finalStopReason, ShotDecisionReason.machineEnded);
+
+        sequencer.dispose();
+      });
+    });
+
+    test('a recent REST stop intent attributes the stop to apiStop', () {
+      fakeAsync((async) {
+        scaleController.emitWeight(0.0);
+        final sequencer = makeSequencer();
+        final decisions = <ShotDecision>[];
+        sequencer.decisions.listen(decisions.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring();
+        async.elapse(Duration(milliseconds: 10));
+
+        de1Controller.recordStopIntent(ShotDecisionReason.apiStop);
+        testDe1.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.pouringDone,
+        );
+        async.elapse(Duration(milliseconds: 10));
+
+        final stop = decisions.singleWhere(
+          (d) => d.kind == ShotDecisionKind.stop,
+        );
+        expect(stop.reason, ShotDecisionReason.apiStop);
+        expect(sequencer.finalStopReason, ShotDecisionReason.apiStop);
+
+        sequencer.dispose();
+      });
+    });
+
+    test('a recent app-UI stop intent attributes the stop to appStop', () {
+      fakeAsync((async) {
+        scaleController.emitWeight(0.0);
+        final sequencer = makeSequencer();
+        final decisions = <ShotDecision>[];
+        sequencer.decisions.listen(decisions.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring();
+        async.elapse(Duration(milliseconds: 10));
+
+        de1Controller.recordStopIntent(ShotDecisionReason.appStop);
+        testDe1.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.pouringDone,
+        );
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(
+          decisions.singleWhere((d) => d.kind == ShotDecisionKind.stop).reason,
+          ShotDecisionReason.appStop,
+        );
+
+        sequencer.dispose();
+      });
+    });
+
+    test('a stale stop intent falls back to machineEnded', () {
+      fakeAsync((async) {
+        scaleController.emitWeight(0.0);
+        final sequencer = makeSequencer();
+        final decisions = <ShotDecision>[];
+        sequencer.decisions.listen(decisions.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        de1Controller.recordStopIntent(ShotDecisionReason.apiStop);
+        async.elapse(Duration(seconds: 6));
+
+        driveToPouring();
+        async.elapse(Duration(milliseconds: 10));
+
+        testDe1.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.pouringDone,
+        );
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(
+          decisions.singleWhere((d) => d.kind == ShotDecisionKind.stop).reason,
+          ShotDecisionReason.machineEnded,
+          reason: 'an intent recorded long before the shot end must not be '
+              'attributed to it',
+        );
+
+        sequencer.dispose();
+      });
+    });
+
+    test('app-issued step weight exit emits advance/profileSkip and no '
+        'profileAdvance for the same frame', () {
+      fakeAsync((async) {
+        final profile = _profileWithSteps([
+          _pressureStep(name: 'first', weight: 10),
+          _pressureStep(name: 'second'),
+        ]);
+        scaleController.emitWeight(0.0);
+        final sequencer = makeSequencer(profile: profile, targetYield: 200);
+        final decisions = <ShotDecision>[];
+        sequencer.decisions.listen(decisions.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring();
+        async.elapse(Duration(milliseconds: 10));
+
+        scaleController.emitWeight(12.0);
+        emitPouringFrame(0);
+        async.elapse(Duration(milliseconds: 10));
+
+        final skip = decisions.singleWhere(
+          (d) => d.reason == ShotDecisionReason.profileSkip,
+        );
+        expect(skip.kind, ShotDecisionKind.advance);
+        expect(skip.data?['frame'], 0);
+        expect(testDe1.requestedStates, contains(MachineState.skipStep));
+
+        // Firmware acknowledges the skip by advancing to frame 1 — the vacated
+        // frame was app-skipped, so no firmware-natural advance is reported.
+        scaleController.emitWeight(12.0);
+        emitPouringFrame(1);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(
+          decisions.where(
+            (d) => d.reason == ShotDecisionReason.profileAdvance,
+          ),
+          isEmpty,
+          reason: 'an app-skipped frame must not double-report as a '
+              'firmware-natural advance',
+        );
+
+        sequencer.dispose();
+      });
+    });
+
+    test('firmware-natural frame advance emits advance/profileAdvance', () {
+      fakeAsync((async) {
+        final profile = _profileWithSteps([
+          _pressureStep(name: 'first'),
+          _pressureStep(name: 'second'),
+        ]);
+        scaleController.emitWeight(0.0);
+        final sequencer = makeSequencer(profile: profile, targetYield: 200);
+        final decisions = <ShotDecision>[];
+        sequencer.decisions.listen(decisions.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring();
+        async.elapse(Duration(milliseconds: 10));
+
+        emitPouringFrame(0);
+        async.elapse(Duration(milliseconds: 10));
+        emitPouringFrame(1);
+        async.elapse(Duration(milliseconds: 10));
+
+        final advance = decisions.singleWhere(
+          (d) => d.reason == ShotDecisionReason.profileAdvance,
+        );
+        expect(advance.kind, ShotDecisionKind.advance);
+        expect(advance.data?['fromFrame'], 0);
+        expect(advance.data?['toFrame'], 1);
+
+        sequencer.dispose();
+      });
+    });
+
+    test('a multi-frame jump reports one advance per vacated frame', () {
+      fakeAsync((async) {
+        final profile = _profileWithSteps([
+          _pressureStep(name: 'a'),
+          _pressureStep(name: 'b'),
+          _pressureStep(name: 'c'),
+        ]);
+        scaleController.emitWeight(0.0);
+        final sequencer = makeSequencer(profile: profile, targetYield: 200);
+        final decisions = <ShotDecision>[];
+        sequencer.decisions.listen(decisions.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring();
+        async.elapse(Duration(milliseconds: 10));
+
+        emitPouringFrame(0);
+        async.elapse(Duration(milliseconds: 10));
+        emitPouringFrame(2);
+        async.elapse(Duration(milliseconds: 10));
+
+        final advances = decisions
+            .where((d) => d.reason == ShotDecisionReason.profileAdvance)
+            .toList();
+        expect(advances, hasLength(2));
+        expect(advances[0].data?['fromFrame'], 0);
+        expect(advances[1].data?['fromFrame'], 1);
+
+        // A frame regression (out-of-order sample) must be ignored.
+        emitPouringFrame(1);
+        async.elapse(Duration(milliseconds: 10));
+        expect(
+          decisions.where(
+            (d) => d.reason == ShotDecisionReason.profileAdvance,
+          ),
+          hasLength(2),
+        );
+
+        sequencer.dispose();
+      });
+    });
+
+    test('machine error mid-shot emits terminal/error and finishes the shot',
+        () {
+      fakeAsync((async) {
+        scaleController.emitWeight(0.0);
+        final sequencer = makeSequencer();
+        final decisions = <ShotDecision>[];
+        final states = <ShotState>[];
+        sequencer.decisions.listen(decisions.add);
+        sequencer.state.listen(states.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring();
+        async.elapse(Duration(milliseconds: 10));
+
+        testDe1.emitStateAndSubstate(
+          MachineState.error,
+          MachineSubstate.idle,
+        );
+        async.elapse(Duration(milliseconds: 10));
+
+        final terminal = decisions.singleWhere(
+          (d) => d.kind == ShotDecisionKind.terminal,
+        );
+        expect(terminal.reason, ShotDecisionReason.error);
+        expect(sequencer.finalStopReason, ShotDecisionReason.error);
+        expect(states, contains(ShotState.finished));
+
+        sequencer.dispose();
+      });
+    });
+
+    test('stopping backstop emits finalize/stoppingBackstop and preserves '
+        'the stop trigger as final reason', () {
+      fakeAsync((async) {
+        scaleController.emitWeight(0.0);
+        final sequencer = makeSequencer();
+        final decisions = <ShotDecision>[];
+        final states = <ShotState>[];
+        sequencer.decisions.listen(decisions.add);
+        sequencer.state.listen(states.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring();
+        async.elapse(Duration(milliseconds: 10));
+
+        // SAW stop — yield latched, shot enters the stopping window.
+        scaleController.emitWeight(40.0);
+        testDe1.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.pouring,
+        );
+        async.elapse(Duration(milliseconds: 10));
+
+        // A noisy scale never settles (flow stays above the settle
+        // threshold and decays, so no spike or removal either).
+        scaleController.emitWeight(40.0, weightFlow: 1.0);
+        testDe1.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.pouringDone,
+        );
+        async.elapse(Duration(milliseconds: 10));
+
+        async.elapse(Duration(seconds: 5));
+
+        final finalize = decisions.singleWhere(
+          (d) => d.kind == ShotDecisionKind.finalize,
+        );
+        expect(finalize.reason, ShotDecisionReason.stoppingBackstop);
+        expect(
+          sequencer.finalStopReason,
+          ShotDecisionReason.targetWeight,
+          reason: 'the backstop closes the settling window; it is not why '
+              'the shot stopped',
+        );
+        expect(states, contains(ShotState.finished));
+
+        sequencer.dispose();
+      });
+    });
+
+    test('abort during preheat (machine leaves espresso before the pour) '
+        'emits an abort decision and never reaches finished', () {
+      fakeAsync((async) {
+        scaleController.emitWeight(0.0);
+        final sequencer = makeSequencer();
+        final decisions = <ShotDecision>[];
+        final states = <ShotState>[];
+        sequencer.decisions.listen(decisions.add);
+        sequencer.state.listen(states.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        testDe1.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.preparingForShot,
+        );
+        async.elapse(Duration(milliseconds: 10));
+
+        // Machine aborts back to idle before first drops.
+        testDe1.emitStateAndSubstate(MachineState.idle, MachineSubstate.idle);
+        async.elapse(Duration(milliseconds: 10));
+
+        final abort = decisions.singleWhere(
+          (d) => d.kind == ShotDecisionKind.abort,
+        );
+        expect(abort.reason, ShotDecisionReason.machineEnded);
+        expect(
+          states,
+          isNot(contains(ShotState.finished)),
+          reason: 'an aborted preheat is torn down by the manager, not '
+              'persisted via the finished path',
+        );
+
+        sequencer.dispose();
+      });
+    });
+
+    test('a preheat abort with a recorded app-stop intent is attributed to '
+        'appStop', () {
+      fakeAsync((async) {
+        scaleController.emitWeight(0.0);
+        final sequencer = makeSequencer();
+        final decisions = <ShotDecision>[];
+        sequencer.decisions.listen(decisions.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        testDe1.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.preparingForShot,
+        );
+        async.elapse(Duration(milliseconds: 10));
+
+        de1Controller.recordStopIntent(ShotDecisionReason.appStop);
+        testDe1.emitStateAndSubstate(MachineState.idle, MachineSubstate.idle);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(
+          decisions.singleWhere((d) => d.kind == ShotDecisionKind.abort).reason,
+          ShotDecisionReason.appStop,
+        );
+
+        sequencer.dispose();
+      });
+    });
+
+    test('a frame regression then recovery does not double-report the '
+        'advance', () {
+      fakeAsync((async) {
+        final profile = _profileWithSteps([
+          _pressureStep(name: 'a'),
+          _pressureStep(name: 'b'),
+        ]);
+        scaleController.emitWeight(0.0);
+        final sequencer = makeSequencer(profile: profile, targetYield: 200);
+        final decisions = <ShotDecision>[];
+        sequencer.decisions.listen(decisions.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring();
+        async.elapse(Duration(milliseconds: 10));
+
+        // frames 0 -> 1 -> (glitch) 0 -> 1
+        for (final frame in [0, 1, 0, 1]) {
+          emitPouringFrame(frame);
+          async.elapse(Duration(milliseconds: 10));
+        }
+
+        expect(
+          decisions.where(
+            (d) => d.reason == ShotDecisionReason.profileAdvance,
+          ),
+          hasLength(1),
+          reason: 'a BLE frame reorder must not re-emit an advance already '
+              'reported',
+        );
+
+        sequencer.dispose();
+      });
+    });
+
+    test('blockOnNoScale abort carries kind abort', () {
+      fakeAsync((async) {
+        scaleController.simulateDisconnect();
+
+        final sequencer = ShotSequencer(
+          scaleController: scaleController,
+          de1controller: de1Controller,
+          persistenceController: persistenceController,
+          targetProfile: _simpleProfile(),
+          targetYield: 36.0,
+          bypassSAW: false,
+          blockOnNoScale: true,
+          weightFlowMultiplier: 0.0,
+          volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
+        );
+
+        final decisions = <ShotDecision>[];
+        sequencer.decisions.listen(decisions.add);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(decisions.single.kind, ShotDecisionKind.abort);
+        expect(decisions.single.reason, ShotDecisionReason.noScale);
+
+        sequencer.dispose();
+      });
+    });
+  });
 }

--- a/test/database/shot_stop_reason_persistence_test.dart
+++ b/test/database/shot_stop_reason_persistence_test.dart
@@ -1,0 +1,46 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/shot_record.dart' as domain;
+import 'package:reaprime/src/services/database/database.dart';
+import 'package:reaprime/src/services/database/mappers/shot_mapper.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  domain.ShotRecord makeRecord({String? stopReason}) {
+    return domain.ShotRecord(
+      id: 'shot-1',
+      timestamp: DateTime.utc(2026, 6, 17, 9, 0),
+      measurements: const [],
+      workflow: WorkflowController().currentWorkflow,
+      stopReason: stopReason,
+    );
+  }
+
+  test('stopReason round-trips through the shots table', () async {
+    await db.shotDao.insertShot(
+      ShotMapper.toCompanion(makeRecord(stopReason: 'targetWeight')),
+    );
+
+    final row = await db.shotDao.getShotById('shot-1');
+    final restored = ShotMapper.fromRow(row!);
+
+    expect(restored.stopReason, 'targetWeight');
+  });
+
+  test('a shot persisted without a stopReason reads back null', () async {
+    await db.shotDao.insertShot(ShotMapper.toCompanion(makeRecord()));
+
+    final row = await db.shotDao.getShotById('shot-1');
+    expect(ShotMapper.fromRow(row!).stopReason, isNull);
+  });
+}

--- a/test/models/shot_record_stop_reason_test.dart
+++ b/test/models/shot_record_stop_reason_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/shot_record.dart';
+
+void main() {
+  final workflow = WorkflowController().currentWorkflow;
+
+  ShotRecord makeRecord({String? stopReason}) {
+    return ShotRecord(
+      id: 'shot-1',
+      timestamp: DateTime.utc(2026, 6, 17, 9, 0),
+      measurements: const [],
+      workflow: workflow,
+      stopReason: stopReason,
+    );
+  }
+
+  group('ShotRecord.stopReason', () {
+    test('serializes to JSON and round-trips', () {
+      final record = makeRecord(stopReason: 'targetWeight');
+
+      final json = record.toJson();
+      expect(json['stopReason'], 'targetWeight');
+
+      final parsed = ShotRecord.fromJson(json);
+      expect(parsed.stopReason, 'targetWeight');
+    });
+
+    test('is omitted from JSON when null', () {
+      final json = makeRecord().toJson();
+      expect(json.containsKey('stopReason'), isFalse);
+    });
+
+    test('parses to null for legacy shots without the field', () {
+      final json = makeRecord().toJson()..remove('stopReason');
+      expect(ShotRecord.fromJson(json).stopReason, isNull);
+    });
+
+    test('an unknown reason string survives a round-trip untouched', () {
+      // The wire vocabulary is an open set — a newer app may persist reasons
+      // this build does not know. They must pass through, not be dropped.
+      final record = makeRecord(stopReason: 'someFutureReason');
+      final parsed = ShotRecord.fromJson(record.toJson());
+      expect(parsed.stopReason, 'someFutureReason');
+    });
+
+    test('appears in the measurement-free list serialization too', () {
+      final json = makeRecord(stopReason: 'machineEnded')
+          .toJsonWithoutMeasurements();
+      expect(json['stopReason'], 'machineEnded');
+    });
+
+    test('copyWith preserves and overrides stopReason', () {
+      final record = makeRecord(stopReason: 'targetWeight');
+      expect(record.copyWith().stopReason, 'targetWeight');
+      expect(
+        record.copyWith(stopReason: 'machineEnded').stopReason,
+        'machineEnded',
+      );
+    });
+  });
+}

--- a/test/models/shot_state_event_test.dart
+++ b/test/models/shot_state_event_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/data/shot_state_event.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+
+void main() {
+  group('ShotDecision', () {
+    test('serializes kind, reason, details and data', () {
+      const decision = ShotDecision(
+        kind: ShotDecisionKind.stop,
+        reason: ShotDecisionReason.targetWeight,
+        details: 'Target weight 36.0g reached',
+        data: {'targetYield': 36.0, 'projectedWeight': 36.4},
+      );
+
+      expect(decision.toJson(), {
+        'kind': 'stop',
+        'reason': 'targetWeight',
+        'details': 'Target weight 36.0g reached',
+        'data': {'targetYield': 36.0, 'projectedWeight': 36.4},
+      });
+    });
+
+    test('serializes null details and data explicitly', () {
+      const decision = ShotDecision(
+        kind: ShotDecisionKind.advance,
+        reason: ShotDecisionReason.profileAdvance,
+      );
+
+      expect(decision.toJson(), {
+        'kind': 'advance',
+        'reason': 'profileAdvance',
+        'details': null,
+        'data': null,
+      });
+    });
+  });
+
+  group('ShotStateEvent', () {
+    test('idle factory produces an idle state frame', () {
+      final event = ShotStateEvent.idle();
+
+      expect(event.event, 'state');
+      expect(event.state, ShotState.idle);
+      expect(event.shotId, isNull);
+      expect(event.decision, isNull);
+      expect(event.scaleConnected, isFalse);
+      expect(event.scaleLost, isFalse);
+      expect(event.machineHasAutonomousSAW, isFalse);
+    });
+
+    test('serializes a state frame with a fixed schema', () {
+      final event = ShotStateEvent(
+        event: 'state',
+        timestamp: DateTime.utc(2026, 6, 17, 10, 0),
+        shotId: 'shot-1',
+        state: ShotState.pouring,
+        machineState: MachineState.espresso,
+        machineSubstate: MachineSubstate.pouring,
+        profileFrame: 2,
+        scaleConnected: true,
+        scaleLost: false,
+        machineHasAutonomousSAW: false,
+      );
+
+      expect(event.toJson(), {
+        'event': 'state',
+        'timestamp': '2026-06-17T10:00:00.000Z',
+        'shotId': 'shot-1',
+        'state': 'pouring',
+        'machineState': 'espresso',
+        'machineSubstate': 'pouring',
+        'profileFrame': 2,
+        'scaleConnected': true,
+        'scaleLost': false,
+        'machineHasAutonomousSAW': false,
+        'decision': null,
+      });
+    });
+
+    test('serializes a decision frame with nested decision', () {
+      final event = ShotStateEvent(
+        event: 'decision',
+        timestamp: DateTime.utc(2026, 6, 17, 10, 0, 5),
+        shotId: 'shot-1',
+        state: ShotState.pouring,
+        machineState: MachineState.espresso,
+        machineSubstate: MachineSubstate.pouring,
+        profileFrame: 2,
+        scaleConnected: true,
+        scaleLost: false,
+        machineHasAutonomousSAW: false,
+        decision: const ShotDecision(
+          kind: ShotDecisionKind.stop,
+          reason: ShotDecisionReason.targetWeight,
+          details: 'Target weight reached',
+        ),
+      );
+
+      final json = event.toJson();
+      expect(json['event'], 'decision');
+      expect(json['decision'], {
+        'kind': 'stop',
+        'reason': 'targetWeight',
+        'details': 'Target weight reached',
+        'data': null,
+      });
+    });
+  });
+}

--- a/test/shot_state_ws_test.dart
+++ b/test/shot_state_ws_test.dart
@@ -1,0 +1,139 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+import 'package:shelf/shelf_io.dart' as io;
+import 'package:web_socket_channel/io.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/shot_state_event.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+
+import 'helpers/mock_device_discovery_service.dart';
+import 'helpers/mock_settings_service.dart';
+
+void main() {
+  late De1Controller de1Controller;
+  late De1Handler de1Handler;
+  late HttpServer server;
+  late Uri wsUri;
+
+  setUp(() async {
+    final deviceController = DeviceController([MockDeviceDiscoveryService()]);
+    await deviceController.initialize();
+
+    de1Controller = De1Controller(controller: deviceController);
+
+    final settingsController = SettingsController(MockSettingsService());
+    await settingsController.loadSettings();
+
+    de1Handler = De1Handler(
+      controller: de1Controller,
+      settingsController: settingsController,
+      scaleController: ScaleController(),
+      workflowController: WorkflowController(),
+    );
+
+    final app = Router().plus;
+    de1Handler.addRoutes(app);
+
+    server = await io.serve(app.call, 'localhost', 0);
+    wsUri = Uri.parse('ws://localhost:${server.port}/ws/v1/machine/shotState');
+  });
+
+  tearDown(() async {
+    await server.close(force: true);
+  });
+
+  (IOWebSocketChannel, Stream<Map<String, dynamic>>) connectWs() {
+    final channel = IOWebSocketChannel.connect(wsUri);
+    final messages = channel.stream
+        .map((msg) => jsonDecode(msg.toString()) as Map<String, dynamic>)
+        .asBroadcastStream();
+    return (channel, messages);
+  }
+
+  group('shotState WebSocket', () {
+    test('sends the current shot state on connect', () async {
+      final (channel, messages) = connectWs();
+
+      final first = await messages.first.timeout(const Duration(seconds: 2));
+
+      expect(first['event'], 'state');
+      expect(first['state'], 'idle');
+      expect(first['decision'], isNull);
+
+      await channel.sink.close();
+    });
+
+    test('streams published events to connected clients', () async {
+      final (channel, messages) = connectWs();
+      // Wait for the replayed seed frame before publishing.
+      await messages.first.timeout(const Duration(seconds: 2));
+
+      final decisionFrame = messages
+          .where((m) => m['event'] == 'decision')
+          .first
+          .timeout(const Duration(seconds: 2));
+
+      de1Controller.publishShotEvent(
+        ShotStateEvent(
+          event: 'decision',
+          timestamp: DateTime.now(),
+          shotId: 'shot-1',
+          state: ShotState.pouring,
+          machineState: MachineState.espresso,
+          machineSubstate: MachineSubstate.pouring,
+          profileFrame: 1,
+          scaleConnected: true,
+          scaleLost: false,
+          machineHasAutonomousSAW: false,
+          decision: const ShotDecision(
+            kind: ShotDecisionKind.stop,
+            reason: ShotDecisionReason.targetWeight,
+            details: 'Target weight 36.0g reached',
+          ),
+        ),
+      );
+
+      final frame = await decisionFrame;
+      expect(frame['shotId'], 'shot-1');
+      expect(frame['state'], 'pouring');
+      expect(frame['decision']['kind'], 'stop');
+      expect(frame['decision']['reason'], 'targetWeight');
+
+      await channel.sink.close();
+    });
+
+    test('a late joiner replays the latest event', () async {
+      de1Controller.publishShotEvent(
+        ShotStateEvent(
+          event: 'state',
+          timestamp: DateTime.now(),
+          shotId: 'shot-2',
+          state: ShotState.pouring,
+          machineState: MachineState.espresso,
+          machineSubstate: MachineSubstate.pouring,
+          profileFrame: 0,
+          scaleConnected: false,
+          scaleLost: false,
+          machineHasAutonomousSAW: false,
+        ),
+      );
+
+      final (channel, messages) = connectWs();
+      final first = await messages.first.timeout(const Duration(seconds: 2));
+
+      expect(first['state'], 'pouring');
+      expect(first['shotId'], 'shot-2');
+
+      await channel.sink.close();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **Problem:** `ShotSequencer` inferred *why* a step advanced or a shot stopped, but every reason except `noScale` was logged inline and dropped — there was no stream of shot decisions and no persisted stop reason. The firmware never reports why a shot ended.
- **Why it matters:** Skins/clients had no way to observe shot-state decisions live, and finished shots carried no record of what stopped them (weight, volume, machine, API, user, error…).
- **What changed:** `ShotSequencer` now emits structured `ShotDecision`s (vocabulary in `lib/src/models/data/shot_state_event.dart`) for every step advance and stop, each with one consolidated `Logger('ShotState')` line. `De1StateManager` forwards each per-shot sequencer's transitions/decisions onto a long-lived `De1Controller.shotState` `BehaviorSubject`, which backs the new read-only **`/ws/v1/machine/shotState`** WebSocket topic. The final stop reason persists as `ShotRecord.stopReason` (Drift schema **v3 → v4**).
- **What did NOT change (scope boundary):** Mid-shot scale-loss handling (reconnect + overfill cap) is intentionally excluded from this PR.

Stop-reason vocabulary: `targetWeight`/`targetVolume` (app SAW), `profileSkip` vs `profileAdvance` (firmware-natural), `apiStop`/`appStop` (attributed via a stop-intent stamp on `De1Controller`), `machineEnded`, `error`, `disconnected`, `noScale`, `stoppingBackstop`.

Robustness (from adversarial review): abort arm ends a shot when the machine leaves espresso during preheat (feed can't hang / be recycled into steam); `profileAdvance` emitted against a high-water mark so a BLE frame reorder can't double-report; REST stop intent recorded only after a successful write and only while a shot is tracked; between-shots idle frames carry real scale/autonomous-SAW context.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] REST API / handlers
- [x] WebSocket API
- [x] Machine state / shot logic
- [x] Storage / Drift database
- [x] Docs / specs

## Linked Issues

- Related #343 (shot-state discussion)
- Related #34, #230 (prior art — `ShotSequencer.decisions` groundwork)

## Root Cause (if bug fix)

N/A (feature)

## Regression Test Plan (if bug fix or refactor)

N/A (feature) — new coverage: `test/shot_state_ws_test.dart` (WS topic), `test/models/shot_record_stop_reason_test.dart`, `test/models/shot_state_event_test.dart`.

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` + `assets/api/websocket_v1.yml`
- [x] API docs updated: `doc/Api.md`
- [x] N/A for Plugins/Skins/Profiles/Device docs — unaffected

Design rationale archived at `doc/plans/archive/shot-state-ws/2026-06-16-shot-state-ws-findings.md`; an sb-dev scenario recipe added under `.agents/skills/decent-app/scenarios/`.

## Security Impact (required)

- New or changed REST endpoints? **No** (spec notes the new `stopReason` field on shot records)
- New or changed WebSocket topics? **Yes** — new read-only `/ws/v1/machine/shotState`
- New or changed network calls? No
- BLE/USB surface changed? No
- File system access changed? No
- Plugin sandbox boundary changed? No
- Risk/mitigation: the new topic is read-only and exposes shot-state decisions already derivable from the existing machine/shot feeds; no new control surface.

## User-Visible Changes

- New WebSocket topic `/ws/v1/machine/shotState`.
- Finished shots now carry a `stopReason`.
- One consolidated `ShotState` log line per shot decision.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings in `lib/`/`test/`)
- [x] `flutter test` — all pass (1887 tests)
- [ ] `(cd packages/dye2-plugin && npm run build)` — N/A, plugin untouched

### Manual verification (if applicable)

- OS / platform tested: macOS (unit + integration tests)
- Simulated devices? (`simulate=1`): covered by the sb-dev scenario recipe
- Real hardware?: No
- What you personally verified and how: full `flutter test` green including the shotState WS and stop-reason suites.
- What you did **not** verify: live DE1 hardware stop-reason attribution.

### Evidence

- [x] Test output — full `flutter test` green (1887 passing).

## Compatibility & Migration

- Backward compatible? **Yes** (new topic + additive field)
- Config / env changes needed? No
- Database migration needed? **Yes** — Drift schema v3 → v4 adds `ShotRecord.stopReason`; applied automatically on app upgrade, existing rows get a null/default stop reason.

## Risks & Mitigations

- Risk: schema migration on existing shot databases.
  - Mitigation: additive nullable column via Drift's versioned migration; no data rewrite.

---

### Review changes (v2, after tadelv's review)

- Nit 1 (clock consistency): `ShotStateEvent.idle()`, the manager's snapshot-fallback stamps, and `_publishIdleFrame` now use `clock.now()` like the stop-intent code, so `fakeAsync` tests can control every timestamp on the feed.
- Nit 3 (dead write): removed the unused `_finalStopReason ??=` on the preheat-abort path — aborted shots are never persisted; the abort decision itself carries the reason (comment added).
- Nit 2 (5s stop-intent window): left as-is per review ("easy to tune later"); `_stopIntentWindow` remains a named constant.
