### PR TITLE
fix(ble): detect zombie DE1 links and auto-reconnect the machine

### DIFF
--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -314,6 +314,39 @@ ConnectionManager listens for disconnects automatically:
 - Watches `scaleController.connectionState` — resets `_scaleConnected` flag on disconnect
 - Resets phase to `idle` when machine disconnects
 
+### Machine Auto-Reconnect (recovery mode)
+
+An *unexpected* machine disconnect (not announced via
+`markExpectingDisconnect` / `disconnectMachine`) puts `ConnectionManager`
+into machine recovery mode: full `connect()` scans retry with the same
+5s→60s exponential backoff the preferred-scale loop uses, rescheduling
+after every attempt that ends without a machine, until the machine
+reconnects (or the user disconnects deliberately). Gated on
+`preferredMachineId` so a background retry can never pop a machine picker —
+the id is auto-set on every successful connect, so coverage is effectively
+total. Motivation: a power outage previously left the app "disconnected"
+indefinitely because nothing ever rescanned for the machine.
+
+### Zombie-Link Detection (BLE transport)
+
+A dead BLE link doesn't always deliver a disconnect event (observed on
+Android: GATT writes time out forever while the app still believes it is
+connected, and no recovery is possible without an app restart).
+`UniversalBleTransport` detects this and emits `disconnected` itself —
+which drives the normal disconnect cascade and, for machines, the
+auto-reconnect above:
+
+- **On a GATT operation timeout** it probes the OS connection state
+  (async, never blocking the caller). An OS-confirmed drop declares the
+  link dead; three consecutive timeouts force a teardown even if the OS
+  still claims connected. A single timeout on a healthy link keeps the
+  existing fail-fast behavior (profile-upload safety — see the comment on
+  `UniversalBleTransport.write`).
+- **On seeing its own deviceId advertising** while believed connected, it
+  runs the same probe (throttled). Teardown is probe-confirmed only,
+  because the transport is shared with scales/sensors and some peripherals
+  legitimately advertise while connected.
+
 ### Preferred Device Settings
 
 Device preferences are stored via `SettingsController`:

