### PR TITLE
fix(ble): recover from zombie DE1 push channel (no-op reconnect + staleness watchdog)

### DIFF
--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -189,8 +189,10 @@ class ConnectionManager {
   /// snapshot frames for this long, the push channel is presumed dead
   /// (live-link + dead-push — the field incident of 2026-07-07). A clean
   /// forced reconnect re-establishes notifications. See Fix #1.
+  /// Overridable in tests so the watchdog can be driven without a real
+  /// 10s wait.
   @visibleForTesting
-  static const Duration snapshotStalenessTimeout = Duration(seconds: 10);
+  Duration snapshotStalenessTimeout = const Duration(seconds: 10);
 
   Timer? _stateWatchdog;
   int _watchdogGeneration = 0;
@@ -729,6 +731,11 @@ class ConnectionManager {
     _machineReconnectFailures = 0;
   }
 
+  /// Whether the machine auto-reconnect recovery loop is currently armed.
+  /// Test hook for asserting the staleness watchdog's strand safety-net.
+  @visibleForTesting
+  bool get machineRecoveryActive => _machineRecoveryActive;
+
   bool _shouldRetryMachine() {
     return _machineRecoveryActive &&
         !_machineConnected &&
@@ -829,6 +836,18 @@ class ConnectionManager {
       await connect();
     } catch (e, st) {
       _log.fine('Forced machine reconnect failed', e, st);
+    } finally {
+      // Safety net against stranding the machine. `disconnectMachine`
+      // marked the drop expected, so the unexpected-disconnect path never
+      // armed machine recovery; and the `connect()` above can be silently
+      // dropped by the concurrent-connect guard (e.g. a scale-only rescan
+      // already in flight) or return without finding the machine. If
+      // we're still machineless, hand off to the recovery loop: it
+      // retries with backoff and cancels itself the moment the machine
+      // reconnects (no-op without a preferredMachineId).
+      if (!_machineConnected) {
+        _startMachineRecovery();
+      }
     }
   }
 

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -185,6 +185,22 @@ class ConnectionManager {
   MachineState? _latestMachineState;
   StreamSubscription<MachineSnapshot>? _machineSnapshotSub;
 
+  /// Snapshot-staleness watchdog: if a connected machine stops pushing
+  /// snapshot frames for this long, the push channel is presumed dead
+  /// (live-link + dead-push — the field incident of 2026-07-07). A clean
+  /// forced reconnect re-establishes notifications. See Fix #1.
+  @visibleForTesting
+  static const Duration snapshotStalenessTimeout = Duration(seconds: 10);
+
+  Timer? _stateWatchdog;
+  int _watchdogGeneration = 0;
+
+  /// Number of times the staleness watchdog forced a machine reconnect.
+  /// Incremented once per force action — tests assert on this instead of
+  /// driving the full disconnect+connect cycle through fake_async.
+  @visibleForTesting
+  int snapshotStalenessReconnects = 0;
+
   /// Set true by [_checkEarlyStop] when it actually cut the scan short on
   /// machine-connect with no preferred scale. Distinguishes that case
   /// from a full scan that simply completed without a scale — only the
@@ -754,7 +770,16 @@ class ConnectionManager {
       _log.fine('Machine snapshot stream unavailable', e, st);
       return;
     }
+    // Arm the initial-grace watchdog before the first frame lands —
+    // covers the Android GATT-busy first-notify-loss race (sb-060/061/062):
+    // if the first push is lost, the watchdog fires and forces a clean
+    // reconnect that re-establishes notifications.
+    _armStateWatchdog(machine.deviceId);
     _machineSnapshotSub = snapshots.listen((snapshot) {
+      // Every frame — including a deduped duplicate of the current state —
+      // proves the push channel is alive. Re-arm BEFORE the dedupe check
+      // so a steady non-transitioning state doesn't false-trigger.
+      _armStateWatchdog(machine.deviceId);
       final state = snapshot.state.state;
       if (_latestMachineState == state) return;
       _latestMachineState = state;
@@ -772,6 +797,41 @@ class ConnectionManager {
     });
   }
 
+  void _armStateWatchdog(String deviceId) {
+    final gen = _watchdogGeneration;
+    _stateWatchdog?.cancel();
+    _stateWatchdog = Timer(snapshotStalenessTimeout, () {
+      if (gen != _watchdogGeneration) return;
+      if (!_machineConnected) return;
+      final current = _disconnectSupervisor.latestMachine;
+      if (current?.deviceId != deviceId) return;
+      _log.warning(
+        'Snapshot stream stale for $deviceId after '
+        '${snapshotStalenessTimeout.inSeconds}s with link still '
+        '"connected"; forcing a clean machine reconnect',
+      );
+      _forceMachineReconnect();
+    });
+  }
+
+  /// Force a deliberate, immediate machine reconnect (no backoff). Bumps
+  /// the generation token first so any in-flight or stale watchdog Timer
+  /// bails; `disconnectMachine` also tears down the watcher (bumps gen
+  /// again, cancels the Timer) and marks the disconnect expected so no
+  /// error banner surfaces.
+  Future<void> _forceMachineReconnect() async {
+    snapshotStalenessReconnects++;
+    _watchdogGeneration++;
+    _stateWatchdog?.cancel();
+    _stateWatchdog = null;
+    try {
+      await disconnectMachine();
+      await connect();
+    } catch (e, st) {
+      _log.fine('Forced machine reconnect failed', e, st);
+    }
+  }
+
   void _pauseScaleReconnectForPowerMode() {
     _deferredScaleScan?.cancel();
     _deferredScaleScan = null;
@@ -782,6 +842,9 @@ class ConnectionManager {
   }
 
   void _stopWatchingConnectedMachineState() {
+    _watchdogGeneration++;
+    _stateWatchdog?.cancel();
+    _stateWatchdog = null;
     _machineSnapshotSub?.cancel();
     _machineSnapshotSub = null;
     _latestMachineState = null;

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -10,7 +10,6 @@ import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/transport/logical_endpoint.dart';
 import 'package:reaprime/src/models/errors.dart';
-import 'package:reaprime/src/services/telemetry/anonymization.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -83,27 +82,41 @@ class UnifiedDe1Transport {
               : TransportType.unknown,
       _log = Logger("UnifiedDe1Transport-${transport.id}");
   Future<void> connect() async {
-    // A connect() while the transport already reports `connected` means BLE
-    // setup is about to re-subscribe to every characteristic without an
-    // intervening disconnect — the no-op reconnect that used to stack
-    // duplicate notification listeners (every frame delivered twice). The
-    // per-characteristic guard now replaces subscriptions idempotently, but
-    // we record the condition as a non-fatal to measure how often it fires.
+    // A connect() while the transport already reports `connected` is a
+    // no-op reconnect: the underlying GATT link never came down (e.g. the
+    // app-level disconnect on machine sleep nulled De1Controller._de1 but
+    // the native BLE transport lingered connected — a zombie link). The
+    // prior fix (PR #246 / sb-030) made `_bleConnect()`'s per-characteristic
+    // `subscribe()` cancel-before-replace so it no longer STACKED duplicate
+    // listeners. But re-subscribing against the zombie link had an inverse
+    // failure mode seen in the field: a pure-push characteristic
+    // (stateInfo/A00E) silently stopped delivering while solicited
+    // reads/writes kept succeeding — invisible to the zombie watchdog,
+    // which only counts GATT op timeouts and own-advert probes.
+    //
+    // The load-bearing fix is to tear down the stale native link BEFORE
+    // re-connecting, so `_bleConnect()` runs against a freshly-established
+    // GATT and every CCCD is written cleanly. The transient `disconnected`
+    // the native link emits during teardown is absorbed without surfacing
+    // to upstream: De1Controller.connectToDe1 has already cancelled its
+    // `connectionState` listener (via _onDisconnect) before `onConnect()`
+    // runs this method, and only re-subscribes after `onConnect()` returns.
     final wasConnected = transportType == TransportType.ble &&
         await _transport.connectionState.first ==
             device.ConnectionState.connected;
+
+    if (wasConnected) {
+      _log.info(
+        'Transport already connected; tearing down stale link before '
+        'reconnect to avoid no-op-reconnect push death',
+      );
+      await _transport.disconnect();
+    }
 
     await _transport.connect();
 
     switch (transportType) {
       case TransportType.ble:
-        if (wasConnected) {
-          _log.warning(
-            're-running BLE setup on already-connected transport (no-op '
-            'reconnect); notify subscriptions replaced, not stacked',
-            DuplicateBleSubscription(Anonymization.anonymizeMac(_transport.id)),
-          );
-        }
         await _bleConnect();
         break;
       case TransportType.serial:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1691,10 +1691,10 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "6a5abe483a8368c00b84b94df92b2f51667247f7"
+      resolved-ref: "1e1f38808ec5dd816a14bbb6ebc3ddb276463ca5"
       url: "https://github.com/tadelv/universal_ble.git"
     source: git
-    version: "2.0.4"
+    version: "2.1.1"
   universal_image:
     dependency: transitive
     description:

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -1755,6 +1755,153 @@ void main() {
         });
       });
     });
+
+    group('snapshot staleness watchdog', () {
+      // The watchdog Timer must be created inside the fakeAsync zone, so
+      // each test constructs a fresh ConnectionManager here (the setUp
+      // instance lives in the real zone — its Timer wouldn't be visible
+      // to async.elapse). Mirrors the 'recovery retries use exponential
+      // backoff' test.
+
+      ConnectionManager newManager() => ConnectionManager(
+            deviceScanner: mockScanner,
+            de1Controller: mockDe1Controller,
+            scaleController: mockScaleController,
+            settingsController: settingsController,
+          );
+
+      test('fires after 10s with no snapshots and forces a reconnect', () {
+        fakeAsync((async) {
+          final manager = newManager();
+          final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
+          mockDe1Controller.de1Subject.add(fakeDe1);
+          async.flushMicrotasks();
+          // First snapshot frame arms (and re-arms) the watchdog.
+          fakeDe1.emitState(MachineState.idle);
+          async.flushMicrotasks();
+
+          expect(manager.snapshotStalenessReconnects, 0);
+          async.elapse(const Duration(seconds: 9));
+          expect(manager.snapshotStalenessReconnects, 0,
+              reason: 'must not fire before the staleness timeout');
+          // Counter increments synchronously at the top of the force
+          // action, so it is observable the moment the Timer fires. The
+          // counter proves the watchdog fired and the force path ran
+          // (disconnectMachine → connect). We don't assert on
+          // fakeDe1.disconnectCalls here: BehaviorSubject's Rx.defer
+          // replay doesn't settle under flushMicrotasks/elapse(0) in
+          // fakeAsync, so the async chain only resumes after dispose —
+          // making that assertion flaky without proving anything the
+          // counter doesn't already show.
+          async.elapse(const Duration(seconds: 2)); // 11s elapsed
+          expect(manager.snapshotStalenessReconnects, 1,
+              reason: 'a silent push channel must trigger a forced reconnect');
+
+          manager.dispose();
+          async.flushMicrotasks();
+        });
+      });
+
+      test('a deduped snapshot within the window re-arms the watchdog', () {
+        fakeAsync((async) {
+          final manager = newManager();
+          final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
+          mockDe1Controller.de1Subject.add(fakeDe1);
+          async.flushMicrotasks();
+          fakeDe1.emitState(MachineState.idle);
+          async.flushMicrotasks();
+
+          async.elapse(const Duration(seconds: 9));
+          // Same state — deduped by _latestMachineState — but still proves
+          // the push channel is alive; watchdog must re-arm.
+          fakeDe1.emitState(MachineState.idle);
+          async.flushMicrotasks();
+
+          async.elapse(const Duration(seconds: 9)); // 18s total, 9s since re-arm
+          expect(manager.snapshotStalenessReconnects, 0,
+              reason: 'a deduped frame must re-arm the watchdog');
+
+          manager.dispose();
+          async.flushMicrotasks();
+        });
+      });
+
+      test('deliberate disconnectMachine cancels the watchdog (no fire, no error)',
+          () {
+        fakeAsync((async) {
+          final manager = newManager();
+          final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
+          mockDe1Controller.de1Subject.add(fakeDe1);
+          async.flushMicrotasks();
+          fakeDe1.emitState(MachineState.idle);
+          async.flushMicrotasks();
+
+          // Deliberate disconnect cancels the watchdog and bumps the
+          // generation token.
+          manager.disconnectMachine();
+          async.flushMicrotasks();
+
+          async.elapse(const Duration(seconds: 15));
+          expect(manager.snapshotStalenessReconnects, 0,
+              reason: 'deliberate disconnect must cancel the watchdog');
+          expect(manager.currentStatus.error, isNull,
+              reason: 'deliberate disconnect must not surface an error banner');
+
+          manager.dispose();
+          async.flushMicrotasks();
+        });
+      });
+
+      test('initial grace: no fire before the first snapshot at 9s, fire at 11s',
+          () {
+        fakeAsync((async) {
+          final manager = newManager();
+          final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
+          mockDe1Controller.de1Subject.add(fakeDe1);
+          async.flushMicrotasks();
+          // No snapshot emitted — only the initial-grace arm at watch setup.
+
+          async.elapse(const Duration(seconds: 9));
+          expect(manager.snapshotStalenessReconnects, 0,
+              reason: 'must not fire within the initial grace window');
+
+          async.elapse(const Duration(seconds: 2)); // 11s
+          expect(manager.snapshotStalenessReconnects, 1,
+              reason: 'watchdog armed at watch setup must fire if no frame '
+                  'ever lands');
+
+          manager.dispose();
+          async.flushMicrotasks();
+        });
+      });
+
+      test('stale generation after a forced reconnect bails (no double-reconnect)',
+          () {
+        fakeAsync((async) {
+          final manager = newManager();
+          final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
+          mockDe1Controller.de1Subject.add(fakeDe1);
+          async.flushMicrotasks();
+          fakeDe1.emitState(MachineState.idle);
+          async.flushMicrotasks();
+
+          async.elapse(const Duration(seconds: 11));
+          expect(manager.snapshotStalenessReconnects, 1);
+          async.flushMicrotasks();
+
+          // The forced reconnect cancelled the watchdog and bumped the
+          // generation. With no new machine connected and no new frames,
+          // no watchdog is re-armed — a long elapse must not trigger a
+          // second forced reconnect.
+          async.elapse(const Duration(seconds: 30));
+          expect(manager.snapshotStalenessReconnects, 1,
+              reason: 'a stale-generation Timer must bail, not re-fire');
+
+          manager.dispose();
+          async.flushMicrotasks();
+        });
+      });
+    });
   });
 }
 

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -1901,6 +1901,42 @@ void main() {
           async.flushMicrotasks();
         });
       });
