### PR TITLE
Add WeighMaster Scale Bluetooth protocol support

### DIFF
--- a/lib/src/models/device/impl/weighmaster/weighmaster_scale.dart
+++ b/lib/src/models/device/impl/weighmaster/weighmaster_scale.dart
@@ -1,0 +1,171 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:reaprime/src/models/device/ble_service_identifier.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:rxdart/subjects.dart';
+
+import '../../scale.dart';
+
+class WeighMasterScale implements Scale {
+  static final BleServiceIdentifier serviceIdentifier =
+      BleServiceIdentifier.short('fff0');
+  static final BleServiceIdentifier dataCharacteristic =
+      BleServiceIdentifier.short('fff4');
+  static final BleServiceIdentifier commandCharacteristic =
+      BleServiceIdentifier.short('fff1');
+
+  static const int _cmdTare = 0x02;
+  static const int _cmdSleepDisplay = 0x03;
+  static const int _cmdBuzzer = 0x05;
+
+  static const int _frameLength = 7;
+  static const int _statusOffset = 3;
+  static const int _weightOffset = 4;
+  static const int _statusNegative = 0x01;
+
+  final String _deviceId;
+  final BLETransport _transport;
+
+  final StreamController<ScaleSnapshot> _streamController =
+      StreamController.broadcast();
+  final StreamController<ConnectionState> _connectionStateController =
+      BehaviorSubject.seeded(ConnectionState.discovered);
+
+  WeighMasterScale({required BLETransport transport})
+      : _transport = transport,
+        _deviceId = transport.id;
+
+  @override
+  Stream<ScaleSnapshot> get currentSnapshot => _streamController.stream;
+
+  @override
+  String get deviceId => _deviceId;
+
+  @override
+  String get name => 'WeighMaster Scale';
+
+  @override
+  Stream<ConnectionState> get connectionState =>
+      _connectionStateController.stream;
+
+  @override
+  DeviceType get type => DeviceType.scale;
+
+  @override
+  Future<void> onConnect() async {
+    if (await _transport.connectionState.first == ConnectionState.connected) {
+      return;
+    }
+    _connectionStateController.add(ConnectionState.connecting);
+
+    StreamSubscription<ConnectionState>? disconnectSub;
+
+    try {
+      await _transport.connect();
+
+      disconnectSub = _transport.connectionState
+          .where((state) => state == ConnectionState.disconnected)
+          .listen((_) {
+        _connectionStateController.add(ConnectionState.disconnected);
+        disconnectSub?.cancel();
+      });
+
+      final services = await _transport.discoverServices();
+      if (!serviceIdentifier.matchesAny(services)) {
+        throw Exception(
+          'Expected service ${serviceIdentifier.long} not found. '
+          'Discovered services: $services',
+        );
+      }
+      await _registerNotifications();
+      _connectionStateController.add(ConnectionState.connected);
+    } catch (_) {
+      disconnectSub?.cancel();
+      _connectionStateController.add(ConnectionState.disconnected);
+      try {
+        await _transport.disconnect();
+      } catch (_) {}
+    }
+  }
+
+  @override
+  Future<void> disconnect() async {
+    await _transport.disconnect();
+  }
+
+  @override
+  Future<void> tare() async {
+    await _write(const [_cmdTare]);
+    unawaited(
+      Future<void>.delayed(const Duration(milliseconds: 300))
+          .then((_) => _write(const [_cmdBuzzer, 0x00]))
+          .catchError((_) {}),
+    );
+  }
+
+  @override
+  Future<void> sleepDisplay() async {
+    await _write(const [_cmdSleepDisplay, 0x00, 0x01]);
+  }
+
+  @override
+  Future<void> wakeDisplay() async {}
+
+  @override
+  Future<void> startTimer() async {}
+
+  @override
+  Future<void> stopTimer() async {}
+
+  @override
+  Future<void> resetTimer() async {}
+
+  Future<void> _write(List<int> bytes) async {
+    await _transport.write(
+      serviceIdentifier.long,
+      commandCharacteristic.long,
+      Uint8List.fromList(bytes),
+    );
+  }
+
+  Future<void> _registerNotifications() async {
+    await _transport.subscribe(
+      serviceIdentifier.long,
+      dataCharacteristic.long,
+      _parseNotification,
+    );
+  }
+
+  static ScaleSnapshot? parseFrame(List<int> data) {
+    if (data.length < _frameLength) {
+      return null;
+    }
+
+    final status = data[_statusOffset];
+    final isNegative = (status & _statusNegative) == _statusNegative;
+    final weightRaw =
+        (data[_weightOffset] << 16) |
+        (data[_weightOffset + 1] << 8) |
+        data[_weightOffset + 2];
+
+    var weight = weightRaw / 10.0;
+    if (isNegative) {
+      weight = -weight;
+    }
+
+    return ScaleSnapshot(
+      timestamp: DateTime.now(),
+      weight: weight,
+      batteryLevel: 0,
+    );
+  }
+
+  void _parseNotification(List<int> data) {
+    final snapshot = parseFrame(data);
+    if (snapshot != null) {
+      _streamController.add(snapshot);
+    }
+  }
+}