--- a/doc/plans/archive/machine-connection-recovery/machine-connection-recovery.md
+++ b/doc/plans/archive/machine-connection-recovery/machine-connection-recovery.md
@@ -1,0 +1,108 @@
+# Machine connection recovery (zombie links + auto-reconnect)
+
+## Incident
+
+2026-07-06, real DE1 tablet (teclast m50mini, Android 14). A power outage at
+~08:50 killed the DE1. The app detected the transport disconnect cleanly at
+08:54 (`Transport disconnected: Connection Timeout`), emitted
+`machineDisconnected`, and then **did nothing for six hours** — no scan ran
+between 08:54 and the 15:02 app restart, because nothing in the app ever
+retries a machine connection automatically (full `connect()` is only called
+from UI taps).
+
+After the 15:02 restart the app reconnected, but the DE1's BLE side was flaky
+(two MMR read timeouts during init). A GATT write then timed out; the
+transport's fail-fast path cleared the queue (by design — see below) but never
+verified the link. The connection silently died shortly after with **no
+disconnect event delivered**, leaving the app in a zombie state:
+
+- `DisconnectSupervisor` only reacts to `disconnected` stream events → never
+  fired → `_machineConnected` stayed true forever.
+- The preferred-scale reconnect loop kept scanning every ~20s but ignores
+  machines entirely (`scaleOnly`).
+- Even a manual full `connect()` would have skipped the machine phase
+  (`if (_machineConnected)` short-circuit). Only an app restart escapes.
+
+## Corrected diagnosis note (important)
+
+The scan reports listing `DE1 (F1:9F..., machine)` during the zombie window do
+**not** prove the DE1 was advertising: `DeviceController.scanForDevices()`
+returns the cumulative device registry (connected devices are deliberately
+kept in `matchedDevices`). Live advertisements are only visible at the
+`UniversalBle.scanStream` level. Fix 2 therefore lives in the transport, not
+in `ConnectionManager` scan-result inspection (which would false-positive on
+every healthy scan).
+
+## Fixes
+
+### 1. Link verification on GATT operation timeout (transport)
+
+`UniversalBleTransport._onOperationTimeout` deliberately does not tear down
+the connection on a single timeout — a forced disconnect mid profile-upload
+wedges DE1 firmware (see comment on `write()`). That stays. Added on top:
+
+- After clearing the queue, fire an **async probe**:
+  `UniversalBle.getConnectionState()`. If the OS reports the device
+  disconnected (the incident's likely state — the disconnect *event* was
+  lost, but polled state is truthful), declare the link dead.
+- Track **consecutive** operation timeouts (reset on any successful
+  read/write). At 3 in a row, declare the link dead even if the OS still
+  claims connected — 30s+ of failed ops is beyond saving, including for an
+  in-flight profile upload.
+- "Declare dead" = idempotent: emit `disconnected` on the connection-state
+  subject (starts the normal recovery cascade: UnifiedDe1 → De1Controller
+  reset → DisconnectSupervisor → fix 3), clear the queue, and fire a
+  best-effort `UniversalBle.disconnect()` so the OS handle doesn't block the
+  next connect.
+
+Single timeout + healthy OS link ⇒ behavior unchanged (clear queue, rethrow).
+
+### 2. Advertising-while-connected detection (transport)
+
+A DE1 never advertises while it holds a connection (codified in
+`De1Interface.cachedFlowEstimation` docs). While the transport believes it is
+connected, it listens to `UniversalBle.scanStream` for its own deviceId.
+Seeing an advert triggers the same OS probe (throttled to one per 5s);
+OS-confirmed disconnected ⇒ declare dead.
+
+Deliberately probe-confirmed only: `UniversalBleTransport` is shared by
+scales/sensors, and some peripherals legitimately advertise while connected —
+an advert alone must not tear down a link. The residual gap (device
+advertising while the OS *also* wrongly claims connected, with no GATT ops in
+flight) is closed within minutes by fix 1's escalation the next time any
+periodic op runs (e.g. BatteryController's USB-charger MMR writes).
+
+This piggybacks on existing scans (scale-reconnect loop, UI scans) — adverts
+only flow while some scan is running; the transport starts none itself.
+
+### 3. Machine auto-reconnect loop (ConnectionManager)
+
+Mirror of the preferred-scale reconnect loop, for the machine:
+
+- `DisconnectSupervisor` gains an unexpected-only machine-disconnect callback
+  (same pattern the scale side already has); expected disconnects
+  (`markExpectingDisconnect`, `disconnectMachine`) do not trigger it.
+- On unexpected machine disconnect with a `preferredMachineId` configured,
+  `ConnectionManager` enters recovery mode: full `connect()` retries with the
+  same 5s→60s exponential backoff used for scales. The loop reschedules
+  itself after each attempt that ends without a machine (including attempts
+  silently dropped by the concurrent-connect guard) and exits when the
+  machine connects, on deliberate disconnect, or on dispose.
+- Gated on `preferredMachineId` so a background retry can never pop a
+  machine-picker ambiguity; the id is always set after any successful
+  connect, so real-world coverage is total.
+
+Known trade-off: recovery scans are full unfiltered scans; on Android in
+background these are throttled by the OS. Acceptable — the DE1 tablet runs
+foreground — and a filtered machine-scan variant can be added later if needed.
+
+## Test tiers
+
+- **Unit (transport):** fake `UniversalBlePlatform` via `UniversalBle.setInstance`
+  — probe-on-timeout, consecutive escalation + reset, advert probe path,
+  throttle, ignore foreign/not-connected adverts.
+- **Unit/integration (ConnectionManager):** real DisconnectSupervisor +
+  SettingsController with mock scanner/controllers (existing harness) —
+  unexpected vs expected disconnect, backoff rearm, cancel on
+  connect/deliberate disconnect, no-preferred gate.
+- **End-to-end:** n/a (no REST/WS surface change); full suite + analyze.

--- a/lib/src/controllers/connection/disconnect_supervisor.dart
+++ b/lib/src/controllers/connection/disconnect_supervisor.dart
@@ -33,6 +33,7 @@ class DisconnectSupervisor {
   final String? Function() _preferredScaleId;
   final void Function()? _onMachineConnected;
   final void Function()? _onMachineDisconnected;
+  final void Function()? _onUnexpectedMachineDisconnect;
   final void Function()? _onScaleConnected;
   final void Function()? _onScaleDisconnected;
 
@@ -55,6 +56,7 @@ class DisconnectSupervisor {
     required String? Function() preferredScaleId,
     void Function()? onMachineConnected,
     void Function()? onMachineDisconnected,
+    void Function()? onUnexpectedMachineDisconnect,
     void Function()? onScaleConnected,
     void Function()? onScaleDisconnected,
   })  : _machineStream = machineStream,
@@ -67,6 +69,7 @@ class DisconnectSupervisor {
         _preferredScaleId = preferredScaleId,
         _onMachineConnected = onMachineConnected,
         _onMachineDisconnected = onMachineDisconnected,
+        _onUnexpectedMachineDisconnect = onUnexpectedMachineDisconnect,
         _onScaleConnected = onScaleConnected,
         _onScaleDisconnected = onScaleDisconnected {
     _start();
@@ -112,7 +115,10 @@ class DisconnectSupervisor {
         );
         final id = _lastKnownMachineId;
         if (id != null) {
-          _handleMachineDisconnect(id);
+          final unexpected = _handleMachineDisconnect(id);
+          if (unexpected) {
+            _onUnexpectedMachineDisconnect?.call();
+          }
         }
       }
     });
@@ -141,10 +147,13 @@ class DisconnectSupervisor {
     });
   }
 
