### PR TITLE
feat(logs): always stitch rotated logs into /api/v1/logs, capped tail window

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3804,15 +3804,23 @@ paths:
     get:
       summary: Get recent log entries
       description: |
-      Returns the last N kilobytes of the app log file, newest entries first. Query parameter `kb` controls the size (default: 16).
+        Returns the most recent window of the app log, newest entries first.
+        The live log file and any rotated siblings (`log.txt.1`, `log.txt.2`,
+        …) are always stitched in chronological order — oldest rotation
+        first, live file last — before the window and `order` are applied.
+        The window is `kb` kilobytes when given (clamped to 4096), 1024 KB
+        otherwise, so a full rotation set is never buffered in memory.
       tags: [System]
       parameters:
         - name: kb
           in: query
           schema:
             type: integer
+            minimum: 1
+            default: 1024
           description: |
-          Number of kilobytes to return (default: 16)
+            Tail window size in kilobytes. Defaults to 1024 (1 MB); values
+            above 4096 (4 MB) are clamped to that ceiling.
         - name: order
           in: query
           schema:
@@ -3820,16 +3828,6 @@ paths:
             enum: [desc, asc]
             default: desc
           description: Line order — desc (newest first, default) or asc (original chronological order).
-        - name: rotated
-          in: query
-          schema:
-            type: boolean
-            default: false
-          description: |
-            When true (`1`/`true`/`yes`), also include the rotated log files
-            (`log.txt.1`, `log.txt.2`, …), stitched in chronological order —
-            oldest rotation first, live file last — before `kb` and `order` are
-            applied. Default returns only the live log file.
       responses:
         "200":
           description: Recent log entries as plain text

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -290,7 +290,7 @@ The **proxy** lets clients *use* the account without ever seeing the credentials
 | GET | `/api/v1/info` | Build metadata (version, commit, branch) + gateway LAN IP (`localIp`) | `info_handler.dart` |
 | GET | `/api/v1/update` | App-update state snapshot (`phase`, `latestVersion`, `releaseNotes`, `releaseUrl`, `installable`). Pure read — no network call; force a re-check via `/ws/v1/update`. | `update_handler.dart` |
 | POST | `/api/v1/feedback` | Submit feedback (creates GitHub issue) | `feedback_handler.dart` |
-| GET | `/api/v1/logs` | Recent log entries, newest first (optional `?kb=N` for last N KB; `?order=asc` for original chronological order; `?rotated=1` to also include rotated files `log.txt.1..N`, stitched chronologically) | `logs_handler.dart` |
+| GET | `/api/v1/logs` | Recent log entries, newest first. Live log + rotated files `log.txt.1..N` are always stitched chronologically; response is a size-bounded tail window (`?kb=N`, default 1024 KB, clamped to 4096 KB). `?order=asc` for original chronological order | `logs_handler.dart` |
 | GET | `/api/v1/webview/logs` | WebView console log forwarding, newest first (`?order=asc` for original chronological order) | `webview_logs_handler.dart` |
 | POST | `/api/v1/derek/answers/stream` | Relay to the Derek RAG assistant: forwards the JSON body verbatim to `derek.decentespresso.com/api/answers/stream` and pipes the SSE response back unbuffered. No auth (public data). Exists so browser skins avoid Derek's failing CORS preflight. | `derek_handler.dart` |
 

--- a/lib/src/services/webserver/logs_handler.dart
+++ b/lib/src/services/webserver/logs_handler.dart
@@ -2,115 +2,158 @@ part of '../webserver_service.dart';
 
 /// REST API handler for log file access
 ///