--- a/lib/src/models/device/impl/weighmaster/weighmaster_scale.dart
+++ b/lib/src/models/device/impl/weighmaster/weighmaster_scale.dart
@@ -21,6 +21,8 @@ class WeighMasterScale implements Scale {
   static const int _cmdBuzzer = 0x05;
 
   static const int _frameLength = 7;
+  static const int _headerByte1 = 0x01;
+  static const int _headerByte2 = 0x02;
   static const int _statusOffset = 3;
   static const int _weightOffset = 4;
   static const int _statusNegative = 0x01;
@@ -140,6 +142,10 @@ class WeighMasterScale implements Scale {
 
   static ScaleSnapshot? parseFrame(List<int> data) {
     if (data.length < _frameLength) {
+      return null;
+    }
+
+    if (data[0] != _headerByte1 || data[1] != _headerByte2) {
       return null;
     }
 

--- a/lib/src/services/device_matcher.dart
+++ b/lib/src/services/device_matcher.dart
@@ -16,6 +16,8 @@ import 'package:reaprime/src/models/device/impl/skale/skale2_scale.dart';
 import 'package:reaprime/src/models/device/impl/smartchef/smartchef_scale.dart';
 import 'package:reaprime/src/models/device/impl/varia/varia_aku_scale.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/models/device/impl/weighmaster/weighmaster_scale.dart';
+
 
 class DeviceMatcher {
   /// Service UUIDs advertised by devices of a given [type].
@@ -36,6 +38,7 @@ class DeviceMatcher {
       DifluidScale.serviceIdentifier.long,
       HiroiaScale.serviceIdentifier.long,
       AtomheartScale.serviceIdentifier.long,
+      WeighMasterScale.serviceIdentifier.long,
       ...AcaiaScale.advertisedServiceUuids,
     ],
     DeviceType.machine => [
@@ -118,6 +121,9 @@ class DeviceMatcher {
     }
     if (nameLower.contains('decent temp')) {
       return DecentTemp(transport: transport);
+    }
+    if (name == 'WeighMaster Scale') {
+      return WeighMasterScale(transport: transport);
     }
 
     return null;

--- a/test/unit/models/weighmaster_scale_test.dart
+++ b/test/unit/models/weighmaster_scale_test.dart
@@ -1,0 +1,148 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/weighmaster/weighmaster_scale.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:rxdart/rxdart.dart';
+
+class _MockWeighMasterBleTransport extends BLETransport {
+  _MockWeighMasterBleTransport({required this.serviceUUIDs});
+
+  final List<String> serviceUUIDs;
+  final BehaviorSubject<ConnectionState> _connectionState =
+      BehaviorSubject.seeded(ConnectionState.discovered);
+  final List<List<int>> receivedWrites = [];
+
+  void Function(Uint8List)? _notificationCallback;
+  String? subscribedServiceUuid;
+  String? subscribedCharUuid;
+
+  @override
+  String get id => 'AA:BB:CC:DD:EE:FF';
+
+  @override
+  String get name => 'Test WeighMaster';
+
+  @override
+  Stream<ConnectionState> get connectionState => _connectionState.stream;
+
+  @override
+  Future<ConnectionState> getConnectionState() async => _connectionState.value;
+
+  @override
+  Future<void> connect() async {
+    _connectionState.add(ConnectionState.connected);
+  }
+
+  @override
+  Future<void> disconnect() async {
+    _connectionState.add(ConnectionState.disconnected);
+  }
+
+  @override
+  Future<List<String>> discoverServices() async => serviceUUIDs;
+
+  @override
+  Future<Uint8List> read(
+    String serviceUUID,
+    String characteristicUUID, {
+    Duration? timeout,
+  }) async => Uint8List(0);
+
+  @override
+  Future<void> subscribe(
+    String serviceUUID,
+    String characteristicUUID,
+    void Function(Uint8List) callback,
+  ) async {
+    subscribedServiceUuid = serviceUUID;
+    subscribedCharUuid = characteristicUUID;
+    _notificationCallback = callback;
+  }
+
+  @override
+  Future<void> write(
+    String serviceUUID,
+    String characteristicUUID,
+    Uint8List data, {
+    bool withResponse = true,
+    Duration? timeout,
+  }) async {
+    receivedWrites.add(data.toList());
+  }
+
+  @override
+  Future<void> setTransportPriority(bool prioritized) async {}
+
+  void simulateNotification(List<int> data) {
+    _notificationCallback?.call(Uint8List.fromList(data));
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _connectionState.close();
+  }
+}
+
+void main() {
+  group('WeighMasterScale', () {
+    test('connects when FFF0 service is present and subscribes to FFF4', () async {
+      final transport = _MockWeighMasterBleTransport(
+        serviceUUIDs: [WeighMasterScale.serviceIdentifier.long],
+      );
+      final scale = WeighMasterScale(transport: transport);
+
+      await scale.onConnect();
+
+      expect(await scale.connectionState.first, ConnectionState.connected);
+      expect(
+        transport.subscribedServiceUuid,
+        WeighMasterScale.serviceIdentifier.long,
+      );
+      expect(
+        transport.subscribedCharUuid,
+        WeighMasterScale.dataCharacteristic.long,
+      );
+    });
+
+    test('parses positive and negative 0.1 g frames', () async {
+      final transport = _MockWeighMasterBleTransport(
+        serviceUUIDs: [WeighMasterScale.serviceIdentifier.long],
+      );
+      final scale = WeighMasterScale(transport: transport);
+      final snapshots = <ScaleSnapshot>[];
+
+      scale.currentSnapshot.listen(snapshots.add);
+      await scale.onConnect();
+
+      transport.simulateNotification([0x01, 0x02, 0x01, 0x00, 0x00, 0x04, 0xD2]);
+      transport.simulateNotification([0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0x7B]);
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(snapshots, hasLength(2));
+      expect(snapshots[0].weight, closeTo(123.4, 0.01));
+      expect(snapshots[1].weight, closeTo(-12.3, 0.01));
+    });
+
+    test('tare sends tare command followed by buzzer beep', () async {
+      final transport = _MockWeighMasterBleTransport(
+        serviceUUIDs: [WeighMasterScale.serviceIdentifier.long],
+      );
+      final scale = WeighMasterScale(transport: transport);
+
+      await scale.onConnect();
+      transport.receivedWrites.clear();
+
+      await scale.tare();
+      await Future<void>.delayed(const Duration(milliseconds: 350));
+
+      expect(transport.receivedWrites, hasLength(2));
+      expect(transport.receivedWrites[0], [0x02]);
+      expect(transport.receivedWrites[1], [0x05, 0x00]);
+    });
+  });
+}

--- a/test/unit/models/weighmaster_scale_test.dart
+++ b/test/unit/models/weighmaster_scale_test.dart
@@ -144,5 +144,26 @@ void main() {
       expect(transport.receivedWrites[0], [0x02]);
       expect(transport.receivedWrites[1], [0x05, 0x00]);
     });
+
+    test('rejects frames with incorrect header', () async {
+      final transport = _MockWeighMasterBleTransport(
+        serviceUUIDs: [WeighMasterScale.serviceIdentifier.long],
+      );
+      final scale = WeighMasterScale(transport: transport);
+      final snapshots = <ScaleSnapshot>[];
+
+      scale.currentSnapshot.listen(snapshots.add);
+      await scale.onConnect();
+
+      transport.simulateNotification([0x01, 0x02, 0x01, 0x00, 0x00, 0x04, 0xD2]);
+      transport.simulateNotification([0x00, 0x02, 0x01, 0x00, 0x00, 0x04, 0xD2]);
+      transport.simulateNotification([0x01, 0x03, 0x01, 0x00, 0x00, 0x04, 0xD2]);
+      transport.simulateNotification([0x99, 0x99, 0x01, 0x00, 0x00, 0x04, 0xD2]);
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(snapshots, hasLength(1));
+      expect(snapshots[0].weight, closeTo(123.4, 0.01));
+    });
   });
 }


### PR DESCRIPTION
## Summary

Add Bluetooth protocol support for the WeighMaster Scale coffee scale.

## Changes

- [1] Implement `WeighMasterScale` class with BLE service/characteristic definitions
- [2] Add device matching for WeighMaster Scale in `DeviceMatcher`
- [3] Implement tare, sleepDisplay, and buzzer commands
- [4] Implement weight data parsing with negative value support
- [5] Add unit tests for connection, data parsing, and tare command

## Testing

All local unit tests pass with a Decent espresso machine.

## Protocol Details

- BLE Service UUID: fff0
- Data Characteristic: fff4
- Command Characteristic: fff1
- Frame format: 7 bytes (status + 3-byte weight value)