### PR TITLE
fix(ios): add NSCameraUsageDescription purpose string

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -40,6 +40,8 @@
 	<array>
 		<string>_decentscale._tcp</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Needed to capture photos for shot notes and feedback when picking images via the file picker</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Needed to import photos for shot notes and feedback</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>


### PR DESCRIPTION
## What
- Adds `NSCameraUsageDescription` to `ios/Runner/Info.plist`.

## Why
Apple ITMS-90683 rejected build 1914 (v0.7.10) for a missing camera purpose string. The app does not call camera APIs directly — the reference comes from `file_picker`'s bundled `DKImagePickerController` (`DKCamera` SPM dependency, introduced in 23379085), which exposes the camera as an image source on iOS. Apple still requires a purpose string when an SDK references the API, even if the app never invokes it.

## Test plan
- [ ] Build IPA on CI (release job) and confirm App Store Connect accepts the upload without ITMS-90683.