### PR TITLE
chore: bump universal_ble fork to v2.2.0

### DIFF
--- a/lib/src/controllers/connection/scan_orchestrator.dart
+++ b/lib/src/controllers/connection/scan_orchestrator.dart
@@ -126,6 +126,7 @@ class ScanOrchestrator {
       return null;
     }
     earlyConnect.stop();
+    reportBuilder.recordScanDuration(scanResult.duration);
 
     // Sticky-error environmental recovery: reaching a completed scan
     // means permission and scan subsystems are working again. Clear

--- a/lib/src/controllers/connection/scan_report_builder.dart
+++ b/lib/src/controllers/connection/scan_report_builder.dart
@@ -40,6 +40,12 @@ class MatchedDeviceTracker {
 /// (roadmap item 15 — god-class split).
 class ScanReportBuilder {
   final DateTime scanStartTime;
+
+  /// Actual scan window as measured by the scanner. Without it, `build()`
+  /// falls back to wall time since [scanStartTime] — which inflates the
+  /// reported duration by however long the post-scan connect/policy phase
+  /// took (a 15s scan read as 35s when two 10s connects followed it).
+  Duration? _measuredScanDuration;
   final Map<String, MatchedDeviceTracker> _trackers = {};
 
   /// Adapter state captured at scan start. Set by the orchestrator
@@ -54,6 +60,11 @@ class ScanReportBuilder {
   /// around the whole scan+connect window (comms-harden #27).
   void recordAdapterStateAtStart(AdapterState state) {
     _adapterStateAtStart = state;
+  }
+
+  /// Record the scanner-measured scan window (see [_measuredScanDuration]).
+  void recordScanDuration(Duration duration) {
+    _measuredScanDuration = duration;
   }
 
   /// Ensure a tracker exists for [d]. Does not clobber an existing
@@ -96,7 +107,8 @@ class ScanReportBuilder {
     return ScanReport(
       totalBleDevicesSeen: matchedDevices.length,
       matchedDevices: matchedDevices,
-      scanDuration: DateTime.now().difference(scanStartTime),
+      scanDuration:
+          _measuredScanDuration ?? DateTime.now().difference(scanStartTime),
       adapterStateAtStart: _adapterStateAtStart,
       adapterStateAtEnd: adapterStateAtEnd,
       scanTerminationReason: terminationReason,

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -1078,17 +1078,19 @@ class ConnectionManager {
     }
   }
 
-  Future<void> connectScale(Scale scale) async {
+  /// Returns the attempt outcome so tracked callers can report it —
+  /// failures are handled here (status emit) and NOT rethrown.
+  Future<ConnectionResult> connectScale(Scale scale) async {
     if (_scaleReconnectBlockedByPowerMode) {
       _log.fine(
         'connectScale: blocked while machine is sleeping and scale power '
         'mode is disconnect',
       );
-      return;
+      return const ConnectionResult.skipped();
     }
     if (_isConnectingScale) {
       _log.fine('connectScale: already connecting, skipping');
-      return;
+      return const ConnectionResult.skipped();
     }
     _isConnectingScale = true;
     _log.fine('connectScale: connecting to ${scale.name} (${scale.deviceId})');
@@ -1114,7 +1116,7 @@ class ConnectionManager {
           ),
         );
         await scale.disconnect();
-        return;
+        return const ConnectionResult.succeeded();
       }
       await settingsController.setPreferredScaleId(scale.deviceId);
       // `_latestScaleState` is populated by the scaleController
@@ -1123,6 +1125,7 @@ class ConnectionManager {
       if (_machineConnected) {
         _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.ready));
       }
+      return const ConnectionResult.succeeded();
     } catch (e) {
       // Scale failure is non-blocking — stay at ready if machine connected, else idle.
       _publishStatus(
@@ -1151,6 +1154,7 @@ class ConnectionManager {
                 'toggle Bluetooth off and on.',
         exception: e,
       ));
+      return ConnectionResult.failed(e.toString());
     } finally {
       _isConnectingScale = false;
     }
@@ -1255,18 +1259,11 @@ class ConnectionManager {
     ScanReportBuilder scanReport,
   ) async {
     scanReport.markAttempted(scale.deviceId);
-    try {
-      await connectScale(scale);
-      scanReport.recordResult(
-        scale.deviceId,
-        const ConnectionResult.succeeded(),
-      );
-    } catch (e) {
-      scanReport.recordResult(
-        scale.deviceId,
-        ConnectionResult.failed(e.toString()),
-      );
-    }
+    // connectScale handles its own failures (status emit) and reports the
+    // outcome instead of throwing — record what actually happened rather
+    // than assuming success (a swallowed failure used to log "— connected").
+    final result = await connectScale(scale);
+    scanReport.recordResult(scale.deviceId, result);
   }
 
   /// Build a [ScanReport] from [scanReport] and publish it on the

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -71,6 +71,11 @@ class UniversalBleTransport implements BLETransport {
   static const Duration _androidPostConnectDelay =
       Duration(milliseconds: 200);
 
+  // Brief pause between stopScan and connectGatt so the scanner actually
+  // releases the radio before the connection attempt starts.
+  static const Duration _androidPreConnectSettleDelay =
+      Duration(milliseconds: 300);
+
   @override
   Future<void> connect() async {
     _linkDeadDeclared = false;
@@ -96,10 +101,27 @@ class UniversalBleTransport implements BLETransport {
       _startAdvertWatch();
       return;
     }
+    // Android: stop any active scan before connecting — connectGatt gets
+    // starved by a lowLatency scan's radio duty cycle (same problem class
+    // as the BlueZ le-connection-abort-by-local mitigation above; observed
+    // 2026-07-15 as repeated 10s connect timeouts to an advertising scale
+    // mid-scan). The ConnectionManager retry loop restarts scanning.
+    if (Platform.isAndroid) {
+      try {
+        await UniversalBle.stopScan();
+      } catch (e) {
+        _log.fine("stopScan before connect failed (ignored): $e");
+      }
+      await Future.delayed(_androidPreConnectSettleDelay);
+    }
     try {
+      // 20s: connectGatt on a busy radio (live DE1 link, recent scan) can
+      // legitimately need more than 10s — fbp defaults to 35s. Must stay
+      // comfortably under ConnectionManager's 30s end-to-end guard so the
+      // richer transport-level error wins over the generic outer timeout.
       await UniversalBle.connect(
         _device.deviceId,
-        timeout: Duration(seconds: 10),
+        timeout: Duration(seconds: 20),
       );
     } on UniversalBleException catch (e) {
       throw mapUniversalConnectError(e);

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -61,9 +61,24 @@ class UniversalBleTransport implements BLETransport {
 
   bool get _isLinux => Platform.isLinux;
 
-  UniversalBleTransport({required BleDevice device}) : _device = device {
+  UniversalBleTransport({
+    required BleDevice device,
+    Future<void> Function()? stopScan,
+  })  : _device = device,
+        _stopScan = stopScan {
     _log = Logger("BLETransport-${device.deviceId}");
   }
+
+  /// Scan-stop hook injected by the discovery service. Routing the
+  /// pre-connect stop through the service ends its scan-duration wait too,
+  /// so the scan cycle (and its report) reflects the actual scan window
+  /// instead of dead-waiting out the full duration after the native scan
+  /// is already stopped. Falls back to a direct platform stop for
+  /// transports constructed without a service.
+  final Future<void> Function()? _stopScan;
+
+  Future<void> _stopScanViaOwner() =>
+      _stopScan?.call() ?? UniversalBle.stopScan();
 
   // Android post-connect settle duration. The Android BLE stack needs
   // a brief period after connectGatt reports success before service
@@ -108,7 +123,8 @@ class UniversalBleTransport implements BLETransport {
     // mid-scan). The ConnectionManager retry loop restarts scanning.
     if (Platform.isAndroid) {
       try {
-        await UniversalBle.stopScan();
+        _log.fine("stopping scan before connect");
+        await _stopScanViaOwner();
       } catch (e) {
         _log.fine("stopScan before connect failed (ignored): $e");
       }
@@ -181,7 +197,7 @@ class UniversalBleTransport implements BLETransport {
 
   Future<void> _stopScanAndSettle() async {
     try {
-      await UniversalBle.stopScan();
+      await _stopScanViaOwner();
     } catch (e) {
       _log.fine("stopScan before BlueZ connect failed (ignored): $e");
     }

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -103,6 +103,16 @@ class UniversalBleDiscoveryService extends BleDiscoveryService {
     UniversalBle.stopScan();
   }
 
+  /// Transport pre-connect hook: stop the native scan AND end the
+  /// scan-duration wait, so a connect started mid-scan closes the scan
+  /// cycle instead of leaving it dead-waiting (native scan already
+  /// stopped, no results flowing) — scan reports then show the real
+  /// scan window.
+  Future<void> _stopScanForConnect() async {
+    _cancelScanDurationWait();
+    await UniversalBle.stopScan();
+  }
+
   /// Cancel the scheduled 15s stopScan and unblock the awaiter in
   /// scanForDevices so it can proceed to cleanup / free `_isScanning`.
   void _cancelScanDurationWait() {
@@ -224,7 +234,10 @@ class UniversalBleDiscoveryService extends BleDiscoveryService {
       if (_devices.containsKey(device.deviceId.toString())) return;
 
       final matchedDevice = await DeviceMatcher.match(
-        transport: UniversalBleTransport(device: device),
+        transport: UniversalBleTransport(
+          device: device,
+          stopScan: _stopScanForConnect,
+        ),
         advertisedName: name,
       );
 
@@ -268,7 +281,10 @@ class UniversalBleDiscoveryService extends BleDiscoveryService {
       bleDevice = BleDevice(deviceId: deviceId, name: remembered.name);
     }
 
-    final transport = UniversalBleTransport(device: bleDevice);
+    final transport = UniversalBleTransport(
+      device: bleDevice,
+      stopScan: _stopScanForConnect,
+    );
     final device = DeviceFactory.createBle(impl, transport);
     if (device == null) {
       log.warning('Quick-connect: DeviceFactory returned null for $impl');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1690,11 +1690,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: d32c569
-      resolved-ref: d32c5697ceaa3ace74813ac3644962ec91572e75
+      ref: "2.2.0"
+      resolved-ref: "734012dd4e880e20b7b3d3a97a5c2dc92e631e10"
       url: "https://github.com/tadelv/universal_ble.git"
     source: git
-    version: "2.1.2"
+    version: "2.2.0"
   universal_image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   universal_ble:
     git:
       url: https://github.com/tadelv/universal_ble.git
-      ref: d32c569
+      ref: 2.2.0
   shared_preferences: ^2.5.3
   # share_plus HELD at 12.x — 13.x requires win32 ^6, which conflicts with
   # file_picker 11's win32 ^5.9 pin. 13.x is only SDK-floor bumps, no API gain.

--- a/test/controllers/connection/scan_report_builder_test.dart
+++ b/test/controllers/connection/scan_report_builder_test.dart
@@ -36,4 +36,38 @@ void main() {
       },
     );
   });
+
+  group('ScanReportBuilder scan duration', () {
+    test('build() prefers the scanner-measured duration over wall time', () {
+      // Start time far in the past — the wall-time fallback would report
+      // a huge duration; the recorded measurement must win.
+      final builder = ScanReportBuilder(
+        scanStartTime: DateTime.now().subtract(const Duration(minutes: 5)),
+      )..recordScanDuration(const Duration(seconds: 15));
+
+      final report = builder.build(
+        preferredMachineId: null,
+        preferredScaleId: null,
+        terminationReason: ScanTerminationReason.completed,
+        adapterStateAtEnd: AdapterState.poweredOn,
+      );
+
+      expect(report.scanDuration, const Duration(seconds: 15));
+    });
+
+    test('build() falls back to wall time since scanStartTime', () {
+      final builder = ScanReportBuilder(
+        scanStartTime: DateTime.now().subtract(const Duration(seconds: 30)),
+      );
+
+      final report = builder.build(
+        preferredMachineId: null,
+        preferredScaleId: null,
+        terminationReason: ScanTerminationReason.completed,
+        adapterStateAtEnd: AdapterState.poweredOn,
+      );
+
+      expect(report.scanDuration.inSeconds, greaterThanOrEqualTo(30));
+    });
+  });
 }

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -1164,6 +1164,19 @@ void main() {
         expect(connectionManager.currentStatus.error, isNotNull);
       });
 
+      test('reports the real outcome so scan reports cannot claim success',
+          () async {
+        final okResult =
+            await connectionManager.connectScale(TestScale(deviceId: 'ok'));
+        expect(okResult.success, isTrue);
+
+        mockScaleController.shouldFailConnect = true;
+        final failResult = await connectionManager
+            .connectScale(TestScale(deviceId: 'fail-scale'));
+        expect(failResult.success, isFalse);
+        expect(failResult.error, isNotNull);
+      });
+
       test('emits scaleConnectFailed when the scale controller throws',
           () async {
         mockScaleController.shouldFailConnect = true;

--- a/test/helpers/mock_connection_manager.dart
+++ b/test/helpers/mock_connection_manager.dart
@@ -84,7 +84,8 @@ class MockConnectionManager extends ConnectionManager {
   Future<void> connectMachine(De1Interface machine) async {}
 
   @override
-  Future<void> connectScale(device_scale.Scale scale) async {}
+  Future<ConnectionResult> connectScale(device_scale.Scale scale) async =>
+      const ConnectionResult.succeeded();
 
   @override
   Future<void> dispose() async {


### PR DESCRIPTION
## What
- Bump `universal_ble` git pin from `d32c569` to tag `2.2.0` (commit `734012d`) on the `tadelv/universal_ble` fork.
- Scale-connect fixes from the 2026-07-15 two-device smoke test:
  - `connectScale` reports the real outcome — scan reports no longer print "— connected" for failed attempts.
  - Android: stop any active scan (+300ms settle) before `connectGatt` — mid-scan connects were starved by the lowLatency scan.
  - Transport BLE connect timeout 10s → 20s (under the 30s end-to-end guard).

## Why
Fork v2.2.0 ships the July 2026 BLE hardening targeting the GATT-133 / multi-device disconnect issues: per-device queue isolation support, queue drain on disconnect, unqueued disconnect, connect-timeout cancellation, native GATT-133 retry removal, 2s connect→disconnect gap, adapter-off GATT cleanup, `scanFailureStream`, and `clearGattCache`. `QueueType.perDevice` was already enabled (ca44ceaf). Smoke test showed the DE1 rock-solid but exposed the three scale-connect issues above (log window 09:10–09:36, m50mini).

🤖 Generated with [Claude Code](https://claude.com/claude-code)