### PR TITLE
feat(ble): persistent background scale watch replaces backoff-burst scale reconnect

### DIFF
--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -328,13 +328,67 @@ ConnectionManager listens for disconnects automatically:
 An *unexpected* machine disconnect (not announced via
 `markExpectingDisconnect` / `disconnectMachine`) puts `ConnectionManager`
 into machine recovery mode: full `connect()` scans retry with the same
-5s→60s exponential backoff the preferred-scale loop uses, rescheduling
+5s→60s exponential backoff the legacy preferred-scale loop uses, rescheduling
 after every attempt that ends without a machine, until the machine
 reconnects (or the user disconnects deliberately). Gated on
 `preferredMachineId` so a background retry can never pop a machine picker —
 the id is auto-set on every successful connect, so coverage is effectively
 total. Motivation: a power outage previously left the app "disconnected"
 indefinitely because nothing ever rescanned for the machine.
+
+### Background Scale Watch (preferred-scale reacquisition)
+
+When a machine is connected but the preferred scale is missing (scale
+powered off, unexpected drop, machine wake without the scale), scale
+reacquisition runs in one of two modes, selected by
+`DeviceScanner.supportsBackgroundWatch`:
+
+- **Watch mode (Android):** one persistent, low-duty-cycle BLE scan.
+  `UniversalBleDiscoveryService` starts an `AndroidScanMode.balanced`
+  scan (~40% radio duty cycle) — the duty cycle, not filtering, is what
+  protects the DE1 link. The scan is deliberately unfiltered: remembered
+  device names are friendly constants ("Felicita Arc") that rarely equal
+  the advertised name a filter would be matched against, and the
+  universal_ble fork evaluates `withNamePrefix` plugin-side anyway (the
+  OS scan runs unfiltered either way, so there is no hardware-filter or
+  screen-off benefit to reclaim). Matching stays with the normal Dart
+  `DeviceMatcher` path, identical to burst scans. The `ScaleWatch`
+  collaborator (`lib/src/controllers/connection/scale_watch.dart`)
+  listens on the device stream and, on sighting the preferred scale id,
+  stops the watch scan (freeing the radio for GATT) and connects —
+  typically 1–5s after the scale powers on. Caveat: Android suspends
+  OS-unfiltered scans while the screen is off, so a scale powered on
+  with the display asleep connects once the screen wakes.
+- **Legacy mode (all other platforms, and fallback when the watch fails
+  to start):** periodic 15s scale-only burst scans with 5s→60s
+  exponential backoff (the pre-watch behavior, unchanged).
+
+The watch replaced the backoff loop on Android because each lowLatency
+burst monopolizes the shared radio and starves DE1 GATT traffic
+(observed as 10s GATT write timeouts → HTTP 500s on machine endpoints),
+while the backoff gaps meant a freshly powered-on scale could wait up
+to 60s to connect.
+
+Watch lifecycle details:
+
+- Armed whenever *machine connected && preferred scale set && scale not
+  connected && not blocked by scale power mode*; disarmed on scale
+  connect, machine disconnect, power-mode sleep, deliberate scale
+  disconnect, at the start of any full `connect()` (EarlyConnectWatcher
+  owns preferred-device connects during bursts), and on dispose.
+- Never armed while a Bengle is the machine — its integrated scale owns
+  the scale slot, mirroring `_runScalePhase`'s rule.
+- Burst scans pause the watch scan (universal_ble has one global scan
+  session) and resume it when they finish; the watch self-restarts
+  every 25 minutes to dodge Android's 30-minute opportunistic-scan
+  downgrade, and survives adapter off/on cycles.
+- `De1StateManager` skips its post-wake scale-only burst when the watch
+  covers reacquisition (watch supported + preferred scale set); the
+  burst remains for the no-preferred-scale discovery/picker case.
+- Watch-driven connects do **not** emit a `ScanReport` — they bypass
+  the scan/report machinery entirely.
+- The watch does not flip `scanningStream`, so no scanning indicator
+  shows in the UI while it runs.
 
 ### Zombie-Link Detection (BLE transport)
 

--- a/doc/plans/archive/background-scale-watch/background-scale-watch.md
+++ b/doc/plans/archive/background-scale-watch/background-scale-watch.md
@@ -1,0 +1,92 @@
+# Persistent Background Scale Watch
+
+**Branch:** `feature/background-scale-watch` (created). **Completion:** local commit, no push/PR.
+
+## Context
+
+When the machine is connected and the preferred scale is offline, `ConnectionManager` today runs periodic 15s BLE scan bursts in `AndroidScanMode.lowLatency` with exponential backoff (5s→60s cap, [connection_manager.dart:154](lib/src/controllers/connection_manager.dart)). Two consequences:
+
+- A scale powered on during a backoff gap waits up to **60s + scan time** to connect.
+- Each `lowLatency` burst monopolizes the Android radio and **starves DE1 GATT traffic** — observed as a 10s GATT write timeout on the MMR write behind `POST /api/v1/machine/calibration` → HTTP 500 (log from 2026-07-14 19:23).
+
+**Goal:** on Android, replace the backoff-burst loop with **one persistent, low-duty-cycle, OS-filtered scan** ("watch") that runs whenever *machine connected && preferred scale set && scale not connected && not blocked by power mode*. Scale powers on → connected in ~1–5s; DE1 link keeps ≥60% of radio time. Non-Android platforms keep the existing backoff behavior byte-for-byte.
+
+**Key mechanism:** Android scan modes are duty cycles (`balanced` ≈ 2s on / 3s off). The universal_ble fork (git 6a5abe4) supports `ScanFilter.withNamePrefix` (OS/controller-level filtering — survives screen-off, host woken only on match) and `AndroidOptions.scanMode`. The preferred scale's advertised name is recoverable without scanning from `RememberedDevicesController` (persists `{id, name, type}`; getter `remembered` at remembered_devices_controller.dart:40). No MAC-address filter exists in the fork, so name prefix (full remembered name ⇒ exact-ish match) is the filter.
+
+## Established facts (verified)
+
+- Live `UniversalBleDiscoveryService.scanForDevices` **ignores** the domain `ScanFilter` param entirely: hardcoded unfiltered scan (line 160), `lowLatency` (line 172), 15s duration (line 201), cancellable wait machinery at lines 99–125, re-entry guard `_isScanning` (line 27). All device matching is Dart-side via `DeviceMatcher`. Results flow through broadcast `devices` stream → `DeviceController` merge → `deviceStream` (BehaviorSubject; consumers `.skip(1)` the replay).
+- universal_ble has **one global scan session** — watch and burst scans must be arbitrated.
+- Loop being replaced: `_maybeSchedulePreferredScaleReconnect` (665–679), gate `_shouldRetryPreferredScale` (681–686), cancel `_cancelPreferredScaleReconnect` (688–692). Schedule call sites: 240, 527, 546, 568, 697, 800. Cancel call sites: 239, 451, 709, 857, disconnectScale, dispose (1240–1252).
+- `EarlyConnectWatcher` (connection/early_connect_watcher.dart) is the existing connect-on-sight pattern: `deviceStream.skip(1)`, one-shot connect on preferred-id match.
+- `De1StateManager` has a second, independent wake-time burst trigger (de1_state_manager.dart:373–395) that must be reconciled.
+- `Platform.isAndroid` is false under `flutter test` — capability must be **injectable**, not Platform-checked (the existing Platform-gated scaleFilter at connection_manager.dart:478 is dead weight and untested).
+- `UniversalBle.setInstance(UniversalBlePlatform)` exists in the fork (universal_ble.dart:17) → the service-level watch is unit-testable on host with a fake platform.
+- `ConnectionManager` is constructed (main.dart:326) **before** `RememberedDevicesController` (main.dart:338); the latter's deps all exist by line 323, so the block can be hoisted.
+- Android platform constraints: scans >30min silently downgrade to opportunistic (→ self-restart every ~25min); **unfiltered** scans are suspended when screen off (filtered ones keep running); ≤5 scan starts per 30s (fine at this cadence).
+
+## Design decisions & deviations from the original plan
+
+The step-by-step implementation list lived here during development; the
+commit chain is now authoritative for *what* changed. What follows is the
+*why* that the diff can't show:
+
+- **Capability interface instead of base-class defaults.** The plan put
+  default no-op watch methods on `DeviceDiscoveryService`, but nearly every
+  service and test fake `implements` (not `extends`) that class, so defaults
+  don't reach them — ~18 classes would have needed stubs. `DeviceWatchCapable`
+  (`lib/src/models/device/device_watch.dart`) is the idiomatic replacement:
+  only `UniversalBleDiscoveryService` implements it, `DeviceController`
+  selects with `whereType<DeviceWatchCapable>()`.
+- **The `shouldWatch` gate doubles as the connect-outcome probe.**
+  `ConnectionManager.connectScale` swallows its own errors, so `ScaleWatch`
+  observes success as the gate flipping false (scale connected) and failure
+  as it staying true → restart the watch scan. No new error channel needed.
+- **Bengle rule re-applied on the watch path.** Watch-driven connects bypass
+  `_runScalePhase`, whose Bengle branch makes the integrated scale own the
+  scale slot. Without re-applying it (arm-time check + `_connectScaleFromWatch`
+  wrapper), a sighted external preferred scale could steal the slot during
+  the virtual-attach window. Caught in self-review; regression test in
+  `test/integration/connection_manager_bengle_scale_test.dart`.
+- **Start-window races.** `_startWatchScan`'s awaited `UniversalBle.startScan`
+  opens a window where (a) `stopDeviceWatch` can race the start, leaving an
+  orphaned OS scan, and (b) a burst can race it, making the watch claim
+  active while the burst's end-of-scan stop actually killed it (dead watch
+  until the 25-min refresh). Both guarded after the await; tests in the
+  `start-window races` group.
+- **Fire-and-forget scan-stream cancels.** Awaiting
+  `StreamSubscription.cancel()` can resolve through the root zone, which
+  deadlocks fakeAsync tests; the ordering is not load-bearing (a stray advert
+  just takes the normal `_deviceScanned` path), so watch-internal cancels are
+  `unawaited` (`_cancelWatchScanSub`).
+- **Name-prefix filtering removed after hardware testing (2026-07-15).** The
+  plan's premise — `withNamePrefix` as an OS/controller-level filter that
+  survives screen-off — is false for the universal_ble fork: with a name
+  prefix set it passes an EMPTY filter list to the Android scanner and
+  filters plugin-side (Kotlin, case-sensitive `startsWith` on the advertised
+  name). Worse, the prefix source was wrong: `RememberedDevicesController`
+  stores `Device.name`, which for most scale impls is a friendly constant
+  ("Felicita Arc", "Bookoo Mini Scale") that never matches the advertised
+  name — so the watch silently discovered nothing (manual tap worked because
+  bursts are unfiltered with fuzzy Dart matching). The watch now scans
+  unfiltered in balanced mode; the duty cycle was always the real win. A
+  future improvement could persist the ADVERTISED name at discovery time and
+  restore plugin-side prefix filtering to cut platform-channel traffic.
+- **Legacy loop retained, not removed.** The 5s→60s backoff-burst loop is the
+  active path on non-Android platforms and the runtime fallback when
+  `startScaleWatch` throws (`onWatchUnavailable`).
+
+## Verification (end-to-end)
+
+1. `flutter analyze` + full `flutter test` (run `bundle_skins.sh` first in fresh worktrees).
+2. `sb-dev` simulate smoke: machine+scale connect, disconnect scale, confirm reconnect and no scanning-indicator flicker.
+3. Real tablet (user-assisted): DE1 connected, scale off → log shows one balanced filtered scan start, **no repeated 15s lowLatency bursts**; power scale on → connected ≤5s; while scale off, loop `curl POST /api/v1/machine/calibration` several minutes → no 500/GATT timeout; screen off ≥2min then power scale on → still connects; >30min soak → 25-min restart visible in log; Bluetooth toggle off/on → watch resumes.
+
+## Risks / edge cases
+
+- **Remembered-name drift** (firmware rename breaks the OS filter silently): log WARNING when a watch is armed >N min with no sighting; do not auto-burst.
+- **Preferred id with no remembered record** (import/dart-define): unfiltered `lowPower` watch — accepts screen-off suspension.
+- **MockScale sentinel:** covered by arm-time device check (+ Step 7).
+- **Dispose ordering:** CM disarms watch before controller disposal; fan-out tolerates closed subjects.
+- **Machine recovery:** `shouldWatch` gate (machine connected) naturally disarms during recovery; recovery bursts arbitrate at the service layer.
+- **Non-Android:** `supportsDeviceWatch` false everywhere → byte-for-byte legacy behavior.

