### PR TITLE
fix(android): call super.onCreate() before early-return guards (Crashlytics bef7d3cd)

### DIFF
--- a/android/app/src/main/kotlin/net/tadel/reaprime/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/tadel/reaprime/MainActivity.kt
@@ -32,6 +32,12 @@ class MainActivity: FlutterFragmentActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // super.onCreate() MUST be called before any early return (incl. finish()).
+        // ActivityThread.performLaunchActivity throws SuperNotCalledException if
+        // onCreate() returns without the superclass having run — the early-return
+        // guards below would otherwise crash the app on launch.
+        super.onCreate(savedInstanceState)
+
         // FIRST: Check for cloned environment (Parallel Space, Island, etc.)
         if (isRunningInClonedEnvironment()) {
             Log.w(TAG, "App running in cloned environment - not supported")
@@ -61,7 +67,6 @@ class MainActivity: FlutterFragmentActivity() {
         }
         
         Log.d(TAG, "onCreate - valid instance starting")
-        super.onCreate(savedInstanceState)
     }
 
     override fun onNewIntent(intent: Intent) {


### PR DESCRIPTION
## Summary

- **Problem:** `MainActivity.onCreate()` had two early-return paths (cloned-environment check, duplicate-launcher check) that called `finish()` + `return` before `super.onCreate(savedInstanceState)`. `ActivityThread.performLaunchActivity` throws `SuperNotCalledException` when `onCreate()` returns without the superclass having run — so these guards crashed the app on launch instead of finishing cleanly.
- **Why it matters:** Crashlytics `bef7d3cd` — FATAL, 16 ev / 4 users, `SIGNAL_FRESH` on v0.7.9→v0.7.11. Launch crash affecting multiple users.
- **What changed:** Moved `super.onCreate(savedInstanceState)` to the top of `onCreate()`; the early-return guards now `finish()` cleanly afterward. Guard logic (`isTaskRoot`, `intent`, `filesDir`) is unchanged — all are valid before `super.onCreate()`.
- **What did NOT change:** The clone-detection heuristic itself. `isRunningInClonedEnvironment()` still false-positives on multi-user / work-profile devices (user id ≠ 0) — likely why this latent-since-January bug surfaced as FRESH. Tracked as a follow-up TODO, not fixed here.

## Change Type
- [x] Bug fix

## Scope
- [x] UI / Flutter widgets (Android host activity)

## Linked Issues
- Related: Crashlytics `bef7d3cd` (Android launch crash)

## Root Cause
- **Root cause:** `finish()` before `super.onCreate()` does not skip `ActivityThread.performLaunchActivity`'s `mCalled` check — the framework requires `super.onCreate()` unconditionally. Both early-return guards violated that.
- **Missing detection:** No Android-side test harness exercises the launch path under clone/duplicate-launcher triggers.
- **Contributing context:** The clone heuristic flags any `filesDir` not under `/data/user/0/<pkg>`, a false positive on legitimate multi-user profiles.

## Regression Test Plan
- Coverage level that should have caught this: End-to-end (Android launch under clone/multi-user trigger) — none exists.
- If no new test added, why not: The crash fires only under device-specific triggers (clone apps, work profiles, duplicate-launcher relaunch) that no JVM test harness reproduces; it requires an instrumented Android device/emulator with multi-user setup. Confirmation is the Crashlytics cluster plateauing post-release (playbook sb-006 re-check window).

## Documentation Obligations
- [x] N/A — no docs affected

## Security Impact
- New/changed REST endpoints? No
- New/changed WebSocket topics? No
- New/changed network calls? No
- BLE/USB surface changed? No
- File system access changed? No
- Plugin sandbox boundary changed? No

## User-Visible Changes
None. Launch path only; the two guards now finish instead of crashing.

## Verification
### Local gates
- [x] `flutter analyze` — clean (no new warnings; 403 pre-existing issues are all in vendored `build/macos/SourcePackages/`)
- [x] `(cd android && ./gradlew :app:compileDebugKotlin)` — BUILD SUCCESSFUL, no warnings in `MainActivity.kt`
- [ ] `flutter test` — not run (no Dart changes)

### Manual verification
- OS/platform tested: Android (compile only)
- Real hardware: No — crash trigger (clone/work-profile/duplicate-launcher) not reproducible on a normal tablet
- What was verified: Kotlin compiles; `super.onCreate()` is now the first statement in `onCreate()`.
- What was NOT verified: on-device launch under a clone/multi-user trigger. Watch `bef7d3cd` cluster post-release.

### Evidence
- [x] `./gradlew :app:compileDebugKotlin` → `BUILD SUCCESSFUL in 45s`

## Compatibility & Migration
- Backward compatible? Yes
- Config/env changes needed? No
- Database migration needed? No

## Risks & Mitigations
- Risk: Calling `super.onCreate()` before the guards does some Flutter setup before a `finish()` on clone/duplicate paths.
  - Mitigation: Harmless — standard Android pattern; setup is torn down with the Activity on `finish()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)