### PR TITLE
fix(profiles): serialize & coalesce DE1 profile uploads, auto-retry failures

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -359,9 +359,12 @@ void main(List<String> args) async {
     persistenceController.saveWorkflow(workflowController.currentWorkflow);
     de1Controller.defaultWorkflow = workflowController.currentWorkflow;
   });
-  // Single writer of DE1 setProfile across REST + UI paths. Must be
-  // constructed after workflowController has its persisted workflow
-  // loaded so its initial snapshot matches what was last pushed.
+  // Single writer of DE1 setProfile for the workflow paths (REST
+  // PUT /api/v1/workflow + UI picker). POST /api/v1/machine/profile and the
+  // reconnect defaults push bypass it — UnifiedDe1.setProfile serializes
+  // uploads across all callers at the device level. Must be constructed
+  // after workflowController has its persisted workflow loaded so its
+  // initial snapshot matches what was last pushed.
   // ignore: unused_local_variable
   final workflowDeviceSync = WorkflowDeviceSync(
     workflowController: workflowController,

--- a/lib/src/controllers/workflow_device_sync.dart
+++ b/lib/src/controllers/workflow_device_sync.dart
@@ -34,6 +34,11 @@ import 'package:reaprime/src/models/errors.dart';
 /// skipped; the existing `De1Controller._setDe1Defaults` path uploads the
 /// current workflow's profile on reconnect (see `defaultWorkflow`
 /// assignment in `main.dart`).
+///
+/// Callers outside this sync (REST `POST /api/v1/machine/profile`, the
+/// reconnect defaults push) are backstopped by the per-device upload queue
+/// in `UnifiedDe1.setProfile`, so they cannot interleave with an upload
+/// from here either.
 class WorkflowDeviceSync {
   WorkflowDeviceSync({
     required WorkflowController workflowController,

--- a/lib/src/controllers/workflow_device_sync.dart
+++ b/lib/src/controllers/workflow_device_sync.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+import 'dart:math';
+
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/errors.dart';
 
 /// Single writer of `setProfile` for both REST (`PUT /api/v1/workflow`)
@@ -10,64 +14,175 @@ import 'package:reaprime/src/models/errors.dart';
 /// value diff; equality is handled by `Profile`'s `Equatable`
 /// implementation.
 ///
-/// Without this, the profile was uploaded twice on every REST-driven
-/// change: once directly from `WorkflowHandler._applyPendingUpdate`
-/// and again from `ProfileTile._workflowChange` listening to the same
-/// `WorkflowController.notifyListeners()` tick — overlapping BLE
-/// frame writes and a profile-download race on the firmware side.
+/// Uploads are strictly serialized and coalesced (queue-with-coalesce):
+/// a profile upload is a stateful BLE multi-write sequence (header
+/// declaring N frames, then each frame), so two concurrent uploads
+/// interleave on the BLE queue and wedge the firmware's profile-receive
+/// state machine. While an upload is in flight, later workflow changes
+/// only update the desired profile; when the upload finishes, the latest
+/// desired profile is pushed and intermediates are skipped.
 ///
-/// On DE1 disconnect the push is skipped silently; the existing
-/// `De1Controller._setDe1Defaults` path uploads the current workflow's
-/// profile on reconnect (see `defaultWorkflow` assignment in
-/// `main.dart`).
+/// A failed upload (e.g. a GATT write timeout on a flaky link) is retried
+/// automatically with capped backoff ([retryDelays]) until it lands, is
+/// superseded, or the machine disconnects — a fresh upload restarts the
+/// firmware receive state machine from the header, so the machine can
+/// never stay wedged while connected. Retries are deliberately not gated
+/// on machine state: pushes mid-shot are already possible today, and a
+/// wedged machine is strictly worse.
+///
+/// On DE1 disconnect pending retries are cancelled and the push is
+/// skipped; the existing `De1Controller._setDe1Defaults` path uploads the
+/// current workflow's profile on reconnect (see `defaultWorkflow`
+/// assignment in `main.dart`).
 class WorkflowDeviceSync {
   WorkflowDeviceSync({
     required WorkflowController workflowController,
     required De1Controller de1Controller,
+    this.retryDelays = const [
+      Duration(seconds: 3),
+      Duration(seconds: 10),
+      Duration(seconds: 30),
+    ],
   })  : _workflow = workflowController,
         _de1 = de1Controller {
     _lastPushedProfile = _workflow.currentWorkflow.profile;
     _workflow.addListener(_onChange);
+    _de1Sub = _de1.de1.listen(_onDe1Change);
   }
 
   final WorkflowController _workflow;
   final De1Controller _de1;
   final Logger _log = Logger('WorkflowDeviceSync');
 
+  /// Backoff schedule for upload retries; the last entry repeats as the cap.
+  final List<Duration> retryDelays;
+
+  /// What the device is known to hold. Stamped only after a successful
+  /// upload; cleared when an upload fails, since a mid-sequence failure
+  /// leaves the device profile state unknown (comms-harden #1).
   Profile? _lastPushedProfile;
-  Profile? _pushingProfile;
+
+  /// Latest profile the device should end up with. Overwritten freely by
+  /// workflow changes while an upload is in flight (latest wins).
+  Profile? _desiredProfile;
+
+  bool _uploading = false;
+  Timer? _retryTimer;
+  int _attempt = 0;
+
+  /// Past the ramp, only every Nth failed attempt logs at WARNING.
+  static const int _retryLogHeartbeat = 10;
+
+  /// Bumped on disconnect and dispose; in-flight drains and pending retry
+  /// timers capture it and bail when it changes.
+  int _generation = 0;
+
+  StreamSubscription<De1Interface?>? _de1Sub;
 
   void _onChange() {
-    final profile = _workflow.currentWorkflow.profile;
-    if (profile == _lastPushedProfile) return; // already on the device
-    if (profile == _pushingProfile) return; // already uploading this profile
-    _pushingProfile = profile;
-    _push(profile);
+    // Record the desired profile and let the drain loop decide — comparing
+    // against `_lastPushedProfile` here would go stale when an upload is in
+    // flight (e.g. reverting to the last-pushed profile while a newer one
+    // uploads: once that lands, the device holds the newer one and the
+    // revert must still be pushed).
+    final next = _workflow.currentWorkflow.profile;
+    if (next == _desiredProfile) {
+      // Not a profile change (a non-profile workflow edit, or a re-select
+      // of the same content): leave a pending retry's backoff undisturbed
+      // rather than resetting a failing upload to the floor delay.
+      return;
+    }
+    _desiredProfile = next;
+    _attempt = 0;
+    _cancelRetry(); // a fresh change replaces any pending retry
+    unawaited(_drain());
   }
 
-  Future<void> _push(Profile profile) async {
+  /// Uploads the latest desired profile, one upload at a time, until the
+  /// device is in sync. Concurrent calls collapse into the running loop.
+  Future<void> _drain() async {
+    if (_uploading) return;
+    _uploading = true;
+    final generation = _generation;
     try {
-      await _de1.connectedDe1().setProfile(profile);
-      // Mark pushed ONLY after the upload lands. The old behaviour marked it
-      // before the write, so a failed upload (e.g. a BLE write timeout on a
-      // flaky link) was still recorded as pushed — re-applying the same profile
-      // then short-circuited and the DE1 never received it.
-      _lastPushedProfile = profile;
-    } on DeviceNotConnectedException {
-      _log.fine(
-        'DE1 not connected; skipping profile push — will sync via '
-        'defaultWorkflow on next connect',
-      );
-    } catch (e, st) {
-      _log.warning('setProfile failed; will retry on next workflow change', e, st);
+      while (generation == _generation) {
+        final profile = _desiredProfile;
+        if (profile == null || profile == _lastPushedProfile) {
+          _desiredProfile = null;
+          return;
+        }
+        try {
+          await _de1.connectedDe1().setProfile(profile);
+          if (generation != _generation) return;
+          _lastPushedProfile = profile;
+          _attempt = 0;
+          // Loop again: if the desired profile advanced mid-upload, the
+          // next iteration pushes it; otherwise the guard above exits.
+        } on DeviceNotConnectedException {
+          _log.fine(
+            'DE1 not connected; skipping profile push — will sync via '
+            'defaultWorkflow on next connect',
+          );
+          return;
+        } catch (e, st) {
+          if (generation != _generation) return;
+          // The upload died mid-sequence: the device profile state is
+          // unknown (possibly wedged mid-receive), so forget what was
+          // last pushed — even a revert to it must re-upload.
+          _lastPushedProfile = null;
+          final delay = _scheduleRetry(generation);
+          final message =
+              'setProfile failed (attempt $_attempt); retrying in '
+              '${delay.inMilliseconds}ms';
+          // Retries are unbounded, so a persistent fault would otherwise
+          // emit a stack-trace WARNING every capped delay forever. Warn
+          // while the backoff ramps and on a periodic heartbeat after
+          // that; log the rest quietly.
+          if (_attempt <= retryDelays.length ||
+              _attempt % _retryLogHeartbeat == 0) {
+            _log.warning(message, e, st);
+          } else {
+            _log.fine(message, e);
+          }
+          return;
+        }
+      }
     } finally {
-      // Clear the in-flight guard so the next change (including a retry of this
-      // same profile after a failure) can push again.
-      if (_pushingProfile == profile) _pushingProfile = null;
+      _uploading = false;
     }
+  }
+
+  /// Arms the retry timer with the next backoff delay and returns it.
+  Duration _scheduleRetry(int generation) {
+    final delay = retryDelays[min(_attempt, retryDelays.length - 1)];
+    _attempt++;
+    _retryTimer = Timer(delay, () {
+      if (generation != _generation) return;
+      unawaited(_drain());
+    });
+    return delay;
+  }
+
+  void _cancelRetry() {
+    _retryTimer?.cancel();
+    _retryTimer = null;
+  }
+
+  void _onDe1Change(De1Interface? device) {
+    if (device != null) return;
+    // Machine gone: cancel retries and forget desired state. The reconnect
+    // path re-uploads the current workflow profile via defaultWorkflow.
+    _generation++;
+    _cancelRetry();
+    _desiredProfile = null;
+    _attempt = 0;
   }
 
   void dispose() {
     _workflow.removeListener(_onChange);
+    _generation++;
+    _cancelRetry();
+    _de1Sub?.cancel();
+    _de1Sub = null;
   }
 }

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -323,8 +323,32 @@ class UnifiedDe1 implements De1Interface {
   }
 
   Profile? _currentProfile;
+
+  /// Tail of the profile-upload queue. An upload is a stateful multi-write
+  /// sequence (header + frames + tail) the firmware consumes as one
+  /// conversation; two uploads whose writes interleave on the transport's
+  /// per-device queue wedge the firmware's profile-receive state machine
+  /// until the GATT timeout. Chaining every [setProfile] onto this future
+  /// serializes uploads across ALL callers — `WorkflowDeviceSync`'s
+  /// queue-with-coalesce only covers the workflow path; the REST handler
+  /// (`POST /api/v1/machine/profile`) and the reconnect defaults push call
+  /// [setProfile] directly.
+  Future<void> _profileUploadQueue = Future.value();
+
   @override
-  Future<void> setProfile(Profile profile) async {
+  Future<void> setProfile(Profile profile) {
+    // Queue unconditionally — the equality guard runs inside the locked
+    // section so it sees the cache as of upload start (after any queued
+    // uploads finished), not as of call time.
+    final upload =
+        _profileUploadQueue.then((_) => _uploadProfileLocked(profile));
+    // Keep the queue alive past a failed upload: the chain swallows the
+    // error, the caller's future still surfaces it.
+    _profileUploadQueue = upload.catchError((_) {});
+    return upload;
+  }
+
+  Future<void> _uploadProfileLocked(Profile profile) async {
     if (_currentProfile == profile) {
       return;
     }
@@ -343,6 +367,8 @@ class UnifiedDe1 implements De1Interface {
     // that flash write returns. If a state=espresso request hits the
     // firmware task loop before the flag clears, doEspresso() aborts to
     // HeaterDown and the shot ends after preinfuse. See BC 9788201734.
+    // Kept inside the locked section: a queued upload must not start while
+    // the firmware is still flushing the previous descriptor.
     await Future.delayed(ConnectionTimings.profileDownloadGuard);
   }
 

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -328,10 +328,13 @@ class UnifiedDe1 implements De1Interface {
     if (_currentProfile == profile) {
       return;
     }
-    // Assign only after a successful send. A mid-upload throw leaves
-    // `_currentProfile` at its previous value so a retry with the same
-    // `Profile` won't silently no-op on the equality guard. See
-    // comms-harden #1.
+    // Invalidate the cache for the duration of the upload and assign only
+    // after a successful send. A mid-upload throw can leave the firmware
+    // wedged mid-receive, so no profile — including the previously
+    // successful one — can be assumed present on the device afterwards; a
+    // stale cache would silently no-op the recovery upload on the equality
+    // guard. See comms-harden #1.
+    _currentProfile = null;
     await _sendProfile(profile);
     _currentProfile = profile;
     // Guard against firmware ProfileDownloadInProgress race: the DE1 writes

--- a/test/controllers/workflow_device_sync_test.dart
+++ b/test/controllers/workflow_device_sync_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
@@ -5,6 +7,8 @@ import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/controllers/workflow_device_sync.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/errors.dart';
 
 import '../helpers/mock_device_discovery_service.dart';
 import '../helpers/test_de1.dart';
@@ -34,15 +38,72 @@ class _RecordingDe1 extends TestDe1 {
 class _FlakyDe1 extends TestDe1 {
   _FlakyDe1({this.failures = 1});
   int failures;
+  int totalCalls = 0;
   final List<Profile> setProfileCalls = [];
 
   @override
   Future<void> setProfile(Profile profile) async {
+    totalCalls++;
     if (failures > 0) {
       failures--;
       throw Exception('simulated BLE write timeout');
     }
     setProfileCalls.add(profile);
+  }
+}
+
+/// Holds every upload open until the test releases it via [completeNext],
+/// tracking how many uploads run concurrently.
+class _GatedDe1 extends TestDe1 {
+  final List<Profile> setProfileCalls = [];
+  final List<Completer<void>> _gates = [];
+  int _inFlight = 0;
+  int maxInFlight = 0;
+
+  int get pendingUploads => _gates.length;
+
+  void completeNext() => _gates.removeAt(0).complete();
+
+  @override
+  Future<void> setProfile(Profile profile) async {
+    _inFlight++;
+    if (_inFlight > maxInFlight) maxInFlight = _inFlight;
+    setProfileCalls.add(profile);
+    final gate = Completer<void>();
+    _gates.add(gate);
+    try {
+      await gate.future;
+    } finally {
+      _inFlight--;
+    }
+  }
+}
+
+/// Fails the calls whose 1-based sequence number is in [failOnCalls].
+class _FailNthDe1 extends TestDe1 {
+  _FailNthDe1(this.failOnCalls);
+  final Set<int> failOnCalls;
+  int totalCalls = 0;
+  final List<Profile> setProfileCalls = [];
+
+  @override
+  Future<void> setProfile(Profile profile) async {
+    totalCalls++;
+    if (failOnCalls.contains(totalCalls)) {
+      throw Exception('simulated failure on call #$totalCalls');
+    }
+    setProfileCalls.add(profile);
+  }
+}
+
+/// Always reports the machine as gone.
+class _NotConnectedDe1 extends TestDe1 {
+  int totalCalls = 0;
+
+  @override
+  Future<void> setProfile(Profile profile) async {
+    totalCalls++;
+    throw const DeviceNotConnectedException.machine();
   }
 }
 
@@ -126,7 +187,8 @@ void main() {
   );
 
   test(
-    'a failed setProfile is retried on the next workflow change',
+    'a failed setProfile is not marked pushed — the same profile still '
+    'lands via the automatic retry',
     () async {
       // Build an isolated sync wired to a DE1 whose first upload fails.
       final wf = WorkflowController();
@@ -149,6 +211,7 @@ void main() {
       final flakySync = WorkflowDeviceSync(
         workflowController: wf,
         de1Controller: controller,
+        retryDelays: const [Duration(milliseconds: 20)],
       );
 
       // First push of the cleaning profile fails (timeout) — nothing recorded,
@@ -157,10 +220,11 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 10));
       expect(flaky.setProfileCalls, isEmpty);
 
-      // Re-applying the SAME profile must RETRY (not skip as already-pushed),
-      // since the first upload never landed on the device.
+      // Re-applying the SAME profile leaves the armed retry undisturbed; the
+      // profile must land when it fires (it was never marked pushed, so it
+      // cannot be skipped by the equality guard).
       wf.setWorkflow(wf.currentWorkflow.copyWith(profile: _profile('Cleaning')));
-      await Future<void>.delayed(const Duration(milliseconds: 10));
+      await Future<void>.delayed(const Duration(milliseconds: 60));
       expect(flaky.setProfileCalls.length, equals(1));
       expect(flaky.setProfileCalls.single.title, equals('Cleaning'));
 
@@ -180,4 +244,255 @@ void main() {
       expect(de1.setProfileCalls, isEmpty);
     },
   );
+
+  // Serialized/coalescing push loop + failure retry. Regression coverage for
+  // the 2026-07-05 stuck-machine incident: rapid temperature "+" presses
+  // produced overlapping profile uploads whose header/frame writes
+  // interleaved on the BLE queue, wedging the firmware's profile-receive
+  // state machine; and after the resulting write timeout nothing retried.
+  group('serialized coalescing push with retry', () {
+    // Short, test-friendly backoff. Last entry is the cap.
+    const retryDelays = [
+      Duration(milliseconds: 20),
+      Duration(milliseconds: 40),
+    ];
+
+    late WorkflowController wf;
+    WorkflowDeviceSync? activeSync;
+
+    Future<De1Controller> connect(TestDe1 testDe1) async {
+      final dc = DeviceController([MockDeviceDiscoveryService()]);
+      await dc.initialize();
+      final controller = De1Controller(controller: dc);
+      await controller.connectToDe1(testDe1);
+      testDe1.emitShotSettings(De1ShotSettings(
+        steamSetting: 0,
+        targetSteamTemp: 150,
+        targetSteamDuration: 30,
+        targetHotWaterTemp: 75,
+        targetHotWaterVolume: 50,
+        targetHotWaterDuration: 30,
+        targetShotVolume: 36,
+        groupTemp: 94.0,
+      ));
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      return controller;
+    }
+
+    WorkflowDeviceSync buildSync(De1Controller controller) {
+      final s = WorkflowDeviceSync(
+        workflowController: wf,
+        de1Controller: controller,
+        retryDelays: retryDelays,
+      );
+      activeSync = s;
+      return s;
+    }
+
+    void applyProfile(String title) {
+      wf.setWorkflow(wf.currentWorkflow.copyWith(profile: _profile(title)));
+    }
+
+    setUp(() {
+      wf = WorkflowController();
+      activeSync = null;
+    });
+
+    tearDown(() {
+      activeSync?.dispose();
+    });
+
+    test('uploads never overlap and intermediate profiles are skipped',
+        () async {
+      final gated = _GatedDe1();
+      final controller = await connect(gated);
+      buildSync(controller);
+
+      applyProfile('A');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(gated.setProfileCalls.map((p) => p.title), ['A'],
+          reason: 'first change starts an upload immediately');
+
+      // Two more changes while upload A is still in flight.
+      applyProfile('B');
+      applyProfile('C');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(gated.setProfileCalls.length, 1,
+          reason: 'no second upload may start while A is in flight');
+
+      gated.completeNext(); // A lands
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(gated.setProfileCalls.map((p) => p.title), ['A', 'C'],
+          reason: 'B was superseded by C before its upload started');
+
+      gated.completeNext(); // C lands
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(gated.maxInFlight, 1,
+          reason: 'profile uploads must be strictly serialized');
+      expect(gated.pendingUploads, 0);
+    });
+
+    test('a failed upload is retried automatically, no workflow change needed',
+        () async {
+      final flaky = _FlakyDe1(failures: 1);
+      final controller = await connect(flaky);
+      buildSync(controller);
+
+      applyProfile('Cleaning');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(flaky.setProfileCalls, isEmpty,
+          reason: 'first attempt fails; retry not due yet');
+
+      // First retry is due after retryDelays[0] (20ms).
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      expect(flaky.setProfileCalls.map((p) => p.title), ['Cleaning'],
+          reason: 'retry must fire without any further workflow change');
+    });
+
+    test('a pending retry pushes the latest desired profile', () async {
+      final flaky = _FlakyDe1(failures: 1);
+      final controller = await connect(flaky);
+      buildSync(controller);
+
+      applyProfile('A'); // fails, retry armed for +20ms
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      applyProfile('B'); // supersedes A before the retry fires
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(flaky.setProfileCalls.map((p) => p.title), ['B'],
+          reason: 'superseded profile A must never be uploaded');
+    });
+
+    test('backoff walks the delay list until the upload lands', () async {
+      final flaky = _FlakyDe1(failures: 2);
+      final controller = await connect(flaky);
+      buildSync(controller);
+
+      applyProfile('Stubborn');
+      // Attempt 1 at ~0ms fails, retry at +20ms fails, retry at +20+40ms lands.
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      expect(flaky.setProfileCalls, isEmpty,
+          reason: 'second retry is not due before 60ms');
+
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+      expect(flaky.setProfileCalls.map((p) => p.title), ['Stubborn']);
+      expect(flaky.totalCalls, 3);
+    });
+
+    test('machine disconnect cancels a pending retry', () async {
+      final flaky = _FlakyDe1(failures: 100);
+      final controller = await connect(flaky);
+      buildSync(controller);
+
+      applyProfile('Doomed');
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      expect(flaky.totalCalls, 1);
+
+      flaky.setConnectionState(ConnectionState.disconnected);
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      expect(flaky.totalCalls, 1,
+          reason: 'no retry may fire after the machine disconnected');
+    });
+
+    test('DeviceNotConnectedException does not schedule a retry', () async {
+      final gone = _NotConnectedDe1();
+      final controller = await connect(gone);
+      buildSync(controller);
+
+      applyProfile('Unreachable');
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      expect(gone.totalCalls, 1,
+          reason: 'reconnect path owns the re-upload; no retry timer');
+    });
+
+    test('dispose cancels a pending retry', () async {
+      final flaky = _FlakyDe1(failures: 100);
+      final controller = await connect(flaky);
+      final s = buildSync(controller);
+
+      applyProfile('Doomed');
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      expect(flaky.totalCalls, 1);
+
+      s.dispose();
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      expect(flaky.totalCalls, 1);
+    });
+
+    test(
+        'reverting to the last-pushed profile while another upload is in '
+        'flight still converges to the reverted profile', () async {
+      final gated = _GatedDe1();
+      final controller = await connect(gated);
+      buildSync(controller);
+
+      applyProfile('P1');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      gated.completeNext(); // P1 lands
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      applyProfile('P2');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      // Revert to P1 while P2 is still uploading. Once P2 lands the device
+      // holds P2, so the loop must push P1 again to match the workflow.
+      applyProfile('P1');
+      gated.completeNext(); // P2 lands
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(gated.setProfileCalls.map((p) => p.title), ['P1', 'P2', 'P1'],
+          reason: 'device must converge to the workflow profile, not P2');
+
+      gated.completeNext(); // trailing P1 lands
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(gated.maxInFlight, 1);
+    });
+
+    test(
+        'a workflow change with the same profile leaves a pending retry\'s '
+        'backoff undisturbed', () async {
+      final flaky = _FlakyDe1(failures: 100);
+      final controller = await connect(flaky);
+      buildSync(controller);
+
+      applyProfile('Same'); // attempt 1 fails, retry armed for +20ms
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      expect(flaky.totalCalls, 1);
+
+      // Same profile content again (e.g. a non-profile workflow edit
+      // notifying listeners): must not trigger an immediate re-attempt.
+      applyProfile('Same');
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      expect(flaky.totalCalls, 1,
+          reason: 'identical content must not reset the backoff to now');
+
+      // The originally armed retry still fires on schedule.
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      expect(flaky.totalCalls, greaterThanOrEqualTo(2),
+          reason: 'the pending retry must survive the duplicate change');
+    });
+
+    test(
+        'failed upload invalidates last-pushed — reverting to the previous '
+        'profile re-uploads instead of short-circuiting', () async {
+      // Call 1 (profile P1) succeeds, call 2 (P2) fails mid-upload.
+      final de1 = _FailNthDe1({2});
+      final controller = await connect(de1);
+      buildSync(controller);
+
+      applyProfile('P1');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(de1.setProfileCalls.map((p) => p.title), ['P1']);
+
+      applyProfile('P2'); // fails — device state now unknown (possibly wedged)
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      // User reverts to P1 before the retry fires. The device may be stuck
+      // mid-receive of P2, so this MUST re-upload P1, not skip it as
+      // already-pushed.
+      applyProfile('P1');
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(de1.setProfileCalls.map((p) => p.title), ['P1', 'P1']);
+    });
+  });
 }

--- a/test/models/device/unified_de1_set_profile_test.dart
+++ b/test/models/device/unified_de1_set_profile_test.dart
@@ -168,4 +168,125 @@ void main() {
           reason: 'different profile must upload even after a prior success');
     });
   });
+
+  group('concurrent setProfile serialization', () {
+    // A profile upload is a stateful multi-write sequence (header + frames +
+    // tail) the firmware consumes as one conversation. Two uploads whose
+    // writes interleave on the transport queue wedge the firmware's
+    // profile-receive state machine — so UnifiedDe1 must serialize uploads
+    // across ALL callers (workflow sync, REST handler, reconnect defaults).
+    //
+    // The two profiles differ in step count so their write sequences differ
+    // in length and content; expectations compare against each profile's
+    // solo-run write sequence, captured once below.
+
+    const profileA = Profile(
+      version: '2',
+      title: 'Serialization A',
+      notes: '',
+      author: 'test',
+      beverageType: BeverageType.espresso,
+      steps: [],
+      targetVolumeCountStart: 0,
+      tankTemperature: 0,
+    );
+
+    const profileB = Profile(
+      version: '2',
+      title: 'Serialization B',
+      notes: '',
+      author: 'test',
+      beverageType: BeverageType.espresso,
+      steps: [
+        ProfileStepPressure(
+          name: 'pour',
+          transition: TransitionType.fast,
+          volume: 0,
+          seconds: 30,
+          temperature: 92,
+          sensor: TemperatureSensor.coffee,
+          pressure: 9,
+        ),
+      ],
+      targetVolumeCountStart: 0,
+      tankTemperature: 0,
+    );
+
+    late List<String> soloWritesA;
+    late List<String> soloWritesB;
+
+    /// The exact transport writes one upload of [p] produces on its own.
+    Future<List<String>> soloWrites(Profile p) async {
+      final t = _RecordingSerialTransport();
+      final d = UnifiedDe1(transport: t);
+      await d.setProfile(p);
+      final writes = List<String>.from(t.writes);
+      await t.dispose();
+      return writes;
+    }
+
+    setUpAll(() async {
+      soloWritesA = await soloWrites(profileA);
+      soloWritesB = await soloWrites(profileB);
+    });
+
+    late _RecordingSerialTransport transport;
+    late UnifiedDe1 de1;
+
+    setUp(() {
+      transport = _RecordingSerialTransport();
+      de1 = UnifiedDe1(transport: transport);
+    });
+
+    tearDown(() {
+      transport.dispose();
+    });
+
+    test('sequences differ so interleaving would be observable', () {
+      expect(soloWritesA.length, greaterThanOrEqualTo(2),
+          reason: 'an upload must be a multi-write sequence');
+      expect(soloWritesB.length, greaterThan(soloWritesA.length));
+    });
+
+    test('concurrent uploads of different profiles do not interleave',
+        () async {
+      final first = de1.setProfile(profileA);
+      final second = de1.setProfile(profileB);
+      await Future.wait([first, second]);
+
+      expect(
+        transport.writes,
+        [...soloWritesA, ...soloWritesB],
+        reason: 'the second upload must not start until the first — '
+            'including its post-upload firmware flash guard — has finished',
+      );
+    });
+
+    test(
+        'concurrent identical uploads collapse to one — the equality guard '
+        'is evaluated when the upload starts, not when it queues', () async {
+      final first = de1.setProfile(profileB);
+      final second = de1.setProfile(profileB);
+      await Future.wait([first, second]);
+
+      expect(transport.writes, soloWritesB,
+          reason: 'the queued duplicate must see the fresh cache and '
+              'short-circuit instead of re-uploading');
+    });
+
+    test('a failed upload releases the queue for the next one', () async {
+      // Fail A's header write; B is already queued behind it.
+      transport.failIndexOnce = 0;
+      final first = de1.setProfile(profileA);
+      final second = de1.setProfile(profileB);
+
+      await expectLater(first, throwsA(isA<Exception>()));
+      await second;
+
+      expect(transport.writes.length, 1 + soloWritesB.length,
+          reason: 'A records only its failed header; B runs in full');
+      expect(transport.writes.sublist(1), soloWritesB,
+          reason: 'the queued upload must run untouched by the failure');
+    });
+  });
 }

--- a/test/models/device/unified_de1_set_profile_test.dart
+++ b/test/models/device/unified_de1_set_profile_test.dart
@@ -131,6 +131,32 @@ void main() {
           reason: 'identical upload on successful cache must short-circuit');
     });
 
+    test(
+        'failed upload invalidates the cache — re-pushing the previously '
+        'successful profile re-uploads', () async {
+      // Land profile successfully first.
+      await de1.setProfile(profile);
+      final writesAfterSuccess = transport.writes.length;
+      expect(writesAfterSuccess, greaterThan(0));
+
+      // A different profile fails on its header write. The firmware may now
+      // be wedged mid-receive, so the previously-successful profile can no
+      // longer be assumed present on the device.
+      final other = profile.copyWith(title: 'Other Profile');
+      transport.failIndexOnce = writesAfterSuccess;
+      await expectLater(
+        () => de1.setProfile(other),
+        throwsA(isA<Exception>()),
+      );
+
+      // Reverting to the original profile MUST re-upload it, not
+      // short-circuit on the stale success cache.
+      await de1.setProfile(profile);
+      expect(transport.writes.length, greaterThan(writesAfterSuccess + 1),
+          reason:
+              'revert after a failed upload must re-drive the full sequence');
+    });
+
     test('different profile always uploads', () async {
       await de1.setProfile(profile);
       final writesAfterFirst = transport.writes.length;


### PR DESCRIPTION
## Summary

- **Problem:** Rapid workflow changes (e.g. tapping temperature "+" repeatedly in a WebUI skin) each produced a different profile. `WorkflowDeviceSync`'s in-flight guard only blocked re-pushing an *identical* profile, so uploads overlapped: their header/frame writes interleaved on `universal_ble`'s per-device queue and the DE1 firmware wedged mid profile-receive until the 10s GATT timeout fired. Nothing retried — the machine stayed stuck until the next workflow change or a reboot.
- **Why it matters:** A stuck profile-receive state machine means the machine silently stops accepting shots until manually recovered.
- **What changed:** `WorkflowDeviceSync` now runs a serialized, coalescing push loop (queue-with-coalesce): one upload in flight at a time, later changes just replace the desired profile, intermediates are skipped. A failed upload retries automatically with capped backoff (3s/10s/30s, constructor-injectable) until it lands, is superseded, or the machine disconnects (generation token + cancellable `Timer`) — a fresh upload restarts the firmware receive state machine from the header, so the machine can no longer stay wedged while connected. A failed upload also invalidates both profile caches (`_lastPushedProfile` and `UnifiedDe1._currentProfile`), so reverting to the previously-successful profile still re-uploads rather than short-circuiting on the equality guards.
- **What did NOT change (scope boundary):** Profile content/format, hashing, and the REST/WS profile API are unchanged — this is purely the upload-to-DE1 sync path.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [x] Profiles / beans / grinders / workflows
- [x] Machine state / shot logic

## Linked Issues

- Closes #
- Related #

## Root Cause (if bug fix)

- **Root cause:** Overlapping profile uploads interleaved their BLE header/frame writes on the shared per-device queue, wedging the DE1's profile-receive state machine until the GATT timeout; the in-flight guard only deduped *identical* profiles, not concurrent *different* ones.
- **Missing detection or guardrail:** No serialization of uploads and no retry after a failed/timed-out upload; equality guards masked the need to re-upload after a mid-sequence failure.
- **Contributing context:** `universal_ble`'s single per-device write queue + firmware that expects an uninterrupted header→frames sequence.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `test/controllers/workflow_device_sync_test.dart` (+ `test/models/device/unified_de1_set_profile_test.dart`).
- Scenario the test should lock in: rapid successive distinct profiles coalesce to a single in-flight upload; a failed upload retries with backoff and invalidates both caches; disconnect cancels pending retries.

## Documentation Obligations (required)

- [x] N/A — no REST/WS endpoints, profile-format, or device-flow docs changed (internal sync/retry behavior only).

## Security Impact (required)

- New or changed REST endpoints? No
- New or changed WebSocket topics? No
- New or changed network calls? No
- BLE/USB surface changed? **No new surface** — same profile characteristic writes, now serialized/retried rather than overlapped.
- File system access changed? No
- Plugin sandbox boundary changed? No

## User-Visible Changes

Profile changes from skins/workflows now apply reliably under rapid edits; a failed upload recovers automatically instead of leaving the machine stuck. No new UI or config.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings in `lib/`/`test/`)
- [x] `flutter test` — all pass (1860 tests)
- [ ] `(cd packages/dye2-plugin && npm run build)` — N/A, plugin untouched

### Manual verification (if applicable)

- OS / platform tested: macOS (unit tests)
- Simulated devices? (`simulate=1`): covered indirectly; core logic is unit-tested with injected backoff
- Real hardware?: No
- What you personally verified and how: full `flutter test` green including the new coalesce/retry suites (288-line `workflow_device_sync_test.dart`).
- What you did **not** verify: reproduction against a live DE1 (the original wedge was hardware/firmware-timing specific).

### Evidence

- [x] Test output — full `flutter test` green (1860 passing).

## Compatibility & Migration

- Backward compatible? **Yes**
- Config / env changes needed? No
- Database migration needed? No

## Risks & Mitigations

- Risk: retry loop could spin if uploads keep failing.
  - Mitigation: capped backoff (3s/10s/30s), superseded-or-disconnect cancellation via generation token + cancellable Timer; one upload in flight at a time.

---

### Review changes (v2, after tadelv's review)

- Backoff-reset nit: `_onChange` now only resets the retry backoff on a real profile-content change; non-profile workflow edits (which also notify listeners) and same-content re-selects leave a pending retry's schedule undisturbed. New test locks this in; the older "retried on next workflow change" test updated to observe delivery via the armed retry timer.
- Log-noise nit: repeated retry failures are throttled — WARNING with stack while the backoff ramps and on every 10th attempt after that, FINE otherwise. Unbounded retry itself is kept (a wedged machine is strictly worse), as discussed.
- `UnifiedDe1._currentProfile = null` during upload: **intended** — a mid-sequence failure leaves device state unknown, so even a revert to the previously successful profile must re-upload rather than short-circuit on the equality guard; the code comment covers this.
- Direct-`setProfile` bypass (REST `_profileHandler`, reconnect `_setDe1Defaults`): **addressed in a second commit** — `UnifiedDe1.setProfile` now chains every upload onto a per-device queue future, serializing uploads across all callers (serialize-only at the device level; coalesce/retry stay in `WorkflowDeviceSync`, which the queue backstops). Equality guard evaluated inside the locked section; the post-upload flash guard stays inside the lock; a failed upload releases the queue. 4 new unit tests over the fake-transport harness (interleave, queued-duplicate collapse, failure releases queue); stale `main.dart` "single writer" comment corrected.
- FakeAsync test migration: deferred — the suite drives real streams through `TestDe1`; converting the ms-scale delays wholesale risks introducing the flakiness it aims to prevent. Can revisit if CI shows timing flakes.