--- a/lib/src/controllers/connection/scale_watch.dart
+++ b/lib/src/controllers/connection/scale_watch.dart
@@ -33,6 +33,7 @@ class ScaleWatch {
   final void Function() _onWatchUnavailable;
 
   StreamSubscription<List<Device>>? _sub;
+  StreamSubscription<void>? _failureSub;
   bool _armed = false;
   bool _connecting = false;
 
@@ -86,10 +87,17 @@ class ScaleWatch {
     if (!_armed && _sub == null) return;
     _generation++;
     _armed = false;
+    _cancelSubs();
+    await _scanner.stopScaleWatch();
+  }
+
+  void _cancelSubs() {
     final sub = _sub;
     _sub = null;
     unawaited(sub?.cancel());
-    await _scanner.stopScaleWatch();
+    final failureSub = _failureSub;
+    _failureSub = null;
+    unawaited(failureSub?.cancel());
   }
 
   Future<void> dispose() => disarm();
@@ -106,7 +114,7 @@ class ScaleWatch {
   /// watch-unavailable so ConnectionManager can fall back to the legacy
   /// backoff loop) when the scanner refuses.
   Future<bool> _startWatchScan() async {
-    const filter = DeviceWatchFilter(deviceTypes: {DeviceType.scale});
+    const filter = DeviceWatchFilter();
     try {
       await _scanner.startScaleWatch(filter);
       return true;
@@ -119,7 +127,7 @@ class ScaleWatch {
   }
 
   void _listen(int gen) {
-    unawaited(_sub?.cancel());
+    _cancelSubs();
     // skip(1) drops the BehaviorSubject replay — the arm-time check
     // already handled devices that are currently visible.
     _sub = _scanner.deviceStream.skip(1).listen((devices) {
@@ -129,6 +137,20 @@ class ScaleWatch {
       final match = _findPreferred(devices, id);
       if (match == null) return;
       unawaited(_onSighting(match, gen));
+    });
+    // The scanner reports a watch it could not restart (failed refresh,
+    // post-burst resume, adapter recovery). The watch is gone — hand
+    // reacquisition to the legacy backoff loop.
+    _failureSub = _scanner.scaleWatchFailures.listen((_) {
+      if (gen != _generation) return;
+      _log.warning(
+        'Background watch died and could not restart; '
+        'falling back to legacy scale reconnect',
+      );
+      _generation++;
+      _armed = false;
+      _cancelSubs();
+      _onWatchUnavailable();
     });
   }
 

--- a/lib/src/controllers/connection/scale_watch.dart
+++ b/lib/src/controllers/connection/scale_watch.dart
@@ -1,0 +1,167 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/device_scanner.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/device/watch_filter.dart';
+
+/// Persistent background scale watch — the low-duty-cycle replacement
+/// for ConnectionManager's preferred-scale backoff-burst reconnect loop.
+///
+/// While armed, a filtered OS-level scan runs continuously (via
+/// [DeviceScanner.startScaleWatch]) and this collaborator listens on the
+/// scanner's device stream; the moment the preferred scale appears it
+/// stops the watch and connects. Modeled on `EarlyConnectWatcher` but
+/// long-lived and re-armable.
+///
+/// The [shouldWatch] gate (ConnectionManager's
+/// `_shouldRetryPreferredScale`) doubles as the connect-outcome probe:
+/// `connectScale` (ConnectionManager.connectScale) swallows its own
+/// errors, so success is observed as the gate flipping false (scale now
+/// connected) and failure as it staying true — in which case the watch
+/// scan restarts.
+///
+/// Eighth comms-layer collaborator (see CLAUDE.md → comms-layer patterns).
+class ScaleWatch {
+  static final _log = Logger('ScaleWatch');
+
+  final DeviceScanner _scanner;
+  final bool Function() _shouldWatch;
+  final String? Function() _preferredScaleId;
+  final Future<void> Function(Scale) _connectScale;
+  final void Function() _onWatchUnavailable;
+
+  StreamSubscription<List<Device>>? _sub;
+  bool _armed = false;
+  bool _connecting = false;
+
+  /// Generation token (comms-harden idiom): bumped by [disarm] so an
+  /// in-flight connect attempt completing afterwards cannot resurrect
+  /// the watch.
+  int _generation = 0;
+
+  ScaleWatch({
+    required DeviceScanner scanner,
+    required bool Function() shouldWatch,
+    required String? Function() preferredScaleId,
+    required Future<void> Function(Scale) connectScale,
+    required void Function() onWatchUnavailable,
+  })  : _scanner = scanner,
+        _shouldWatch = shouldWatch,
+        _preferredScaleId = preferredScaleId,
+        _connectScale = connectScale,
+        _onWatchUnavailable = onWatchUnavailable;
+
+  bool get armed => _armed;
+
+  /// Arm the watch. Idempotent; no-op when the gate ([shouldWatch])
+  /// doesn't hold.
+  Future<void> arm() async {
+    if (_armed) return;
+    if (!_shouldWatch()) return;
+    final id = _preferredScaleId();
+    if (id == null) return; // shouldWatch covers this; belt-and-braces
+    _armed = true;
+    final gen = _generation;
+
+    // A scale that is already discovered never re-advertises through the
+    // watch (the scanner de-dups known devices) — connect it directly.
+    // Also covers simulate mode, where MockScale never BLE-advertises.
+    final existing = _findPreferred(_scanner.devices, id);
+    if (existing != null) {
+      _log.fine('Preferred scale already discovered; connecting directly');
+      await _tryConnect(existing, gen);
+      return;
+    }
+
+    if (!await _startWatchScan()) return;
+    _listen(gen);
+    _log.info('Background scale watch armed');
+  }
+
+  /// Disarm the watch and stop the underlying scan. Idempotent; safe
+  /// to call before [arm].
+  Future<void> disarm() async {
+    if (!_armed && _sub == null) return;
+    _generation++;
+    _armed = false;
+    final sub = _sub;
+    _sub = null;
+    unawaited(sub?.cancel());
+    await _scanner.stopScaleWatch();
+  }
+
+  Future<void> dispose() => disarm();
+
+  Scale? _findPreferred(List<Device> devices, String id) =>
+      devices.whereType<Scale>().where((s) => s.deviceId == id).firstOrNull;
+
+  /// Start the watch scan. Deliberately unfiltered (no name prefix):
+  /// remembered device names are friendly constants ("Felicita Arc")
+  /// that rarely equal the advertised name the filter is matched
+  /// against, and the universal_ble fork evaluates name filters
+  /// plugin-side anyway — matching stays with the Dart DeviceMatcher
+  /// path, same as burst scans. Returns false (and reports
+  /// watch-unavailable so ConnectionManager can fall back to the legacy
+  /// backoff loop) when the scanner refuses.
+  Future<bool> _startWatchScan() async {
+    const filter = DeviceWatchFilter(deviceTypes: {DeviceType.scale});
+    try {
+      await _scanner.startScaleWatch(filter);
+      return true;
+    } catch (e, st) {
+      _log.warning('Failed to start background scale watch', e, st);
+      _armed = false;
+      _onWatchUnavailable();
+      return false;
+    }
+  }
+
+  void _listen(int gen) {
+    unawaited(_sub?.cancel());
+    // skip(1) drops the BehaviorSubject replay — the arm-time check
+    // already handled devices that are currently visible.
+    _sub = _scanner.deviceStream.skip(1).listen((devices) {
+      if (gen != _generation || _connecting) return;
+      final id = _preferredScaleId();
+      if (id == null) return;
+      final match = _findPreferred(devices, id);
+      if (match == null) return;
+      unawaited(_onSighting(match, gen));
+    });
+  }
+
+  Future<void> _onSighting(Scale scale, int gen) async {
+    _connecting = true;
+    try {
+      _log.fine(
+        'Preferred scale ${scale.deviceId} sighted; '
+        'stopping watch and connecting',
+      );
+      await _scanner.stopScaleWatch();
+      if (gen != _generation) return;
+      await _tryConnect(scale, gen);
+    } finally {
+      _connecting = false;
+    }
+  }
+
+  Future<void> _tryConnect(Scale scale, int gen) async {
+    try {
+      await _connectScale(scale);
+    } catch (e, st) {
+      // ConnectionManager.connectScale handles its own failures; anything
+      // surfacing here is unexpected but must not kill the watch cycle.
+      _log.warning('Watch-driven scale connect threw', e, st);
+    }
+    if (gen != _generation) return; // disarmed while connecting
+    if (_shouldWatch()) {
+      _log.fine('Scale still missing after connect attempt; watch continues');
+      if (!await _startWatchScan()) return;
+      _listen(gen);
+    } else {
+      await disarm();
+    }
+  }
+}

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -7,6 +7,7 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/connection/disconnect_expectations.dart';
 import 'package:reaprime/src/controllers/connection/disconnect_supervisor.dart';
 import 'package:reaprime/src/controllers/connection/policy_resolver.dart';
+import 'package:reaprime/src/controllers/connection/scale_watch.dart';
 import 'package:reaprime/src/controllers/connection/scan_orchestrator.dart';
 import 'package:reaprime/src/controllers/connection/scan_report_builder.dart';
 import 'package:reaprime/src/controllers/connection/status_publisher.dart';
@@ -131,6 +132,7 @@ class ConnectionManager {
 
   late final DisconnectSupervisor _disconnectSupervisor;
   late final ScanOrchestrator _scanOrchestrator;
+  late final ScaleWatch _scaleWatch;
 
   StreamSubscription<AdapterState>? _adapterSub;
 
@@ -225,6 +227,11 @@ class ConnectionManager {
   @visibleForTesting
   Duration deferredScaleScanDelay = const Duration(seconds: 3);
 
+  /// Whether the scanner supports the persistent background scale watch
+  /// (Android). De1StateManager consults this to skip its wake-time
+  /// scale-only burst scan when the watch already covers reacquisition.
+  bool get supportsBackgroundScaleWatch => deviceScanner.supportsBackgroundWatch;
+
   ConnectionManager({
     required this.deviceScanner,
     required this.de1Controller,
@@ -244,8 +251,15 @@ class ConnectionManager {
       onMachineConnected: _handleMachineConnected,
       onMachineDisconnected: _handleMachineDisconnected,
       onUnexpectedMachineDisconnect: _startMachineRecovery,
-      onScaleConnected: _cancelPreferredScaleReconnect,
-      onScaleDisconnected: _maybeSchedulePreferredScaleReconnect,
+      onScaleConnected: _cancelScaleReacquisition,
+      onScaleDisconnected: _ensureScaleReacquisition,
+    );
+    _scaleWatch = ScaleWatch(
+      scanner: deviceScanner,
+      shouldWatch: _shouldRetryPreferredScale,
+      preferredScaleId: () => settingsController.preferredScaleId,
+      connectScale: _connectScaleFromWatch,
+      onWatchUnavailable: _maybeSchedulePreferredScaleReconnect,
     );
     _scanOrchestrator = ScanOrchestrator(
       scanner: deviceScanner,
@@ -481,7 +495,10 @@ class ConnectionManager {
   }
 
   Future<void> _connectImpl({required bool scaleOnly}) async {
-    _cancelPreferredScaleReconnect();
+    // Also disarms the watch: during a full scan EarlyConnectWatcher
+    // observes the same deviceStream and owns preferred-scale connects —
+    // a live watch would race it. Re-armed at the end-of-connect sites.
+    _cancelScaleReacquisition();
     if (scaleOnly && _scaleReconnectBlockedByPowerMode) {
       _log.fine(
         'Skipping scale-only scan while machine is sleeping and scale '
@@ -510,7 +527,12 @@ class ConnectionManager {
           await _attachBengleVirtualScale(qcMachine);
         } else if (!_scaleConnected) {
           if (settingsController.preferredScaleId != null) {
-            _maybeSchedulePreferredScaleReconnect();
+            // Route through the reacquisition selector: on watch-capable
+            // platforms the background scale watch (also armed by the
+            // machine-connected handler) owns this — scheduling the
+            // legacy backoff here would run radio-starving bursts
+            // alongside it.
+            _ensureScaleReacquisition();
           } else {
             _armPostQuickConnectScaleScan();
           }
@@ -582,7 +604,7 @@ class ConnectionManager {
         preferredScaleId: preferredScaleId,
         terminationReason: ScanTerminationReason.completed,
       );
-      _maybeSchedulePreferredScaleReconnect();
+      _ensureScaleReacquisition();
       return;
     }
 
@@ -601,7 +623,7 @@ class ConnectionManager {
         scanReport,
       );
       _maybeArmDeferredScaleScan();
-      _maybeSchedulePreferredScaleReconnect();
+      _ensureScaleReacquisition();
       _emitScanReport(
         scanReport: scanReport,
         preferredMachineId: preferredMachineId,
@@ -623,7 +645,7 @@ class ConnectionManager {
         await _connectMachineTracked(m, scanReport);
         await _runScalePhase(m, scales, preferredScaleId, scanReport);
         _maybeArmDeferredScaleScan();
-        _maybeSchedulePreferredScaleReconnect();
+        _ensureScaleReacquisition();
       case MachinePickerAction():
         _publishStatus(currentStatus.copyWith(
           phase: ConnectionPhase.idle,
@@ -741,6 +763,48 @@ class ConnectionManager {
     });
   }
 
+  /// Route scale reacquisition to the persistent background watch when
+  /// the scanner supports it (Android), else to the legacy backoff-burst
+  /// loop. Every former `_maybeSchedulePreferredScaleReconnect` call
+  /// site goes through here; the legacy loop also remains the fallback
+  /// when the watch fails to start (see `onWatchUnavailable`).
+  void _ensureScaleReacquisition() {
+    if (deviceScanner.supportsBackgroundWatch) {
+      // On a Bengle the integrated scale owns the slot (the legacy path
+      // enforces this inside _runScalePhase, which the watch bypasses) —
+      // there is nothing to reacquire externally.
+      if (_disconnectSupervisor.latestMachine is BengleInterface) {
+        _log.fine(
+          'Bengle machine: integrated scale owns the slot; '
+          'not arming scale watch',
+        );
+        return;
+      }
+      unawaited(_scaleWatch.arm());
+    } else {
+      _maybeSchedulePreferredScaleReconnect();
+    }
+  }
+
+  void _cancelScaleReacquisition() {
+    unawaited(_scaleWatch.disarm());
+    _cancelPreferredScaleReconnect();
+  }
+
+  /// Watch-driven connects bypass `_runScalePhase`, so the Bengle rule
+  /// is re-applied here for sightings that land after the watch armed
+  /// but once a Bengle has become the machine.
+  Future<void> _connectScaleFromWatch(Scale scale) async {
+    if (_disconnectSupervisor.latestMachine is BengleInterface) {
+      _log.fine(
+        'Ignoring watch scale sighting ${scale.deviceId}: '
+        'Bengle integrated scale owns the slot',
+      );
+      return;
+    }
+    await connectScale(scale);
+  }
+
   void _maybeSchedulePreferredScaleReconnect() {
     if (_preferredScaleReconnect != null) return;
     if (!_shouldRetryPreferredScale()) return;
@@ -773,7 +837,7 @@ class ConnectionManager {
   void _handleMachineConnected() {
     _stopMachineRecovery();
     _watchConnectedMachineState();
-    _maybeSchedulePreferredScaleReconnect();
+    _ensureScaleReacquisition();
   }
 
   void _handleMachineDisconnected() {
@@ -785,7 +849,7 @@ class ConnectionManager {
     _stopWatchingConnectedMachineState();
     _deferredScaleScan?.cancel();
     _deferredScaleScan = null;
-    _cancelPreferredScaleReconnect();
+    _cancelScaleReacquisition();
     if (_activeScaleOnlyScan) {
       deviceScanner.stopScan();
     }
@@ -876,7 +940,7 @@ class ConnectionManager {
         );
         _pauseScaleReconnectForPowerMode();
       } else {
-        _maybeSchedulePreferredScaleReconnect();
+        _ensureScaleReacquisition();
       }
     }, onError: (Object e, StackTrace st) {
       _log.fine('Machine snapshot stream error', e, st);
@@ -933,7 +997,7 @@ class ConnectionManager {
   void _pauseScaleReconnectForPowerMode() {
     _deferredScaleScan?.cancel();
     _deferredScaleScan = null;
-    _cancelPreferredScaleReconnect();
+    _cancelScaleReacquisition();
     if (_activeScaleOnlyScan) {
       deviceScanner.stopScan();
     }
@@ -1303,7 +1367,7 @@ class ConnectionManager {
   }
 
   Future<void> disconnectScale() async {
-    _cancelPreferredScaleReconnect();
+    _cancelScaleReacquisition();
     try {
       final scale = scaleController.connectedScale();
       markExpectingDisconnect(scale.deviceId);
@@ -1320,6 +1384,10 @@ class ConnectionManager {
     _stopMachineRecovery();
     _deferredScaleScan?.cancel();
     _cancelPreferredScaleReconnect();
+    // Awaited (not via _cancelScaleReacquisition) so the watch is
+    // deterministically stopped before the controllers it feeds are
+    // disposed.
+    await _scaleWatch.dispose();
     _stopWatchingConnectedMachineState();
     await de1Controller.dispose();
     scaleController.dispose();

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -256,7 +256,14 @@ class ConnectionManager {
     );
     _scaleWatch = ScaleWatch(
       scanner: deviceScanner,
-      shouldWatch: _shouldRetryPreferredScale,
+      // The Bengle clause covers arm time AND the post-connect
+      // continuation: a Bengle's integrated scale owns the scale slot
+      // (the rule _runScalePhase enforces on the burst path), so a
+      // refused external-scale sighting must end the watch cycle, not
+      // restart the scan indefinitely.
+      shouldWatch: () =>
+          _shouldRetryPreferredScale() &&
+          _disconnectSupervisor.latestMachine is! BengleInterface,
       preferredScaleId: () => settingsController.preferredScaleId,
       connectScale: _connectScaleFromWatch,
       onWatchUnavailable: _maybeSchedulePreferredScaleReconnect,
@@ -770,16 +777,8 @@ class ConnectionManager {
   /// when the watch fails to start (see `onWatchUnavailable`).
   void _ensureScaleReacquisition() {
     if (deviceScanner.supportsBackgroundWatch) {
-      // On a Bengle the integrated scale owns the slot (the legacy path
-      // enforces this inside _runScalePhase, which the watch bypasses) —
-      // there is nothing to reacquire externally.
-      if (_disconnectSupervisor.latestMachine is BengleInterface) {
-        _log.fine(
-          'Bengle machine: integrated scale owns the slot; '
-          'not arming scale watch',
-        );
-        return;
-      }
+      // The watch's shouldWatch gate covers the full arming policy,
+      // including the Bengle integrated-scale rule.
       unawaited(_scaleWatch.arm());
     } else {
       _maybeSchedulePreferredScaleReconnect();

--- a/lib/src/controllers/de1_state_manager.dart
+++ b/lib/src/controllers/de1_state_manager.dart
@@ -73,6 +73,11 @@ class De1StateManager with WidgetsBindingObserver {
   /// on the DE1 when scale service discovery monopolizes the shared radio.
   Timer? _deferredScaleScan;
 
+  /// Delay before the post-wake scale reconnect fires. Overridable in
+  /// tests to avoid a real 3s wait.
+  @visibleForTesting
+  Duration deferredScaleScanDelay = const Duration(seconds: 3);
+
   // Platform-specific background states
   final Set<AppLifecycleState> _backgroundStates;
 
@@ -380,8 +385,24 @@ class De1StateManager with WidgetsBindingObserver {
           'to avoid BLE radio starvation',
         );
         _deferredScaleScan?.cancel();
-        _deferredScaleScan = Timer(const Duration(seconds: 3), () {
+        _deferredScaleScan = Timer(deferredScaleScanDelay, () {
           _deferredScaleScan = null;
+          // With a preferred scale and background-watch support, the
+          // ConnectionManager's persistent scale watch (re-armed by its
+          // own machine-state listener on this same wake transition)
+          // covers reacquisition — a lowLatency burst here would only
+          // starve the freshly woken DE1 link. The burst stays for the
+          // no-preferred-scale case (feeds discovery/picker) and for
+          // platforms without watch support. Gate evaluated at fire
+          // time, not arm time.
+          if (_connectionManager.supportsBackgroundScaleWatch &&
+              _settingsController.preferredScaleId != null) {
+            _logger.fine(
+              'Background scale watch handles reacquisition; '
+              'skipping wake burst',
+            );
+            return;
+          }
           _triggerScaleScan();
         });
       }

--- a/lib/src/controllers/device_controller.dart
+++ b/lib/src/controllers/device_controller.dart
@@ -288,6 +288,17 @@ class DeviceController implements DeviceScanner {
     }
   }
 
+  @override
+  Stream<void> get scaleWatchFailures {
+    final streams = _services
+        .whereType<DeviceWatchCapable>()
+        .map((s) => s.deviceWatchFailures)
+        .toList();
+    if (streams.isEmpty) return const Stream.empty();
+    if (streams.length == 1) return streams.single;
+    return Rx.merge(streams);
+  }
+
   void _serviceUpdate(DeviceDiscoveryService service, List<Device> devices) {
     _log.fine("$service update: $devices");
     _devices[service] = devices;

--- a/lib/src/controllers/device_controller.dart
+++ b/lib/src/controllers/device_controller.dart
@@ -5,8 +5,10 @@ import 'package:reaprime/src/controllers/connection/connection_timings.dart';
 import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_scanner.dart';
+import 'package:reaprime/src/models/device/device_watch.dart';
 import 'package:reaprime/src/models/device/remembered_device.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
+import 'package:reaprime/src/models/device/watch_filter.dart';
 import 'package:reaprime/src/services/ble/ble_discovery_service.dart';
 import 'package:reaprime/src/services/telemetry/telemetry_service.dart';
 import 'package:rxdart/rxdart.dart';
@@ -252,6 +254,38 @@ class DeviceController implements DeviceScanner {
       }
     }
     return null;
+  }
+
+  Iterable<DeviceWatchCapable> get _watchCapableServices => _services
+      .whereType<DeviceWatchCapable>()
+      .where((s) => s.supportsDeviceWatch);
+
+  @override
+  bool get supportsBackgroundWatch => _watchCapableServices.isNotEmpty;
+
+  /// Fan a persistent scale watch out to every supporting discovery
+  /// service. Unlike [scanForDevices] this touches neither
+  /// [_scanningStream] (no UI scanning indicator) nor the pre-scan
+  /// stale-device prune — the watch is invisible bookkeeping until a
+  /// device actually appears on [deviceStream].
+  @override
+  Future<void> startScaleWatch(DeviceWatchFilter filter) async {
+    for (final service in _watchCapableServices) {
+      await service.startDeviceWatch(filter);
+    }
+  }
+
+  @override
+  Future<void> stopScaleWatch() async {
+    for (final service in _watchCapableServices) {
+      try {
+        await service.stopDeviceWatch();
+      } catch (e, st) {
+        // Best-effort teardown — a service failing to stop its watch
+        // (e.g. already disposed) must not block the others.
+        _log.fine('stopDeviceWatch failed for $service', e, st);
+      }
+    }
   }
 
   void _serviceUpdate(DeviceDiscoveryService service, List<Device> devices) {

--- a/lib/src/models/device/device_scanner.dart
+++ b/lib/src/models/device/device_scanner.dart
@@ -55,4 +55,8 @@ abstract class DeviceScanner {
 
   /// Stop a watch started with [startScaleWatch]. Idempotent.
   Future<void> stopScaleWatch();
+
+  /// Emits when a running scale watch dies and cannot be restarted.
+  /// Consumers (ScaleWatch) must fall back to the legacy reconnect loop.
+  Stream<void> get scaleWatchFailures;
 }

--- a/lib/src/models/device/device_scanner.dart
+++ b/lib/src/models/device/device_scanner.dart
@@ -3,6 +3,7 @@ import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/remembered_device.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/device/scan_result.dart';
+import 'package:reaprime/src/models/device/watch_filter.dart';
 
 export 'package:reaprime/src/models/device/scan_result.dart';
 
@@ -41,4 +42,17 @@ abstract class DeviceScanner {
   /// Iterates the registered discovery services, returning the first
   /// connected device or null if all services return null.
   Future<Device?> tryQuickConnect(RememberedDevice remembered);
+
+  /// Whether any registered discovery service supports a persistent
+  /// background device watch. Drives ConnectionManager's choice between
+  /// the watch and the legacy backoff-burst scale reconnect loop.
+  bool get supportsBackgroundWatch;
+
+  /// Start a persistent low-duty-cycle scale watch on every supporting
+  /// discovery service. Discoveries arrive through [deviceStream]; the
+  /// watch does NOT flip [scanningStream] (no UI scanning indicator).
+  Future<void> startScaleWatch(DeviceWatchFilter filter);
+
+  /// Stop a watch started with [startScaleWatch]. Idempotent.
+  Future<void> stopScaleWatch();
 }

--- a/lib/src/models/device/device_watch.dart
+++ b/lib/src/models/device/device_watch.dart
@@ -23,4 +23,10 @@ abstract class DeviceWatchCapable {
   /// Stop a watch started with [startDeviceWatch]. Idempotent; safe to
   /// call when no watch is active.
   Future<void> stopDeviceWatch();
+
+  /// Emits when a requested watch dies and cannot be restarted (failed
+  /// refresh, post-burst resume, or adapter-recovery restart). The
+  /// service clears the watch request before emitting; consumers must
+  /// treat the watch as gone and activate their fallback.
+  Stream<void> get deviceWatchFailures;
 }

--- a/lib/src/models/device/device_watch.dart
+++ b/lib/src/models/device/device_watch.dart
@@ -1,0 +1,26 @@
+import 'package:reaprime/src/models/device/watch_filter.dart';
+
+/// Capability interface for discovery services that can run a
+/// persistent, low-duty-cycle background device watch.
+///
+/// A separate interface (rather than default members on
+/// `DeviceDiscoveryService`) because most services `implements` the
+/// base class and would otherwise be forced to stub these out; the
+/// capability check is `service is DeviceWatchCapable &&
+/// service.supportsDeviceWatch`.
+abstract class DeviceWatchCapable {
+  /// Whether the watch is available right now. The type implements the
+  /// capability; this gate covers runtime conditions (e.g. the BLE
+  /// watch is Android-only — CoreBluetooth has no scan-duty-cycle knob).
+  bool get supportsDeviceWatch;
+
+  /// Start a persistent, low-duty-cycle watch for devices matching
+  /// [filter]. Unlike `scanForDevices` this has no bounded duration —
+  /// it runs until [stopDeviceWatch] and yields discoveries through the
+  /// service's normal `devices` stream.
+  Future<void> startDeviceWatch(DeviceWatchFilter filter);
+
+  /// Stop a watch started with [startDeviceWatch]. Idempotent; safe to
+  /// call when no watch is active.
+  Future<void> stopDeviceWatch();
+}

--- a/lib/src/models/device/watch_filter.dart
+++ b/lib/src/models/device/watch_filter.dart
@@ -1,0 +1,29 @@
+import 'package:reaprime/src/models/device/device.dart';
+
+/// Filter for a persistent, low-duty-cycle background device watch.
+///
+/// Deliberately a separate type from [ScanFilter]: burst-scan semantics
+/// (one bounded cycle, unfiltered, aggressive duty cycle) stay untouched,
+/// and `ScanFilter.preferredDeviceId` — which cannot be pushed down to the
+/// OS scanner (no address filter in universal_ble) — doesn't leak into the
+/// watch API.
+class DeviceWatchFilter {
+  /// Advertised-name prefix for the scan. The universal_ble fork
+  /// evaluates this plugin-side (the OS scan runs unfiltered either
+  /// way), so it only reduces platform-channel/Dart traffic — it is
+  /// NOT a hardware filter and does not keep the scan alive with the
+  /// screen off. It must match the ADVERTISED name, not a friendly
+  /// display name. `null` means no name filtering (the current scale
+  /// watch always passes null and matches Dart-side via DeviceMatcher).
+  final String? namePrefix;
+
+  /// Device types the watch is interested in. Applied Dart-side by the
+  /// normal `DeviceMatcher` path; not an OS-level filter.
+  final Set<DeviceType> deviceTypes;
+
+  const DeviceWatchFilter({this.namePrefix, required this.deviceTypes});
+
+  @override
+  String toString() =>
+      'DeviceWatchFilter(namePrefix: $namePrefix, deviceTypes: $deviceTypes)';
+}

--- a/lib/src/models/device/watch_filter.dart
+++ b/lib/src/models/device/watch_filter.dart
@@ -1,5 +1,3 @@
-import 'package:reaprime/src/models/device/device.dart';
-
 /// Filter for a persistent, low-duty-cycle background device watch.
 ///
 /// Deliberately a separate type from [ScanFilter]: burst-scan semantics
@@ -17,13 +15,8 @@ class DeviceWatchFilter {
   /// watch always passes null and matches Dart-side via DeviceMatcher).
   final String? namePrefix;
 
-  /// Device types the watch is interested in. Applied Dart-side by the
-  /// normal `DeviceMatcher` path; not an OS-level filter.
-  final Set<DeviceType> deviceTypes;
-
-  const DeviceWatchFilter({this.namePrefix, required this.deviceTypes});
+  const DeviceWatchFilter({this.namePrefix});
 
   @override
-  String toString() =>
-      'DeviceWatchFilter(namePrefix: $namePrefix, deviceTypes: $deviceTypes)';
+  String toString() => 'DeviceWatchFilter(namePrefix: $namePrefix)';
 }

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -51,6 +51,17 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
   /// the watch scan before that kicks in.
   static const _watchRefreshInterval = Duration(minutes: 25);
 
+  final StreamController<void> _watchFailureController =
+      StreamController.broadcast();
+
+  @override
+  Stream<void> get deviceWatchFailures => _watchFailureController.stream;
+
+  /// In-flight [_startWatchScan] call. Pause/stop paths await this so
+  /// watch-start and burst-start are genuinely serialized — universal_ble
+  /// has one global scan session and ownership must be deterministic.
+  Future<void>? _watchStartInFlight;
+
   @override
   Future<void> startDeviceWatch(DeviceWatchFilter filter) async {
     _watchRequested = filter;
@@ -59,6 +70,26 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
       return;
     }
     await _startWatchScan();
+  }
+
+  @override
+  Future<void> stopDeviceWatch() async {
+    _watchRequested = null;
+    await _awaitInFlightWatchStart();
+    await _deactivateWatchScan(
+      stopOsScan: _watchScanActive && !_isScanning,
+      context: 'stopDeviceWatch',
+    );
+  }
+
+  Future<void> _awaitInFlightWatchStart() async {
+    final inflight = _watchStartInFlight;
+    if (inflight == null) return;
+    try {
+      await inflight;
+    } catch (_) {
+      // The start failed — its own error handling ran; nothing to settle.
+    }
   }
 
   /// Detach the watch's scan-stream listener. Fire-and-forget: awaiting
@@ -72,23 +103,56 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     unawaited(sub?.cancel());
   }
 
-  @override
-  Future<void> stopDeviceWatch() async {
-    _watchRequested = null;
+  /// Single teardown path for the watch scan's local state (refresh
+  /// timer, scan-stream listener, active flag). [stopOsScan] also stops
+  /// the OS scan; pass false when something else owns or already killed
+  /// the session (burst hand-over, adapter power-off).
+  Future<void> _deactivateWatchScan({
+    required bool stopOsScan,
+    required String context,
+  }) async {
     _watchRefreshTimer?.cancel();
     _watchRefreshTimer = null;
     _cancelWatchScanSub();
-    if (_watchScanActive && !_isScanning) {
+    _watchScanActive = false;
+    if (stopOsScan) {
       try {
         await UniversalBle.stopScan();
       } catch (e, st) {
-        log.warning('stopDeviceWatch: stopScan failed', e, st);
+        log.warning('$context: stopScan failed', e, st);
       }
     }
-    _watchScanActive = false;
   }
 
-  Future<void> _startWatchScan() async {
+  /// Restart the watch scan after it lost the OS session (refresh,
+  /// post-burst resume, adapter recovery). On failure the watch is dead
+  /// and cannot self-heal: clear the request and report it so ScaleWatch
+  /// activates the legacy backoff fallback instead of staying silently
+  /// armed.
+  Future<void> _restartWatchOrReportFailure(String context) async {
+    try {
+      await _startWatchScan();
+    } catch (e, st) {
+      log.warning('$context: watch restart failed — reporting', e, st);
+      _watchRequested = null;
+      await _deactivateWatchScan(stopOsScan: false, context: context);
+      if (!_watchFailureController.isClosed) {
+        _watchFailureController.add(null);
+      }
+    }
+  }
+
+  Future<void> _startWatchScan() {
+    final start = _runWatchScanStart();
+    _watchStartInFlight = start;
+    return start.whenComplete(() {
+      if (identical(_watchStartInFlight, start)) {
+        _watchStartInFlight = null;
+      }
+    });
+  }
+
+  Future<void> _runWatchScanStart() async {
     final filter = _watchRequested;
     // _watchScanStarting guards the await window below — the adapter
     // availability replay (or a concurrent caller) arriving mid-start
@@ -117,10 +181,9 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
         // balanced (~40% duty cycle) discovers a freshly powered-on scale
         // in 1-5s while leaving most radio time to DE1 GATT traffic —
         // the duty cycle, not filtering, is what protects the DE1 link.
-        // Note: the universal_ble fork evaluates withNamePrefix
-        // plugin-side (the OS scan runs unfiltered either way), so a
-        // prefix saves platform-channel/Dart churn only; it does not
-        // keep the scan alive with the screen off.
+        // The fork evaluates withNamePrefix plugin-side (the OS scan runs
+        // unfiltered either way), so it neither hardware-filters nor
+        // keeps the scan alive with the screen off.
         platformConfig: PlatformConfig(
           android: AndroidOptions(
             scanMode: AndroidScanMode.balanced,
@@ -136,26 +199,23 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
       _watchScanStarting = false;
     }
     // Guard the start window: state may have moved while startScan was
-    // in flight.
+    // in flight. Ordered by ownership: a stop means undo the scan; a
+    // burst owns the session now (its finally-block resume restarts the
+    // watch); an adapter that left poweredOn already killed the scan and
+    // power-on recovery must find the watch inactive to restart it.
     if (_watchRequested == null) {
-      // stopDeviceWatch raced the start — undo the scan we just started
-      // or it runs orphaned forever.
       log.fine('Watch stopped during start; undoing scan');
-      _cancelWatchScanSub();
-      try {
-        await UniversalBle.stopScan();
-      } catch (e, st) {
-        log.warning('Watch start-undo stopScan failed', e, st);
-      }
+      await _deactivateWatchScan(stopOsScan: true, context: 'start-undo');
       return;
     }
     if (_isScanning) {
-      // A burst raced the start — it owns the radio now and its
-      // finally-block resume will start a fresh watch scan. Claiming
-      // active here would make that resume bail and leave a dead watch
-      // once the burst's end-of-scan stop fires.
       log.fine('Burst scan raced watch start; standing down until it ends');
-      _cancelWatchScanSub();
+      await _deactivateWatchScan(stopOsScan: false, context: 'start-burst');
+      return;
+    }
+    if (_adapterStateSubject.value != AdapterState.poweredOn) {
+      log.fine('Adapter left poweredOn during watch start; standing down');
+      await _deactivateWatchScan(stopOsScan: false, context: 'start-adapter');
       return;
     }
     _watchScanActive = true;
@@ -171,45 +231,26 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
       // start a fresh watch scan anyway.
       if (!_watchScanActive || _isScanning) return;
       log.fine('Refreshing watch scan (30-min opportunistic-downgrade guard)');
-      _cancelWatchScanSub();
-      try {
-        await UniversalBle.stopScan();
-      } catch (e, st) {
-        log.warning('Watch refresh: stopScan failed', e, st);
-      }
-      _watchScanActive = false;
-      try {
-        await _startWatchScan();
-      } catch (e, st) {
-        log.warning('Watch refresh: restart failed', e, st);
-      }
+      await _deactivateWatchScan(stopOsScan: true, context: 'watch-refresh');
+      await _restartWatchOrReportFailure('watch-refresh');
     });
   }
 
-  /// Pause the watch scan so a burst scan can own the radio. The burst's
-  /// finally-block calls [_resumeWatchAfterBurst] to bring it back.
+  /// Pause the watch scan so a burst scan can own the radio. Awaits any
+  /// in-flight watch start first so session ownership is deterministic.
+  /// The burst's finally-block calls [_resumeWatchAfterBurst].
   Future<void> _pauseWatchForBurst() async {
+    await _awaitInFlightWatchStart();
     if (!_watchScanActive) return;
     log.fine('Pausing background watch for burst scan');
-    _watchRefreshTimer?.cancel();
-    _watchRefreshTimer = null;
-    _cancelWatchScanSub();
-    try {
-      await UniversalBle.stopScan();
-    } catch (e, st) {
-      log.warning('Watch pause: stopScan failed', e, st);
-    }
-    _watchScanActive = false;
+    await _deactivateWatchScan(stopOsScan: true, context: 'watch-pause');
   }
 
   Future<void> _resumeWatchAfterBurst() async {
     if (_watchRequested == null) return;
-    try {
-      await _startWatchScan();
-    } catch (e, st) {
-      // A resume failure must never fail the burst that triggered it.
-      log.warning('Failed to resume background watch after burst', e, st);
-    }
+    // A resume failure must never fail the burst that triggered it —
+    // _restartWatchOrReportFailure never throws.
+    await _restartWatchOrReportFailure('post-burst resume');
   }
 
   /// Adapter transitions: the OS kills any running scan on power-off; a
@@ -217,21 +258,14 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
   void _onAdapterStateForWatch(AdapterState state) {
     if (state == AdapterState.poweredOff) {
       if (!_watchScanActive) return;
-      _watchRefreshTimer?.cancel();
-      _watchRefreshTimer = null;
-      _cancelWatchScanSub();
-      _watchScanActive = false;
+      unawaited(
+        _deactivateWatchScan(stopOsScan: false, context: 'adapter-off'),
+      );
     } else if (state == AdapterState.poweredOn &&
         _watchRequested != null &&
         !_watchScanActive &&
         !_isScanning) {
-      unawaited(() async {
-        try {
-          await _startWatchScan();
-        } catch (e, st) {
-          log.warning('Watch restart after adapter recovery failed', e, st);
-        }
-      }());
+      unawaited(_restartWatchOrReportFailure('adapter recovery'));
     }
   }
 

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -10,6 +10,8 @@ import 'package:reaprime/src/services/ble/ble_discovery_service.dart';
 import 'package:reaprime/src/services/ble/universal_ble_transport.dart';
 import 'package:reaprime/src/services/device_factory.dart';
 import 'package:reaprime/src/services/device_matcher.dart';
+import 'package:reaprime/src/models/device/device_watch.dart';
+import 'package:reaprime/src/models/device/watch_filter.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:universal_ble/universal_ble.dart';
 import '../models/device/device.dart';
@@ -17,8 +19,221 @@ import '../models/device/machine.dart';
 import '../models/device/impl/de1/de1.models.dart';
 import 'package:logging/logging.dart' as logging;
 
-class UniversalBleDiscoveryService extends BleDiscoveryService {
-  UniversalBleDiscoveryService();
+class UniversalBleDiscoveryService extends BleDiscoveryService
+    implements DeviceWatchCapable {
+  /// [watchSupportGate] gates [supportsDeviceWatch]. Defaults to
+  /// Android-only: the background watch relies on `AndroidScanMode`
+  /// duty cycles; CoreBluetooth has no equivalent knob and a
+  /// continuous scan there is battery-hostile. Injectable so host
+  /// tests (where `Platform.isAndroid` is false) can exercise the
+  /// watch path.
+  UniversalBleDiscoveryService({bool Function()? watchSupportGate})
+      : _watchSupportGate = watchSupportGate ?? (() => Platform.isAndroid);
+
+  final bool Function() _watchSupportGate;
+
+  @override
+  bool get supportsDeviceWatch => _watchSupportGate();
+
+  // Persistent background watch state. `_watchRequested` is the desired
+  // state (a watch has been asked for and not stopped); `_watchScanActive`
+  // is the actual state (an OS scan is running for it). They diverge while
+  // a burst scan owns the radio (universal_ble has one global scan
+  // session) and while the adapter is off.
+  DeviceWatchFilter? _watchRequested;
+  bool _watchScanActive = false;
+  bool _watchScanStarting = false;
+  StreamSubscription<BleDevice>? _watchScanSub;
+  Timer? _watchRefreshTimer;
+
+  /// Android silently downgrades scans running longer than 30 minutes to
+  /// opportunistic mode (results only when another app scans). Restart
+  /// the watch scan before that kicks in.
+  static const _watchRefreshInterval = Duration(minutes: 25);
+
+  @override
+  Future<void> startDeviceWatch(DeviceWatchFilter filter) async {
+    _watchRequested = filter;
+    if (_isScanning) {
+      log.fine('Burst scan in flight; watch starts when it completes');
+      return;
+    }
+    await _startWatchScan();
+  }
+
+  /// Detach the watch's scan-stream listener. Fire-and-forget: awaiting
+  /// `StreamSubscription.cancel()` can resolve through the root zone,
+  /// which deadlocks fakeAsync tests, and the ordering is not
+  /// load-bearing — a stray advert between cancel and stopScan just
+  /// takes the normal `_deviceScanned` path.
+  void _cancelWatchScanSub() {
+    final sub = _watchScanSub;
+    _watchScanSub = null;
+    unawaited(sub?.cancel());
+  }
+
+  @override
+  Future<void> stopDeviceWatch() async {
+    _watchRequested = null;
+    _watchRefreshTimer?.cancel();
+    _watchRefreshTimer = null;
+    _cancelWatchScanSub();
+    if (_watchScanActive && !_isScanning) {
+      try {
+        await UniversalBle.stopScan();
+      } catch (e, st) {
+        log.warning('stopDeviceWatch: stopScan failed', e, st);
+      }
+    }
+    _watchScanActive = false;
+  }
+
+  Future<void> _startWatchScan() async {
+    final filter = _watchRequested;
+    // _watchScanStarting guards the await window below — the adapter
+    // availability replay (or a concurrent caller) arriving mid-start
+    // must not double-start the scan.
+    if (filter == null || _watchScanActive || _watchScanStarting) return;
+    if (_adapterStateSubject.value != AdapterState.poweredOn) {
+      log.fine('Adapter not powered on; watch pends adapter recovery');
+      return;
+    }
+    _watchScanStarting = true;
+
+    _watchScanSub = UniversalBle.scanStream.listen((result) async {
+      if (_currentlyScanning.contains(result.deviceId)) {
+        return;
+      }
+      await _deviceScanned(result);
+    });
+
+    final namePrefix = filter.namePrefix;
+    try {
+      await UniversalBle.startScan(
+        scanFilter: ScanFilter(
+          withNamePrefix: namePrefix != null ? [namePrefix] : [],
+          withServices: [],
+        ),
+        // balanced (~40% duty cycle) discovers a freshly powered-on scale
+        // in 1-5s while leaving most radio time to DE1 GATT traffic —
+        // the duty cycle, not filtering, is what protects the DE1 link.
+        // Note: the universal_ble fork evaluates withNamePrefix
+        // plugin-side (the OS scan runs unfiltered either way), so a
+        // prefix saves platform-channel/Dart churn only; it does not
+        // keep the scan alive with the screen off.
+        platformConfig: PlatformConfig(
+          android: AndroidOptions(
+            scanMode: AndroidScanMode.balanced,
+            matchMode: AndroidScanMatchMode.aggressive,
+            numOfMatches: AndroidScanNumOfMatches.max,
+          ),
+        ),
+      );
+    } catch (e) {
+      _cancelWatchScanSub();
+      rethrow;
+    } finally {
+      _watchScanStarting = false;
+    }
+    // Guard the start window: state may have moved while startScan was
+    // in flight.
+    if (_watchRequested == null) {
+      // stopDeviceWatch raced the start — undo the scan we just started
+      // or it runs orphaned forever.
+      log.fine('Watch stopped during start; undoing scan');
+      _cancelWatchScanSub();
+      try {
+        await UniversalBle.stopScan();
+      } catch (e, st) {
+        log.warning('Watch start-undo stopScan failed', e, st);
+      }
+      return;
+    }
+    if (_isScanning) {
+      // A burst raced the start — it owns the radio now and its
+      // finally-block resume will start a fresh watch scan. Claiming
+      // active here would make that resume bail and leave a dead watch
+      // once the burst's end-of-scan stop fires.
+      log.fine('Burst scan raced watch start; standing down until it ends');
+      _cancelWatchScanSub();
+      return;
+    }
+    _watchScanActive = true;
+    _armWatchRefresh();
+    log.info('Background device watch started (prefix: $namePrefix)');
+  }
+
+  void _armWatchRefresh() {
+    _watchRefreshTimer?.cancel();
+    _watchRefreshTimer = Timer(_watchRefreshInterval, () async {
+      _watchRefreshTimer = null;
+      // A burst owns the radio right now; its finally-block resume will
+      // start a fresh watch scan anyway.
+      if (!_watchScanActive || _isScanning) return;
+      log.fine('Refreshing watch scan (30-min opportunistic-downgrade guard)');
+      _cancelWatchScanSub();
+      try {
+        await UniversalBle.stopScan();
+      } catch (e, st) {
+        log.warning('Watch refresh: stopScan failed', e, st);
+      }
+      _watchScanActive = false;
+      try {
+        await _startWatchScan();
+      } catch (e, st) {
+        log.warning('Watch refresh: restart failed', e, st);
+      }
+    });
+  }
+
+  /// Pause the watch scan so a burst scan can own the radio. The burst's
+  /// finally-block calls [_resumeWatchAfterBurst] to bring it back.
+  Future<void> _pauseWatchForBurst() async {
+    if (!_watchScanActive) return;
+    log.fine('Pausing background watch for burst scan');
+    _watchRefreshTimer?.cancel();
+    _watchRefreshTimer = null;
+    _cancelWatchScanSub();
+    try {
+      await UniversalBle.stopScan();
+    } catch (e, st) {
+      log.warning('Watch pause: stopScan failed', e, st);
+    }
+    _watchScanActive = false;
+  }
+
+  Future<void> _resumeWatchAfterBurst() async {
+    if (_watchRequested == null) return;
+    try {
+      await _startWatchScan();
+    } catch (e, st) {
+      // A resume failure must never fail the burst that triggered it.
+      log.warning('Failed to resume background watch after burst', e, st);
+    }
+  }
+
+  /// Adapter transitions: the OS kills any running scan on power-off; a
+  /// still-requested watch restarts on power-on (unless a burst runs).
+  void _onAdapterStateForWatch(AdapterState state) {
+    if (state == AdapterState.poweredOff) {
+      if (!_watchScanActive) return;
+      _watchRefreshTimer?.cancel();
+      _watchRefreshTimer = null;
+      _cancelWatchScanSub();
+      _watchScanActive = false;
+    } else if (state == AdapterState.poweredOn &&
+        _watchRequested != null &&
+        !_watchScanActive &&
+        !_isScanning) {
+      unawaited(() async {
+        try {
+          await _startWatchScan();
+        } catch (e, st) {
+          log.warning('Watch restart after adapter recovery failed', e, st);
+        }
+      }());
+    }
+  }
 
   final Map<String, Device> _devices = {};
 
@@ -74,7 +289,9 @@ class UniversalBleDiscoveryService extends BleDiscoveryService {
 
     UniversalBle.availabilityStream.listen((state) {
       log.info("BLE Adapter state: ${state.name}");
-      _adapterStateSubject.add(_mapAvailabilityState(state));
+      final mapped = _mapAvailabilityState(state);
+      _adapterStateSubject.add(mapped);
+      _onAdapterStateForWatch(mapped);
     });
 
     if (initialState != AvailabilityState.poweredOn) {
@@ -99,6 +316,13 @@ class UniversalBleDiscoveryService extends BleDiscoveryService {
 
   @override
   void stopScan() {
+    // stopScan means "stop the burst". When only the watch scan is
+    // running, killing it would silently end scale reacquisition — the
+    // watch has its own lifecycle via stopDeviceWatch().
+    if (!_isScanning && _watchScanActive) {
+      log.fine('stopScan ignored: only the background watch is running');
+      return;
+    }
     _cancelScanDurationWait();
     UniversalBle.stopScan();
   }
@@ -148,6 +372,10 @@ class UniversalBleDiscoveryService extends BleDiscoveryService {
     StreamSubscription<BleDevice>? sub;
 
     try {
+      // universal_ble has one global scan session — a running watch scan
+      // must yield to the burst and is resumed in the finally below.
+      await _pauseWatchForBurst();
+
       log.fine("Clearing stale connections");
       _currentlyScanning.clear();
 
@@ -211,6 +439,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService {
       _cancelScanDurationWait();
       _deviceStreamController.add(_devices.values.toList());
       _isScanning = false;
+      await _resumeWatchAfterBurst();
     }
   }
 

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -42,9 +42,21 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
   // session) and while the adapter is off.
   DeviceWatchFilter? _watchRequested;
   bool _watchScanActive = false;
-  bool _watchScanStarting = false;
   StreamSubscription<BleDevice>? _watchScanSub;
   Timer? _watchRefreshTimer;
+
+  /// Bumped on every adapter state CHANGE (replays of the same state
+  /// don't count). A watch start captures it and discards itself on
+  /// completion if it changed — the transition may have killed the
+  /// native scan the start opened, so claiming active would leave the
+  /// watch permanently silent.
+  int _watchAdapterGeneration = 0;
+  AdapterState? _lastWatchAdapterState;
+
+  /// One-shot flag set when a start discarded itself on an adapter
+  /// generation change; the retry runs after the in-flight future is
+  /// cleared (a retry from within the start would await itself).
+  bool _watchStartNeedsRetry = false;
 
   /// Android silently downgrades scans running longer than 30 minutes to
   /// opportunistic mode (results only when another app scans). Restart
@@ -143,26 +155,32 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
   }
 
   Future<void> _startWatchScan() {
+    // Concurrent callers (adapter replay, power-on recovery) share the
+    // in-flight start instead of replacing it — replacing would leave
+    // pause/stop awaiting a no-op future while the real start runs.
+    final existing = _watchStartInFlight;
+    if (existing != null) return existing;
     final start = _runWatchScanStart();
     _watchStartInFlight = start;
     return start.whenComplete(() {
       if (identical(_watchStartInFlight, start)) {
         _watchStartInFlight = null;
       }
+      if (_watchStartNeedsRetry) {
+        _watchStartNeedsRetry = false;
+        unawaited(_restartWatchOrReportFailure('adapter-transition retry'));
+      }
     });
   }
 
   Future<void> _runWatchScanStart() async {
     final filter = _watchRequested;
-    // _watchScanStarting guards the await window below — the adapter
-    // availability replay (or a concurrent caller) arriving mid-start
-    // must not double-start the scan.
-    if (filter == null || _watchScanActive || _watchScanStarting) return;
+    if (filter == null || _watchScanActive) return;
     if (_adapterStateSubject.value != AdapterState.poweredOn) {
       log.fine('Adapter not powered on; watch pends adapter recovery');
       return;
     }
-    _watchScanStarting = true;
+    final adapterGen = _watchAdapterGeneration;
 
     _watchScanSub = UniversalBle.scanStream.listen((result) async {
       if (_currentlyScanning.contains(result.deviceId)) {
@@ -195,14 +213,13 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     } catch (e) {
       _cancelWatchScanSub();
       rethrow;
-    } finally {
-      _watchScanStarting = false;
     }
     // Guard the start window: state may have moved while startScan was
     // in flight. Ordered by ownership: a stop means undo the scan; a
     // burst owns the session now (its finally-block resume restarts the
-    // watch); an adapter that left poweredOn already killed the scan and
-    // power-on recovery must find the watch inactive to restart it.
+    // watch); ANY adapter transition (even off-and-back-on) may have
+    // killed the native scan, so the start discards itself and a fresh
+    // start runs once this one settles.
     if (_watchRequested == null) {
       log.fine('Watch stopped during start; undoing scan');
       await _deactivateWatchScan(stopOsScan: true, context: 'start-undo');
@@ -213,9 +230,16 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
       await _deactivateWatchScan(stopOsScan: false, context: 'start-burst');
       return;
     }
-    if (_adapterStateSubject.value != AdapterState.poweredOn) {
-      log.fine('Adapter left poweredOn during watch start; standing down');
-      await _deactivateWatchScan(stopOsScan: false, context: 'start-adapter');
+    if (adapterGen != _watchAdapterGeneration) {
+      log.fine('Adapter transitioned during watch start; discarding start');
+      await _deactivateWatchScan(
+        stopOsScan: true,
+        context: 'start-adapter-transition',
+      );
+      // Retry (via _startWatchScan's whenComplete) once this future is
+      // no longer the in-flight one; its own guards re-check adapter
+      // state and the request.
+      _watchStartNeedsRetry = true;
       return;
     }
     _watchScanActive = true;
@@ -255,7 +279,12 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
 
   /// Adapter transitions: the OS kills any running scan on power-off; a
   /// still-requested watch restarts on power-on (unless a burst runs).
+  /// Every transition bumps the generation so an in-flight start
+  /// invalidates itself (see [_runWatchScanStart]).
   void _onAdapterStateForWatch(AdapterState state) {
+    if (state == _lastWatchAdapterState) return;
+    _lastWatchAdapterState = state;
+    _watchAdapterGeneration++;
     if (state == AdapterState.poweredOff) {
       if (!_watchScanActive) return;
       unawaited(
@@ -319,7 +348,11 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
       initialState = await UniversalBle.getBluetoothAvailabilityState();
     }
 
-    _adapterStateSubject.add(_mapAvailabilityState(initialState));
+    final mappedInitialState = _mapAvailabilityState(initialState);
+    _adapterStateSubject.add(mappedInitialState);
+    // Seed the watch's change detector so the availability stream's
+    // initial replay of this same state doesn't count as a transition.
+    _lastWatchAdapterState = mappedInitialState;
 
     UniversalBle.availabilityStream.listen((state) {
       log.info("BLE Adapter state: ${state.name}");

--- a/test/controllers/connection/scale_watch_test.dart
+++ b/test/controllers/connection/scale_watch_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/connection/scale_watch.dart';
-import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 
 import '../../helpers/mock_device_scanner.dart';
@@ -78,7 +77,6 @@ void main() {
     // rarely match advertised names, and the universal_ble fork filters
     // plugin-side anyway. Matching happens in Dart via DeviceMatcher.
     expect(scanner.lastWatchFilter?.namePrefix, isNull);
-    expect(scanner.lastWatchFilter?.deviceTypes, {DeviceType.scale});
   });
 
   test('arm is idempotent', () async {
@@ -224,6 +222,31 @@ void main() {
     await pump();
     expect(connectCalls, hasLength(1),
         reason: 'the re-armed watch must still react to sightings');
+  });
+
+  test('a watch-failure event disarms and falls back to legacy reconnect',
+      () async {
+    await watch.arm();
+    expect(watch.armed, isTrue);
+
+    scanner.emitWatchFailure();
+    await pump();
+
+    expect(watch.armed, isFalse,
+        reason: 'a dead watch must not stay armed — that leaves scale '
+            'reacquisition silently off');
+    expect(unavailableCalls, 1,
+        reason: 'the legacy backoff loop must take over');
+  });
+
+  test('watch-failure events after disarm are ignored', () async {
+    await watch.arm();
+    await watch.disarm();
+
+    scanner.emitWatchFailure();
+    await pump();
+
+    expect(unavailableCalls, 0);
   });
 
   test('dispose stops the watch', () async {

--- a/test/controllers/connection/scale_watch_test.dart
+++ b/test/controllers/connection/scale_watch_test.dart
@@ -1,0 +1,235 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection/scale_watch.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+
+import '../../helpers/mock_device_scanner.dart';
+import '../../helpers/test_scale.dart';
+
+void main() {
+  const scaleId = 'pref-scale';
+
+  late MockDeviceScanner scanner;
+
+  /// The gate ScaleWatch consults — mirrors ConnectionManager's
+  /// `_shouldRetryPreferredScale`. Successful connects flip it false
+  /// (scale now connected), failed connects leave it true; ScaleWatch
+  /// itself never throws out of connectScale (ConnectionManager's
+  /// connectScale swallows errors).
+  late bool gate;
+  late String? preferredId;
+  late List<Scale> connectCalls;
+  late int unavailableCalls;
+  late bool connectSucceeds;
+  Completer<void>? connectGate;
+
+  late ScaleWatch watch;
+
+  ScaleWatch build() => ScaleWatch(
+        scanner: scanner,
+        shouldWatch: () => gate,
+        preferredScaleId: () => preferredId,
+        connectScale: (scale) async {
+          connectCalls.add(scale);
+          if (connectGate != null) {
+            await connectGate!.future;
+          }
+          if (connectSucceeds) gate = false;
+        },
+        onWatchUnavailable: () => unavailableCalls++,
+      );
+
+  setUp(() {
+    scanner = MockDeviceScanner()..supportsWatch = true;
+    gate = true;
+    preferredId = scaleId;
+    connectCalls = [];
+    unavailableCalls = 0;
+    connectSucceeds = true;
+    connectGate = null;
+    watch = build();
+  });
+
+  tearDown(() async {
+    await watch.dispose();
+    scanner.dispose();
+  });
+
+  Future<void> pump([int n = 2]) async {
+    for (var i = 0; i < n; i++) {
+      await Future<void>.delayed(Duration.zero);
+    }
+  }
+
+  test('arm is a no-op when the gate does not hold', () async {
+    gate = false;
+    await watch.arm();
+    expect(watch.armed, isFalse);
+    expect(scanner.startWatchCallCount, 0);
+  });
+
+  test('arm starts an unfiltered scale watch', () async {
+    await watch.arm();
+    expect(watch.armed, isTrue);
+    expect(scanner.startWatchCallCount, 1);
+    // No OS name filter: remembered names are friendly constants that
+    // rarely match advertised names, and the universal_ble fork filters
+    // plugin-side anyway. Matching happens in Dart via DeviceMatcher.
+    expect(scanner.lastWatchFilter?.namePrefix, isNull);
+    expect(scanner.lastWatchFilter?.deviceTypes, {DeviceType.scale});
+  });
+
+  test('arm is idempotent', () async {
+    await watch.arm();
+    await watch.arm();
+    expect(scanner.startWatchCallCount, 1);
+  });
+
+  test(
+      'preferred scale already discovered at arm time connects directly, '
+      'no watch scan', () async {
+    scanner.addDevice(TestScale(deviceId: scaleId));
+    await watch.arm();
+    await pump();
+
+    expect(connectCalls.map((s) => s.deviceId), [scaleId]);
+    expect(scanner.startWatchCallCount, 0,
+        reason: 'device is already visible — no scan needed');
+    expect(watch.armed, isFalse,
+        reason: 'successful connect ends the watch cycle');
+  });
+
+  test('sighting stops the watch before connecting, then disarms on success',
+      () async {
+    var watchActiveDuringConnect = true;
+    watch = build();
+    // Re-wire connectScale via a fresh instance capturing watch state.
+    final probe = ScaleWatch(
+      scanner: scanner,
+      shouldWatch: () => gate,
+      preferredScaleId: () => preferredId,
+      connectScale: (scale) async {
+        connectCalls.add(scale);
+        watchActiveDuringConnect = scanner.watchActive;
+        gate = false;
+      },
+      onWatchUnavailable: () => unavailableCalls++,
+    );
+    await probe.arm();
+    scanner.addDevice(TestScale(deviceId: scaleId));
+    await pump();
+
+    expect(connectCalls.map((s) => s.deviceId), [scaleId]);
+    expect(watchActiveDuringConnect, isFalse,
+        reason: 'the watch scan must stop before the connect attempt so '
+            'the radio is free for GATT');
+    expect(probe.armed, isFalse);
+    await probe.dispose();
+  });
+
+  test('a sighting of a different device is ignored', () async {
+    await watch.arm();
+    scanner.addDevice(TestScale(deviceId: 'other-scale'));
+    await pump();
+
+    expect(connectCalls, isEmpty);
+    expect(watch.armed, isTrue);
+    expect(scanner.watchActive, isTrue);
+  });
+
+  test('failed connect (gate still true) restarts the watch', () async {
+    connectSucceeds = false;
+    await watch.arm();
+    scanner.addDevice(TestScale(deviceId: scaleId));
+    await pump();
+
+    expect(connectCalls, hasLength(1));
+    expect(scanner.startWatchCallCount, 2,
+        reason: 'gate still holds after the attempt — keep watching');
+    expect(watch.armed, isTrue);
+  });
+
+  test('concurrent sightings coalesce into one connect', () async {
+    connectGate = Completer<void>();
+    await watch.arm();
+    scanner.addDevice(TestScale(deviceId: scaleId));
+    await pump();
+    // Second emission while the first connect is still in flight.
+    scanner.removeDevice(scaleId);
+    scanner.addDevice(TestScale(deviceId: scaleId));
+    await pump();
+
+    expect(connectCalls, hasLength(1),
+        reason: 'in-flight connect must swallow repeat sightings');
+    connectGate!.complete();
+    await pump();
+  });
+
+  test('startScaleWatch failure reports watch-unavailable and stays disarmed',
+      () async {
+    scanner.failNextWatchWith = Exception('no watch for you');
+    await watch.arm();
+
+    expect(unavailableCalls, 1);
+    expect(watch.armed, isFalse);
+  });
+
+  test('disarm stops the watch and is idempotent', () async {
+    await watch.arm();
+    expect(scanner.watchActive, isTrue);
+
+    await watch.disarm();
+    expect(watch.armed, isFalse);
+    expect(scanner.watchActive, isFalse);
+
+    await watch.disarm(); // second call must not throw or double-stop
+    expect(scanner.stopWatchCallCount, 1);
+  });
+
+  test('disarm before arm is safe', () async {
+    await watch.disarm();
+    expect(scanner.stopWatchCallCount, 0);
+  });
+
+  test('disarm during an in-flight connect does not resurrect the watch',
+      () async {
+    connectSucceeds = false; // would normally re-arm after the attempt
+    connectGate = Completer<void>();
+    await watch.arm();
+    scanner.addDevice(TestScale(deviceId: scaleId));
+    await pump();
+    expect(connectCalls, hasLength(1));
+
+    await watch.disarm();
+    connectGate!.complete();
+    await pump();
+
+    expect(watch.armed, isFalse);
+    expect(scanner.startWatchCallCount, 1,
+        reason: 'a connect completing after disarm must not restart the '
+            'watch (generation token)');
+  });
+
+  test('re-arm after disarm starts a fresh watch', () async {
+    await watch.arm();
+    await watch.disarm();
+    await watch.arm();
+
+    expect(scanner.startWatchCallCount, 2);
+    expect(watch.armed, isTrue);
+
+    scanner.addDevice(TestScale(deviceId: scaleId));
+    await pump();
+    expect(connectCalls, hasLength(1),
+        reason: 'the re-armed watch must still react to sightings');
+  });
+
+  test('dispose stops the watch', () async {
+    await watch.arm();
+    await watch.dispose();
+    expect(scanner.watchActive, isFalse);
+    expect(watch.armed, isFalse);
+  });
+}

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -4,6 +4,8 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/connection_error.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/controllers/remembered_devices_controller.dart';
+import 'package:reaprime/src/models/device/remembered_device.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
@@ -52,6 +54,14 @@ class _FakeDe1 implements De1Interface {
 
   @override
   Stream<MachineSnapshot> get currentSnapshot => _snapshotController.stream;
+
+  // Non-null so De1Controller.adoptDevice (quick-connect) can subscribe
+  // and De1Controller.dispose can await teardown of an adopted device.
+  @override
+  Stream<bool> get ready => const Stream.empty();
+
+  @override
+  Future<void> dispose() async {}
 
   _FakeDe1({this.deviceId = 'fake-de1'}) : name = 'DE1-$deviceId';
 
@@ -1950,6 +1960,259 @@ void main() {
         expect(connectionManager.machineRecoveryActive, isTrue,
             reason: 'a stranded forced reconnect must hand off to the '
                 'machine-recovery loop, not leave the machine disconnected');
+      });
+    });
+
+    group('background scale watch', () {
+      const scaleId = 'pref-scale';
+
+      ConnectionManager buildWatchManager() => ConnectionManager(
+            deviceScanner: mockScanner,
+            de1Controller: mockDe1Controller,
+            scaleController: mockScaleController,
+            settingsController: settingsController,
+          );
+
+      setUp(() async {
+        // Retire the shared legacy manager from the outer setUp — it
+        // listens to the same subjects and, with supportsWatch flipped
+        // on, would double-arm the watch alongside this group's manager.
+        await connectionManager.dispose();
+        mockScanner.supportsWatch = true;
+      });
+
+      test(
+          'machine connect with preferred scale missing arms the watch '
+          'and never runs backoff bursts', () {
+        fakeAsync((async) {
+          final manager = buildWatchManager();
+          settingsController.setPreferredScaleId(scaleId);
+          async.flushMicrotasks();
+          mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
+          async.flushMicrotasks();
+
+          expect(mockScanner.startWatchCallCount, 1,
+              reason: 'watch must arm on machine connect with scale missing');
+          expect(mockScanner.lastWatchFilter?.namePrefix, isNull,
+              reason: 'no OS name filter — remembered friendly names do not '
+                  'match advertised names; Dart-side matching owns this');
+          expect(mockScanner.lastWatchFilter?.deviceTypes, {DeviceType.scale});
+
+          // The load-bearing regression assertion: past the full legacy
+          // backoff ladder (5→60s), no burst scan may fire — the watch
+          // replaces the loop entirely.
+          async.elapse(const Duration(seconds: 70));
+          async.flushMicrotasks();
+          expect(mockScanner.scanCallCount, 0,
+              reason: 'watch replaces the backoff-burst reconnect loop');
+
+          manager.dispose();
+          async.flushMicrotasks();
+        });
+      });
+
+      test('watch sighting connects the scale and stops the watch', () async {
+        connectionManager = buildWatchManager();
+        await settingsController.setPreferredScaleId(scaleId);
+        mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
+        await Future<void>.delayed(Duration.zero);
+        expect(mockScanner.watchActive, isTrue);
+
+        mockScanner.addDevice(TestScale(deviceId: scaleId));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          mockScaleController.connectCalls.map((s) => s.deviceId),
+          contains(scaleId),
+        );
+        expect(mockScanner.watchActive, isFalse,
+            reason: 'watch stops once the scale is connected');
+        expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
+        expect(mockScanner.scanCallCount, 0,
+            reason: 'the connect must not go through a burst scan');
+      });
+
+      test('failed watch connect re-arms the watch', () async {
+        connectionManager = buildWatchManager();
+        await settingsController.setPreferredScaleId(scaleId);
+        mockScaleController.shouldFailConnect = true;
+        mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
+        await Future<void>.delayed(Duration.zero);
+        expect(mockScanner.startWatchCallCount, 1);
+
+        mockScanner.addDevice(TestScale(deviceId: scaleId));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(mockScaleController.connectCalls, isNotEmpty);
+        expect(mockScanner.startWatchCallCount, 2,
+            reason: 'a failed connect must restart the watch');
+        expect(mockScanner.watchActive, isTrue);
+      });
+
+      test('unexpected preferred scale disconnect arms the watch', () async {
+        connectionManager = buildWatchManager();
+        await settingsController.setPreferredScaleId(scaleId);
+        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
+        mockScaleController.debugSetLastConnectedId(scaleId);
+        mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
+        await Future<void>.delayed(Duration.zero);
+        expect(mockScanner.startWatchCallCount, 0,
+            reason: 'scale is connected — nothing to watch for');
+
+        mockScaleController
+            .mockEmitConnectionState(ConnectionState.disconnected);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(mockScanner.startWatchCallCount, 1);
+        expect(mockScanner.scanCallCount, 0,
+            reason: 'no burst scan on unexpected disconnect either');
+      });
+
+      test(
+          'power-mode sleep stops the watch and wake re-arms it '
+          'without a burst', () async {
+        await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
+        connectionManager = buildWatchManager();
+        await settingsController.setPreferredScaleId(scaleId);
+        final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
+        mockDe1Controller.de1Subject.add(fakeDe1);
+        await Future<void>.delayed(Duration.zero);
+        fakeDe1.emitState(MachineState.idle);
+        await Future<void>.delayed(Duration.zero);
+        expect(mockScanner.watchActive, isTrue,
+            reason: 'machine awake + scale missing → watch armed');
+
+        fakeDe1.emitState(MachineState.sleeping);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        expect(mockScanner.watchActive, isFalse,
+            reason: 'sleeping + ScalePowerMode.disconnect must stop the watch');
+
+        final startsBeforeWake = mockScanner.startWatchCallCount;
+        fakeDe1.emitState(MachineState.idle);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        expect(mockScanner.startWatchCallCount, startsBeforeWake + 1,
+            reason: 'wake must re-arm the watch');
+        expect(mockScanner.scanCallCount, 0);
+      });
+
+      test('machine disconnect stops the watch', () async {
+        connectionManager = buildWatchManager();
+        await settingsController.setPreferredScaleId(scaleId);
+        mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
+        await Future<void>.delayed(Duration.zero);
+        expect(mockScanner.watchActive, isTrue);
+
+        mockDe1Controller.de1Subject.add(null);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(mockScanner.watchActive, isFalse,
+            reason: 'no machine → nothing to reacquire a scale for');
+      });
+
+      test(
+          'machine quick-connect arms the watch, not the legacy backoff loop',
+          () {
+        // Quick-connect is the common startup path when a preferred
+        // machine is remembered; its success branch must route scale
+        // reacquisition through the watch selector like every other
+        // machine-connected site — not schedule backoff bursts alongside
+        // the watch.
+        fakeAsync((async) {
+          mockSettingsService.setRememberedDevices(RememberedDevice.encodeList([
+            const RememberedDevice(
+              id: 'pref-de1',
+              name: 'DE1',
+              type: DeviceType.machine,
+            ),
+          ]));
+          final remembered = RememberedDevicesController(
+            machineConnections: const Stream.empty(),
+            scaleConnections: const Stream.empty(),
+            settings: mockSettingsService,
+          );
+          remembered.initialize();
+          async.flushMicrotasks();
+
+          final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+          mockScanner.quickConnectResult = fakeDe1;
+          // Fresh controller: the group setUp disposed the shared one
+          // (closing its subjects), which would make adoptDevice throw.
+          final qcDe1Controller = MockDe1Controller(
+            controller: DeviceController([dummyDiscoveryService]),
+          );
+          final manager = ConnectionManager(
+            deviceScanner: mockScanner,
+            de1Controller: qcDe1Controller,
+            scaleController: mockScaleController,
+            settingsController: settingsController,
+            rememberedDevices: remembered,
+          );
+          settingsController.setPreferredMachineId('pref-de1');
+          settingsController.setPreferredScaleId(scaleId);
+          async.flushMicrotasks();
+
+          manager.connect();
+          async.flushMicrotasks();
+          expect(mockScanner.quickConnectCallCount, 1,
+              reason: 'the quick-connect path must be the one exercised');
+
+          // Production: adoptDevice propagates onto the de1 stream and
+          // the supervisor fires machine-connected; simulate that here
+          // (MockDe1Controller overrides the stream adoptDevice feeds).
+          qcDe1Controller.de1Subject.add(fakeDe1);
+          async.flushMicrotasks();
+
+          expect(mockScanner.startWatchCallCount, 1,
+              reason: 'watch must arm after a quick-connected machine');
+          async.elapse(const Duration(seconds: 70));
+          async.flushMicrotasks();
+          expect(mockScanner.scanCallCount, 0,
+              reason: 'quick-connect success must not schedule legacy '
+                  'backoff bursts alongside the watch');
+
+          manager.dispose();
+          remembered.dispose();
+          async.flushMicrotasks();
+        });
+      });
+
+      test('watch start failure falls back to the legacy backoff loop', () {
+        fakeAsync((async) {
+          final manager = buildWatchManager();
+          settingsController.setPreferredScaleId(scaleId);
+          async.flushMicrotasks();
+          mockScanner.failNextWatchWith = Exception('watch unavailable');
+          mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
+          async.flushMicrotasks();
+
+          expect(mockScanner.startWatchCallCount, 0,
+              reason: 'the start attempt threw before recording');
+          // Legacy backoff base delay is 5s — the fallback burst fires then.
+          async.elapse(const Duration(seconds: 6));
+          async.flushMicrotasks();
+          expect(mockScanner.scanCallCount, 1,
+              reason: 'watch failure must fall back to backoff bursts');
+
+          manager.dispose();
+          async.flushMicrotasks();
+        });
+      });
+
+      test('dispose stops the watch', () async {
+        connectionManager = buildWatchManager();
+        await settingsController.setPreferredScaleId(scaleId);
+        mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
+        await Future<void>.delayed(Duration.zero);
+        expect(mockScanner.watchActive, isTrue);
+
+        await connectionManager.dispose();
+        expect(mockScanner.watchActive, isFalse);
       });
     });
   });

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -1996,7 +1996,6 @@ void main() {
           expect(mockScanner.lastWatchFilter?.namePrefix, isNull,
               reason: 'no OS name filter — remembered friendly names do not '
                   'match advertised names; Dart-side matching owns this');
-          expect(mockScanner.lastWatchFilter?.deviceTypes, {DeviceType.scale});
 
           // The load-bearing regression assertion: past the full legacy
           // backoff ladder (5→60s), no burst scan may fire — the watch
@@ -2198,6 +2197,32 @@ void main() {
           async.flushMicrotasks();
           expect(mockScanner.scanCallCount, 1,
               reason: 'watch failure must fall back to backoff bursts');
+
+          manager.dispose();
+          async.flushMicrotasks();
+        });
+      });
+
+      test('a watch that dies mid-flight falls back to legacy backoff', () {
+        fakeAsync((async) {
+          final manager = buildWatchManager();
+          settingsController.setPreferredScaleId(scaleId);
+          async.flushMicrotasks();
+          mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
+          async.flushMicrotasks();
+          expect(mockScanner.startWatchCallCount, 1);
+
+          // Simulates a failed refresh / post-burst resume / adapter
+          // recovery inside the discovery service.
+          mockScanner.emitWatchFailure();
+          async.flushMicrotasks();
+
+          async.elapse(const Duration(seconds: 6));
+          async.flushMicrotasks();
+          expect(mockScanner.scanCallCount, 1,
+              reason: 'the legacy backoff loop must take over when the '
+                  'watch dies — scale reacquisition must never be '
+                  'silently off');
 
           manager.dispose();
           async.flushMicrotasks();

--- a/test/controllers/de1_state_manager_wake_scan_test.dart
+++ b/test/controllers/de1_state_manager_wake_scan_test.dart
@@ -1,0 +1,164 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/de1_state_manager.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/persistence_controller.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/services/storage/storage_service.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:rxdart/rxdart.dart';
+
+import '../helpers/mock_device_discovery_service.dart';
+import '../helpers/mock_device_scanner.dart';
+import '../helpers/mock_settings_service.dart';
+import '../helpers/test_de1.dart';
+
+/// De1Controller whose `de1` stream and `connectedDe1()` are test-driven.
+class _TestDe1Controller extends De1Controller {
+  final BehaviorSubject<De1Interface?> de1Subject = BehaviorSubject.seeded(
+    null,
+  );
+  De1Interface? current;
+
+  _TestDe1Controller({required super.controller});
+
+  @override
+  Stream<De1Interface?> get de1 => de1Subject.stream;
+
+  @override
+  De1Interface connectedDe1() {
+    final de1 = current;
+    if (de1 == null) throw 'no de1 connected';
+    return de1;
+  }
+
+  void connect(De1Interface de1) {
+    current = de1;
+    de1Subject.add(de1);
+  }
+}
+
+/// StorageService stub — De1StateManager never touches storage in the
+/// wake path; PersistenceController is lazy so nothing is called.
+class _NoopStorageService implements StorageService {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => Future<dynamic>.value(null);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late TestDe1 testDe1;
+  late _TestDe1Controller de1Controller;
+  late ScaleController scaleController;
+  late MockDeviceScanner mockScanner;
+  late SettingsController settingsController;
+  late ConnectionManager connectionManager;
+  late De1StateManager manager;
+
+  Future<void> pump([int n = 3]) async {
+    for (var i = 0; i < n; i++) {
+      await Future<void>.delayed(Duration.zero);
+    }
+  }
+
+  setUp(() async {
+    testDe1 = TestDe1();
+    final deviceController = DeviceController([MockDeviceDiscoveryService()]);
+    await deviceController.initialize();
+    de1Controller = _TestDe1Controller(controller: deviceController);
+    scaleController = ScaleController();
+    mockScanner = MockDeviceScanner();
+
+    final settingsService = MockSettingsService();
+    settingsController = SettingsController(settingsService);
+    await settingsController.loadSettings();
+
+    connectionManager = ConnectionManager(
+      deviceScanner: mockScanner,
+      de1Controller: de1Controller,
+      scaleController: scaleController,
+      settingsController: settingsController,
+    );
+
+    manager = De1StateManager(
+      de1Controller: de1Controller,
+      scaleController: scaleController,
+      workflowController: WorkflowController(),
+      persistenceController: PersistenceController(
+        storageService: _NoopStorageService(),
+      ),
+      settingsController: settingsController,
+      connectionManager: connectionManager,
+      navigatorKey: GlobalKey<NavigatorState>(),
+    );
+    manager.deferredScaleScanDelay = Duration.zero;
+  });
+
+  tearDown(() async {
+    manager.dispose();
+    await connectionManager.dispose();
+    await testDe1.dispose();
+    mockScanner.dispose();
+  });
+
+  /// Drive the machine through idle → sleeping → idle so the wake
+  /// transition (sleeping → non-sleeping) fires the deferred scale scan.
+  Future<void> wakeMachine() async {
+    testDe1.emitStateAndSubstate(MachineState.idle, MachineSubstate.idle);
+    await pump();
+    testDe1.emitStateAndSubstate(MachineState.sleeping, MachineSubstate.idle);
+    await pump();
+    testDe1.emitStateAndSubstate(MachineState.idle, MachineSubstate.idle);
+    await pump(6);
+  }
+
+  test(
+      'wake with watch support and a preferred scale skips the '
+      'scale-only burst scan', () async {
+    mockScanner.supportsWatch = true;
+    await settingsController.setPreferredScaleId('pref-scale');
+    de1Controller.connect(testDe1);
+    await pump();
+
+    await wakeMachine();
+
+    expect(mockScanner.scanCallCount, 0,
+        reason: 'the persistent watch covers reacquisition — a wake burst '
+            'would starve the freshly woken DE1 link');
+    expect(mockScanner.startWatchCallCount, greaterThan(0),
+        reason: 'the watch (not the burst) must be handling reacquisition');
+  });
+
+  test('wake with no preferred scale still runs the discovery burst',
+      () async {
+    mockScanner.supportsWatch = true;
+    de1Controller.connect(testDe1);
+    await pump();
+
+    await wakeMachine();
+
+    expect(mockScanner.scanCallCount, 1,
+        reason: 'without a preferred scale the watch cannot help — the '
+            'burst feeds discovery/picker');
+  });
+
+  test('wake without watch support runs the legacy burst', () async {
+    mockScanner.supportsWatch = false;
+    await settingsController.setPreferredScaleId('pref-scale');
+    de1Controller.connect(testDe1);
+    await pump();
+
+    await wakeMachine();
+
+    expect(mockScanner.scanCallCount, 1,
+        reason: 'non-watch platforms keep the legacy wake reconnect');
+  });
+}

--- a/test/helpers/mock_device_scanner.dart
+++ b/test/helpers/mock_device_scanner.dart
@@ -5,6 +5,7 @@ import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_scanner.dart';
 import 'package:reaprime/src/models/device/remembered_device.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
+import 'package:reaprime/src/models/device/watch_filter.dart';
 import 'package:rxdart/rxdart.dart';
 
 /// A controllable [DeviceScanner] for testing [ConnectionManager].
@@ -25,6 +26,10 @@ class MockDeviceScanner implements DeviceScanner {
   /// Number of times [stopScan] has been called.
   int stopScanCallCount = 0;
 
+  /// Number of times [scanForDevices] has been called (successful starts
+  /// only — a [failNextScanWith] throw does not count).
+  int scanCallCount = 0;
+
   /// When set, [scanForDevices] will emit `scanning: true` then wait for
   /// this completer before emitting `scanning: false`. This lets tests
   /// add devices mid-scan and verify early-stop behavior.
@@ -34,6 +39,28 @@ class MockDeviceScanner implements DeviceScanner {
   /// running a scan. Consumed after one throw. Tests use this to exercise
   /// scan-start failure classification in [ConnectionManager].
   Object? failNextScanWith;
+
+  /// Watch capability flag. Defaults to false so existing tests exercise
+  /// the legacy backoff-reconnect path unchanged; background-scale-watch
+  /// tests flip it on.
+  bool supportsWatch = false;
+
+  /// Filter passed to the most recent [startScaleWatch] call.
+  DeviceWatchFilter? lastWatchFilter;
+
+  /// Number of times [startScaleWatch] has been called.
+  int startWatchCallCount = 0;
+
+  /// Number of times [stopScaleWatch] has been called.
+  int stopWatchCallCount = 0;
+
+  /// True while a watch is running (started and not yet stopped).
+  bool watchActive = false;
+
+  /// When set, the next [startScaleWatch] call throws this object.
+  /// Consumed after one throw. Tests use this to exercise the
+  /// fall-back-to-legacy-backoff path in [ConnectionManager].
+  Object? failNextWatchWith;
 
   @override
   Stream<List<Device>> get deviceStream => _deviceSubject.stream;
@@ -83,6 +110,7 @@ class MockDeviceScanner implements DeviceScanner {
       failNextScanWith = null;
       throw e!;
     }
+    scanCallCount++;
     final start = DateTime.now();
     _scanningSubject.add(true);
     // Re-emit current devices to simulate scan rediscovery.
@@ -119,6 +147,27 @@ class MockDeviceScanner implements DeviceScanner {
   Future<Device?> tryQuickConnect(RememberedDevice remembered) async {
     quickConnectCallCount++;
     return quickConnectResult;
+  }
+
+  @override
+  bool get supportsBackgroundWatch => supportsWatch;
+
+  @override
+  Future<void> startScaleWatch(DeviceWatchFilter filter) async {
+    if (failNextWatchWith != null) {
+      final e = failNextWatchWith;
+      failNextWatchWith = null;
+      throw e!;
+    }
+    startWatchCallCount++;
+    lastWatchFilter = filter;
+    watchActive = true;
+  }
+
+  @override
+  Future<void> stopScaleWatch() async {
+    stopWatchCallCount++;
+    watchActive = false;
   }
 
   void dispose() {

--- a/test/helpers/mock_device_scanner.dart
+++ b/test/helpers/mock_device_scanner.dart
@@ -62,6 +62,15 @@ class MockDeviceScanner implements DeviceScanner {
   /// fall-back-to-legacy-backoff path in [ConnectionManager].
   Object? failNextWatchWith;
 
+  final _watchFailuresSubject = PublishSubject<void>();
+
+  /// Simulate a running watch dying without a possible restart (failed
+  /// refresh / resume / adapter recovery in the real service).
+  void emitWatchFailure() {
+    watchActive = false;
+    _watchFailuresSubject.add(null);
+  }
+
   @override
   Stream<List<Device>> get deviceStream => _deviceSubject.stream;
 
@@ -170,7 +179,11 @@ class MockDeviceScanner implements DeviceScanner {
     watchActive = false;
   }
 
+  @override
+  Stream<void> get scaleWatchFailures => _watchFailuresSubject.stream;
+
   void dispose() {
+    _watchFailuresSubject.close();
     _deviceSubject.close();
     _scanningSubject.close();
     _adapterStateSubject.close();

--- a/test/integration/connection_manager_bengle_scale_test.dart
+++ b/test/integration/connection_manager_bengle_scale_test.dart
@@ -174,6 +174,41 @@ void main() {
     });
 
     test(
+        'background scale watch ignores external scale sightings while a '
+        'Bengle is the machine', () async {
+      // Watch-path variant of the Bengle rule: watch-driven connects
+      // bypass _runScalePhase, so ConnectionManager must re-apply
+      // "integrated scale owns the slot" before connecting a sighted
+      // external scale.
+      await connectionManager.dispose();
+      mockScanner.supportsWatch = true;
+      connectionManager = ConnectionManager(
+        deviceScanner: mockScanner,
+        de1Controller: mockDe1Controller,
+        scaleController: mockScaleController,
+        settingsController: settingsController,
+      );
+      await settingsController.setPreferredScaleId('external-scale');
+
+      // Bengle connects (pushed directly — virtual attach hasn't run,
+      // so the scale slot is still open and the watch gate holds).
+      mockDe1Controller.de1Subject.add(_FakeBengle(deviceId: 'bengle-1'));
+      await Future<void>.delayed(Duration.zero);
+
+      mockScanner.addDevice(TestScale(deviceId: 'external-scale'));
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        mockScaleController.connectCalls
+            .where((s) => s.deviceId == 'external-scale'),
+        isEmpty,
+        reason: 'Bengle integrated scale owns the slot — the watch must '
+            'not connect an external scale into it',
+      );
+    });
+
+    test(
         'external scale visible BEFORE Bengle still loses the slot to the '
         'virtual scale', () async {
       // Regression for the interleaved-discovery race the synchronous

--- a/test/integration/connection_manager_bengle_scale_test.dart
+++ b/test/integration/connection_manager_bengle_scale_test.dart
@@ -206,6 +206,47 @@ void main() {
         reason: 'Bengle integrated scale owns the slot — the watch must '
             'not connect an external scale into it',
       );
+      expect(mockScanner.watchActive, isFalse,
+          reason: 'nothing external to reacquire on a Bengle — no watch');
+    });
+
+    test(
+        'a late Bengle transition disarms the watch instead of restarting '
+        'it forever', () async {
+      // The watch arms legitimately while a DE1 is the machine; a Bengle
+      // then takes over. A sighting of the (still-preferred) external
+      // scale is refused — and the refusal must END the watch cycle, not
+      // restart the scan indefinitely.
+      await connectionManager.dispose();
+      mockScanner.supportsWatch = true;
+      connectionManager = ConnectionManager(
+        deviceScanner: mockScanner,
+        de1Controller: mockDe1Controller,
+        scaleController: mockScaleController,
+        settingsController: settingsController,
+      );
+      await settingsController.setPreferredScaleId('external-scale');
+
+      mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'de1-1'));
+      await Future<void>.delayed(Duration.zero);
+      expect(mockScanner.watchActive, isTrue,
+          reason: 'DE1 machine + missing preferred scale → watch armed');
+
+      mockDe1Controller.de1Subject.add(_FakeBengle(deviceId: 'bengle-1'));
+      await Future<void>.delayed(Duration.zero);
+
+      mockScanner.addDevice(TestScale(deviceId: 'external-scale'));
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        mockScaleController.connectCalls
+            .where((s) => s.deviceId == 'external-scale'),
+        isEmpty,
+      );
+      expect(mockScanner.watchActive, isFalse,
+          reason: 'the refused sighting must disarm the watch — Bengle '
+              'owns the scale slot');
     });
 
     test(

--- a/test/services/universal_ble_discovery_service_test.dart
+++ b/test/services/universal_ble_discovery_service_test.dart
@@ -133,10 +133,7 @@ class _FakeBlePlatform extends UniversalBlePlatform {
       [];
 }
 
-const _watchFilter = DeviceWatchFilter(
-  namePrefix: 'Decent Scale',
-  deviceTypes: {domain.DeviceType.scale},
-);
+const _watchFilter = DeviceWatchFilter(namePrefix: 'Decent Scale');
 
 void main() {
   late _FakeBlePlatform platform;
@@ -172,9 +169,7 @@ void main() {
     });
 
     test('null name prefix scans unfiltered, still balanced', () async {
-      await service.startDeviceWatch(
-        const DeviceWatchFilter(deviceTypes: {domain.DeviceType.scale}),
-      );
+      await service.startDeviceWatch(const DeviceWatchFilter());
 
       expect(platform.startScanCalls, hasLength(1));
       expect(lastStart().filter?.withNamePrefix, isEmpty);
@@ -291,7 +286,9 @@ void main() {
               'otherwise it runs orphaned forever');
     });
 
-    test('a burst racing the watch start does not leave a dead watch',
+    test(
+        'a burst racing the watch start is serialized: the burst scan '
+        'starts only after the watch start settles and owns the session',
         () async {
       final hold = Completer<void>();
       platform.holdNextStartScan = hold;
@@ -301,28 +298,137 @@ void main() {
       final burst = service.scanForDevices();
       await pump();
 
+      expect(platform.startScanCalls, isEmpty,
+          reason: 'the burst must wait for the in-flight watch start — '
+              'issuing its startScan concurrently leaves session '
+              'ownership undefined');
+
       hold.complete();
       await start;
       await pump();
+
+      // Ownership order: the watch start settles first, then the burst's
+      // startScan runs — the burst's unfiltered scan is the live native
+      // session for the whole burst.
+      final prefixes = platform.startScanCalls
+          .map((c) => c.filter?.withNamePrefix ?? const <String>[])
+          .toList();
+      expect(prefixes.first, ['Decent Scale'],
+          reason: 'the raced watch start settles before the burst starts');
+      expect(prefixes[1], isEmpty,
+          reason: 'the burst scan follows and owns the session');
 
       service.stopScan(); // end the burst
       await burst;
       await pump();
 
-      // The watch must be genuinely running after the burst — the last
-      // start must be the watch's filtered scan AND it must be a fresh
-      // start issued by the burst's resume (3 total: the raced watch
-      // start, the burst, the resume). A raced start that claims
-      // active would make the resume bail at 2 calls, leaving a dead
-      // watch after the burst's end-of-scan stop.
-      expect(platform.startScanCalls, hasLength(3));
+      expect(platform.startScanCalls, hasLength(3),
+          reason: 'the watch must resume after the burst');
       expect(lastStart().filter?.withNamePrefix, ['Decent Scale'],
           reason: 'the burst finally-block must resume a real watch scan, '
               'not skip it because the raced start claimed to be active');
     });
+
+    test(
+        'stopDeviceWatch waits for an in-flight start before stopping',
+        () async {
+      final hold = Completer<void>();
+      platform.holdNextStartScan = hold;
+
+      final start = service.startDeviceWatch(_watchFilter);
+      await pump();
+      final stop = service.stopDeviceWatch();
+      await pump();
+
+      hold.complete();
+      await start;
+      await stop;
+      await pump();
+
+      expect(platform.startScanCalls, hasLength(1));
+      expect(platform.stopScanCalls, greaterThanOrEqualTo(1),
+          reason: 'the scan the raced start opened must be stopped');
+    });
   });
 
   group('resilience', () {
+    test('adapter powering off during the start window stands the watch '
+        'down and power-on restarts it', () async {
+      final hold = Completer<void>();
+      platform.holdNextStartScan = hold;
+
+      final start = service.startDeviceWatch(_watchFilter);
+      await pump();
+      platform.updateAvailability(AvailabilityState.poweredOff);
+      await pump();
+
+      hold.complete();
+      await start;
+      await pump();
+
+      expect(platform.startScanCalls, hasLength(1),
+          reason: 'the raced start alone — nothing may claim active while '
+              'the adapter is off');
+
+      platform.updateAvailability(AvailabilityState.poweredOn);
+      await pump();
+
+      expect(platform.startScanCalls, hasLength(2),
+          reason: 'a still-requested watch must restart on power-on; a '
+              'stale active claim from the raced start would block this');
+      expect(lastStart().filter?.withNamePrefix, ['Decent Scale']);
+    });
+
+    test('a failed post-burst resume emits a watch failure', () async {
+      await service.startDeviceWatch(_watchFilter);
+      final failures = <void>[];
+      final sub = service.deviceWatchFailures.listen(failures.add);
+
+      final burst = service.scanForDevices();
+      await pump();
+      platform.failNextStartScanWith = Exception('resume denied');
+      service.stopScan();
+      await burst;
+      await pump();
+
+      expect(failures, hasLength(1),
+          reason: 'a dead watch must be reported so ScaleWatch can fall '
+              'back to the legacy loop instead of staying silently armed');
+
+      // The request is cleared: adapter recovery must not resurrect it.
+      platform.updateAvailability(AvailabilityState.poweredOff);
+      await pump();
+      platform.updateAvailability(AvailabilityState.poweredOn);
+      await pump();
+      expect(platform.startScanCalls, hasLength(2),
+          reason: 'watch start + burst only — no resurrection after a '
+              'reported failure');
+      await sub.cancel();
+    });
+
+    test('a failed refresh restart emits a watch failure', () {
+      fakeAsync((async) {
+        final zoned = UniversalBleDiscoveryService(
+          watchSupportGate: () => true,
+        );
+        zoned.initialize();
+        async.flushMicrotasks();
+        final failures = <void>[];
+        zoned.deviceWatchFailures.listen(failures.add);
+        zoned.startDeviceWatch(_watchFilter);
+        async.flushMicrotasks();
+        expect(platform.startScanCalls, hasLength(1));
+
+        platform.failNextStartScanWith = Exception('refresh denied');
+        async.elapse(const Duration(minutes: 26));
+        async.flushMicrotasks();
+
+        expect(failures, hasLength(1),
+            reason: 'a refresh that cannot restart the scan leaves the '
+                'watch dead — it must be reported, not swallowed');
+      });
+    });
+
     test('adapter off kills the watch; adapter on restarts it', () async {
       await service.startDeviceWatch(_watchFilter);
       expect(platform.startScanCalls, hasLength(1));

--- a/test/services/universal_ble_discovery_service_test.dart
+++ b/test/services/universal_ble_discovery_service_test.dart
@@ -1,0 +1,368 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart' as domain;
+import 'package:reaprime/src/models/device/watch_filter.dart';
+import 'package:reaprime/src/services/universal_ble_discovery_service.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+/// Fake platform backend for universal_ble. The abstract base class
+/// already carries the stream plumbing (`updateScanResult`,
+/// `updateAvailability`); this fake records scan start/stop calls.
+class _FakeBlePlatform extends UniversalBlePlatform {
+  final List<({ScanFilter? filter, PlatformConfig? config})> startScanCalls =
+      [];
+  int stopScanCalls = 0;
+  Object? failNextStartScanWith;
+
+  @override
+  Future<AvailabilityState> getBluetoothAvailabilityState() async =>
+      AvailabilityState.poweredOn;
+
+  @override
+  Future<bool> enableBluetooth() async => true;
+
+  @override
+  Future<bool> disableBluetooth() async => true;
+
+  /// When set, the next [startScan] call blocks until this completes
+  /// (consumed after one use). Lets tests race other operations into
+  /// the start window.
+  Completer<void>? holdNextStartScan;
+
+  @override
+  Future<void> startScan({
+    ScanFilter? scanFilter,
+    PlatformConfig? platformConfig,
+  }) async {
+    if (failNextStartScanWith != null) {
+      final e = failNextStartScanWith;
+      failNextStartScanWith = null;
+      throw e!;
+    }
+    final hold = holdNextStartScan;
+    if (hold != null) {
+      holdNextStartScan = null;
+      await hold.future;
+    }
+    startScanCalls.add((filter: scanFilter, config: platformConfig));
+  }
+
+  @override
+  Future<void> stopScan() async {
+    stopScanCalls++;
+  }
+
+  @override
+  Future<bool> isScanning() async => false;
+
+  @override
+  Future<void> connect(
+    String deviceId, {
+    Duration? connectionTimeout,
+    bool autoConnect = false,
+  }) async {}
+
+  @override
+  Future<void> disconnect(String deviceId) async {}
+
+  @override
+  Future<List<BleService>> discoverServices(
+    String deviceId,
+    bool withDescriptors,
+  ) async =>
+      [];
+
+  @override
+  Future<void> setNotifiable(
+    String deviceId,
+    String service,
+    String characteristic,
+    BleInputProperty bleInputProperty,
+  ) async {}
+
+  @override
+  Future<Uint8List> readValue(
+    String deviceId,
+    String service,
+    String characteristic, {
+    Duration? timeout,
+  }) async =>
+      Uint8List(0);
+
+  @override
+  Future<void> writeValue(
+    String deviceId,
+    String service,
+    String characteristic,
+    Uint8List value,
+    BleOutputProperty bleOutputProperty,
+  ) async {}
+
+  @override
+  Future<int> requestMtu(String deviceId, int expectedMtu) async => 23;
+
+  @override
+  Future<int> readRssi(String deviceId) async => 0;
+
+  @override
+  Future<void> requestConnectionPriority(
+    String deviceId,
+    BleConnectionPriority priority,
+  ) async {}
+
+  @override
+  Future<bool> isPaired(String deviceId) async => false;
+
+  @override
+  Future<bool> pair(String deviceId) async => true;
+
+  @override
+  Future<void> unpair(String deviceId) async {}
+
+  @override
+  Future<BleConnectionState> getConnectionState(String deviceId) async =>
+      BleConnectionState.disconnected;
+
+  @override
+  Future<List<BleDevice>> getSystemDevices(
+    List<String>? withServices,
+  ) async =>
+      [];
+}
+
+const _watchFilter = DeviceWatchFilter(
+  namePrefix: 'Decent Scale',
+  deviceTypes: {domain.DeviceType.scale},
+);
+
+void main() {
+  late _FakeBlePlatform platform;
+  late UniversalBleDiscoveryService service;
+
+  Future<void> pump([int n = 3]) async {
+    for (var i = 0; i < n; i++) {
+      await Future<void>.delayed(Duration.zero);
+    }
+  }
+
+  setUp(() async {
+    platform = _FakeBlePlatform();
+    UniversalBle.setInstance(platform);
+    service = UniversalBleDiscoveryService(watchSupportGate: () => true);
+    await service.initialize();
+  });
+
+  ({ScanFilter? filter, PlatformConfig? config}) lastStart() =>
+      platform.startScanCalls.last;
+
+  group('startDeviceWatch', () {
+    test('starts a name-prefix-filtered balanced scan', () async {
+      await service.startDeviceWatch(_watchFilter);
+
+      expect(platform.startScanCalls, hasLength(1));
+      expect(lastStart().filter?.withNamePrefix, ['Decent Scale']);
+      expect(
+        lastStart().config?.android?.scanMode,
+        AndroidScanMode.balanced,
+        reason: 'the watch must leave most of the radio duty cycle to GATT',
+      );
+    });
+
+    test('null name prefix scans unfiltered, still balanced', () async {
+      await service.startDeviceWatch(
+        const DeviceWatchFilter(deviceTypes: {domain.DeviceType.scale}),
+      );
+
+      expect(platform.startScanCalls, hasLength(1));
+      expect(lastStart().filter?.withNamePrefix, isEmpty);
+      // The duty cycle protects the DE1 link; the fork's name filter is
+      // plugin-side anyway, so mode does not depend on filtering.
+      expect(lastStart().config?.android?.scanMode, AndroidScanMode.balanced);
+    });
+
+    test('watch discovery flows into the devices stream', () async {
+      final emissions = <List<domain.Device>>[];
+      final sub = service.devices.listen(emissions.add);
+      await service.startDeviceWatch(_watchFilter);
+
+      platform.updateScanResult(
+        BleDevice(deviceId: 'AA:BB:CC:DD:EE:FF', name: 'Decent Scale'),
+      );
+      await pump();
+
+      expect(
+        emissions.expand((l) => l).map((d) => d.deviceId),
+        contains('AA:BB:CC:DD:EE:FF'),
+      );
+      await sub.cancel();
+    });
+  });
+
+  group('stopDeviceWatch', () {
+    test('stops the platform scan', () async {
+      await service.startDeviceWatch(_watchFilter);
+      await service.stopDeviceWatch();
+      expect(platform.stopScanCalls, 1);
+    });
+
+    test('is idempotent and safe without a watch', () async {
+      await service.stopDeviceWatch();
+      expect(platform.stopScanCalls, 0);
+    });
+  });
+
+  group('burst arbitration', () {
+    test('a burst scan pauses the watch and resumes it afterwards', () async {
+      await service.startDeviceWatch(_watchFilter);
+      expect(platform.startScanCalls, hasLength(1));
+
+      final burst = service.scanForDevices();
+      await pump();
+      // Watch paused (one stopScan), burst started with lowLatency.
+      expect(platform.stopScanCalls, 1,
+          reason: 'the watch scan must be stopped before the burst starts');
+      expect(platform.startScanCalls, hasLength(2));
+      expect(
+        lastStart().filter?.withNamePrefix,
+        isEmpty,
+        reason: 'bursts stay unfiltered (name-match happens in Dart)',
+      );
+
+      service.stopScan(); // end the burst early
+      await burst;
+      await pump();
+
+      expect(platform.startScanCalls, hasLength(3),
+          reason: 'the watch must resume after the burst');
+      expect(lastStart().filter?.withNamePrefix, ['Decent Scale']);
+      expect(lastStart().config?.android?.scanMode, AndroidScanMode.balanced);
+    });
+
+    test('startDeviceWatch during a burst defers until the burst ends',
+        () async {
+      final burst = service.scanForDevices();
+      await pump();
+      expect(platform.startScanCalls, hasLength(1)); // the burst itself
+
+      await service.startDeviceWatch(_watchFilter);
+      expect(platform.startScanCalls, hasLength(1),
+          reason: 'watch start must not fight the in-flight burst');
+
+      service.stopScan();
+      await burst;
+      await pump();
+
+      expect(platform.startScanCalls, hasLength(2),
+          reason: 'the requested watch starts once the burst is done');
+      expect(lastStart().filter?.withNamePrefix, ['Decent Scale']);
+    });
+
+    test('external stopScan() with only the watch active is a no-op',
+        () async {
+      await service.startDeviceWatch(_watchFilter);
+      service.stopScan();
+      await pump();
+
+      expect(platform.stopScanCalls, 0,
+          reason: 'stopScan means "stop burst" — it must not kill the watch');
+    });
+  });
+
+  group('start-window races', () {
+    test('stopDeviceWatch during an in-flight start undoes the scan',
+        () async {
+      final hold = Completer<void>();
+      platform.holdNextStartScan = hold;
+
+      final start = service.startDeviceWatch(_watchFilter);
+      await pump();
+      await service.stopDeviceWatch();
+
+      hold.complete();
+      await start;
+      await pump();
+
+      expect(platform.startScanCalls, hasLength(1));
+      expect(platform.stopScanCalls, 1,
+          reason: 'the scan that started after the stop must be undone — '
+              'otherwise it runs orphaned forever');
+    });
+
+    test('a burst racing the watch start does not leave a dead watch',
+        () async {
+      final hold = Completer<void>();
+      platform.holdNextStartScan = hold;
+
+      final start = service.startDeviceWatch(_watchFilter);
+      await pump();
+      final burst = service.scanForDevices();
+      await pump();
+
+      hold.complete();
+      await start;
+      await pump();
+
+      service.stopScan(); // end the burst
+      await burst;
+      await pump();
+
+      // The watch must be genuinely running after the burst — the last
+      // start must be the watch's filtered scan AND it must be a fresh
+      // start issued by the burst's resume (3 total: the raced watch
+      // start, the burst, the resume). A raced start that claims
+      // active would make the resume bail at 2 calls, leaving a dead
+      // watch after the burst's end-of-scan stop.
+      expect(platform.startScanCalls, hasLength(3));
+      expect(lastStart().filter?.withNamePrefix, ['Decent Scale'],
+          reason: 'the burst finally-block must resume a real watch scan, '
+              'not skip it because the raced start claimed to be active');
+    });
+  });
+
+  group('resilience', () {
+    test('adapter off kills the watch; adapter on restarts it', () async {
+      await service.startDeviceWatch(_watchFilter);
+      expect(platform.startScanCalls, hasLength(1));
+
+      platform.updateAvailability(AvailabilityState.poweredOff);
+      await pump();
+      platform.updateAvailability(AvailabilityState.poweredOn);
+      await pump();
+
+      expect(platform.startScanCalls, hasLength(2),
+          reason: 'a still-requested watch must restart when the adapter '
+              'comes back');
+      expect(lastStart().filter?.withNamePrefix, ['Decent Scale']);
+    });
+
+    test('the periodic refresh restarts the scan before the Android '
+        '30-minute opportunistic downgrade', () {
+      fakeAsync((async) {
+        // Fresh service inside the fake zone so its Timer is controllable.
+        final zoned = UniversalBleDiscoveryService(
+          watchSupportGate: () => true,
+        );
+        zoned.initialize();
+        async.flushMicrotasks();
+        zoned.startDeviceWatch(_watchFilter);
+        async.flushMicrotasks();
+        expect(platform.startScanCalls, hasLength(1));
+
+        async.elapse(const Duration(minutes: 26));
+        async.flushMicrotasks();
+
+        expect(platform.stopScanCalls, greaterThanOrEqualTo(1),
+            reason: 'refresh must stop the aging scan');
+        expect(platform.startScanCalls.length, greaterThanOrEqualTo(2),
+            reason: 'and start a fresh one');
+        expect(lastStart().filter?.withNamePrefix, ['Decent Scale']);
+
+        zoned.stopDeviceWatch();
+        async.flushMicrotasks();
+      });
+    });
+  });
+}

--- a/test/services/universal_ble_discovery_service_test.dart
+++ b/test/services/universal_ble_discovery_service_test.dart
@@ -267,22 +267,30 @@ void main() {
   });
 
   group('start-window races', () {
-    test('stopDeviceWatch during an in-flight start undoes the scan',
-        () async {
+    test(
+        'stopDeviceWatch during an in-flight start waits for it and '
+        'undoes the scan', () async {
+      // stopDeviceWatch serializes against the in-flight start (it must
+      // not act while session ownership is undecided), so the test
+      // releases the hold before awaiting the stop.
       final hold = Completer<void>();
       platform.holdNextStartScan = hold;
 
       final start = service.startDeviceWatch(_watchFilter);
       await pump();
-      await service.stopDeviceWatch();
+      final stop = service.stopDeviceWatch();
+      await pump();
+      expect(platform.stopScanCalls, 0,
+          reason: 'stop must wait for the start to settle first');
 
       hold.complete();
       await start;
+      await stop;
       await pump();
 
       expect(platform.startScanCalls, hasLength(1));
       expect(platform.stopScanCalls, 1,
-          reason: 'the scan that started after the stop must be undone — '
+          reason: 'the scan the raced start opened must be undone — '
               'otherwise it runs orphaned forever');
     });
 
@@ -329,26 +337,6 @@ void main() {
               'not skip it because the raced start claimed to be active');
     });
 
-    test(
-        'stopDeviceWatch waits for an in-flight start before stopping',
-        () async {
-      final hold = Completer<void>();
-      platform.holdNextStartScan = hold;
-
-      final start = service.startDeviceWatch(_watchFilter);
-      await pump();
-      final stop = service.stopDeviceWatch();
-      await pump();
-
-      hold.complete();
-      await start;
-      await stop;
-      await pump();
-
-      expect(platform.startScanCalls, hasLength(1));
-      expect(platform.stopScanCalls, greaterThanOrEqualTo(1),
-          reason: 'the scan the raced start opened must be stopped');
-    });
   });
 
   group('resilience', () {
@@ -376,6 +364,34 @@ void main() {
       expect(platform.startScanCalls, hasLength(2),
           reason: 'a still-requested watch must restart on power-on; a '
               'stale active claim from the raced start would block this');
+      expect(lastStart().filter?.withNamePrefix, ['Decent Scale']);
+    });
+
+    test(
+        'adapter off AND on completing within the start window discards '
+        'the raced start and starts a fresh scan', () async {
+      // The off/on transition may have killed the native scan the raced
+      // start opened; its completion must never claim active. The
+      // power-on recovery fires while the start is still in flight, so
+      // the retry must happen after the raced start settles.
+      final hold = Completer<void>();
+      platform.holdNextStartScan = hold;
+
+      final start = service.startDeviceWatch(_watchFilter);
+      await pump();
+      platform.updateAvailability(AvailabilityState.poweredOff);
+      await pump();
+      platform.updateAvailability(AvailabilityState.poweredOn);
+      await pump();
+
+      hold.complete();
+      await start;
+      await pump(6);
+
+      expect(platform.startScanCalls, hasLength(2),
+          reason: 'the raced start is discarded and a fresh start must '
+              'own the session — claiming active over a possibly-dead '
+              'native scan leaves the watch permanently silent');
       expect(lastStart().filter?.withNamePrefix, ['Decent Scale']);
     });
 


### PR DESCRIPTION
## Summary

- Problem: with a machine connected and the preferred scale offline, `ConnectionManager` ran periodic 15s `lowLatency` BLE scan bursts with 5s→60s exponential backoff. Each burst monopolizes the shared Android radio and starves DE1 GATT traffic (observed in the field: 10s GATT write timeout on the calibration MMR write → HTTP 500 on `POST /api/v1/machine/calibration`), while the backoff gaps mean a freshly powered-on scale can wait up to 60s+scan to connect.
- Why it matters: skins hitting machine endpoints get spurious 500s whenever the scale is off, and scale reconnect feels slow and random.
- What changed: on Android, scale reacquisition is now one persistent `AndroidScanMode.balanced` scan (~40% duty cycle — the duty cycle, not filtering, is what protects the DE1 link). A new `ScaleWatch` comms-layer collaborator listens on the device stream, and on sighting the preferred scale stops the watch scan (freeing the radio for GATT) and connects — typically 1–5s after power-on. Watch and burst scans are arbitrated inside `UniversalBleDiscoveryService` (universal_ble has one global scan session); the watch self-restarts every 25min (Android's 30-min opportunistic downgrade), survives adapter off/on, and never runs on Bengle machines (integrated scale owns the slot). `De1StateManager` skips its post-wake scale burst when the watch covers reacquisition.
- What did NOT change (scope boundary): non-Android platforms keep the legacy backoff loop byte-for-byte, and it remains the runtime fallback if the watch fails to start. Burst-scan semantics, machine recovery, zombie-link detection, and the quick-connect path are untouched. Watch scans don't flip `scanningStream` and emit no `ScanReport`.

Design doc (the *why*, including deviations found during hardware verification): `doc/plans/archive/background-scale-watch/background-scale-watch.md`. Notably: the originally planned OS-level name-prefix filter was dropped — remembered device names are friendly constants that don't match advertised names, and the universal_ble fork evaluates name filters plugin-side anyway (no hardware-filter or screen-off benefit exists). Matching stays with the normal Dart `DeviceMatcher` path.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [x] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #
- Related #441 (scan report telemetry that surfaced the burst/backoff behavior)

## Root Cause (if bug fix)

N/A (feature), but the motivating incident: a 15s `lowLatency` scale-reconnect scan overlapped a DE1 MMR write; the write starved for the full 10s universal_ble timeout and the REST handler returned 500. The backoff loop guarantees such overlaps recur whenever the scale is off.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/controllers/connection/scale_watch_test.dart` (15 tests), `test/services/universal_ble_discovery_service_test.dart` (12 tests incl. burst arbitration + start-window races against a fake `UniversalBlePlatform`), `test/controllers/connection_manager_test.dart` → `background scale watch` group (8 tests), `test/controllers/de1_state_manager_wake_scan_test.dart` (3 tests), Bengle watch regression in `test/integration/connection_manager_bengle_scale_test.dart`.
- Scenario the test should lock in: machine connected + preferred scale missing → watch armed and **no backoff timer ever fires** (fake_async over the full 5→60s ladder); scale sighting → connect with zero burst scans; the entire pre-existing ConnectionManager suite passes unmodified with the watch capability off (compatibility gate).
- If no new test added, why not: N/A — added.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [x] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A — no docs affected

New section "Background Scale Watch (preferred-scale reacquisition)" documents watch vs legacy mode, lifecycle, and the no-ScanReport caveat.

## Security Impact (required)

- New or changed REST endpoints? No
- New or changed WebSocket topics? No
- New or changed network calls? No
- BLE/USB surface changed? Yes
- File system access changed? No
- Plugin sandbox boundary changed? No
- If any `Yes`, explain risk and mitigation: adds a persistent passive BLE scan (receive-only, no new GATT writes) on Android while a machine is connected and the preferred scale is missing. It uses the existing `BLUETOOTH_SCAN` permission (`neverForLocation`), stops the moment the scale connects / machine disconnects / power-mode sleep, and connects only to the device id already stored as `preferredScaleId`.

## User-Visible Changes

- Android: a preferred scale powered on near a connected machine now connects in ~1–5s (previously up to ~60s+scan, depending on backoff phase).
- Machine REST/GATT operations no longer intermittently fail while the scale is off (no more 15s lowLatency bursts).
- No scanning indicator is shown for the background watch (deliberate — it is not a user-initiated scan).
- Caveat: Android suspends OS-unfiltered scans while the screen is off, so a scale powered on with the display asleep connects once the screen wakes.

## Compatibility & Migration

- Backward compatible? Yes
- Config / env changes needed? No
- Database migration needed? No

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass (2114 passing; the 3 failures in `webui_token_injection_test.dart` are pre-existing on `main` and environment-dependent — they assert offline fallback on a host that has a live Wi-Fi IP)
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds

### Manual verification (if applicable)

- OS / platform tested: Android tablet (M50Mini), release build
- Simulated devices? (`simulate=1`): No (integration tier covers the simulated flows; macOS host cannot keep the GUI build resident headless)
- Real hardware? (DE1/Bengle/scale): Yes — DE1 + BLE scale
- What you personally verified and how: machine connected with scale off → single `Background device watch started` log line, no repeating 15s bursts; scale powered on → auto-connected within seconds via the watch (previously required a manual connect tap after the fix for the name-filter issue, which is included here); manual scan/connect flows unaffected.
- Edge cases checked: machine sleep/wake with `ScalePowerMode.disconnect` (watch pauses/resumes), machine disconnect (watch stops), watch-start failure (falls back to legacy backoff — unit/integration tested), Bengle slot rule, burst-vs-watch radio arbitration and start-window races (unit tested against a fake platform).
- What you did **not** verify on hardware: the 25-min refresh over a >30min soak, Bluetooth off/on recovery, and multi-hour stability — covered by unit tests only so far.

### Evidence

- [x] Test output (failing before + passing after) — suites listed above; written test-first (RED verified before implementation).
- [x] Log snippets — motivating incident: `GATT write(A000/A006) timed out — clearing BLE queue` → `POST [500] /api/v1/machine/calibration` while `Scan report: … preferred scale … NOT found` (scale-reconnect burst overlapping the write).

## Risks & Mitigations

- Risk: a persistent scan could still contend with DE1 GATT traffic.
  - Mitigation: `balanced` (~40% duty) instead of `lowLatency` (100%); the watch scan is stopped before every watch-driven connect and paused for the whole duration of any burst scan.
- Risk: watch silently dead (e.g. Android downgrades or kills the scan) → scale never reconnects.
  - Mitigation: 25-min self-restart, adapter off/on re-arm, start-window race guards; legacy backoff loop remains as runtime fallback whenever the watch fails to start.
- Risk: regression on non-Android platforms.
  - Mitigation: capability-gated (`supportsDeviceWatch` is Android-only); the full pre-existing ConnectionManager suite passes unmodified with the capability off.