+
+      // Runs in the real async zone (not fakeAsync): the forced reconnect's
+      // `disconnectMachine → connect` chain awaits `de1Controller.de1.first`,
+      // which a BehaviorSubject does not settle under fakeAsync — so the
+      // strand safety-net in the `finally` only runs with real microtasks.
+      // A short overridden staleness timeout keeps the test fast.
+      test(
+          'a forced reconnect that cannot recover the machine hands off to '
+          'the recovery loop (no strand)', () async {
+        await settingsController.setPreferredMachineId('stale-de1');
+        // Non-zero base delay avoids a hot recovery loop within the wait
+        // window; we only assert the loop is armed, not how often it scans.
+        connectionManager.machineReconnectBaseDelay =
+            const Duration(milliseconds: 50);
+        connectionManager.snapshotStalenessTimeout =
+            const Duration(milliseconds: 20);
+        final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
+        mockDe1Controller.de1Subject.add(fakeDe1);
+        await Future<void>.delayed(Duration.zero);
+        fakeDe1.emitState(MachineState.idle);
+        await Future<void>.delayed(Duration.zero);
+
+        // Let the 20ms watchdog fire and force a reconnect. The scanner
+        // surfaces no machine, so the forced `connect()` completes without
+        // reconnecting → the machine is left disconnected.
+        // `disconnectMachine` marked the drop expected, so the
+        // unexpected-disconnect path never armed recovery; without the
+        // safety net nothing would retry.
+        await Future<void>.delayed(const Duration(milliseconds: 60));
+
+        expect(connectionManager.snapshotStalenessReconnects, greaterThan(0),
+            reason: 'the watchdog must have forced a reconnect');
+        expect(connectionManager.machineRecoveryActive, isTrue,
+            reason: 'a stranded forced reconnect must hand off to the '
+                'machine-recovery loop, not leave the machine disconnected');
+      });
     });
   });
 }