-  void _handleMachineDisconnect(String deviceId) {
+  /// Returns `true` when the disconnect was unexpected (no matching
+  /// expectation) — mirrors [_handleScaleDisconnect] so the caller can
+  /// gate recovery behavior on it.
+  bool _handleMachineDisconnect(String deviceId) {
     if (_expectations.consume(deviceId)) {
       _log.fine('Machine $deviceId: expected disconnect, suppressing error');
-      return;
+      return false;
     }
     _statusPublisher.emitError(ConnectionError(
       kind: ConnectionErrorKind.machineDisconnected,
@@ -155,6 +164,7 @@ class DisconnectSupervisor {
       suggestion:
           'Check the machine is powered on and in range, then reconnect.',
     ));
+    return true;
   }
 
   bool _handleScaleDisconnect(String deviceId) {

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -159,6 +159,29 @@ class ConnectionManager {
     return Duration(seconds: seconds.clamp(5, 60));
   }
 
+  /// Machine auto-reconnect (recovery mode). Armed by an *unexpected*
+  /// machine disconnect when a preferred machine is configured; retries
+  /// full `connect()` scans with the same 5s→60s backoff the scale loop
+  /// uses, and reschedules itself after every attempt that ends without
+  /// a machine. Cleared on machine connect, deliberate disconnect, and
+  /// dispose. Motivated by a power-outage incident where the app sat
+  /// "disconnected" for six hours because nothing ever rescanned — see
+  /// doc/plans/machine-connection-recovery.md.
+  bool _machineRecoveryActive = false;
+  Timer? _machineReconnect;
+  int _machineReconnectFailures = 0;
+
+  /// Base delay for the machine-reconnect backoff. Overridable in tests.
+  @visibleForTesting
+  Duration machineReconnectBaseDelay = const Duration(seconds: 5);
+
+  Duration get _machineReconnectBackoff {
+    final multiplier = (1 << _machineReconnectFailures).clamp(1, 12);
+    final delay = machineReconnectBaseDelay * multiplier;
+    const cap = Duration(seconds: 60);
+    return delay > cap ? cap : delay;
+  }
+
   MachineState? _latestMachineState;
   StreamSubscription<MachineSnapshot>? _machineSnapshotSub;
 
@@ -194,6 +217,7 @@ class ConnectionManager {
       preferredScaleId: () => settingsController.preferredScaleId,
       onMachineConnected: _handleMachineConnected,
       onMachineDisconnected: _handleMachineDisconnected,
+      onUnexpectedMachineDisconnect: _startMachineRecovery,
       onScaleConnected: _cancelPreferredScaleReconnect,
       onScaleDisconnected: _maybeSchedulePreferredScaleReconnect,
     );
@@ -650,11 +674,17 @@ class ConnectionManager {
   }
 
   void _handleMachineConnected() {
+    _stopMachineRecovery();
     _watchConnectedMachineState();
     _maybeSchedulePreferredScaleReconnect();
   }
 
   void _handleMachineDisconnected() {
+    // Deliberate disconnects route only through here (disconnectMachine
+    // pre-nulls the supervisor view), so recovery stays off for them.
+    // For unexpected drops the supervisor fires
+    // [_startMachineRecovery] right after this cleanup.
+    _stopMachineRecovery();
     _stopWatchingConnectedMachineState();
     _deferredScaleScan?.cancel();
     _deferredScaleScan = null;
@@ -662,6 +692,55 @@ class ConnectionManager {
     if (_activeScaleOnlyScan) {
       deviceScanner.stopScan();
     }
+  }
+
+  /// Enter machine recovery mode after an unexpected disconnect and arm
+  /// the first retry. No-op without a `preferredMachineId` — a
+  /// background retry must never surface a machine-picker ambiguity.
+  void _startMachineRecovery() {
+    if (settingsController.preferredMachineId == null) return;
+    _machineRecoveryActive = true;
+    _log.info(
+      'Machine disconnected unexpectedly — starting auto-reconnect scans',
+    );
+    _maybeScheduleMachineReconnect();
+  }
+
+  void _stopMachineRecovery() {
+    _machineRecoveryActive = false;
+    _machineReconnect?.cancel();
+    _machineReconnect = null;
+    _machineReconnectFailures = 0;
+  }
+
+  bool _shouldRetryMachine() {
+    return _machineRecoveryActive &&
+        !_machineConnected &&
+        settingsController.preferredMachineId != null;
+  }
+
+  void _maybeScheduleMachineReconnect() {
+    if (_machineReconnect != null) return;
+    if (!_shouldRetryMachine()) return;
+    final delay = _machineReconnectBackoff;
+    _machineReconnectFailures++;
+    _log.fine(
+      'Machine is missing (attempt #$_machineReconnectFailures); '
+      'retrying full scan in ${delay.inSeconds}s',
+    );
+    _machineReconnect = Timer(delay, () async {
+      _machineReconnect = null;
+      if (!_shouldRetryMachine()) return;
+      try {
+        await connect();
+      } catch (e, st) {
+        _log.fine('Machine reconnect attempt failed', e, st);
+      }
+      // Reschedule regardless of how the attempt ended — including
+      // attempts silently dropped by the concurrent-connect guard.
+      // No-op once the machine is back or recovery was stopped.
+      _maybeScheduleMachineReconnect();
+    });
   }
 
   void _watchConnectedMachineState() {
@@ -1077,6 +1156,7 @@ class ConnectionManager {
   }
 
   Future<void> dispose() async {
+    _stopMachineRecovery();
     _deferredScaleScan?.cancel();
     _cancelPreferredScaleReconnect();
     _stopWatchingConnectedMachineState();

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -21,6 +21,31 @@ class UniversalBleTransport implements BLETransport {
 
   StreamSubscription? _connectionStateSubscription;
 
+  // --- Zombie-link detection (see doc/plans/machine-connection-recovery.md).
+  // A dead link doesn't always deliver a disconnect event (observed on
+  // Android after a DE1 power outage: writes time out forever while the
+  // app believes it is connected). Two independent detectors feed
+  // [_declareLinkDead]:
+  //  1. GATT operation timeouts trigger an OS-level connection-state probe;
+  //     [_maxConsecutiveOpTimeouts] in a row force a teardown even when the
+  //     OS still claims connected.
+  //  2. Advertisements for our own deviceId while we believe we are
+  //     connected trigger the same probe (throttled) — probe-confirmed
+  //     only, because some peripherals legitimately advertise while
+  //     connected (this transport is shared by scales and sensors).
+  int _consecutiveOpTimeouts = 0;
+  bool _linkDeadDeclared = false;
+  DateTime? _lastAdvertProbe;
+  StreamSubscription<BleDevice>? _advertSub;
+
+  static const int _maxConsecutiveOpTimeouts = 3;
+  static const Duration _linkProbeTimeout = Duration(seconds: 2);
+
+  /// Minimum spacing between advert-triggered OS probes. A disconnected
+  /// peripheral advertises ~1/s during a scan; one probe per window is
+  /// plenty.
+  static const Duration _advertProbeThrottle = Duration(seconds: 5);
+
   // BlueZ-specific timings (Linux only). universal_ble's Linux backend is the
   // pure-Dart `bluez` client, which needs the same handling the former
   // LinuxBluePlusTransport applied: connecting while (or right after) a scan
@@ -47,9 +72,13 @@ class UniversalBleTransport implements BLETransport {
 
   @override
   Future<void> connect() async {
+    _linkDeadDeclared = false;
+    _consecutiveOpTimeouts = 0;
+    _lastAdvertProbe = null;
     // Use connectionUpdateStream (from our universal_ble fork) to get
     // native disconnect reason codes (GATT error, HCI status) — the
     // standard connectionStream only emits bool.
+    _connectionStateSubscription?.cancel();
     _connectionStateSubscription = UniversalBle.connectionUpdateStream(
       _device.deviceId,
     ).listen((update) {
@@ -63,6 +92,7 @@ class UniversalBleTransport implements BLETransport {
     });
     if (_isLinux) {
       await _connectBlueZ();
+      _startAdvertWatch();
       return;
     }
     try {
@@ -73,6 +103,7 @@ class UniversalBleTransport implements BLETransport {
     } on UniversalBleException catch (e) {
       throw mapUniversalConnectError(e);
     }
+    _startAdvertWatch();
 
     // Android: post-connect settle + MTU bump.
     // The 200ms settle avoids service-discovery races on tablet SoCs
@@ -211,6 +242,8 @@ class UniversalBleTransport implements BLETransport {
 
   @override
   Future<void> disconnect() async {
+    _advertSub?.cancel();
+    _advertSub = null;
     try {
       _log.fine("disconnect");
       for (var sub in _subscriptions.keys) {
@@ -285,12 +318,14 @@ class UniversalBleTransport implements BLETransport {
   @override
   Future<Uint8List> read(String serviceUUID, String characteristicUUID, {Duration? timeout}) async {
     try {
-      return await UniversalBle.read(
+      final value = await UniversalBle.read(
         _device.deviceId,
         serviceUUID,
         characteristicUUID,
         timeout: timeout
       );
+      _noteOperationSuccess();
+      return value;
     } on TimeoutException {
       // Fail fast (see write() — a read-timeout reconnect mid profile-upload
       // would wedge the firmware the same way). Clear the stuck queue entry and
@@ -309,9 +344,99 @@ class UniversalBleTransport implements BLETransport {
   /// timeout propagate. Do NOT convert it to a [BleTimeoutException]: that would
   /// trigger a disconnect/reconnect+single-write retry, which corrupts an
   /// in-flight profile upload (a stateful multi-write sequence).
+  ///
+  /// A timeout is also a zombie-link symptom: verify the link async (never
+  /// blocking the caller). A single timeout with a healthy OS link changes
+  /// nothing; an OS-confirmed drop — or [_maxConsecutiveOpTimeouts] in a
+  /// row — declares the link dead so recovery can start instead of the app
+  /// staying "connected" to a corpse forever.
   void _onOperationTimeout(String operation, String path) {
     _log.warning('GATT $operation($path) timed out — clearing BLE queue');
     UniversalBle.clearQueue(_device.deviceId);
+    _consecutiveOpTimeouts++;
+    if (_consecutiveOpTimeouts >= _maxConsecutiveOpTimeouts) {
+      _declareLinkDead(
+        '$_consecutiveOpTimeouts consecutive GATT timeouts',
+        forceOsDisconnect: true,
+      );
+    } else {
+      unawaited(_probeAndDeclareIfDead('GATT $operation timeout'));
+    }
+  }
+
+  void _noteOperationSuccess() {
+    _consecutiveOpTimeouts = 0;
+  }
+
+  /// Listen for advertisements carrying our own deviceId while we believe
+  /// the link is up. Adverts only flow while some scan runs (the scale
+  /// reconnect loop, UI scans) — this starts none itself.
+  void _startAdvertWatch() {
+    _advertSub?.cancel();
+    _advertSub = UniversalBle.scanStream
+        .where((d) => d.deviceId == _device.deviceId)
+        .listen(_onOwnAdvertisement);
+  }
+
+  void _onOwnAdvertisement(BleDevice _) {
+    if (_connectionStateSubject.valueOrNull !=
+        device.ConnectionState.connected) {
+      return;
+    }
+    final now = DateTime.now();
+    final last = _lastAdvertProbe;
+    if (last != null && now.difference(last) < _advertProbeThrottle) return;
+    _lastAdvertProbe = now;
+    _log.warning(
+      'Received advertisement while believed connected — probing OS link state',
+    );
+    unawaited(_probeAndDeclareIfDead('advertising while believed connected'));
+  }
+
+  /// Ask the OS for the actual connection state. Declares the link dead
+  /// only on an explicit disconnected/disconnecting answer — a probe
+  /// error is inconclusive and must not tear down a possibly-live link.
+  Future<void> _probeAndDeclareIfDead(String context) async {
+    final BleConnectionState state;
+    try {
+      state = await UniversalBle.getConnectionState(
+        _device.deviceId,
+        timeout: _linkProbeTimeout,
+      );
+    } catch (e) {
+      _log.fine('Link probe inconclusive ($context): $e');
+      return;
+    }
+    if (state == BleConnectionState.connected ||
+        state == BleConnectionState.connecting) {
+      return;
+    }
+    _declareLinkDead('$context; OS reports ${state.name}');
+  }
+
+  /// Emit `disconnected` so the normal recovery cascade runs (device impl →
+  /// controller reset → DisconnectSupervisor → machine auto-reconnect).
+  /// Idempotent per connection. [forceOsDisconnect] additionally releases
+  /// the OS-level GATT handle (best-effort) so it can't block the next
+  /// connect — used when the OS still claims the dead link is connected.
+  void _declareLinkDead(String reason, {bool forceOsDisconnect = false}) {
+    if (_linkDeadDeclared) return;
+    _linkDeadDeclared = true;
+    _log.warning('Declaring BLE link dead: $reason');
+    _advertSub?.cancel();
+    _advertSub = null;
+    UniversalBle.clearQueue(_device.deviceId);
+    _connectionStateSubject.add(device.ConnectionState.disconnected);
+    if (forceOsDisconnect) {
+      unawaited(
+        UniversalBle.disconnect(
+          _device.deviceId,
+          timeout: const Duration(seconds: 5),
+        ).catchError((Object e) {
+          _log.fine('Best-effort OS disconnect failed: $e');
+        }),
+      );
+    }
   }
 
   final Map<String, StreamSubscription<Uint8List>> _subscriptions = {};
@@ -362,6 +487,7 @@ class UniversalBleTransport implements BLETransport {
         withoutResponse: !withResponse,
         timeout: timeout
       );
+      _noteOperationSuccess();
     } on TimeoutException {
       // Fail fast — do NOT map this to a BleTimeoutException. Doing so routes it
       // into the DE1 transport's reconnect-and-retry-this-one-write recovery,
@@ -397,6 +523,8 @@ class UniversalBleTransport implements BLETransport {
 
   @override
   Future<void> dispose() async {
+    _advertSub?.cancel();
+    _advertSub = null;
     _connectionStateSubscription?.cancel();
     _connectionStateSubscription = null;
     for (final sub in _subscriptions.values) {

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -52,6 +52,9 @@ class _FakeDe1 implements De1Interface {
   }
 
   @override
+  Future<void> disconnect() async {}
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => null;
 }
 
@@ -1582,6 +1585,174 @@ void main() {
         expect(connectionManager.currentStatus.error, isNotNull);
         await connectionManager.connect(scaleOnly: true);
         expect(connectionManager.currentStatus.error, isNull);
+      });
+    });
+
+    group('machine auto-reconnect', () {
+      /// Pump enough microtask/zero-timer turns for a drop → timer →
+      /// connect() → scan → connect-machine cycle to complete.
+      Future<void> pumpCycles([int n = 8]) async {
+        for (var i = 0; i < n; i++) {
+          await Future<void>.delayed(Duration.zero);
+        }
+      }
+
+      test(
+          'unexpected machine disconnect starts recovery scans and '
+          'reconnects the preferred machine', () async {
+        connectionManager.machineReconnectBaseDelay = Duration.zero;
+        await settingsController.setPreferredMachineId('pref-de1');
+        final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+        mockScanner.addDevice(fakeDe1); // still advertising / came back
+        mockDe1Controller.de1Subject.add(fakeDe1);
+        await Future<void>.delayed(Duration.zero);
+
+        mockDe1Controller.de1Subject.add(null); // unexpected drop
+        await pumpCycles();
+
+        expect(
+          mockDe1Controller.connectCalls.map((d) => d.deviceId),
+          contains('pref-de1'),
+          reason: 'recovery loop must rescan and reconnect the machine',
+        );
+      });
+
+      test('recovery keeps retrying until the machine reappears, then stops',
+          () async {
+        connectionManager.machineReconnectBaseDelay = Duration.zero;
+        await settingsController.setPreferredMachineId('pref-de1');
+        final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+        mockDe1Controller.de1Subject.add(fakeDe1);
+        await Future<void>.delayed(Duration.zero);
+
+        var scanStarts = 0;
+        final sub = mockScanner.scanningStream.listen((s) {
+          if (s) scanStarts++;
+        });
+
+        // Machine drops and is NOT in scan results yet.
+        mockDe1Controller.de1Subject.add(null);
+        await pumpCycles();
+        expect(scanStarts, greaterThan(0),
+            reason: 'loop must scan even while the machine is absent');
+        expect(mockDe1Controller.connectCalls, isEmpty);
+
+        // Machine comes back — next cycle reconnects and the loop stops.
+        mockScanner.addDevice(fakeDe1);
+        await pumpCycles();
+        expect(
+          mockDe1Controller.connectCalls.map((d) => d.deviceId),
+          contains('pref-de1'),
+        );
+
+        final scansAfterReconnect = scanStarts;
+        await pumpCycles();
+        expect(scanStarts, scansAfterReconnect,
+            reason: 'loop must stop once the machine is connected');
+        await sub.cancel();
+      });
+
+      test('expected machine disconnect does not start recovery', () async {
+        connectionManager.machineReconnectBaseDelay = Duration.zero;
+        await settingsController.setPreferredMachineId('pref-de1');
+        final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+        mockScanner.addDevice(fakeDe1);
+        mockDe1Controller.de1Subject.add(fakeDe1);
+        await Future<void>.delayed(Duration.zero);
+
+        var scanStarts = 0;
+        final sub = mockScanner.scanningStream.listen((s) {
+          if (s) scanStarts++;
+        });
+
+        connectionManager.markExpectingDisconnect('pref-de1');
+        mockDe1Controller.de1Subject.add(null);
+        await pumpCycles();
+
+        expect(scanStarts, 0,
+            reason: 'expected disconnects must not trigger background scans');
+        expect(mockDe1Controller.connectCalls, isEmpty);
+        await sub.cancel();
+      });
+
+      test('deliberate disconnectMachine does not start recovery', () async {
+        connectionManager.machineReconnectBaseDelay = Duration.zero;
+        await settingsController.setPreferredMachineId('pref-de1');
+        final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+        mockScanner.addDevice(fakeDe1);
+        mockDe1Controller.de1Subject.add(fakeDe1);
+        await Future<void>.delayed(Duration.zero);
+
+        var scanStarts = 0;
+        final sub = mockScanner.scanningStream.listen((s) {
+          if (s) scanStarts++;
+        });
+
+        await connectionManager.disconnectMachine();
+        await pumpCycles();
+
+        expect(scanStarts, 0);
+        expect(mockDe1Controller.connectCalls, isEmpty);
+        await sub.cancel();
+      });
+
+      test('no preferred machine → no recovery scans', () async {
+        connectionManager.machineReconnectBaseDelay = Duration.zero;
+        final fakeDe1 = _FakeDe1(deviceId: 'some-de1');
+        mockScanner.addDevice(fakeDe1);
+        mockDe1Controller.de1Subject.add(fakeDe1);
+        await Future<void>.delayed(Duration.zero);
+
+        var scanStarts = 0;
+        final sub = mockScanner.scanningStream.listen((s) {
+          if (s) scanStarts++;
+        });
+
+        mockDe1Controller.de1Subject.add(null);
+        await pumpCycles();
+
+        expect(scanStarts, 0,
+            reason: 'without a preferred machine a background retry could '
+                'pop a picker — must stay off');
+        await sub.cancel();
+      });
+
+      test('recovery retries use exponential backoff', () {
+        fakeAsync((async) {
+          final manager = ConnectionManager(
+            deviceScanner: mockScanner,
+            de1Controller: mockDe1Controller,
+            scaleController: mockScaleController,
+            settingsController: settingsController,
+          );
+          settingsController.setPreferredMachineId('pref-de1');
+          async.flushMicrotasks();
+          mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'pref-de1'));
+          async.flushMicrotasks();
+
+          var scanStarts = 0;
+          mockScanner.scanningStream.listen((s) {
+            if (s) scanStarts++;
+          });
+
+          mockDe1Controller.de1Subject.add(null); // unexpected drop at t=0
+          async.flushMicrotasks();
+
+          // First retry at t=5s (base delay).
+          async.elapse(const Duration(seconds: 4));
+          expect(scanStarts, 0, reason: 'no retry before the base delay');
+          async.elapse(const Duration(seconds: 2)); // t=6
+          expect(scanStarts, 1, reason: 'first retry fires at 5s');
+
+          // Second retry doubles: due 10s after the first (t≈15s).
+          async.elapse(const Duration(seconds: 8)); // t=14
+          expect(scanStarts, 1, reason: 'second retry must back off to 10s');
+          async.elapse(const Duration(seconds: 2)); // t=16
+          expect(scanStarts, 2);
+
+          manager.dispose();
+          async.flushMicrotasks();
+        });
       });
     });
   });

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -1,0 +1,318 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart' as device;
+import 'package:reaprime/src/services/ble/universal_ble_transport.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+const _serviceUuid = '0000a000-0000-1000-8000-00805f9b34fb';
+const _charUuid = '0000a00e-0000-1000-8000-00805f9b34fb';
+const _writeTimeout = Duration(milliseconds: 50);
+
+/// Fake [UniversalBlePlatform] driving [UniversalBleTransport] recovery
+/// tests. `hangWrites` makes writeValue never complete (so the facade's
+/// command queue times out, the same path a dead link produces);
+/// `connectionStateResult` is what the OS-level probe reports.
+class _FakeBlePlatform extends UniversalBlePlatform {
+  BleConnectionState connectionStateResult = BleConnectionState.connected;
+  bool hangWrites = false;
+  int getConnectionStateCalls = 0;
+  final List<String> disconnectCalls = [];
+
+  @override
+  Future<AvailabilityState> getBluetoothAvailabilityState() async =>
+      AvailabilityState.poweredOn;
+
+  @override
+  Future<bool> enableBluetooth() async => true;
+
+  @override
+  Future<bool> disableBluetooth() async => false;
+
+  @override
+  Future<void> startScan({
+    ScanFilter? scanFilter,
+    PlatformConfig? platformConfig,
+  }) async {}
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  Future<bool> isScanning() async => false;
+
+  @override
+  Future<void> connect(
+    String deviceId, {
+    Duration? connectionTimeout,
+    bool autoConnect = false,
+  }) async {
+    updateConnection(deviceId, true);
+  }
+
+  @override
+  Future<void> disconnect(String deviceId) async {
+    disconnectCalls.add(deviceId);
+    updateConnection(deviceId, false);
+  }
+
+  @override
+  Future<List<BleService>> discoverServices(
+    String deviceId,
+    bool withDescriptors,
+  ) async =>
+      [];
+
+  @override
+  Future<void> setNotifiable(
+    String deviceId,
+    String service,
+    String characteristic,
+    BleInputProperty bleInputProperty,
+  ) async {}
+
+  @override
+  Future<Uint8List> readValue(
+    String deviceId,
+    String service,
+    String characteristic, {
+    Duration? timeout,
+  }) async =>
+      Uint8List(0);
+
+  @override
+  Future<void> writeValue(
+    String deviceId,
+    String service,
+    String characteristic,
+    Uint8List value,
+    BleOutputProperty bleOutputProperty,
+  ) async {
+    if (hangWrites) {
+      await Completer<void>().future;
+    }
+  }
+
+  @override
+  Future<int> requestMtu(String deviceId, int expectedMtu) async => 23;
+
+  @override
+  Future<int> readRssi(String deviceId) async => -50;
+
+  @override
+  Future<void> requestConnectionPriority(
+    String deviceId,
+    BleConnectionPriority priority,
+  ) async {}
+
+  @override
+  Future<bool> isPaired(String deviceId) async => false;
+
+  @override
+  Future<bool> pair(String deviceId) async => true;
+
+  @override
+  Future<void> unpair(String deviceId) async {}
+
+  @override
+  Future<BleConnectionState> getConnectionState(String deviceId) async {
+    getConnectionStateCalls++;
+    return connectionStateResult;
+  }
+
+  @override
+  Future<List<BleDevice>> getSystemDevices(
+    List<String>? withServices,
+  ) async =>
+      [];
+}
+
+void main() {
+  late _FakeBlePlatform platform;
+  late UniversalBleTransport transport;
+  late List<device.ConnectionState> observedStates;
+  late StreamSubscription<device.ConnectionState> stateSub;
+  var deviceCounter = 0;
+  late String deviceId;
+
+  BleDevice bleDevice(String id, {String name = 'DE1'}) =>
+      BleDevice(deviceId: id, name: name);
+
+  Future<void> pump([int ms = 50]) =>
+      Future<void>.delayed(Duration(milliseconds: ms));
+
+  setUp(() async {
+    platform = _FakeBlePlatform();
+    UniversalBle.setInstance(platform);
+    // Drop any queues left over from a previous test (a hung write keeps
+    // its per-device queue slot busy forever otherwise).
+    UniversalBle.clearQueue();
+    // Unique id per test so per-device queue state can't bleed over.
+    deviceId = 'AA:BB:CC:DD:EE:${(deviceCounter++).toString().padLeft(2, '0')}';
+    transport = UniversalBleTransport(device: bleDevice(deviceId));
+    observedStates = [];
+    stateSub = transport.connectionState.listen(observedStates.add);
+    await transport.connect();
+    await pump(10);
+    expect(observedStates, contains(device.ConnectionState.connected));
+  });
+
+  tearDown(() async {
+    await stateSub.cancel();
+    await transport.dispose();
+  });
+
+  Future<void> timedOutWrite() async {
+    await expectLater(
+      transport.write(
+        _serviceUuid,
+        _charUuid,
+        Uint8List.fromList([1]),
+        timeout: _writeTimeout,
+      ),
+      throwsA(isA<TimeoutException>()),
+    );
+  }
+
+  group('GATT timeout link verification (fix 1)', () {
+    test(
+        'write timeout with OS reporting disconnected → emits disconnected',
+        () async {
+      platform.hangWrites = true;
+      platform.connectionStateResult = BleConnectionState.disconnected;
+
+      await timedOutWrite();
+      await pump();
+
+      expect(observedStates, contains(device.ConnectionState.disconnected));
+    });
+
+    test('write timeout with OS reporting connected → stays connected',
+        () async {
+      platform.hangWrites = true;
+      platform.connectionStateResult = BleConnectionState.connected;
+
+      await timedOutWrite();
+      await pump();
+
+      expect(
+        observedStates,
+        isNot(contains(device.ConnectionState.disconnected)),
+        reason: 'a single timeout on a live link must stay fail-fast only '
+            '(profile-upload safety)',
+      );
+      expect(platform.getConnectionStateCalls, greaterThan(0),
+          reason: 'the timeout should have probed the OS link state');
+    });
+
+    test(
+        'three consecutive timeouts with OS claiming connected → forced '
+        'teardown', () async {
+      platform.hangWrites = true;
+      platform.connectionStateResult = BleConnectionState.connected;
+
+      await timedOutWrite();
+      await timedOutWrite();
+      expect(observedStates,
+          isNot(contains(device.ConnectionState.disconnected)));
+
+      await timedOutWrite();
+      await pump();
+
+      expect(observedStates, contains(device.ConnectionState.disconnected));
+      expect(platform.disconnectCalls, contains(deviceId),
+          reason: 'forced teardown must release the OS-level handle');
+    });
+
+    test('successful write resets the consecutive-timeout counter', () async {
+      platform.connectionStateResult = BleConnectionState.connected;
+
+      platform.hangWrites = true;
+      await timedOutWrite();
+      await timedOutWrite();
+
+      platform.hangWrites = false;
+      await transport.write(
+        _serviceUuid,
+        _charUuid,
+        Uint8List.fromList([1]),
+        timeout: _writeTimeout,
+      );
+
+      platform.hangWrites = true;
+      await timedOutWrite();
+      await timedOutWrite();
+      await pump();
+
+      expect(
+        observedStates,
+        isNot(contains(device.ConnectionState.disconnected)),
+        reason: 'counter must reset on success — only 2 consecutive '
+            'timeouts since',
+      );
+    });
+  });
+
+  group('advertising-while-connected detection (fix 2)', () {
+    test('own advert + OS reporting disconnected → emits disconnected',
+        () async {
+      platform.connectionStateResult = BleConnectionState.disconnected;
+
+      platform.updateScanResult(bleDevice(deviceId));
+      await pump();
+
+      expect(observedStates, contains(device.ConnectionState.disconnected));
+    });
+
+    test('own advert + OS reporting connected → no teardown', () async {
+      platform.connectionStateResult = BleConnectionState.connected;
+
+      platform.updateScanResult(bleDevice(deviceId));
+      await pump();
+
+      expect(observedStates,
+          isNot(contains(device.ConnectionState.disconnected)));
+      expect(platform.getConnectionStateCalls, greaterThan(0),
+          reason: 'the advert should have triggered an OS probe');
+    });
+
+    test('advert for a different device is ignored', () async {
+      platform.connectionStateResult = BleConnectionState.disconnected;
+
+      platform.updateScanResult(bleDevice('11:22:33:44:55:66'));
+      await pump();
+
+      expect(observedStates,
+          isNot(contains(device.ConnectionState.disconnected)));
+      expect(platform.getConnectionStateCalls, 0);
+    });
+
+    test('advert while transport already disconnected is ignored', () async {
+      // Deliver a real disconnect event first.
+      platform.updateConnection(deviceId, false);
+      await pump(10);
+      expect(observedStates, contains(device.ConnectionState.disconnected));
+      final probesBefore = platform.getConnectionStateCalls;
+
+      platform.updateScanResult(bleDevice(deviceId));
+      await pump();
+
+      expect(platform.getConnectionStateCalls, probesBefore,
+          reason: 'no probe when we already know we are disconnected');
+    });
+
+    test('advert probes are throttled', () async {
+      platform.connectionStateResult = BleConnectionState.connected;
+
+      platform.updateScanResult(bleDevice(deviceId));
+      platform.updateScanResult(bleDevice(deviceId));
+      platform.updateScanResult(bleDevice(deviceId));
+      await pump();
+
+      expect(platform.getConnectionStateCalls, 1,
+          reason: 'adverts arrive ~1/s during a scan; one probe per '
+              'throttle window is enough');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Problem: two recovery gaps observed after a real power outage (DE1 tablet, Android 14). (1) After an unexpected machine disconnect, nothing ever rescans — the app sat "disconnected" for six hours until a manual restart. (2) After reconnecting, the BLE link died *silently* (no disconnect event): GATT ops timed out forever, machine API returned 500, scale-only scans ignored the machine, and even a manual connect skipped the machine phase because the app still believed it was connected. Only an app restart escapes.
- Why it matters: a kiosk-style gateway must survive power/BLE flakiness unattended; today a single lost disconnect event bricks the session.
- What changed: `UniversalBleTransport` detects dead links (OS-state probe on GATT timeout, escalation after 3 consecutive timeouts, own-advertisement-while-connected check) and emits `disconnected` so the normal cascade runs; `ConnectionManager` gains a machine auto-reconnect loop (unexpected disconnects only, 5s→60s backoff, mirrors the preferred-scale loop) via a new unexpected-machine-disconnect callback on `DisconnectSupervisor`.
- What did NOT change (scope boundary): single-timeout fail-fast behavior on a healthy link is preserved exactly (profile-upload safety — see comment on `UniversalBleTransport.write`); no REST/WS surface, no UI, no scale/sensor behavior (advert detection is probe-confirmed precisely so peripherals that legitimately advertise while connected are unaffected).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #
- Related #

## Root Cause (if bug fix)

- Root cause: `DisconnectSupervisor` reacts only to pushed `disconnected` events; a dead link that never delivers one leaves `_machineConnected` true forever with no health check anywhere. Independently, `_handleMachineDisconnected` only cancels timers — the machine reconnect policy was "wait for a UI tap".
- Missing detection or guardrail: no link-liveness verification (the OS's *polled* connection state stays truthful even when the event is lost), and no background retry loop for machines (scales already had one).
- Contributing context: the GATT-timeout path deliberately avoids teardown to protect in-flight profile uploads, which is correct for a live link but masked genuinely dead ones. Note: `ScanResult.matchedDevices` echoes the connected-device registry, so scan reports listing the machine were *not* evidence of advertising — real adverts are only visible on `UniversalBle.scanStream`, which is why detection lives in the transport (details in `doc/plans/archive/machine-connection-recovery/`).

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/universal_ble_transport_recovery_test.dart` (new, fake `UniversalBlePlatform` via `UniversalBle.setInstance`); `test/controllers/connection_manager_test.dart` → new `machine auto-reconnect` group (real `DisconnectSupervisor` + `SettingsController`).
- Scenario the test should lock in: write timeout + OS-reports-disconnected ⇒ `disconnected` emitted; 3 consecutive timeouts ⇒ forced teardown incl. OS handle release; single timeout on healthy link ⇒ unchanged fail-fast; own advert probe path incl. throttling and foreign/stale adverts ignored; unexpected machine disconnect ⇒ backoff rescan until reconnect, with expected/deliberate disconnects and missing `preferredMachineId` staying quiet.
- If no new test added, why not: N/A (15 new tests)

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [x] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A — no docs affected

## Security Impact (required)

- New or changed REST endpoints? No
- New or changed WebSocket topics? No
- New or changed network calls? No
- BLE/USB surface changed? Yes
- File system access changed? No
- Plugin sandbox boundary changed? No
- If any `Yes`, explain risk and mitigation: BLE behavior only — adds passive listening on the existing scan stream (starts no scans itself), OS connection-state probes (throttled/bounded), and best-effort `UniversalBle.disconnect` on confirmed-dead links. Worst case of a false positive is a disconnect+auto-reconnect cycle; teardown therefore requires OS confirmation or 3 consecutive 10s op timeouts.

## User-Visible Changes

After an unexpected machine disconnect (power loss, BLE drop, zombie link), the app now reconnects automatically once the machine is reachable again — previously it required a manual reconnect tap or a full app restart. The `machineDisconnected` error banner still appears while recovery runs.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass (1917/1917)
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds

### Manual verification (if applicable)

- OS / platform tested: macOS host (unit/integration suites)
- Simulated devices? (`simulate=1`): No
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: TDD — all 15 new tests written first and confirmed failing for the right reason, then passing after implementation; full suite green.
- Edge cases checked: single timeout on live link (no teardown), counter reset on successful op, foreign-device adverts, adverts after real disconnect, probe throttling, expected vs deliberate vs unexpected disconnects, missing `preferredMachineId`, backoff timing via `fakeAsync`.
- What you did **not** verify: on-hardware reproduction of the original outage (requires physically power-cycling a DE1 mid-connection). Known residual gap, documented in the design doc: a silent death while the OS *also* wrongly claims connected and no GATT ops run is only caught by the next periodic op (minutes); a DE1 notification-silence watchdog is a possible follow-up but risks sleep-state false positives.

### Evidence

- [x] Test output (failing before + passing after)

RED (before implementation):
```
00:01 +3 -6: Some tests failed.  (universal_ble_transport_recovery_test.dart)
Error: The setter 'machineReconnectBaseDelay' isn't defined for the type 'ConnectionManager'.
```
GREEN (after):
```
00:01 +9: All tests passed!   (universal_ble_transport_recovery_test.dart)
00:20 +82: All tests passed!  (connection_manager_test.dart)
03:08 +1917: All tests passed!  (full suite)
```

## Compatibility & Migration

- Backward compatible? Yes
- Config / env changes needed? No
- Database migration needed? No

## Risks & Mitigations

- Risk: false-positive link teardown disconnecting a healthy device.
  - Mitigation: teardown requires OS-confirmed disconnect or 3 consecutive 10s GATT timeouts; advert detection never tears down on adverts alone (shared transport with scales/sensors); single timeouts keep today's exact behavior.
- Risk: background recovery scans compete for the BLE radio.
  - Mitigation: same backoff/cap discipline as the existing preferred-scale loop (5s→60s); loop stops the moment the machine connects and never runs after deliberate disconnects.