### PR TITLE
Add Insight skin to bundled remote skin sources

### DIFF
--- a/skin_sources.json
+++ b/skin_sources.json
@@ -22,5 +22,9 @@
   {
     "type": "github_release",
     "repo": "Sabotage1/WorkFlow-Skin"
+  },
+  {
+    "type": "github_release",
+    "repo": "decentespresso/insight-js"
   }
 ]


### PR DESCRIPTION
Adds **Insight** (`decentespresso/insight-js`) to `skin_sources.json` as a `github_release` source, so decent.app auto-downloads it on startup alongside the other bundled skins.

### About the skin
Insight is a browser-native (vanilla ES modules + importmap, **no build step**) port of the classic de1app **Insight** skin, running entirely against the reaprime REST/WebSocket API. It covers the four brew modes, the profile selector + pressure/flow/advanced editors, DYE, and the machine/app/calibrate settings pages — image-backed on the original Insight/default-skin 2560×1600 assets.

- Repo: https://github.com/decentespresso/insight-js (public, GPL-3.0)
- Release: [`v0.1.0`](https://github.com/decentespresso/insight-js/releases/tag/v0.1.0)
- Asset: `insight-v0.1.0.zip` — `manifest.json` (`id: "insight"`) + `index.html` at the archive root, per `doc/Skins.md`.

### Change
```diff
   {
     "type": "github_release",
     "repo": "Sabotage1/WorkFlow-Skin"
-  }
+  },
+  {
+    "type": "github_release",
+    "repo": "decentespresso/insight-js"
+  }
 ]
```

No `asset` field is set, so it resolves to the single `.zip` asset of the latest release (matching the existing entries). Verified the release archive has `index.html` + `manifest.json` at its root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)