--- a/test/unit/models/unified_de1_transport_resubscribe_test.dart
+++ b/test/unit/models/unified_de1_transport_resubscribe_test.dart
@@ -13,11 +13,22 @@ import 'package:rxdart/rxdart.dart';
 /// Minimal BLE transport whose initial connection state is controllable, so
 /// we can drive `UnifiedDe1Transport.connect()` down the first-connect path
 /// (transport disconnected) vs. the no-op-reconnect path (already connected).
+/// Records call order and captures per-characteristic subscribe callbacks so
+/// tests can assert on disconnect-before-connect ordering and on which
+/// listener receives a pushed notification after a re-subscribe.
 class _Fake extends BLETransport {
   _Fake(ConnectionState initial)
       : _connState = BehaviorSubject<ConnectionState>.seeded(initial);
 
   final BehaviorSubject<ConnectionState> _connState;
+
+  /// Ordered record of `disconnect` / `connect` / `subscribe:<uuid>` calls,
+  /// so tests can assert a no-op reconnect now tears down before re-connect.
+  final List<String> callOrder = [];
+
+  /// Last callback registered per characteristic uuid — lets a test invoke
+  /// the *current* listener and assert it (not a stale one) receives pushes.
+  final Map<String, void Function(Uint8List)> subscribers = {};
 
   @override
   String get id => 'fake-id';
@@ -29,10 +40,15 @@ class _Fake extends BLETransport {
   Future<ConnectionState> getConnectionState() async =>
       ConnectionState.disconnected;
   @override
-  Future<void> connect() async => _connState.add(ConnectionState.connected);
+  Future<void> connect() async {
+    callOrder.add('connect');
+    _connState.add(ConnectionState.connected);
+  }
   @override
-  Future<void> disconnect() async =>
-      _connState.add(ConnectionState.disconnected);
+  Future<void> disconnect() async {
+    callOrder.add('disconnect');
+    _connState.add(ConnectionState.disconnected);
+  }
   @override
   Future<List<String>> discoverServices() async => [de1ServiceUUID];
   @override
@@ -40,7 +56,10 @@ class _Fake extends BLETransport {
       Uint8List(20);
   @override
   Future<void> subscribe(
-      String s, String c, void Function(Uint8List) cb) async {}
+      String s, String c, void Function(Uint8List) cb) async {
+    callOrder.add('subscribe:$c');
+    subscribers[c] = cb;
+  }
   @override
   Future<void> setTransportPriority(bool prioritized) async {}
   @override
@@ -64,30 +83,28 @@ void main() {
     await logSub.cancel();
   });
 
-  test('records DuplicateBleSubscription when connect runs on an '
-      'already-connected transport', () async {
-    final transport = UnifiedDe1Transport(transport: _Fake(
-      ConnectionState.connected,
-    ));
+  test('no-op reconnect tears down stale link before connect and re-subscribe',
+      () async {
+    final fake = _Fake(ConnectionState.connected);
+    final transport = UnifiedDe1Transport(transport: fake);
 
     await transport.connect();
 
-    final hits =
-        records.where((r) => r.error is DuplicateBleSubscription).toList();
-    expect(hits.length, 1,
-        reason: 'no-op reconnect should record exactly one non-fatal');
-
-    // Privacy: the recorded error is forwarded to Crashlytics unscrubbed, so
-    // it must carry an anonymized id, never the raw device id / MAC.
-    final err = hits.single.error as DuplicateBleSubscription;
-    expect(err.anonymizedDeviceId, startsWith('mac_'));
-    expect(err.toString(), isNot(contains('fake-id')));
+    // disconnect must come before connect, and connect before any subscribe.
+    final disconnectAt = fake.callOrder.indexOf('disconnect');
+    final connectAt = fake.callOrder.indexOf('connect');
+    final firstSubscribeAt = fake.callOrder
+        .indexWhere((e) => e.startsWith('subscribe:'));
+    expect(disconnectAt, greaterThanOrEqualTo(0),
+        reason: 'no-op reconnect should disconnect the stale link first');
+    expect(connectAt, greaterThan(disconnectAt));
+    expect(firstSubscribeAt, greaterThan(connectAt));
   });
 
-  test('does not record on a first connect (transport disconnected)',
-      () async {
+  test('no-op reconnect no longer records DuplicateBleSubscription (handled '
+      'by clean teardown)', () async {
     final transport = UnifiedDe1Transport(transport: _Fake(
-      ConnectionState.disconnected,
+      ConnectionState.connected,
     ));
 
     await transport.connect();
@@ -95,6 +112,59 @@ void main() {
     expect(
       records.any((r) => r.error is DuplicateBleSubscription),
       isFalse,
+      reason: 'the no-op reconnect is now handled by a clean disconnect, so '
+          'the measurement non-fatal should no longer fire',
     );
+  });
+
+  test('first connect (transport disconnected) does not disconnect first',
+      () async {
+    final fake = _Fake(ConnectionState.disconnected);
+    final transport = UnifiedDe1Transport(transport: fake);
+
+    await transport.connect();
+
+    expect(fake.callOrder, isNot(contains('disconnect')),
+        reason: 'a fresh connect must not tear down a link that is not there');
+    expect(fake.callOrder, contains('connect'));
+  });
+
+  test('re-subscribe after reconnect wires a new stateInfo callback that '
+      'drives the state stream', () async {
+    final fake = _Fake(ConnectionState.connected);
+    final transport = UnifiedDe1Transport(transport: fake);
+
+    await transport.connect();
+    final stateInfoUuid = Endpoint.stateInfo.uuid;
+    final firstCb = fake.subscribers[stateInfoUuid];
+    expect(firstCb, isNotNull,
+        reason: '_bleConnect should subscribe stateInfo on connect');
+
+    // Drive a push through the first listener and observe it on `state`.
+    final firstSeen = <ByteData>[];
+    final sub = transport.state.listen(firstSeen.add);
+    firstCb!(Uint8List.fromList([0x05, 0x00, 0x00, 0x00]));
+    await Future<void>.delayed(Duration.zero);
+    expect(firstSeen, isNotEmpty,
+        reason: 'first listener should receive the pushed state frame');
+
+    // Reconnect (no-op reconnect path): _bleConnect re-subscribes stateInfo.
+    await transport.connect();
+    final secondCb = fake.subscribers[stateInfoUuid];
+    expect(secondCb, isNot(same(firstCb)),
+        reason: 're-subscribe must wire a NEW callback');
+
+    // The new callback must still drive the state stream (the transport's
+    // internal wiring is intact after the clean teardown + reconnect).
+    final secondSeen = <ByteData>[];
+    final sub2 = transport.state.listen(secondSeen.add);
+    secondCb!(Uint8List.fromList([0x06, 0x00, 0x00, 0x00]));
+    await Future<void>.delayed(Duration.zero);
+    expect(secondSeen, isNotEmpty,
+        reason: 'new listener must drive the state stream on a post-reconnect '
+            'push');
+
+    await sub.cancel();
+    await sub2.cancel();
   });
 }

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -20,6 +20,12 @@ class _FakeBlePlatform extends UniversalBlePlatform {
   int getConnectionStateCalls = 0;
   final List<String> disconnectCalls = [];
 
+  /// When true, the second `setNotifiable` call (per device+characteristic)
+  /// throws a [UniversalBleException] — used to prove `subscribe()`
+  /// surfaces the error instead of swallowing it.
+  bool throwOnSecondSetNotifiable = false;
+  final Map<String, int> _setNotifiableCounts = {};
+
   @override
   Future<AvailabilityState> getBluetoothAvailabilityState() async =>
       AvailabilityState.poweredOn;
@@ -70,7 +76,17 @@ class _FakeBlePlatform extends UniversalBlePlatform {
     String service,
     String characteristic,
     BleInputProperty bleInputProperty,
-  ) async {}
+  ) async {
+    final key = '$deviceId/$characteristic';
+    final count = (_setNotifiableCounts[key] ?? 0) + 1;
+    _setNotifiableCounts[key] = count;
+    if (throwOnSecondSetNotifiable && count == 2) {
+      throw UniversalBleException(
+        code: UniversalBleErrorCode.failed,
+        message: 'simulated CCCD write failure',
+      );
+    }
+  }
 
   @override
   Future<Uint8List> readValue(
@@ -313,6 +329,109 @@ void main() {
       expect(platform.getConnectionStateCalls, 1,
           reason: 'adverts arrive ~1/s during a scan; one probe per '
               'throttle window is enough');
+    });
+  });
+
+  // Characterization tests for the universal_ble shared broadcast
+  // controller (the `_valueStreamController` with `onCancel: close`). The
+  // 2026-07-07 field incident showed A00E push notifications dying while
+  // A005 solicited reads kept working. These tests prove the Dart-side
+  // broadcast controller does NOT silently drop pushes on a no-op
+  // reconnect — so the silent A00E-only death is a native-layer behavior
+  // (CCCD write succeeds locally but is lost on the zombie GATT link),
+  // confirmable only on real Android hardware. They pin that boundary so
+  // a future regression in the Dart layer is caught.
+  group('re-subscribe push channel (universal_ble broadcast controller)',
+      () {
+    const service = '0000a000-0000-1000-8000-00805f9b34fb';
+    // The six DE1 characteristics _bleConnect re-subscribes on reconnect.
+    const chars = [
+      '0000a00e-0000-1000-8000-00805f9b34fb', // stateInfo (A00E)
+      '0000a005-0000-1000-8000-00805f9b34fb', // readFromMMR (A005)
+      '0000a00b-0000-1000-8000-00805f9b34fb', // shotSettings (A00B)
+      '0000a00d-0000-1000-8000-00805f9b34fb', // shotSample (A00D)
+      '0000a011-0000-1000-8000-00805f9b34fb', // waterLevels (A011)
+      '0000a009-0000-1000-8000-00805f9b34fb', // fwMapRequest (A009)
+    ];
+
+    void push(String char, int byte) =>
+        platform.updateCharacteristicValue(
+          deviceId,
+          char,
+          Uint8List.fromList([byte]),
+          null,
+        );
+
+    test('single-char re-subscribe: new callback fires, old does not', () async {
+      final oldReceived = <int>[];
+      await transport.subscribe(service, chars[0], (d) => oldReceived.add(d[0]));
+      push(chars[0], 1);
+      await pump();
+      expect(oldReceived, [1]);
+
+      // No-op reconnect path: cancel old, listen new.
+      final newReceived = <int>[];
+      await transport.subscribe(service, chars[0], (d) => newReceived.add(d[0]));
+      push(chars[0], 2);
+      await pump();
+
+      expect(newReceived, [2],
+          reason: 'the re-subscribed callback must receive the push');
+      expect(oldReceived, [1],
+          reason: 'the cancelled callback must NOT receive the push');
+    });
+
+    test(
+        'sequential 6-char re-subscribe: all new callbacks fire (≥5 listeners '
+        'always remain, so onCancel:close never fires mid-sequence)', () async {
+      final oldReceived = <int, List<int>>{};
+      final newReceived = <int, List<int>>{};
+      for (var i = 0; i < chars.length; i++) {
+        oldReceived[i] = [];
+        newReceived[i] = [];
+        await transport.subscribe(service, chars[i], (d) => oldReceived[i]!.add(d[0]));
+      }
+      // Initial pushes land on the old callbacks.
+      for (var i = 0; i < chars.length; i++) {
+        push(chars[i], i + 1);
+      }
+      await pump();
+      for (var i = 0; i < chars.length; i++) {
+        expect(oldReceived[i], [i + 1]);
+      }
+
+      // Re-subscribe all six sequentially — the shared broadcast controller
+      // always has ≥5 listeners during each swap, so onCancel:close never
+      // fires mid-sequence.
+      for (var i = 0; i < chars.length; i++) {
+        await transport.subscribe(service, chars[i], (d) => newReceived[i]!.add(d[0]));
+      }
+      for (var i = 0; i < chars.length; i++) {
+        push(chars[i], (i + 1) * 10);
+      }
+      await pump();
+
+      for (var i = 0; i < chars.length; i++) {
+        expect(newReceived[i], [(i + 1) * 10],
+            reason: 'new callback for ${chars[i]} must receive the push');
+        expect(oldReceived[i], [i + 1],
+            reason: 'old callback for ${chars[i]} must NOT receive the push');
+      }
+    });
+
+    test('setNotifiable throwing on 2nd call surfaces the error, not silent',
+        () async {
+      platform.throwOnSecondSetNotifiable = true;
+
+      // First subscribe succeeds (first setNotifiable).
+      await transport.subscribe(service, chars[0], (_) {});
+
+      // Second subscribe (second setNotifiable for the same char) must
+      // throw — not swallow — so the caller learns the CCCD write failed.
+      await expectLater(
+        transport.subscribe(service, chars[0], (_) {}),
+        throwsA(isA<UniversalBleException>()),
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

- **Problem:** On 2026-07-07 a DE1 was reported connected but stopped updating snapshot values for ~12 min. The machine idle→sleep triggered an app-level disconnect that nulled `De1Controller._de1`, but the underlying `UniversalBleTransport` native GATT link lingered (zombie). On wake, `EarlyConnectWatcher` fired a no-op reconnect that re-subscribed all 6 DE1 characteristics against the zombie link; `stateInfo` (A00E) push notifications then died while solicited MMR reads (A005) kept working. The existing zombie watchdog missed it — its detectors (GATT-op timeouts, own-advert probes) assume dead-link = all-ops-fail, not "live link + dead push."
- **Why it matters:** App froze "connected, no snapshot updates" until manual restart; no error surfaced.
- **What changed:**
  - `UnifiedDe1Transport.connect()` now tears down the stale link first (`_transport.disconnect()` before `connect()`+`_bleConnect()`) when already connected, converting the no-op reconnect into a clean reconnect. `DuplicateBleSubscription` warning downgraded to info.
  - `ConnectionManager` gains a 10s snapshot-staleness watchdog that re-arms on watch setup (initial grace) and every snapshot frame (incl. deduped), and forces a clean `disconnectMachine()`+`connect()` if the push channel goes silent while the link still reports connected. Generation-token + cancellable Timer idiom; deliberate disconnects cancel it.
- **What did NOT change (scope boundary):** No `universal_ble` fork changes (repro tests ruled out the Dart broadcast controller as the silent-drop cause; the A00E death is native-layer). No `EarlyConnectWatcher` transport guard. No De1StateManager lifecycle coupling. No API/REST/WS surface changes.

## Change Type
- [x] Bug fix

## Scope
- [x] BLE transport / device comms
- [x] Machine state / shot logic

## Root Cause
- **Root cause:** A no-op reconnect re-subscribed DE1 characteristics against a lingering native GATT link. On Android, the CCCD re-write left `stateInfo` push dead while solicited reads survived.
- **Missing detection or guardrail:** No watchdog for "link reports connected but pushes stopped." The zombie watchdog's op-timeout detector was starved by successful solicited reads; the advert probe only fires during scans.
- **Contributing context:** App-level sleep disconnect nulled `_de1` without tearing down the native GATT link.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file:
  - `test/unit/models/unified_de1_transport_resubscribe_test.dart` — Fix #2: disconnect-before-connect ordering, no `DuplicateBleSubscription`, fresh connect doesn't disconnect, re-subscribe wires a new driving callback.
  - `test/controllers/connection_manager_test.dart` (`snapshot staleness watchdog`) — Fix #1: fires after 10s, deduped frame re-arms, deliberate disconnect cancels, initial grace, stale generation bails.
  - `test/universal_ble_transport_recovery_test.dart` (`re-subscribe push channel`) — characterization: rules out the Dart broadcast controller as the silent-drop cause.

## Documentation Obligations
- [x] N/A — no docs affected (internal transport/connection-manager logic only; no API/WS/plugin/skin/profile/device-flow surface changes).

## Security Impact
- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `Yes` — reconnect teardown ordering only; no new endpoints, no new permissions. Mitigation: clean disconnect-before-reconnect is race-safe (verified: no De1Controller listener during teardown, supervisor listens to the de1 stream not the transport, subscribe() cancel is idempotent).
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`

## User-Visible Changes
- None. A stuck "connected but no updates" state now self-recovers within ~10s via a clean reconnect instead of requiring an app restart.

## Verification
### Local gates
- [x] `flutter analyze` — clean
- [x] `flutter test` — 1960 pass

### Manual verification
- OS / platform tested: Android (m50mini tablet, build `d1b34bdc` on `fix/de1-state-push-zombie`)
- Simulated devices? `No`
- Real hardware? `Yes` — DE1 `D9:11:0B:E6:9F:86` connected + sleeping.
- What you personally verified: forced `PUT /api/v1/devices/connect` on the connected DE1 — no regression, snapshots kept flowing, no spurious error, no false watchdog fire during sleep (0 `Snapshot stream stale`).
- What you did **not** verify: Fix #2's transport disconnect-before-reconnect path could not be exercised via REST — `De1Controller.connectToDe1` short-circuits on same-instance (`de1Interface == _de1`) before reaching `UnifiedDe1Transport.connect()`, and the zombie precondition (`_de1` null + transport connected) is a native-link race not deliberately triggerable. Fix #2's ordering + re-subscribe behavior is pinned by the 4 unit tests. Fix #1's forced-reconnect-on-dead-push couldn't be induced on hardware (no false fires confirmed during sleep/idle).

### Evidence
- [x] Test output — `flutter test`: 1960 pass; `flutter analyze`: clean.
- [x] Log snippets — pre-fix logs show repeated `re-running BLE setup on already-connected transport (no-op reconnect)` WARNING (19:35–19:48); post-fix forced connect produced no freeze and no `Snapshot stream stale`.

## Compatibility & Migration
- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`

## Risks & Mitigations
- **Risk:** Staleness watchdog false-fires during a legitimately long silent period (e.g. very slow idle frame cadence), forcing an unnecessary reconnect.
  - Mitigation: 10s threshold is ~2–3× DE1 idle frame cadence; false-trigger cost is one clean reconnect, no data loss. Deduped frames re-arm (a duplicate frame proves the channel alive), so a steady non-transitioning state won't false-trigger. Deliberate disconnects cancel the watchdog. Tunable via `snapshotStalenessTimeout`.
- **Risk:** Disconnect-before-reconnect introduces a transient `disconnected` that surfaces an error banner.
  - Mitigation: Verified race-safe — during teardown `De1Controller` has no active `connectionState` listener; `disconnectMachine` marks the disconnect expected (suppresses banner); `subscribe()`'s `remove(key)?.cancel()` is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
