### PR TITLE
fix: downgrade skin-overwrite log from WARNING to INFO

### DIFF
--- a/lib/src/webui_support/webui_storage.dart
+++ b/lib/src/webui_support/webui_storage.dart
@@ -1195,7 +1195,7 @@ class WebUIStorage {
       return skinId;
     }
     if (destDir.existsSync()) {
-      _log.warning('Skin already exists: $skinId, overwriting...');
+      _log.info('Skin already exists: $skinId, overwriting...');
       await destDir.delete(recursive: true);
     }
 


### PR DESCRIPTION
## What

Downgrade `_log.warning` → `_log.info` in `WebUIStorage._installFromDirectory` for the "Skin already exists, overwriting…" message.

## Why

This WARNING-level log enters the log buffer (captured at ≥WARNING in `main.dart`) and pollutes every real crash report's context via `setCustomKey('log_buffer', …)`, showing up as Crashlytics `bb1c4163` (69 events/7d, NON_FATAL noise).

The SEVERE forwarder floor (PR #288) already drops WARNING from being forwarded as individual crash reports, but the message still appears in crash context. Downgrading to INFO removes it from the buffer entirely.

## Verification

- `flutter test test/services/telemetry/` — 23/23 pass
- `flutter analyze lib/src/webui_support/webui_storage.dart` — clean

## Related

- Crashlytics: [`bb1c4163`](https://console.firebase.google.com/project/rea-1-556fd/crashlytics/app/ios:net.tadel.reaprime/issues/bb1c4163c5e28a57e0af7b396621acf8)