### PR TITLE
flip kalmanFlow to default ON (Phase 2 — validation gate passed)

### DIFF
--- a/lib/src/settings/advanced_page.dart
+++ b/lib/src/settings/advanced_page.dart
@@ -132,9 +132,9 @@ class AdvancedPage extends StatelessWidget {
                   horizontal: 16,
                 ),
                 child: Text(
-                  'Replaces the flow calculator with a Kalman filter for '
-                  'smoother, signed flow estimates. Experimental — may '
-                  'slightly shift stop timing on declining-flow profiles.',
+                  'Uses a Kalman filter for smoother, signed flow estimates '
+                  'with disturbance rejection. Enabled by default. Disable if '
+                  'you prefer the legacy endpoint-difference flow calculator.',
                   style: Theme.of(context).textTheme.bodySmall,
                 ),
               ),

--- a/lib/src/settings/feature_flags.dart
+++ b/lib/src/settings/feature_flags.dart
@@ -15,7 +15,8 @@ enum FeatureFlag {
   /// ([KalmanFlowEstimator]) that provides signed, low-lag flow estimates
   /// with disturbance rejection (issue #417).
   ///
-  /// Default: **false** (opt-in — validation window for stop-timing risk).
+  /// Default: **true** (opt-out — 10-shot validation gate passed;
+  /// mean |Δyield| 0.44g ≤ 1g baseline, flow noise 8–13% vs 14.7% old).
   kalmanFlow,
 }
 
@@ -23,5 +24,5 @@ enum FeatureFlag {
 /// flags that ship as experimental default to false.
 const Map<FeatureFlag, bool> defaultFeatureFlagValues = {
   FeatureFlag.stepExitArbiter: true,
-  FeatureFlag.kalmanFlow: false,
+  FeatureFlag.kalmanFlow: true,
 };


### PR DESCRIPTION
## Summary

Flips the `kalmanFlow` feature flag from default OFF (Phase 1 opt-in) to default ON (Phase 2 opt-out) after the 10-shot acceptance gate passed.

## Acceptance gate results

| Criteria | Result |
|----------|--------|
| (a) Mean \|actual − target yield\| | **0.44g** (excluding one fluke outlier) ≤ 1g baseline |
| (b) Flow-trace noise | **8–13% stdev/mean** vs old estimator 14.7% (29–46% reduction) |
| (c) Negative flow on cup-lift | Confirmed in unit tests; removal branch live |

10 SAW shots across 3 days, varying flow rates (2–8 g/s), two different profiles.

Users can still disable in Advanced Settings → Kalman Flow Estimator.

## Related

- Closes #417
- #420 (SAW lead decomposition, deferred)