-/// GET /api/v1/logs?kb=N — returns last N kilobytes of the log file.
-/// Without `kb`, returns the entire file.
+/// GET /api/v1/logs?kb=N — returns the most recent N kilobytes of the app
+/// log. The live log file and any rotated siblings the appender leaves behind
+/// (`log.txt.1`, `log.txt.2`, …) are always stitched in true chronological
+/// order — oldest rotation first, live file last — before the window is
+/// applied.
+///
+/// The window is size-bounded in all cases: `kb` when given (clamped to
+/// [maxTailKb]), [defaultTailKb] otherwise. A full rotation set can reach
+/// tens of MB (10 MB per file × keepRotateCount + live), which
+/// memory-constrained tablets cannot afford to buffer, so the whole set is
+/// never read at once.
 ///
 /// Lines are served newest-first by default. Pass `order=asc` to get the
-/// original on-disk chronological order (oldest first); `order=desc` is the
-/// explicit form of the default.
-///
-/// Pass `rotated=1` to also include the rotated log files the appender leaves
-/// behind (`log.txt.1`, `log.txt.2`, …). They are stitched into the response
-/// in true chronological order — oldest rotation first, the live file last —
-/// before `kb` windowing and `order` are applied.
+/// original on-disk chronological order; `asc` responses are streamed
+/// straight from the file byte ranges without buffering the window.
+/// `order=desc` (the explicit form of the default) must reverse lines, so it
+/// buffers the window — the clamp is what keeps that buffer bounded.
 class LogsHandler {
   final String _logFilePath;
+  final int _defaultTailBytes;
+  final int _maxTailBytes;
 
-  LogsHandler({required String logFilePath}) : _logFilePath = logFilePath;
+  /// Tail window in KB when the request has no `kb` (1 MB).
+  static const int defaultTailKb = 1024;
+
+  /// Hard ceiling in KB an explicit `kb` is clamped to (4 MB).
+  static const int maxTailKb = 4096;
+
+  /// Caps are injectable so tests can exercise the windowing with small files.
+  LogsHandler({
+    required String logFilePath,
+    int defaultTailKb = LogsHandler.defaultTailKb,
+    int maxTailKb = LogsHandler.maxTailKb,
+  })  : _logFilePath = logFilePath,
+        _defaultTailBytes = defaultTailKb * 1024,
+        _maxTailBytes = maxTailKb * 1024;
 
   void addRoutes(RouterPlus app) {
     app.get('/api/v1/logs', _handleGetLogs);
   }
 
   Future<Response> _handleGetLogs(Request request) async {
-    if (!await File(_logFilePath).exists()) {
-      return Response.notFound('Log file not found');
-    }
-
     final order = _parseLogOrder(request);
     if (order == null) {
       return Response.badRequest(body: "order must be 'asc' or 'desc'");
     }
 
-    final rotated = _parseLogRotated(request);
-    if (rotated == null) {
-      return Response.badRequest(
-        body: "rotated must be a boolean (1/0, true/false)",
-      );
-    }
-
-    int? maxBytes;
+    var maxBytes = _defaultTailBytes;
     final kbParam = request.url.queryParameters['kb'];
     if (kbParam != null) {
       final kb = int.tryParse(kbParam);
       if (kb == null || kb <= 0) {
         return Response.badRequest(body: 'kb must be a positive integer');
       }
-      maxBytes = kb * 1024;
+      maxBytes = min(kb * 1024, _maxTailBytes);
     }
 
-    final files = rotated ? _logFilesOldestToNewest() : [File(_logFilePath)];
-    final contents = await _readChronological(files, maxBytes: maxBytes);
+    final files = await _logFilesOldestToNewest();
+    if (files.isEmpty) {
+      return Response.notFound('Log file not found');
+    }
+
+    final window = await _tailWindow(files, maxBytes);
+    if (order == _LogOrder.ascending) {
+      return Response.ok(
+        _streamSegments(window),
+        headers: {'content-type': 'text/plain'},
+      );
+    }
+    final contents = await _readSegments(window);
     return Response.ok(
-      _orderLogLines(contents, order),
+      _reverseLogLines(contents),
       headers: {'content-type': 'text/plain'},
     );
   }
 
-  /// The live log file plus any rotated siblings, ordered oldest-first so their
-  /// concatenation reads chronologically.
+  /// The live log file plus any rotated siblings, ordered oldest-first so
+  /// their concatenation reads chronologically. Empty when no log files exist.
   ///
   /// Rotation naming mirrors `RotatingFileAppender`: rotation 0 is the base
   /// path (newest), higher numbers are progressively older (`log.txt.1`,
   /// `log.txt.2`, …). We probe upward until a rotation is missing, so the set
   /// stays in sync with whatever `keepRotateCount` the appender uses without
   /// this handler needing to know it.
-  List<File> _logFilesOldestToNewest() {
+  Future<List<File>> _logFilesOldestToNewest() async {
     final rotated = <File>[];
     for (var i = 1; ; i++) {
       final file = File('$_logFilePath.$i');
-      if (!file.existsSync()) break;
+      if (!await file.exists()) break;
       rotated.add(file);
     }
+    final live = File(_logFilePath);
     // Higher index = older, so oldest-first is the rotated files reversed,
     // with the live (newest) file last.
-    return [...rotated.reversed, File(_logFilePath)];
+    return [
+      ...rotated.reversed,
+      if (await live.exists()) live,
+    ];
   }
 
-  /// Read [files] (assumed oldest-first) into one chronological string.
+  /// The byte ranges, oldest-first, that make up the most recent [maxBytes]
+  /// bytes across [files] (given oldest-first).
   ///
-  /// When [maxBytes] is null the whole set is read. Otherwise only the most
-  /// recent [maxBytes] bytes across the set are returned: files are read
-  /// newest-first until the budget is filled, so older rotations that fall
-  /// outside the window are never loaded. As with the single-file tail read,
-  /// the byte cut can slice the oldest returned line mid-way.
-  Future<String> _readChronological(List<File> files, {int? maxBytes}) async {
-    if (maxBytes == null) {
-      final buffer = StringBuffer();
-      for (final file in files) {
-        buffer.write(await file.readAsString());
-      }
-      return buffer.toString();
-    }
-
+  /// Files are measured newest-first until the budget is filled, so older
+  /// rotations that fall wholly outside the window are never opened. As with
+  /// any byte-tail, the cut can slice the oldest returned line (or a
+  /// multi-byte character) mid-way.
+  Future<List<_FileSegment>> _tailWindow(List<File> files, int maxBytes) async {
     var remaining = maxBytes;
-    final chunks = <String>[]; // newest-first; reversed before joining
+    final segments = <_FileSegment>[]; // newest-first; reversed before return
     for (final file in files.reversed) {
       if (remaining <= 0) break;
       final length = await file.length();
       final start = length > remaining ? length - remaining : 0;
-      final raf = await file.open();
-      try {
-        await raf.setPosition(start);
-        final data = await raf.read(length - start);
-        chunks.add(String.fromCharCodes(data));
-      } finally {
-        await raf.close();
+      if (length > start) {
+        segments.add(_FileSegment(file, start, length));
       }
       remaining -= length - start;
     }
-    return chunks.reversed.join();
+    return segments.reversed.toList();
   }
+
+  /// Stream [segments] to the client without buffering them in memory.
+  Stream<List<int>> _streamSegments(List<_FileSegment> segments) async* {
+    for (final segment in segments) {
+      yield* segment.file.openRead(segment.start, segment.end);
+    }
+  }
+
+  /// Read [segments] into one string, for responses that must be transformed
+  /// whole (line reversal). Callers keep the window capped so this buffer
+  /// stays bounded. A window cut mid-character decodes to U+FFFD rather than
+  /// throwing.
+  Future<String> _readSegments(List<_FileSegment> segments) async {
+    final buffer = BytesBuilder(copy: false);
+    for (final segment in segments) {
+      await for (final chunk
+          in segment.file.openRead(segment.start, segment.end)) {
+        buffer.add(chunk);
+      }
+    }
+    return utf8.decode(buffer.takeBytes(), allowMalformed: true);
+  }
+}
+
+/// A byte range `[start, end)` of one log file inside the served tail window.
+class _FileSegment {
+  final File file;
+  final int start;
+  final int end;
+
+  _FileSegment(this.file, this.start, this.end);
 }
 
 /// Output line order for the log endpoints.
@@ -135,28 +178,6 @@ _LogOrder? _parseLogOrder(Request request) {
       return _LogOrder.ascending;
     case 'desc':
       return _LogOrder.descending;
-    default:
-      return null;
-  }
-}
-
-/// Parse the optional `rotated` query parameter for `/api/v1/logs`.
-///
-/// Absent means `false` (live file only). Accepts `1`/`true`/`yes` and
-/// `0`/`false`/`no`, case-insensitive. Returns `null` for an unrecognized
-/// value so the caller can reject it with `400`.
-bool? _parseLogRotated(Request request) {
-  final raw = request.url.queryParameters['rotated'];
-  if (raw == null) return false;
-  switch (raw.toLowerCase()) {
-    case '1':
-    case 'true':
-    case 'yes':
-      return true;
-    case '0':
-    case 'false':
-    case 'no':
-      return false;
     default:
       return null;
   }

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -53,6 +53,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'dart:convert';
+import 'dart:typed_data';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';

--- a/test/webserver/logs_handler_test.dart
+++ b/test/webserver/logs_handler_test.dart
@@ -33,13 +33,17 @@ void main() {
       if (tmpDir.existsSync()) tmpDir.deleteSync(recursive: true);
     });
 
-    Handler handlerFor(String path) {
+    Handler handlerFor(String path, {int? defaultTailKb, int? maxTailKb}) {
       final app = Router().plus;
-      LogsHandler(logFilePath: path).addRoutes(app);
+      LogsHandler(
+        logFilePath: path,
+        defaultTailKb: defaultTailKb ?? LogsHandler.defaultTailKb,
+        maxTailKb: maxTailKb ?? LogsHandler.maxTailKb,
+      ).addRoutes(app);
       return app.call;
     }
 
-    test('returns the whole file with lines newest-first', () async {
+    test('returns the file with lines newest-first', () async {
       // Written oldest-first, as the app writes them.
       const lines = ['oldest', 'middle', 'newest'];
       logFile.writeAsStringSync('${lines.join('\n')}\n');
@@ -63,6 +67,14 @@ void main() {
     test('empty file yields an empty body (not a blank line)', () async {
       logFile.writeAsStringSync('');
       final res = await get(handlerFor(logFile.path), '/api/v1/logs');
+      expect(res.statusCode, 200);
+      expect(await res.readAsString(), '');
+    });
+
+    test('empty file yields an empty body for order=asc too', () async {
+      logFile.writeAsStringSync('');
+      final res =
+          await get(handlerFor(logFile.path), '/api/v1/logs?order=asc');
       expect(res.statusCode, 200);
       expect(await res.readAsString(), '');
     });
@@ -149,7 +161,7 @@ void main() {
       expect(body.indexOf('line0150'), lessThan(body.indexOf('line0199')));
     });
 
-    group('?rotated', () {
+    group('rotation stitching', () {
       // Rotation naming (RotatingFileAppender): log.txt is newest, log.txt.1
       // is older, log.txt.2 older still. Within each file, lines are
       // oldest-first.
@@ -159,16 +171,21 @@ void main() {
         logFile.writeAsStringSync('base_a\nbase_b\n');
       }
 
-      test('is off by default — only the live file is returned', () async {
+      test('rotated files are always included, newest-first by default',
+          () async {
         writeRotationSet();
         final res = await get(handlerFor(logFile.path), '/api/v1/logs');
-        expect(await res.readAsString(), 'base_b\nbase_a\n');
+        expect(res.statusCode, 200);
+        expect(
+          await res.readAsString(),
+          'base_b\nbase_a\nr1b\nr1a\nr2b\nr2a\n',
+        );
       });
 
-      test('=1&order=asc stitches all files oldest rotation first', () async {
+      test('order=asc stitches all files oldest rotation first', () async {
         writeRotationSet();
-        final res = await get(
-            handlerFor(logFile.path), '/api/v1/logs?rotated=1&order=asc');
+        final res =
+            await get(handlerFor(logFile.path), '/api/v1/logs?order=asc');
         expect(res.statusCode, 200);
         expect(
           await res.readAsString(),
@@ -176,35 +193,24 @@ void main() {
         );
       });
 
-      test('=1 default order is newest-first across all files', () async {
-        writeRotationSet();
-        final res =
-            await get(handlerFor(logFile.path), '/api/v1/logs?rotated=1');
-        expect(
-          await res.readAsString(),
-          'base_b\nbase_a\nr1b\nr1a\nr2b\nr2a\n',
-        );
-      });
-
-      test('=1 with no rotated files present falls back to the live file',
-          () async {
+      test('no rotated files present serves just the live file', () async {
         logFile.writeAsStringSync('only_a\nonly_b\n');
-        final res = await get(
-            handlerFor(logFile.path), '/api/v1/logs?rotated=1&order=asc');
+        final res =
+            await get(handlerFor(logFile.path), '/api/v1/logs?order=asc');
         expect(await res.readAsString(), 'only_a\nonly_b\n');
       });
 
-      test('=1 stops probing at the first missing rotation', () async {
+      test('stops probing at the first missing rotation', () async {
         // .1 and .3 exist but .2 does not — .3 must not be picked up.
         File('${logFile.path}.3').writeAsStringSync('r3\n');
         File('${logFile.path}.1').writeAsStringSync('r1\n');
         logFile.writeAsStringSync('base\n');
-        final res = await get(
-            handlerFor(logFile.path), '/api/v1/logs?rotated=1&order=asc');
+        final res =
+            await get(handlerFor(logFile.path), '/api/v1/logs?order=asc');
         expect(await res.readAsString(), 'r1\nbase\n');
       });
 
-      test('=1&kb=N windows the tail across file boundaries', () async {
+      test('?kb=N windows the tail across file boundaries', () async {
         // Each file is 1000 bytes ("lineNNNN\n" = 9 bytes x ~111). Ask for a
         // window that spans the live file and reaches into log.txt.1.
         String block(String prefix) => [
@@ -214,8 +220,8 @@ void main() {
         File('${logFile.path}.1').writeAsStringSync('${block("old")}\n');
         logFile.writeAsStringSync('${block("new")}\n');
 
-        final res = await get(
-            handlerFor(logFile.path), '/api/v1/logs?rotated=1&kb=1&order=asc');
+        final res =
+            await get(handlerFor(logFile.path), '/api/v1/logs?kb=1&order=asc');
         final body = await res.readAsString();
 
         expect(res.statusCode, 200);
@@ -228,11 +234,96 @@ void main() {
         expect(body.indexOf('old0110'), lessThan(body.indexOf('new0000')));
       });
 
-      test('an unrecognized ?rotated value is rejected', () async {
-        logFile.writeAsStringSync('x\n');
+      test('the legacy ?rotated param is ignored, not rejected', () async {
+        writeRotationSet();
         final res = await get(
-            handlerFor(logFile.path), '/api/v1/logs?rotated=maybe');
-        expect(res.statusCode, 400);
+            handlerFor(logFile.path), '/api/v1/logs?rotated=0&order=asc');
+        expect(res.statusCode, 200);
+        // Rotations included regardless of the (removed) param's value.
+        expect(
+          await res.readAsString(),
+          'r2a\nr2b\nr1a\nr1b\nbase_a\nbase_b\n',
+        );
+      });
+    });
+
+    group('tail window caps', () {
+      test('without ?kb the default cap bounds the response', () async {
+        // 2KB of content against an injected 1KB default cap.
+        final lines = [
+          for (var i = 0; i < 228; i++) 'line${i.toString().padLeft(4, '0')}',
+        ];
+        logFile.writeAsStringSync('${lines.join('\n')}\n');
+
+        final res = await get(
+          handlerFor(logFile.path, defaultTailKb: 1),
+          '/api/v1/logs?order=asc',
+        );
+        final body = await res.readAsString();
+
+        expect(res.statusCode, 200);
+        expect(body.endsWith('line0227\n'), isTrue);
+        // Content beyond the 1KB default cap is dropped.
+        expect(body.contains('line0000'), isFalse);
+        expect(body.length, lessThanOrEqualTo(1024));
+      });
+
+      test('the default cap spans rotated files but stays bounded', () async {
+        // Live file (1000 bytes) + rotation (1000 bytes) against a 1KB cap:
+        // the window covers the live file and only the tail of the rotation.
+        String block(String prefix) => [
+              for (var i = 0; i < 111; i++)
+                '$prefix${i.toString().padLeft(4, '0')}',
+            ].join('\n');
+        File('${logFile.path}.1').writeAsStringSync('${block("old")}\n');
+        logFile.writeAsStringSync('${block("new")}\n');
+
+        final res = await get(
+          handlerFor(logFile.path, defaultTailKb: 1),
+          '/api/v1/logs?order=asc',
+        );
+        final body = await res.readAsString();
+
+        expect(res.statusCode, 200);
+        expect(body.endsWith('new0110\n'), isTrue);
+        expect(body.contains('old0000'), isFalse);
+        expect(body.contains('old0110'), isTrue);
+      });
+
+      test('an explicit ?kb above the ceiling is clamped', () async {
+        // 2KB of content, 1KB ceiling: kb=100 must still return only 1KB.
+        final lines = [
+          for (var i = 0; i < 228; i++) 'line${i.toString().padLeft(4, '0')}',
+        ];
+        logFile.writeAsStringSync('${lines.join('\n')}\n');
+
+        final res = await get(
+          handlerFor(logFile.path, maxTailKb: 1),
+          '/api/v1/logs?kb=100&order=asc',
+        );
+        final body = await res.readAsString();
+
+        expect(res.statusCode, 200);
+        expect(body.endsWith('line0227\n'), isTrue);
+        expect(body.contains('line0000'), isFalse);
+        expect(body.length, lessThanOrEqualTo(1024));
+      });
+
+      test('the clamp bounds desc responses too', () async {
+        final lines = [
+          for (var i = 0; i < 228; i++) 'line${i.toString().padLeft(4, '0')}',
+        ];
+        logFile.writeAsStringSync('${lines.join('\n')}\n');
+
+        final res = await get(
+          handlerFor(logFile.path, maxTailKb: 1),
+          '/api/v1/logs?kb=100',
+        );
+        final body = await res.readAsString();
+
+        expect(res.statusCode, 200);
+        expect(body.startsWith('line0227'), isTrue);
+        expect(body.contains('line0000'), isFalse);
       });
     });
   });


### PR DESCRIPTION
## Summary

- **Problem:** `GET /api/v1/logs` only ever read the live `log.txt`, so the rotated siblings the appender leaves behind (`log.txt.1`, `log.txt.2`, …) were unreachable over the API — a real problem on release APKs where `run-as` is blocked and those files are otherwise inaccessible.
- **Why it matters:** Rotated logs hold the history right before a crash/disconnect; without API access they're effectively lost on locked-down devices.
- **What changed:** Rotated files are now **always** stitched into the response in true chronological order (oldest rotation first, live file last) — no opt-in flag. The response is size-bounded in all cases: `?kb=N` when given (clamped to 4 MB) and a **1 MB default tail window** otherwise, so a full rotation set (up to ~40 MB: 10 MB rotate size × keepRotateCount + live) is never buffered on memory-constrained tablets. `order=asc` responses are **streamed** straight from file byte ranges to the HTTP response with no window buffering at all; `order=desc` (default) must reverse lines, so it buffers only the capped window.
- **What did NOT change (scope boundary):** No change to log writing/rotation. `order` semantics unchanged. The `?rotated=` param merged in #399 is ignored, not rejected — clients already sending it keep working.

### Relationship to #399

This is the follow-up discussed in [#399](https://github.com/tadelv/reaprime/pull/399) ("maybe this should be the default behavior") — #399 merged with the opt-in `?rotated=1` design just before this rewrite was pushed to its branch, so it lands here instead. It supersedes the `rotated` param and folds in every remark from that review:

- **Spec block rewritten** with valid block-scalar indentation, including the two *pre-existing* broken `description: |` bodies on this endpoint (they only parsed by accident — their body lines contain colons and became stray mapping keys); parse-verified. Supersedes the `rotated` block that the indent fix in #399 repaired.
- **Unbounded-read concern:** resolved by design — the `rotated` flag is gone and every response is capped (maintainer follow-up discussion: always-on stitching + auto-cap).
- **`existsSync` nit:** rotation probing is now fully async.
- **Error-message/`yes|no` nit:** moot — the `rotated` param no longer exists.
- Gap-contiguity (stop at first missing rotation) intentionally kept, as the review deemed reasonable; still locked in by test.

## Change Type (select all)

- [x] Feature
- [x] Docs

## Scope (select all touched areas)

- [x] REST API / handlers
- [x] Docs / specs

## Linked Issues

- Related [#399](https://github.com/tadelv/reaprime/pull/399) (supersedes its `?rotated=1` opt-in)

## Root Cause (if bug fix)

N/A

## Regression Test Plan (if bug fix or refactor)

N/A (feature) — covered by unit tests in `test/webserver/logs_handler_test.dart` (always-on stitching in both orders, kb windowing across file boundaries, injected default-cap and clamp bounds, gap probing, legacy-param tolerance, 404-when-no-files).

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` (endpoint block rewritten; now parses)
- [x] API docs updated: `doc/Api.md`

## Security Impact (required)

- New or changed REST endpoints? **Yes** (changed semantics of existing `/api/v1/logs`: always includes rotations; default 1 MB cap; `kb` clamped to 4 MB)
- New or changed WebSocket topics? No
- New or changed network calls? No
- BLE/USB surface changed? No
- File system access changed? **Yes** — also reads the app-private rotated `log.txt.1..N` next to `log.txt`. Same app-private directory, read-only, and the cap bounds how much is served/buffered per request.

## User-Visible Changes

- `GET /api/v1/logs` now always includes rotated log history.
- Without `?kb`, the response is a 1 MB tail instead of the unbounded whole live file; explicit `?kb` is honored up to a 4 MB ceiling.
- The `rotated` query parameter from earlier drafts does not exist; sending it is harmless (ignored).

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings in `lib/`/`test/`)
- [x] `flutter test` — all pass (1935 tests, on top of the merged #399/#400/#401/#402)
- [x] `ruby -ryaml` parse check on `assets/api/rest_v1.yml` — passes (fails on the previous revision)
- [ ] `(cd packages/dye2-plugin && npm run build)` — N/A, plugin untouched

### Manual verification (if applicable)

- OS / platform tested: macOS (unit tests)
- Simulated devices? (`simulate=1`): N/A
- Real hardware?: No
- What you personally verified and how: `flutter test test/webserver/` green; spec parse verified before/after.
- What you did **not** verify: on-device APK behavior with real rotated files; streaming behavior over a slow real network.

### Evidence

- [x] Test output — full `flutter test` green (1935 passing).

## Compatibility & Migration

- Backward compatible? **Mostly** — same endpoint and params, but two behavior changes: rotated content is now included by default, and a bare `GET /api/v1/logs` returns a 1 MB tail instead of the entire live file. Clients wanting more history pass `?kb=` (up to 4096).
- Config / env changes needed? No
- Database migration needed? No

## Risks & Mitigations

- Risk: a client that assumed "whole live file" semantics on the bare endpoint now gets a 1 MB tail.
  - Mitigation: documented in spec + `doc/Api.md`; `?kb=4096` covers any realistic diagnostic need and the previous behavior was unbounded-memory on tablets.
- Risk: desc (default) responses still buffer the window in memory.
  - Mitigation: window is hard-capped at 4 MB; asc responses stream with no window buffering.
