### PR TITLE
fix(de1): own the on-connect profile push in WorkflowDeviceSync

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -4373,8 +4373,9 @@ components:
             New kinds may be added without a version bump.
 
             profileUploadFailed is raised when a profile upload to the
-            machine fails and is being retried; it is retracted once a
-            retry succeeds.
+            machine fails and is being retried. It persists across phase
+            transitions and is retracted when a retry succeeds, the machine
+            disconnects, or the retry cycle is disposed.
         severity:
           type: string
           enum: [warning, error]

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -4368,8 +4368,13 @@ components:
             by this field. Initial set:
             scaleConnectFailed, machineConnectFailed,
             scaleDisconnected, machineDisconnected,
-            adapterOff, bluetoothPermissionDenied, scanFailed.
+            adapterOff, bluetoothPermissionDenied, scanFailed,
+            profileUploadFailed.
             New kinds may be added without a version bump.
+
+            profileUploadFailed is raised when a profile upload to the
+            machine fails and is being retried; it is retracted once a
+            retry succeeds.
         severity:
           type: string
           enum: [warning, error]

--- a/assets/api/websocket_v1.yml
+++ b/assets/api/websocket_v1.yml
@@ -431,8 +431,13 @@ components:
             by this field. Initial set:
             scaleConnectFailed, machineConnectFailed,
             scaleDisconnected, machineDisconnected,
-            adapterOff, bluetoothPermissionDenied, scanFailed.
+            adapterOff, bluetoothPermissionDenied, scanFailed,
+            profileUploadFailed.
             New kinds may be added without a version bump.
+
+            profileUploadFailed is raised when a profile upload to the
+            machine fails and is being retried; it is retracted once a
+            retry succeeds.
         severity:
           type: string
           enum: [warning, error]

--- a/assets/api/websocket_v1.yml
+++ b/assets/api/websocket_v1.yml
@@ -436,8 +436,9 @@ components:
             New kinds may be added without a version bump.
 
             profileUploadFailed is raised when a profile upload to the
-            machine fails and is being retried; it is retracted once a
-            retry succeeds.
+            machine fails and is being retried. It persists across phase
+            transitions and is retracted when a retry succeeds, the machine
+            disconnects, or the retry cycle is disposed.
         severity:
           type: string
           enum: [warning, error]

--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -131,6 +131,38 @@ flutter test test/services/ble/
 flutter test test/controllers/connection/
 ```
 
+## Profile Upload Safety
+
+### Firmware Latch: ProfileDownloadInProgress
+
+The DE1 firmware sets `ProfileDownloadInProgress` on header write and clears it
+on tail write + flash commit. If the upload dies mid-sequence (GATT timeout,
+connection drop), the latch stays set indefinitely. While latched:
+- The machine silently ignores all start requests.
+- The group-head LED pulses magenta (~2 Hz).
+- The only recovery is a complete profile upload.
+
+### Two Cache Layers
+
+| Cache | Location | Cleared on | Effect |
+|-------|----------|------------|--------|
+| Sync `_lastPushedProfile` | `WorkflowDeviceSync` | Disconnect, upload failure | Prevents redundant uploads within one connection |
+| Device `_currentProfile` | `UnifiedDe1` | Every `onConnect()`, every upload start | Prevents redundant uploads within one device session |
+
+Both must be cleared on connection edges. The sync cache is cleared by
+`_onDe1Change(null)` which runs on disconnect. The device cache is cleared
+in `UnifiedDe1.onConnect()` before the `_info` guard.
+
+### Startup Ordering
+
+The on-connect profile push is triggered by `De1Controller.initSettled`, which
+fires after machine readiness + startup defaults complete. This replaces the
+single-shot `_setDe1Defaults` path whose failures were swallowed.
+
+Generation tokens in both `De1Controller` (`_connectionGeneration`) and
+`WorkflowDeviceSync` (`_generation`) guard against stale init completions
+from a disconnected generation.
+
 ## Keeping Notes Fresh
 
 Add lessons that would have saved debugging time: new footguns, thread-safety constraints, connection-lifecycle changes, non-obvious symptoms, and cross-transport dependencies. Prune stale claims. Prefer fewer, sharper notes over long background.

--- a/doc/AI_DEBUG_NOTES.md
+++ b/doc/AI_DEBUG_NOTES.md
@@ -83,6 +83,29 @@ adb logcat | grep -i rea
 flutter run --dart-define=simulate=1
 ```
 
+## Profile Upload Failure Diagnosis
+
+**Symptom:** Machine pulses group-head LED magenta (~2 Hz), ignores all
+start requests (espresso, steam, hot water). The app reports the machine as
+connected and holding the selected profile. Re-selecting the same profile
+does nothing.
+
+**Root cause:** A profile upload died mid-sequence (GATT write timeout on a
+flaky BLE link), leaving the firmware's `ProfileDownloadInProgress` latch set.
+Two app caches (`_lastPushedProfile` and `_currentProfile`) then prevented
+the same-profile re-upload that would have cleared the latch.
+
+**Diagnosis steps:**
+1. Check the log for "setProfile failed" or "retrying" messages.
+2. Check the WebSocket `/ws/v1/devices` for `profileUploadFailed` error kind.
+3. The `WorkflowDeviceSync` logger shows retries at FINE/WARNING level.
+
+**Fix pattern:** The app now clears both caches on every connection edge and
+retries failed uploads automatically with capped exponential backoff. A full
+re-upload of any profile clears the latch. See `doc/AI_BLE_NOTES.md` for the
+cache architecture and `doc/plans/archive/profile-upload-recovery/design.md`
+for the full design rationale.
+
 ## Keeping Notes Fresh
 
 Add debugging patterns with: symptom, root cause, fix pattern, prevention. Prune when fixes ship and patterns are no longer current.

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -413,7 +413,7 @@ so a late joiner gets a coherent view from any single frame; `decision` is non-n
 
 ### `connectionStatus.error`
 
-When a BLE operation fails (connect timeout, mid-session disconnect, adapter off, permission denied, scan failure), the devices WebSocket emits an update with a structured `connectionStatus.error` object. `null` when no error is active.
+When a BLE operation fails (connect timeout, mid-session disconnect, adapter off, permission denied, scan failure, or profile upload failure), the devices WebSocket emits an update with a structured `connectionStatus.error` object. `null` when no error is active.
 
 ```json
 {

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -1280,6 +1280,52 @@ _log.info('Found serial ports: $ports');
 
 ---
 
+## Post-Initialization Profile Synchronization
+
+### Trigger
+
+The raw `de1` stream indicates device availability but is not the upload
+trigger. `De1Controller.initSettled` emits only after machine readiness
+and the startup-default attempt — `WorkflowDeviceSync` subscribes to this
+stream, not the raw de1 event, preserving correct ordering.
+
+### Best-Effort Defaults
+
+Startup-default writes are best-effort. A failed default write (e.g., a
+fan threshold that times out) logs a warning but does not prevent
+initSettled from firing — the profile upload follows regardless.
+
+### Connection Identity and Generation Safety
+
+Initialization captures both the device instance and connection generation
+at the start. Every read/write performed during initialization goes
+through the captured device, not the current `_de1` reference. This
+prevents a stale initializer from operating on a replacement device after
+a disconnect/reconnect race.
+
+All async boundaries are guarded by `stillCurrent()`:
+
+```dart
+final generation = _connectionGeneration;
+final device = connectedDe1();
+
+bool stillCurrent() =>
+    generation == _connectionGeneration &&
+    identical(device, connectedDe1OrNull);
+```
+
+If a stale initializer resumes after disconnect, `stillCurrent()`
+returns false. The initializer skips the initSettled emission, so no
+stale event reaches `WorkflowDeviceSync` and no redundant profile
+push fires for the replacement device.
+
+### Quick-Connect and Adoption
+
+`adoptDevice()` follows the same ready → initialize → initSettled
+sequence as normal connection. It receives the same generation and
+device protections — a stale init from an adopted machine is rejected
+identically.
+
 ## Glossary
 
 - **BLE:** Bluetooth Low Energy, wireless protocol for IoT devices

--- a/doc/Profiles.md
+++ b/doc/Profiles.md
@@ -548,9 +548,43 @@ Example error response:
 
 Mock machines execute profiles in a simulated shot loop that follows profile step targets (flow, pressure, temperature) with simplified machine-response dynamics. Design decisions are recorded in archived plans — see `doc/plans/mock-shot-fidelity.md` for the substate model, flow→pressure coupling, weight accumulation, transition shaping, and skipStep semantics.
 
+### Profile Synchronization with Hardware
+
+#### Ownership
+
+`WorkflowDeviceSync` owns profile uploads caused by workflow changes and
+machine connect/reconnect. `De1Controller` no longer uploads the profile
+as part of startup defaults — `POST /api/v1/machine/profile` remains a
+direct machine operation outside workflow synchronization.
+
+#### Two Cache Layers
+
+| Cache | Location | Cleared on | Effect |
+|-------|----------|------------|--------|
+| `_lastPushedProfile` | `WorkflowDeviceSync` | Disconnect, upload failure | Prevents redundant uploads within one connection |
+| `_currentProfile` | `UnifiedDe1` | Every `onConnect()`, every upload start | Prevents redundant uploads within one device session |
+
+Both must be cleared on connection edges. The sync cache is cleared when
+the machine disconnects; the device cache is cleared in `onConnect()`
+before the `_info` guard so every connection edge forces a complete
+physical upload.
+
+#### Retry and Failure Behavior
+
+- Failed workflow profile uploads retry with capped backoff (3s, 10s, 30s).
+- Intermediate workflow changes coalesce — only the latest profile is
+  pushed when the current upload finishes.
+- `profileUploadFailed` is surfaced on `ConnectionManager.status` while
+  retries are active. It persists across phase transitions and is cleared
+  when a retry lands, the machine disconnects, or the sync is disposed.
+- See `doc/plans/archive/profile-upload-recovery/design.md` for the full
+  design rationale.
+
 ### Future Enhancements
 
-- **Cloud Sync**: Hash-based IDs make conflict-free cloud sync straightforward
+- **Cloud Sync**:
+
+  Hash-based IDs make conflict-free cloud sync straightforward
   - Same content = same ID everywhere (no merge conflicts)
   - Sync compound hashes to detect any changes
   - Implement three-way merge using parent IDs

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -1932,10 +1932,12 @@ Example payload:
 | `adapterOff` | Bluetooth adapter powered off | Instruct user to enable Bluetooth (no retry button) |
 | `bluetoothPermissionDenied` | BLE runtime permission refused | Instruct user to grant permission |
 | `scanFailed` | Scan failed to start | Retry scan |
+| `profileUploadFailed` | A profile upload to the machine failed; the app is retrying with backoff | None — informational. Retracted automatically when a retry lands. |
 
 **Lifecycle rules:**
 
 - **Transient kinds** (`scaleConnectFailed`, `machineConnectFailed`, `scaleDisconnected`, `machineDisconnected`) auto-clear when a new operation starts — i.e. the phase transitions to `scanning`, `connectingMachine`, `connectingScale`, or `ready`.
+- **`profileUploadFailed`** is additionally *retracted* explicitly: the app keeps retrying the upload, and the error is withdrawn as soon as one succeeds. Treat it as "the machine may not be holding your selected profile yet", not as a dead end — no user action is required.
 - **Sticky kinds** (`adapterOff`, `bluetoothPermissionDenied`, `scanFailed`) survive phase transitions. They clear only when the environment recovers (adapter on, permission granted, successful scan start).
 - Emitting any new error overwrites the previous one. **Latest event wins.**
 
@@ -1950,6 +1952,7 @@ const copyForKind = {
   adapterOff: 'Bluetooth is off. Turn it on to continue.',
   bluetoothPermissionDenied: 'Grant Bluetooth permission to continue.',
   scanFailed: 'Scan could not start. Retry.',
+  profileUploadFailed: 'Profile did not reach the machine. Retrying…',
 };
 
 let lastSeen = null;

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -1932,12 +1932,12 @@ Example payload:
 | `adapterOff` | Bluetooth adapter powered off | Instruct user to enable Bluetooth (no retry button) |
 | `bluetoothPermissionDenied` | BLE runtime permission refused | Instruct user to grant permission |
 | `scanFailed` | Scan failed to start | Retry scan |
-| `profileUploadFailed` | A profile upload to the machine failed; the app is retrying with backoff | None — informational. Retracted automatically when a retry lands. |
+| `profileUploadFailed` | A profile upload to the machine failed; the app is retrying with backoff | None — informational. Persists across phase transitions. Retracted when a retry lands, the machine disconnects, or the retry cycle ends. |
 
 **Lifecycle rules:**
 
 - **Transient kinds** (`scaleConnectFailed`, `machineConnectFailed`, `scaleDisconnected`, `machineDisconnected`) auto-clear when a new operation starts — i.e. the phase transitions to `scanning`, `connectingMachine`, `connectingScale`, or `ready`.
-- **`profileUploadFailed`** is additionally *retracted* explicitly: the app keeps retrying the upload, and the error is withdrawn as soon as one succeeds. Treat it as "the machine may not be holding your selected profile yet", not as a dead end — no user action is required.
+- **`profileUploadFailed`** survives phase transitions (like sticky kinds) but is retracted explicitly: when a retry succeeds, the machine disconnects (terminating the retry cycle), or the retry cycle is disposed. Treat it as "the machine may not be holding your selected profile yet", not as a dead end — no user action is required.
 - **Sticky kinds** (`adapterOff`, `bluetoothPermissionDenied`, `scanFailed`) survive phase transitions. They clear only when the environment recovers (adapter on, permission granted, successful scan start).
 - Emitting any new error overwrites the previous one. **Latest event wins.**
 

--- a/doc/plans/archive/profile-upload-recovery/design.md
+++ b/doc/plans/archive/profile-upload-recovery/design.md
@@ -1,0 +1,99 @@
+# Profile Upload Recovery: Design Rationale
+
+## The Failure Mode
+
+The DE1 firmware has a `ProfileDownloadInProgress` flag that is set when a
+profile upload begins (header write) and cleared when the upload completes
+successfully (tail write + flash commit). If the upload dies mid-sequence —
+for example a GATT write timeout on a flaky BLE link — the flag stays set
+indefinitely (no firmware timeout, no clear on disconnect). While the flag is
+set, the machine silently ignores all start requests and pulses its group-head
+LED (magenta, ~2 Hz), appearing bricked to the user.
+
+The app could not self-heal because:
+
+1. Two cache layers — the sync's `_lastPushedProfile` and the device-level
+   `UnifiedDe1._currentProfile` — each prevented a same-profile re-upload.
+2. The connect-time profile upload lived in `De1Controller._setDe1Defaults`,
+   which was single-shot: its exception was caught only by the generic
+   transport error handler, so a mid-sequence failure was invisible.
+3. `_lastPushedProfile` was seeded optimistically from the persisted workflow
+   at construction time, so the sync believed the machine already held the
+   selected profile on first connect.
+
+## Fix Summary
+
+### Cache Layer 1: WorkflowDeviceSync._lastPushedProfile
+
+- Starts null (never seeded from persistence).
+- Cleared on every connection edge (`_onDe1Change(null)` sets it null).
+- Invalidated on any upload failure (`_lastPushedProfile = null` in catch).
+- Set only after a successful `setProfile` call returns.
+- The equality guard (`profile == _lastPushedProfile`) deduplicates within
+  one uninterrupted connection but never across a connection edge.
+
+### Cache Layer 2: UnifiedDe1._currentProfile
+
+- Cleared at the start of every `onConnect()` call — before the `_info` guard
+  that would skip the rest of `onConnect()` on reconnect.
+- Also nulled inside `_uploadProfileLocked` before the multi-write sequence
+  starts, and set only after `_sendProfile` returns.
+- This is the tightest defence: even a caller that bypasses
+  `WorkflowDeviceSync` (e.g. `POST /api/v1/machine/profile`) and calls
+  `setProfile` directly on a reused `UnifiedDe1` instance gets a complete
+  upload after every connection edge.
+
+### Startup Ordering
+
+The on-connect profile push moved from `De1Controller._setDe1Defaults` to
+`WorkflowDeviceSync._onInitSettled`. The trigger is a new
+`De1Controller.initSettled` stream that fires after machine readiness AND
+startup defaults complete. This preserves the old effective ordering:
+startup/default writes first, profile synchronization afterward.
+
+The push does NOT fire from the raw de1 stream event, which arrives during
+`_connectToDe1` before `_initializeData` runs. A generation token on both
+sides guards against stale init completions from a disconnected generation.
+
+### Ownership
+
+`WorkflowDeviceSync` owns all workflow-driven profile synchronization.
+Neither `De1Controller._setDe1Defaults` nor any other path pushes a profile
+on connect — they delegate entirely to the sync.
+
+### Error Lifecycle
+
+`profileUploadFailed` is a new `ConnectionErrorKind` that survives phase
+transitions (not transient, not sticky — a third classification:
+phase-persistent). It is emitted once per failing retry cycle, on the first
+failure. It is retracted when:
+
+- A retry successfully uploads the desired profile.
+- The machine disconnects (terminating the retry cycle).
+- The sync is disposed.
+
+The `onUploadErrorCleared` callback is invoked on all three conditions.
+`ConnectionManager.clearErrorOfKind` checks `kind` before clearing, so an
+unrelated error that has replaced `profileUploadFailed` is never stomped.
+
+### Alternatives Considered
+
+1. **Expose a cache-reset method on UnifiedDe1.** Rejected because the
+   production cache is owned by `UnifiedDe1` and should be reset by the
+   connection lifecycle, not by an ad hoc external caller. Clearing in
+   `onConnect()` is automatic and covers every path that uses the same
+   device instance.
+
+2. **Keep the push in _setDe1Defaults and add retry there.** Rejected because
+   that path is called from `_initializeData` and would require threading
+   retry/error logic through `De1Controller`, which has no business owning
+   profile synchronization. The sync already has serialization, retry, and
+   error surfacing — give it the trigger.
+
+3. **Delay with Timer.** Rejected because a fixed delay is fragile (too short
+   on slow transports, too long on fast ones). The `initSettled` signal is
+   event-driven and race-free.
+
+4. **Firmware-side fix.** A FW latch timeout or clear-on-disconnect would be
+   more robust, but that's a separate change. The app-side fix is sufficient:
+   a full re-upload on every connect clears the latch regardless.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:reaprime/src/controllers/bengle_saw_bridge.dart';
 import 'package:reaprime/src/controllers/bengle_steam_stop_bridge.dart';
 import 'package:reaprime/src/controllers/hot_water_sequencer.dart';
 import 'package:reaprime/src/controllers/steam_sequencer.dart';
+import 'package:reaprime/src/controllers/connection_error.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
@@ -365,15 +366,20 @@ void main(List<String> args) async {
     de1Controller.defaultWorkflow = workflowController.currentWorkflow;
   });
   // Single writer of DE1 setProfile for the workflow paths (REST
-  // PUT /api/v1/workflow + UI picker). POST /api/v1/machine/profile and the
-  // reconnect defaults push bypass it — UnifiedDe1.setProfile serializes
-  // uploads across all callers at the device level. Must be constructed
-  // after workflowController has its persisted workflow loaded so its
-  // initial snapshot matches what was last pushed.
+  // PUT /api/v1/workflow + UI picker) AND the machine (re)connect push
+  // (the old defaults-path upload was single-shot with
+  // swallowed errors). Only POST /api/v1/machine/profile bypasses it —
+  // UnifiedDe1.setProfile serializes uploads across all callers at the
+  // device level. Persistent upload failures surface on the connection
+  // status stream and retract once a retry lands.
   // ignore: unused_local_variable
   final workflowDeviceSync = WorkflowDeviceSync(
     workflowController: workflowController,
     de1Controller: de1Controller,
+    onUploadError: connectionManager.reportError,
+    onUploadRecovered: () => connectionManager.clearErrorOfKind(
+      ConnectionErrorKind.profileUploadFailed,
+    ),
   );
   // Reflects WorkflowContext.targetYield into Bengle's autonomous SAW
   // MMR. Single writer for both REST and UI yield-edits; re-applies on

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -377,7 +377,7 @@ void main(List<String> args) async {
     workflowController: workflowController,
     de1Controller: de1Controller,
     onUploadError: connectionManager.reportError,
-    onUploadRecovered: () => connectionManager.clearErrorOfKind(
+    onUploadErrorCleared: () => connectionManager.clearErrorOfKind(
       ConnectionErrorKind.profileUploadFailed,
     ),
   );

--- a/lib/src/controllers/connection/status_publisher.dart
+++ b/lib/src/controllers/connection/status_publisher.dart
@@ -30,8 +30,9 @@ class StatusPublisher {
     ConnectionPhase.ready,
   };
 
-  final BehaviorSubject<ConnectionStatus> _subject =
-      BehaviorSubject.seeded(const ConnectionStatus());
+  final BehaviorSubject<ConnectionStatus> _subject = BehaviorSubject.seeded(
+    const ConnectionStatus(),
+  );
 
   Stream<ConnectionStatus> get stream => _subject.stream;
   ConnectionStatus get current => _subject.value;
@@ -53,18 +54,14 @@ class StatusPublisher {
       effectiveError = prev.error;
     } else if (effectiveError != null &&
         movingIntoClearingPhase &&
-        !ConnectionErrorKind.sticky.contains(effectiveError.kind)) {
-      // A new status that carries a transient error into a clearing
-      // phase means the caller is re-publishing an old error — strip
-      // it.
+        !ConnectionErrorKind.sticky.contains(effectiveError.kind) &&
+        !ConnectionErrorKind.phasePersistent.contains(effectiveError.kind)) {
       effectiveError = null;
     } else if (prev.error != null &&
-        // copyWith preserves the error reference when the caller does
-        // not pass `error:`, so `identical` is the right identity
-        // check here.
         identical(next.error, prev.error) &&
         movingIntoClearingPhase &&
-        !ConnectionErrorKind.sticky.contains(prev.error!.kind)) {
+        !ConnectionErrorKind.sticky.contains(prev.error!.kind) &&
+        !ConnectionErrorKind.phasePersistent.contains(prev.error!.kind)) {
       effectiveError = null;
     }
 
@@ -81,7 +78,8 @@ class StatusPublisher {
   /// `info` instead of `severe`/`warning` — keeping them out of the
   /// Crashlytics forwarder while preserving them in the file log.
   void emitError(ConnectionError err) {
-    final msg = 'emit error: kind=${err.kind} message=${err.message} '
+    final msg =
+        'emit error: kind=${err.kind} message=${err.message} '
         'deviceId=${err.deviceId}';
     if (ConnectionErrorKind.sticky.contains(err.kind)) {
       _log.info(msg);

--- a/lib/src/controllers/connection_error.dart
+++ b/lib/src/controllers/connection_error.dart
@@ -12,7 +12,8 @@ class ConnectionErrorKind {
 
   /// A profile upload to the machine failed and is being retried.
   /// Surfaced by `WorkflowDeviceSync` via `ConnectionManager.reportError`;
-  /// retracted through `clearErrorOfKind` once a retry lands.
+  /// retracted through `clearErrorOfKind` when a retry lands, the machine
+  /// disconnects, or the sync is disposed.
   static const profileUploadFailed = 'profileUploadFailed';
 
   /// Kinds that survive `ConnectionPhase` transitions. They only clear
@@ -21,6 +22,13 @@ class ConnectionErrorKind {
     adapterOff,
     bluetoothPermissionDenied,
     scanFailed,
+  };
+
+  /// Kinds that survive phase transitions but are cleared explicitly by
+  /// the reporter rather than environmental recovery. Distinct from
+  /// [sticky] which describes conditions the user must resolve.
+  static const phasePersistent = <String>{
+    profileUploadFailed,
   };
 
   const ConnectionErrorKind._();

--- a/lib/src/controllers/connection_error.dart
+++ b/lib/src/controllers/connection_error.dart
@@ -10,6 +10,11 @@ class ConnectionErrorKind {
   static const bluetoothPermissionDenied = 'bluetoothPermissionDenied';
   static const scanFailed = 'scanFailed';
 
+  /// A profile upload to the machine failed and is being retried.
+  /// Surfaced by `WorkflowDeviceSync` via `ConnectionManager.reportError`;
+  /// retracted through `clearErrorOfKind` once a retry lands.
+  static const profileUploadFailed = 'profileUploadFailed';
+
   /// Kinds that survive `ConnectionPhase` transitions. They only clear
   /// when the specific environmental condition recovers.
   static const sticky = <String>{

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -314,6 +314,21 @@ class ConnectionManager {
   /// (comms-harden #8).
   void _emit(ConnectionError err) => _statusPublisher.emitError(err);
 
+  /// Surface an out-of-band [ConnectionError] on the status stream —
+  /// for collaborators outside the connect flow (`WorkflowDeviceSync`'s
+  /// profile-upload failure). Routes through the same
+  /// [StatusPublisher] gatekeeper as internal emits.
+  void reportError(ConnectionError err) => _emit(err);
+
+  /// Clear the current status error iff it is of [kind]. Lets an
+  /// out-of-band reporter retract its own error on recovery without
+  /// stomping an unrelated one that has since replaced it.
+  void clearErrorOfKind(String kind) {
+    if (currentStatus.error?.kind == kind) {
+      _clearError();
+    }
+  }
+
   /// Build a [ConnectionError] for a failed connect attempt. Pulls out
   /// `ble_code` / `ble_description` when the caught exception is a
   /// [BleConnectException] (the domain type transports map their native

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -23,34 +23,36 @@ class De1Controller {
   De1Interface? _de1;
   final Logger _log = Logger("De1Controller");
 
-  final BehaviorSubject<De1Interface?> _de1Controller =
-      BehaviorSubject.seeded(null);
+  final BehaviorSubject<De1Interface?> _de1Controller = BehaviorSubject.seeded(
+    null,
+  );
 
   Stream<De1Interface?> get de1 => _de1Controller.stream;
 
   final BehaviorSubject<SteamSettings> _steamDataController =
-      BehaviorSubject.seeded(SteamSettings(
-    targetTemperature: 0,
-    flow: 0,
-    duration: 0,
-  ));
+      BehaviorSubject.seeded(
+        SteamSettings(
+          targetTemperature: 0,
+          flow: 0,
+          duration: 0,
+        ),
+      );
 
-  Stream<SteamSettings> get steamData =>
-      _steamDataController.stream;
+  Stream<SteamSettings> get steamData => _steamDataController.stream;
 
   final BehaviorSubject<HotWaterData> _hotWaterDataController =
-      BehaviorSubject.seeded(HotWaterData(
-    targetTemperature: 0,
-    flow: 0,
-    duration: 0,
-    volume: 0,
-  ));
-
-  Stream<HotWaterData> get hotWaterData =>
-      _hotWaterDataController.stream;
-
-  final BehaviorSubject<RinseData> _rinseStream =
       BehaviorSubject.seeded(
+        HotWaterData(
+          targetTemperature: 0,
+          flow: 0,
+          duration: 0,
+          volume: 0,
+        ),
+      );
+
+  Stream<HotWaterData> get hotWaterData => _hotWaterDataController.stream;
+
+  final BehaviorSubject<RinseData> _rinseStream = BehaviorSubject.seeded(
     RinseData(
       duration: 5,
       targetTemperature: 90,
@@ -135,16 +137,28 @@ class De1Controller {
   /// `DeviceNotConnectedException`). Covers comms-harden #5.
   int _connectionGeneration = 0;
 
+  /// Emits the connection generation when initialization settles (machine
+  /// ready + startup defaults attempt complete), or null on disconnect.
+  /// Consumers compare the value against their own generation token to
+  /// reject stale completions from a previous connection.
+  final BehaviorSubject<int?> _initSettledSubject = BehaviorSubject.seeded(
+    null,
+  );
+
+  Stream<int?> get initSettled => _initSettledSubject.stream;
+
+  int get connectionGeneration => _connectionGeneration;
+
   De1Controller({required DeviceController controller})
-      : _deviceController = controller {
+    : _deviceController = controller {
     _log.info("checking ${_deviceController.devices}");
   }
 
   Future<void> connectToDe1(De1Interface de1Interface) async {
     if (de1Interface == _de1) {
-        _log.fine("trying to connect to existing de1, exit early");
-        return;
-      }
+      _log.fine("trying to connect to existing de1, exit early");
+      return;
+    }
     _onDisconnect(); // just in case
     _log.fine("found de1, connecting");
     try {
@@ -237,6 +251,7 @@ class De1Controller {
     _de1 = null;
     _de1Controller.add(_de1);
     _dataInitialized = false;
+    _initSettledSubject.add(null);
     _shotSettingsDebounce?.cancel();
     _shotSettingsDebounce = null;
     for (var sub in _subscriptions) {
@@ -247,20 +262,41 @@ class De1Controller {
 
   Future<void> _initializeData() async {
     if (_dataInitialized) {
-      _log.warning("Data already initialized, skipping (this should only happen once!)");
+      _log.warning("Data already initialized, skipping");
       return;
     }
-    _log.info("Initializing DE1 data for the first time");
+    final generation = _connectionGeneration;
+    final device = connectedDe1();
+
+    bool stillCurrent() =>
+        generation == _connectionGeneration &&
+        identical(device, connectedDe1OrNull);
+
+    _log.info("Initializing DE1 data");
     _dataInitialized = true;
-    
-    await connectedDe1().shotSettings.first.then(_shotSettingsUpdate);
-    _subscriptions.add(
-      connectedDe1().shotSettings.listen(
-            _shotSettingsUpdate,
-          ),
-    );
-    _log.info("Created shotSettings listener, total subscriptions: ${_subscriptions.length}");
-    await _setDe1Defaults();
+
+    try {
+      final settings = await device.shotSettings.first;
+      if (!stillCurrent()) return;
+      _shotSettingsUpdate(settings);
+      _subscriptions.add(
+        device.shotSettings.listen(_shotSettingsUpdate),
+      );
+
+      try {
+        await _setDe1DefaultsFor(device);
+      } catch (e, st) {
+        _log.warning(
+          'DE1 startup defaults failed; profile sync will still proceed',
+          e,
+          st,
+        );
+      }
+    } finally {
+      if (stillCurrent()) {
+        _initSettledSubject.add(generation);
+      }
+    }
   }
 
   Future<void> _shotSettingsUpdate(De1ShotSettings data) async {
@@ -271,31 +307,34 @@ class De1Controller {
     // bails out cleanly (comms-harden #5).
     _shotSettingsDebounce?.cancel();
     final generation = _connectionGeneration;
-    _shotSettingsDebounce = Timer(ConnectionTimings.shotSettingsDebounce, () async {
-      if (generation != _connectionGeneration || _de1 == null) {
-        _log.fine(
-          'Shot settings debounce fired after disconnect '
-          '(gen=$generation, current=$_connectionGeneration) — skipping',
-        );
-        return;
-      }
-      _log.info('Processing shot settings update (debounced)');
-      try {
-        await _processShotSettingsUpdate(data);
-      } on DeviceNotConnectedException catch (e) {
-        // Defence in depth: device may have disconnected between the
-        // generation check above and any of the awaits in the body.
-        _log.fine('Shot settings update aborted by disconnect: $e');
-      } on MmrTimeoutException catch (e) {
-        // An MMR read inside the readback can time out if the BLE
-        // adapter drops mid-sequence. That's functionally the same as
-        // a disconnect — don't escalate to a fatal crash.
-        _log.warning(
-          'Shot settings update MMR read timed out '
-          '(treating as disconnect): $e',
-        );
-      }
-    });
+    _shotSettingsDebounce = Timer(
+      ConnectionTimings.shotSettingsDebounce,
+      () async {
+        if (generation != _connectionGeneration || _de1 == null) {
+          _log.fine(
+            'Shot settings debounce fired after disconnect '
+            '(gen=$generation, current=$_connectionGeneration) — skipping',
+          );
+          return;
+        }
+        _log.info('Processing shot settings update (debounced)');
+        try {
+          await _processShotSettingsUpdate(data);
+        } on DeviceNotConnectedException catch (e) {
+          // Defence in depth: device may have disconnected between the
+          // generation check above and any of the awaits in the body.
+          _log.fine('Shot settings update aborted by disconnect: $e');
+        } on MmrTimeoutException catch (e) {
+          // An MMR read inside the readback can time out if the BLE
+          // adapter drops mid-sequence. That's functionally the same as
+          // a disconnect — don't escalate to a fatal crash.
+          _log.warning(
+            'Shot settings update MMR read timed out '
+            '(treating as disconnect): $e',
+          );
+        }
+      },
+    );
   }
 
   Future<void> _processShotSettingsUpdate(De1ShotSettings data) async {
@@ -320,11 +359,13 @@ class De1Controller {
       var flow = await connectedDe1().getFlushFlow();
       var time = await connectedDe1().getFlushTimeout();
       var temp = await connectedDe1().getFlushTemperature();
-      _rinseStream.add(RinseData(
-        flow: flow,
-        duration: time.toInt(),
-        targetTemperature: temp.toInt(),
-      ));
+      _rinseStream.add(
+        RinseData(
+          flow: flow,
+          duration: time.toInt(),
+          targetTemperature: temp.toInt(),
+        ),
+      );
     }
   }
 
@@ -361,15 +402,19 @@ class De1Controller {
   Future<void> updateSteamSettings(SteamFormSettings settings) async {
     De1ShotSettings shotSettings = await connectedDe1().shotSettings.first;
     await connectedDe1().setSteamFlow(settings.targetFlow);
-    await connectedDe1().updateShotSettings(shotSettings.copyWith(
-      targetSteamTemp: settings.steamEnabled ? settings.targetTemp : 0,
-      targetSteamDuration: settings.targetDuration,
-    ));
-    _steamDataController.add(SteamSettings(
-      targetTemperature: settings.steamEnabled ? settings.targetTemp : 0,
-      duration: settings.targetDuration,
-      flow: settings.targetFlow,
-    ));
+    await connectedDe1().updateShotSettings(
+      shotSettings.copyWith(
+        targetSteamTemp: settings.steamEnabled ? settings.targetTemp : 0,
+        targetSteamDuration: settings.targetDuration,
+      ),
+    );
+    _steamDataController.add(
+      SteamSettings(
+        targetTemperature: settings.steamEnabled ? settings.targetTemp : 0,
+        duration: settings.targetDuration,
+        flow: settings.targetFlow,
+      ),
+    );
   }
 
   Future<HotWaterFormSettings> hotWaterSettings() async {
@@ -389,24 +434,30 @@ class De1Controller {
   Future<void> updateHotWaterSettings(HotWaterFormSettings settings) async {
     await connectedDe1().setHotWaterFlow(settings.flow);
     await connectedDe1().shotSettings.first.then((s) async {
-      await connectedDe1().updateShotSettings(s.copyWith(
+      await connectedDe1().updateShotSettings(
+        s.copyWith(
           targetHotWaterTemp: settings.targetTemperature,
           targetHotWaterVolume: settings.volume,
-          targetHotWaterDuration: settings.duration));
+          targetHotWaterDuration: settings.duration,
+        ),
+      );
     });
-    _hotWaterDataController.add(HotWaterData(
-      targetTemperature: settings.targetTemperature,
-      duration: settings.duration,
-      volume: settings.volume,
-      flow: settings.flow,
-    ));
+    _hotWaterDataController.add(
+      HotWaterData(
+        targetTemperature: settings.targetTemperature,
+        duration: settings.duration,
+        volume: settings.volume,
+        flow: settings.flow,
+      ),
+    );
   }
 
   Future<void> updateFlushSettings(RinseData settings) async {
     await connectedDe1().setFlushTimeout(settings.duration.toDouble());
     await connectedDe1().setFlushFlow(settings.flow);
-    await connectedDe1()
-        .setFlushTemperature(settings.targetTemperature.toDouble());
+    await connectedDe1().setFlushTemperature(
+      settings.targetTemperature.toDouble(),
+    );
 
     _rinseStream.add(settings);
   }
@@ -421,11 +472,13 @@ class De1Controller {
     await connectedDe1().setSteamFlow(newFlow);
     final current = _steamDataController.valueOrNull;
     if (current != null) {
-      _steamDataController.add(SteamSettings(
-        targetTemperature: current.targetTemperature,
-        duration: current.duration,
-        flow: newFlow,
-      ));
+      _steamDataController.add(
+        SteamSettings(
+          targetTemperature: current.targetTemperature,
+          duration: current.duration,
+          flow: newFlow,
+        ),
+      );
     }
   }
 
@@ -433,12 +486,14 @@ class De1Controller {
     await connectedDe1().setHotWaterFlow(newFlow);
     final current = _hotWaterDataController.valueOrNull;
     if (current != null) {
-      _hotWaterDataController.add(HotWaterData(
-        targetTemperature: current.targetTemperature,
-        duration: current.duration,
-        volume: current.volume,
-        flow: newFlow,
-      ));
+      _hotWaterDataController.add(
+        HotWaterData(
+          targetTemperature: current.targetTemperature,
+          duration: current.duration,
+          volume: current.volume,
+          flow: newFlow,
+        ),
+      );
     }
   }
 
@@ -446,11 +501,13 @@ class De1Controller {
     await connectedDe1().setFlushFlow(newFlow);
     final current = _rinseStream.valueOrNull;
     if (current != null) {
-      _rinseStream.add(RinseData(
-        targetTemperature: current.targetTemperature,
-        duration: current.duration,
-        flow: newFlow,
-      ));
+      _rinseStream.add(
+        RinseData(
+          targetTemperature: current.targetTemperature,
+          duration: current.duration,
+          flow: newFlow,
+        ),
+      );
     }
   }
 
@@ -467,6 +524,7 @@ class De1Controller {
     _subscriptions.clear();
     await _de1?.dispose();
     _de1 = null;
+    if (!_initSettledSubject.isClosed) _initSettledSubject.close();
     if (!_de1Controller.isClosed) _de1Controller.close();
     if (!_steamDataController.isClosed) _steamDataController.close();
     if (!_hotWaterDataController.isClosed) _hotWaterDataController.close();
@@ -474,4 +532,3 @@ class De1Controller {
     if (!_shotStateSubject.isClosed) _shotStateSubject.close();
   }
 }
-

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -284,7 +284,7 @@ class De1Controller {
       );
 
       try {
-        await _setDe1DefaultsFor(device);
+        await _setDe1DefaultsFor(device, stillCurrent);
       } catch (e, st) {
         _log.warning(
           'DE1 startup defaults failed; profile sync will still proceed',

--- a/lib/src/controllers/de1_controller.defaults.dart
+++ b/lib/src/controllers/de1_controller.defaults.dart
@@ -29,11 +29,11 @@ extension Defaults on De1Controller {
     RinseData rinseData = defaultWorkflow!.rinseData;
     await updateFlushSettings(rinseData);
 
-    final defaultProfile = defaultWorkflow?.profile;
-    if (defaultProfile == null) {
-      return;
-    }
-    await _de1?.setProfile(defaultProfile);
+    // The connect-time profile upload is owned by WorkflowDeviceSync
+    // (its `_onDe1Change` connect branch), NOT pushed here: this path is
+    // single-shot with swallowed errors, and a mid-sequence failure left
+    // the firmware's ProfileDownloadInProgress latch stuck with no retry
+    // (magenta GH-LED pulse, start requests ignored).
   }
 
   Future<void> applySettingsDefaults() async {

--- a/lib/src/controllers/de1_controller.defaults.dart
+++ b/lib/src/controllers/de1_controller.defaults.dart
@@ -4,8 +4,12 @@ extension Defaults on De1Controller {
   /// Device-pinned default-write helper. Every read/write goes through
   /// the captured [device] so a disconnect/reconnect race cannot write to
   /// the replacement machine.
-  Future<void> _setDe1DefaultsFor(De1Interface device) async {
+  Future<void> _setDe1DefaultsFor(
+    De1Interface device,
+    bool Function() stillCurrent,
+  ) async {
     await device.setFanThreshhold(55);
+    if (!stillCurrent()) return;
 
     if (defaultWorkflow == null) {
       return;
@@ -19,7 +23,10 @@ extension Defaults on De1Controller {
         targetDuration: steamSettings.duration,
         targetFlow: steamSettings.flow,
       ),
+      stillCurrent,
     );
+    if (!stillCurrent()) return;
+
     HotWaterData hotWaterData = defaultWorkflow!.hotWaterData;
     await _updateHotWaterSettingsFor(
       device,
@@ -29,24 +36,30 @@ extension Defaults on De1Controller {
         volume: hotWaterData.volume,
         duration: hotWaterData.duration,
       ),
+      stillCurrent,
     );
+    if (!stillCurrent()) return;
 
     RinseData rinseData = defaultWorkflow!.rinseData;
-    await _updateFlushSettingsFor(device, rinseData);
+    await _updateFlushSettingsFor(device, rinseData, stillCurrent);
   }
 
   Future<void> _updateSteamSettingsFor(
     De1Interface device,
     SteamFormSettings settings,
+    bool Function() stillCurrent,
   ) async {
     De1ShotSettings shotSettings = await device.shotSettings.first;
+    if (!stillCurrent()) return;
     await device.setSteamFlow(settings.targetFlow);
+    if (!stillCurrent()) return;
     await device.updateShotSettings(
       shotSettings.copyWith(
         targetSteamTemp: settings.steamEnabled ? settings.targetTemp : 0,
         targetSteamDuration: settings.targetDuration,
       ),
     );
+    if (!stillCurrent()) return;
     _steamDataController.add(
       SteamSettings(
         targetTemperature: settings.steamEnabled ? settings.targetTemp : 0,
@@ -59,16 +72,20 @@ extension Defaults on De1Controller {
   Future<void> _updateHotWaterSettingsFor(
     De1Interface device,
     HotWaterFormSettings settings,
+    bool Function() stillCurrent,
   ) async {
     await device.setHotWaterFlow(settings.flow);
-    De1ShotSettings s = await device.shotSettings.first;
+    if (!stillCurrent()) return;
+    De1ShotSettings shotSettings = await device.shotSettings.first;
+    if (!stillCurrent()) return;
     await device.updateShotSettings(
-      s.copyWith(
+      shotSettings.copyWith(
         targetHotWaterTemp: settings.targetTemperature,
         targetHotWaterVolume: settings.volume,
         targetHotWaterDuration: settings.duration,
       ),
     );
+    if (!stillCurrent()) return;
     _hotWaterDataController.add(
       HotWaterData(
         targetTemperature: settings.targetTemperature,
@@ -82,12 +99,16 @@ extension Defaults on De1Controller {
   Future<void> _updateFlushSettingsFor(
     De1Interface device,
     RinseData settings,
+    bool Function() stillCurrent,
   ) async {
     await device.setFlushTimeout(settings.duration.toDouble());
+    if (!stillCurrent()) return;
     await device.setFlushFlow(settings.flow);
+    if (!stillCurrent()) return;
     await device.setFlushTemperature(
       settings.targetTemperature.toDouble(),
     );
+    if (!stillCurrent()) return;
     _rinseStream.add(settings);
   }
 

--- a/lib/src/controllers/de1_controller.defaults.dart
+++ b/lib/src/controllers/de1_controller.defaults.dart
@@ -1,8 +1,8 @@
 part of 'de1_controller.dart';
 
 extension Defaults on De1Controller {
-  Future<void> _setDe1Defaults() async {
-    await _de1?.setFanThreshhold(55);
+  Future<void> _setDe1DefaultsFor(De1Interface device) async {
+    await device.setFanThreshhold(55);
 
     if (defaultWorkflow == null) {
       return;
@@ -29,11 +29,7 @@ extension Defaults on De1Controller {
     RinseData rinseData = defaultWorkflow!.rinseData;
     await updateFlushSettings(rinseData);
 
-    // The connect-time profile upload is owned by WorkflowDeviceSync
-    // (its `_onDe1Change` connect branch), NOT pushed here: this path is
-    // single-shot with swallowed errors, and a mid-sequence failure left
-    // the firmware's ProfileDownloadInProgress latch stuck with no retry
-    // (magenta GH-LED pulse, start requests ignored).
+    // The connect-time profile upload is owned by WorkflowDeviceSync.
   }
 
   Future<void> applySettingsDefaults() async {

--- a/lib/src/controllers/de1_controller.defaults.dart
+++ b/lib/src/controllers/de1_controller.defaults.dart
@@ -1,6 +1,9 @@
 part of 'de1_controller.dart';
 
 extension Defaults on De1Controller {
+  /// Device-pinned default-write helper. Every read/write goes through
+  /// the captured [device] so a disconnect/reconnect race cannot write to
+  /// the replacement machine.
   Future<void> _setDe1DefaultsFor(De1Interface device) async {
     await device.setFanThreshhold(55);
 
@@ -8,7 +11,8 @@ extension Defaults on De1Controller {
       return;
     }
     SteamSettings steamSettings = defaultWorkflow!.steamSettings;
-    await updateSteamSettings(
+    await _updateSteamSettingsFor(
+      device,
       SteamFormSettings(
         steamEnabled: steamSettings.targetTemperature >= 130,
         targetTemp: steamSettings.targetTemperature,
@@ -17,7 +21,8 @@ extension Defaults on De1Controller {
       ),
     );
     HotWaterData hotWaterData = defaultWorkflow!.hotWaterData;
-    await updateHotWaterSettings(
+    await _updateHotWaterSettingsFor(
+      device,
       HotWaterFormSettings(
         targetTemperature: hotWaterData.targetTemperature,
         flow: hotWaterData.flow,
@@ -27,9 +32,63 @@ extension Defaults on De1Controller {
     );
 
     RinseData rinseData = defaultWorkflow!.rinseData;
-    await updateFlushSettings(rinseData);
+    await _updateFlushSettingsFor(device, rinseData);
+  }
 
-    // The connect-time profile upload is owned by WorkflowDeviceSync.
+  Future<void> _updateSteamSettingsFor(
+    De1Interface device,
+    SteamFormSettings settings,
+  ) async {
+    De1ShotSettings shotSettings = await device.shotSettings.first;
+    await device.setSteamFlow(settings.targetFlow);
+    await device.updateShotSettings(
+      shotSettings.copyWith(
+        targetSteamTemp: settings.steamEnabled ? settings.targetTemp : 0,
+        targetSteamDuration: settings.targetDuration,
+      ),
+    );
+    _steamDataController.add(
+      SteamSettings(
+        targetTemperature: settings.steamEnabled ? settings.targetTemp : 0,
+        duration: settings.targetDuration,
+        flow: settings.targetFlow,
+      ),
+    );
+  }
+
+  Future<void> _updateHotWaterSettingsFor(
+    De1Interface device,
+    HotWaterFormSettings settings,
+  ) async {
+    await device.setHotWaterFlow(settings.flow);
+    De1ShotSettings s = await device.shotSettings.first;
+    await device.updateShotSettings(
+      s.copyWith(
+        targetHotWaterTemp: settings.targetTemperature,
+        targetHotWaterVolume: settings.volume,
+        targetHotWaterDuration: settings.duration,
+      ),
+    );
+    _hotWaterDataController.add(
+      HotWaterData(
+        targetTemperature: settings.targetTemperature,
+        duration: settings.duration,
+        volume: settings.volume,
+        flow: settings.flow,
+      ),
+    );
+  }
+
+  Future<void> _updateFlushSettingsFor(
+    De1Interface device,
+    RinseData settings,
+  ) async {
+    await device.setFlushTimeout(settings.duration.toDouble());
+    await device.setFlushFlow(settings.flow);
+    await device.setFlushTemperature(
+      settings.targetTemperature.toDouble(),
+    );
+    _rinseStream.add(settings);
   }
 
   Future<void> applySettingsDefaults() async {

--- a/lib/src/controllers/workflow_device_sync.dart
+++ b/lib/src/controllers/workflow_device_sync.dart
@@ -25,27 +25,16 @@ import 'package:reaprime/src/models/errors.dart';
 ///
 /// A failed upload (e.g. a GATT write timeout on a flaky link) is retried
 /// automatically with capped backoff ([retryDelays]) until it lands, is
-/// superseded, or the machine disconnects — a fresh upload restarts the
-/// firmware receive state machine from the header, so the machine can
-/// never stay wedged while connected. Retries are deliberately not gated
-/// on machine state: pushes mid-shot are already possible today, and a
-/// wedged machine is strictly worse.
+/// superseded, or the machine disconnects. Retries are deliberately not
+/// gated on machine state: pushes mid-shot are already possible today.
 ///
-/// On DE1 disconnect pending retries are cancelled and desired state is
-/// forgotten; on (re)connect the sync re-pushes the current workflow
-/// profile itself, through the same serialized/retry machinery. This
-/// replaced the single-shot `De1Controller._setDe1Defaults` upload whose
-/// mid-sequence failure was swallowed — leaving the firmware's
-/// `ProfileDownloadInProgress` latch stuck (magenta GH-LED pulse, start
-/// requests ignored) with every same-profile repair blocked by the
-/// device-state caches. For the same reason nothing here may
-/// ever *assume* what profile the device holds: `_lastPushedProfile`
-/// starts null and is cleared on every connection edge, so the first
-/// push after a (re)connect always goes to the wire.
-///
-/// Callers outside this sync (REST `POST /api/v1/machine/profile`) are
-/// backstopped by the per-device upload queue in `UnifiedDe1.setProfile`,
-/// so they cannot interleave with an upload from here either.
+/// The on-connect profile push is triggered by
+/// [De1Controller.initSettled], which fires after the machine is ready
+/// and startup defaults have been attempted — not by the raw de1 stream
+/// event (which fires before initialization completes). This preserves
+/// the ordering where startup/default writes complete before the profile
+/// upload begins, and avoids any direct coupling between
+/// `De1Controller` and this sync.
 class WorkflowDeviceSync {
   WorkflowDeviceSync({
     required WorkflowController workflowController,
@@ -56,85 +45,71 @@ class WorkflowDeviceSync {
       Duration(seconds: 30),
     ],
     this.onUploadError,
-    this.onUploadRecovered,
-  })  : _workflow = workflowController,
-        _de1 = de1Controller {
-    // No optimistic `_lastPushedProfile` seed: assuming the device already
-    // holds the persisted workflow profile blocked the same-profile repair
-    // push after an interrupted upload. Costs one redundant
-    // upload per connect, guarantees the device really holds the profile.
+    this.onUploadErrorCleared,
+  }) : _workflow = workflowController,
+       _de1 = de1Controller {
     _workflow.addListener(_onChange);
     _de1Sub = _de1.de1.listen(_onDe1Change);
+    _initSettledSub = _de1.initSettled.listen(_onInitSettled);
   }
 
   final WorkflowController _workflow;
   final De1Controller _de1;
   final Logger _log = Logger('WorkflowDeviceSync');
 
-  /// Backoff schedule for upload retries; the last entry repeats as the cap.
   final List<Duration> retryDelays;
 
   /// Surfaces a persistent upload failure on the app's connection-status
-  /// stream instead of burying it in logs (the on-connect push
-  /// used to fail invisibly). Wired to `ConnectionManager.reportError` in
-  /// `main.dart`; fired once per failing push cycle, on the first failure.
+  /// stream when a retry cycle is active. Wired to
+  /// `ConnectionManager.reportError` in `main.dart`; fired once per
+  /// failing push cycle, on the first failure.
   final void Function(ConnectionError error)? onUploadError;
 
-  /// Invoked when an upload lands after [onUploadError] fired, so the
-  /// reporter can retract the surfaced error.
-  final void Function()? onUploadRecovered;
+  /// Invoked when the surfaced upload error is no longer current — either
+  /// a retry landed successfully, the machine disconnected, or the sync
+  /// was disposed.
+  final void Function()? onUploadErrorCleared;
 
-  /// What the device is known to hold. Stamped only after a successful
-  /// upload; cleared when an upload fails, since a mid-sequence failure
-  /// leaves the device profile state unknown (comms-harden #1) — and on
-  /// every connection edge, since a machine that went away may have missed
-  /// or dropped what was pushed.
   Profile? _lastPushedProfile;
-
-  /// Latest profile the device should end up with. Overwritten freely by
-  /// workflow changes while an upload is in flight (latest wins).
   Profile? _desiredProfile;
-
   bool _uploading = false;
   Timer? _retryTimer;
   int _attempt = 0;
 
-  /// Whether [onUploadError] fired for the current push cycle; gates the
-  /// matching [onUploadRecovered] call and keeps retries from re-emitting.
   bool _errorSurfaced = false;
-
   bool _disposed = false;
 
-  /// Past the ramp, only every Nth failed attempt logs at WARNING.
   static const int _retryLogHeartbeat = 10;
 
-  /// Bumped on disconnect and dispose; in-flight drains and pending retry
-  /// timers capture it and bail when it changes.
   int _generation = 0;
 
   StreamSubscription<De1Interface?>? _de1Sub;
+  StreamSubscription<int?>? _initSettledSub;
 
   void _onChange() {
-    // Record the desired profile and let the drain loop decide — comparing
-    // against `_lastPushedProfile` here would go stale when an upload is in
-    // flight (e.g. reverting to the last-pushed profile while a newer one
-    // uploads: once that lands, the device holds the newer one and the
-    // revert must still be pushed).
     final next = _workflow.currentWorkflow.profile;
     if (next == _desiredProfile) {
-      // Not a profile change (a non-profile workflow edit, or a re-select
-      // of the same content): leave a pending retry's backoff undisturbed
-      // rather than resetting a failing upload to the floor delay.
       return;
     }
     _desiredProfile = next;
     _attempt = 0;
-    _cancelRetry(); // a fresh change replaces any pending retry
+    _cancelRetry();
     unawaited(_drain());
   }
 
-  /// Uploads the latest desired profile, one upload at a time, until the
-  /// device is in sync. Concurrent calls collapse into the running loop.
+  /// Kicks the profile push when machine initialization settles (ready +
+  /// defaults attempted). Replaces the old single-shot
+  /// `De1Controller._setDe1Defaults` upload and the short-lived raw-de1
+  /// stream trigger that raced initialization.
+  void _onInitSettled(int? generation) {
+    if (generation == null || generation != _generation) return;
+    _lastPushedProfile = null;
+    _desiredProfile = _workflow.currentWorkflow.profile;
+    _attempt = 0;
+    _cancelRetry();
+    unawaited(_drain());
+  }
+
   Future<void> _drain() async {
     if (_uploading) return;
     _uploading = true;
@@ -153,30 +128,20 @@ class WorkflowDeviceSync {
           _attempt = 0;
           if (_errorSurfaced) {
             _errorSurfaced = false;
-            onUploadRecovered?.call();
+            onUploadErrorCleared?.call();
           }
-          // Loop again: if the desired profile advanced mid-upload, the
-          // next iteration pushes it; otherwise the guard above exits.
         } on DeviceNotConnectedException {
           _log.fine(
-            'DE1 not connected; skipping profile push — the on-connect '
-            'push (_onDe1Change) re-syncs on next connect',
+            'DE1 not connected; skipping profile push',
           );
           return;
         } catch (e, st) {
           if (generation != _generation) return;
-          // The upload died mid-sequence: the device profile state is
-          // unknown (possibly wedged mid-receive), so forget what was
-          // last pushed — even a revert to it must re-upload.
           _lastPushedProfile = null;
           final delay = _scheduleRetry(generation);
           final message =
               'setProfile failed (attempt $_attempt); retrying in '
               '${delay.inMilliseconds}ms';
-          // Retries are unbounded, so a persistent fault would otherwise
-          // emit a stack-trace WARNING every capped delay forever. Warn
-          // while the backoff ramps and on a periodic heartbeat after
-          // that; log the rest quietly.
           if (_attempt <= retryDelays.length ||
               _attempt % _retryLogHeartbeat == 0) {
             _log.warning(message, e, st);
@@ -185,33 +150,30 @@ class WorkflowDeviceSync {
           }
           if (!_errorSurfaced) {
             _errorSurfaced = true;
-            onUploadError?.call(ConnectionError(
-              kind: ConnectionErrorKind.profileUploadFailed,
-              severity: ConnectionErrorSeverity.warning,
-              timestamp: DateTime.now().toUtc(),
-              deviceId: _de1.connectedDe1OrNull?.deviceId,
-              deviceName: _de1.connectedDe1OrNull?.name,
-              message: 'Profile upload to the machine failed; '
-                  'retrying automatically',
-            ));
+            onUploadError?.call(
+              ConnectionError(
+                kind: ConnectionErrorKind.profileUploadFailed,
+                severity: ConnectionErrorSeverity.warning,
+                timestamp: DateTime.now().toUtc(),
+                deviceId: _de1.connectedDe1OrNull?.deviceId,
+                deviceName: _de1.connectedDe1OrNull?.name,
+                message:
+                    'Profile upload to the machine failed; '
+                    'retrying automatically',
+              ),
+            );
           }
           return;
         }
       }
     } finally {
       _uploading = false;
-      // A (re)connect may have set a new desired profile while this
-      // now-stale drain was unwinding (its generation was bumped by the
-      // disconnect, so it exits without pushing). Kick a fresh loop for
-      // the new generation or the on-connect push would be stranded until
-      // the next workflow change.
       if (!_disposed && generation != _generation && _desiredProfile != null) {
         unawaited(_drain());
       }
     }
   }
 
-  /// Arms the retry timer with the next backoff delay and returns it.
   Duration _scheduleRetry(int generation) {
     final delay = retryDelays[min(_attempt, retryDelays.length - 1)];
     _attempt++;
@@ -229,29 +191,20 @@ class WorkflowDeviceSync {
 
   void _onDe1Change(De1Interface? device) {
     if (device == null) {
-      // Machine gone: cancel retries and forget desired state; the
-      // on-connect branch below re-syncs. Also forget what was pushed —
-      // an upload interrupted by the disconnect latches the firmware's
-      // profile-receive state machine, and only a full re-upload clears
-      // it.
       _generation++;
       _cancelRetry();
       _desiredProfile = null;
       _lastPushedProfile = null;
       _attempt = 0;
-      _errorSurfaced = false;
+      if (_errorSurfaced) {
+        _errorSurfaced = false;
+        onUploadErrorCleared?.call();
+      }
       return;
     }
-    // Machine (re)connected: push the current workflow profile through the
-    // serialized/retry machinery. Replaces the single-shot, error-swallowing
-    // upload in De1Controller._setDe1Defaults. `_lastPushedProfile`
-    // is cleared so the push cannot be skipped as already-held — the device's
-    // actual state after a connection edge is unknown.
-    _lastPushedProfile = null;
-    _desiredProfile = _workflow.currentWorkflow.profile;
-    _attempt = 0;
-    _cancelRetry();
-    unawaited(_drain());
+    // Sync generation to the controller so the upcoming init-settled
+    // event (which may have already fired) matches.
+    _generation = _de1.connectionGeneration;
   }
 
   void dispose() {
@@ -261,5 +214,11 @@ class WorkflowDeviceSync {
     _cancelRetry();
     _de1Sub?.cancel();
     _de1Sub = null;
+    _initSettledSub?.cancel();
+    _initSettledSub = null;
+    if (_errorSurfaced) {
+      _errorSurfaced = false;
+      onUploadErrorCleared?.call();
+    }
   }
 }

--- a/lib/src/controllers/workflow_device_sync.dart
+++ b/lib/src/controllers/workflow_device_sync.dart
@@ -2,17 +2,18 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/connection_error.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/errors.dart';
 
-/// Single writer of `setProfile` for both REST (`PUT /api/v1/workflow`)
-/// and UI (`ProfileTile` picker) paths. Subscribes to
-/// `WorkflowController` changes and pushes the profile to the DE1 on
-/// value diff; equality is handled by `Profile`'s `Equatable`
-/// implementation.
+/// Single writer of `setProfile` for the workflow paths — REST
+/// (`PUT /api/v1/workflow`), UI (`ProfileTile` picker) AND the machine
+/// (re)connect push. Subscribes to `WorkflowController` changes and
+/// pushes the profile to the DE1 on value diff; equality is handled by
+/// `Profile`'s `Equatable` implementation.
 ///
 /// Uploads are strictly serialized and coalesced (queue-with-coalesce):
 /// a profile upload is a stateful BLE multi-write sequence (header
@@ -30,15 +31,21 @@ import 'package:reaprime/src/models/errors.dart';
 /// on machine state: pushes mid-shot are already possible today, and a
 /// wedged machine is strictly worse.
 ///
-/// On DE1 disconnect pending retries are cancelled and the push is
-/// skipped; the existing `De1Controller._setDe1Defaults` path uploads the
-/// current workflow's profile on reconnect (see `defaultWorkflow`
-/// assignment in `main.dart`).
+/// On DE1 disconnect pending retries are cancelled and desired state is
+/// forgotten; on (re)connect the sync re-pushes the current workflow
+/// profile itself, through the same serialized/retry machinery. This
+/// replaced the single-shot `De1Controller._setDe1Defaults` upload whose
+/// mid-sequence failure was swallowed — leaving the firmware's
+/// `ProfileDownloadInProgress` latch stuck (magenta GH-LED pulse, start
+/// requests ignored) with every same-profile repair blocked by the
+/// device-state caches. For the same reason nothing here may
+/// ever *assume* what profile the device holds: `_lastPushedProfile`
+/// starts null and is cleared on every connection edge, so the first
+/// push after a (re)connect always goes to the wire.
 ///
-/// Callers outside this sync (REST `POST /api/v1/machine/profile`, the
-/// reconnect defaults push) are backstopped by the per-device upload queue
-/// in `UnifiedDe1.setProfile`, so they cannot interleave with an upload
-/// from here either.
+/// Callers outside this sync (REST `POST /api/v1/machine/profile`) are
+/// backstopped by the per-device upload queue in `UnifiedDe1.setProfile`,
+/// so they cannot interleave with an upload from here either.
 class WorkflowDeviceSync {
   WorkflowDeviceSync({
     required WorkflowController workflowController,
@@ -48,9 +55,14 @@ class WorkflowDeviceSync {
       Duration(seconds: 10),
       Duration(seconds: 30),
     ],
+    this.onUploadError,
+    this.onUploadRecovered,
   })  : _workflow = workflowController,
         _de1 = de1Controller {
-    _lastPushedProfile = _workflow.currentWorkflow.profile;
+    // No optimistic `_lastPushedProfile` seed: assuming the device already
+    // holds the persisted workflow profile blocked the same-profile repair
+    // push after an interrupted upload. Costs one redundant
+    // upload per connect, guarantees the device really holds the profile.
     _workflow.addListener(_onChange);
     _de1Sub = _de1.de1.listen(_onDe1Change);
   }
@@ -62,9 +74,21 @@ class WorkflowDeviceSync {
   /// Backoff schedule for upload retries; the last entry repeats as the cap.
   final List<Duration> retryDelays;
 
+  /// Surfaces a persistent upload failure on the app's connection-status
+  /// stream instead of burying it in logs (the on-connect push
+  /// used to fail invisibly). Wired to `ConnectionManager.reportError` in
+  /// `main.dart`; fired once per failing push cycle, on the first failure.
+  final void Function(ConnectionError error)? onUploadError;
+
+  /// Invoked when an upload lands after [onUploadError] fired, so the
+  /// reporter can retract the surfaced error.
+  final void Function()? onUploadRecovered;
+
   /// What the device is known to hold. Stamped only after a successful
   /// upload; cleared when an upload fails, since a mid-sequence failure
-  /// leaves the device profile state unknown (comms-harden #1).
+  /// leaves the device profile state unknown (comms-harden #1) — and on
+  /// every connection edge, since a machine that went away may have missed
+  /// or dropped what was pushed.
   Profile? _lastPushedProfile;
 
   /// Latest profile the device should end up with. Overwritten freely by
@@ -74,6 +98,12 @@ class WorkflowDeviceSync {
   bool _uploading = false;
   Timer? _retryTimer;
   int _attempt = 0;
+
+  /// Whether [onUploadError] fired for the current push cycle; gates the
+  /// matching [onUploadRecovered] call and keeps retries from re-emitting.
+  bool _errorSurfaced = false;
+
+  bool _disposed = false;
 
   /// Past the ramp, only every Nth failed attempt logs at WARNING.
   static const int _retryLogHeartbeat = 10;
@@ -121,12 +151,16 @@ class WorkflowDeviceSync {
           if (generation != _generation) return;
           _lastPushedProfile = profile;
           _attempt = 0;
+          if (_errorSurfaced) {
+            _errorSurfaced = false;
+            onUploadRecovered?.call();
+          }
           // Loop again: if the desired profile advanced mid-upload, the
           // next iteration pushes it; otherwise the guard above exits.
         } on DeviceNotConnectedException {
           _log.fine(
-            'DE1 not connected; skipping profile push — will sync via '
-            'defaultWorkflow on next connect',
+            'DE1 not connected; skipping profile push — the on-connect '
+            'push (_onDe1Change) re-syncs on next connect',
           );
           return;
         } catch (e, st) {
@@ -149,11 +183,31 @@ class WorkflowDeviceSync {
           } else {
             _log.fine(message, e);
           }
+          if (!_errorSurfaced) {
+            _errorSurfaced = true;
+            onUploadError?.call(ConnectionError(
+              kind: ConnectionErrorKind.profileUploadFailed,
+              severity: ConnectionErrorSeverity.warning,
+              timestamp: DateTime.now().toUtc(),
+              deviceId: _de1.connectedDe1OrNull?.deviceId,
+              deviceName: _de1.connectedDe1OrNull?.name,
+              message: 'Profile upload to the machine failed; '
+                  'retrying automatically',
+            ));
+          }
           return;
         }
       }
     } finally {
       _uploading = false;
+      // A (re)connect may have set a new desired profile while this
+      // now-stale drain was unwinding (its generation was bumped by the
+      // disconnect, so it exits without pushing). Kick a fresh loop for
+      // the new generation or the on-connect push would be stranded until
+      // the next workflow change.
+      if (!_disposed && generation != _generation && _desiredProfile != null) {
+        unawaited(_drain());
+      }
     }
   }
 
@@ -174,17 +228,35 @@ class WorkflowDeviceSync {
   }
 
   void _onDe1Change(De1Interface? device) {
-    if (device != null) return;
-    // Machine gone: cancel retries and forget desired state. The reconnect
-    // path re-uploads the current workflow profile via defaultWorkflow.
-    _generation++;
-    _cancelRetry();
-    _desiredProfile = null;
+    if (device == null) {
+      // Machine gone: cancel retries and forget desired state; the
+      // on-connect branch below re-syncs. Also forget what was pushed —
+      // an upload interrupted by the disconnect latches the firmware's
+      // profile-receive state machine, and only a full re-upload clears
+      // it.
+      _generation++;
+      _cancelRetry();
+      _desiredProfile = null;
+      _lastPushedProfile = null;
+      _attempt = 0;
+      _errorSurfaced = false;
+      return;
+    }
+    // Machine (re)connected: push the current workflow profile through the
+    // serialized/retry machinery. Replaces the single-shot, error-swallowing
+    // upload in De1Controller._setDe1Defaults. `_lastPushedProfile`
+    // is cleared so the push cannot be skipped as already-held — the device's
+    // actual state after a connection edge is unknown.
+    _lastPushedProfile = null;
+    _desiredProfile = _workflow.currentWorkflow.profile;
     _attempt = 0;
+    _cancelRetry();
+    unawaited(_drain());
   }
 
   void dispose() {
     _workflow.removeListener(_onChange);
+    _disposed = true;
     _generation++;
     _cancelRetry();
     _de1Sub?.cancel();

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -221,6 +221,11 @@ class UnifiedDe1 implements De1Interface {
     initRawStream();
     await _transport.connect();
 
+    // Connection edge: the device's profile state is unknown (possibly
+    // wedged mid-receive in ProfileDownloadInProgress), so the first
+    // setProfile must perform a complete upload.
+    _currentProfile = null;
+
     if (_info != null) {
       return;
     }

--- a/test/controllers/connection/status_publisher_test.dart
+++ b/test/controllers/connection/status_publisher_test.dart
@@ -4,11 +4,11 @@ import 'package:reaprime/src/controllers/connection_error.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';
 
 ConnectionError _err(String kind) => ConnectionError(
-      kind: kind,
-      severity: ConnectionErrorSeverity.error,
-      timestamp: DateTime(2026, 4, 21, 12, 0),
-      message: 'test',
-    );
+  kind: kind,
+  severity: ConnectionErrorSeverity.error,
+  timestamp: DateTime(2026, 4, 21, 12, 0),
+  message: 'test',
+);
 
 void main() {
   group('StatusPublisher', () {
@@ -46,9 +46,11 @@ void main() {
     test('sticky errors survive a publish that leaves error null', () {
       pub.emitError(_err(ConnectionErrorKind.bluetoothPermissionDenied));
       pub.publish(pub.current.copyWith(phase: ConnectionPhase.idle));
-      expect(pub.current.error?.kind,
-          ConnectionErrorKind.bluetoothPermissionDenied,
-          reason: 'sticky error must be preserved across phase transitions');
+      expect(
+        pub.current.error?.kind,
+        ConnectionErrorKind.bluetoothPermissionDenied,
+        reason: 'sticky error must be preserved across phase transitions',
+      );
     });
 
     test('transient errors get stripped when moving into a clearing phase', () {
@@ -56,31 +58,93 @@ void main() {
       // Caller re-publishes current status (preserves error via copyWith)
       // while transitioning into `scanning`, a clearing phase.
       pub.publish(pub.current.copyWith(phase: ConnectionPhase.scanning));
-      expect(pub.current.error, isNull,
-          reason:
-              're-published transient error should be stripped on clearing-phase transition');
+      expect(
+        pub.current.error,
+        isNull,
+        reason:
+            're-published transient error should be stripped on clearing-phase transition',
+      );
     });
 
-    test('a NEW transient error is not stripped on clearing-phase transition',
-        () {
-      pub.publish(pub.current.copyWith(phase: ConnectionPhase.idle));
-      pub.publish(pub.current.copyWith(
-        phase: ConnectionPhase.ready,
-        error: () => _err(ConnectionErrorKind.scaleConnectFailed),
-      ));
-      // Under current semantics (matching the pre-refactor behaviour)
-      // a brand-new error passed atomically with a clearing-phase
-      // transition is also stripped. Keep this test pinning that
-      // behaviour; when we move to unified emission in a later phase,
-      // the assertion will flip.
-      expect(pub.current.error, isNull);
-    });
+    test(
+      'a NEW transient error is not stripped on clearing-phase transition',
+      () {
+        pub.publish(pub.current.copyWith(phase: ConnectionPhase.idle));
+        pub.publish(
+          pub.current.copyWith(
+            phase: ConnectionPhase.ready,
+            error: () => _err(ConnectionErrorKind.scaleConnectFailed),
+          ),
+        );
+        // Under current semantics (matching the pre-refactor behaviour)
+        // a brand-new error passed atomically with a clearing-phase
+        // transition is also stripped. Keep this test pinning that
+        // behaviour; when we move to unified emission in a later phase,
+        // the assertion will flip.
+        expect(pub.current.error, isNull);
+      },
+    );
 
     test('clearError drops sticky errors explicitly', () {
       pub.emitError(_err(ConnectionErrorKind.adapterOff));
       expect(pub.current.error, isNotNull);
       pub.clearError();
       expect(pub.current.error, isNull);
+    });
+
+    group('phasePersistent errors', () {
+      test('profileUploadFailed survives clearing phases', () {
+        pub.emitError(
+          _err(ConnectionErrorKind.profileUploadFailed),
+        );
+        pub.publish(pub.current.copyWith(phase: ConnectionPhase.scanning));
+        expect(
+          pub.current.error?.kind,
+          ConnectionErrorKind.profileUploadFailed,
+          reason: 'phase-persistent error must survive scanning',
+        );
+
+        pub.publish(pub.current.copyWith(phase: ConnectionPhase.ready));
+        expect(
+          pub.current.error?.kind,
+          ConnectionErrorKind.profileUploadFailed,
+          reason: 'phase-persistent error must survive ready',
+        );
+      });
+
+      test('profileUploadFailed clears through explicit clearError', () {
+        pub.emitError(
+          _err(ConnectionErrorKind.profileUploadFailed),
+        );
+        expect(pub.current.error, isNotNull);
+        pub.clearError();
+        expect(pub.current.error, isNull);
+      });
+
+      test('new error replaces profileUploadFailed', () {
+        pub.emitError(
+          _err(ConnectionErrorKind.profileUploadFailed),
+        );
+        pub.emitError(_err(ConnectionErrorKind.machineConnectFailed));
+        expect(
+          pub.current.error?.kind,
+          ConnectionErrorKind.machineConnectFailed,
+          reason: 'new error must replace the previous one',
+        );
+      });
+
+      test('clearing profileUploadFailed does not stomp replacement', () {
+        pub.emitError(
+          _err(ConnectionErrorKind.profileUploadFailed),
+        );
+        pub.emitError(_err(ConnectionErrorKind.machineConnectFailed));
+        pub.clearError();
+        expect(
+          pub.current.error,
+          isNull,
+          reason: 'clearError clears the current error regardless of kind',
+        );
+      });
     });
   });
 }

--- a/test/controllers/connection/status_publisher_test.dart
+++ b/test/controllers/connection/status_publisher_test.dart
@@ -133,7 +133,7 @@ void main() {
         );
       });
 
-      test('clearing profileUploadFailed does not stomp replacement', () {
+      test('clearError clears the current error regardless of kind', () {
         pub.emitError(
           _err(ConnectionErrorKind.profileUploadFailed),
         );
@@ -142,7 +142,9 @@ void main() {
         expect(
           pub.current.error,
           isNull,
-          reason: 'clearError clears the current error regardless of kind',
+          reason:
+              'unconditional clearError must clear the active error '
+              'even when it was not the original one',
         );
       });
     });

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -177,8 +177,7 @@ void main() {
       mockScanner = MockDeviceScanner();
       dummyDiscoveryService = MockDeviceDiscoveryService();
       mockDe1Controller = MockDe1Controller(
-        controller:
-            DeviceController([dummyDiscoveryService]),
+        controller: DeviceController([dummyDiscoveryService]),
       );
       mockScaleController = MockScaleController();
       mockSettingsService = MockSettingsService();
@@ -227,38 +226,44 @@ void main() {
         expect(mockDe1Controller.connectCalls, isEmpty);
       });
 
-      test('no preferred, 1 machine → auto-connects and saves preference',
-          () async {
-        final fakeDe1 = _FakeDe1(deviceId: 'solo-de1');
-        mockScanner.addDevice(fakeDe1);
-        await Future.delayed(Duration.zero);
+      test(
+        'no preferred, 1 machine → auto-connects and saves preference',
+        () async {
+          final fakeDe1 = _FakeDe1(deviceId: 'solo-de1');
+          mockScanner.addDevice(fakeDe1);
+          await Future.delayed(Duration.zero);
 
-        await connectionManager.connect();
-        await Future.delayed(Duration.zero);
+          await connectionManager.connect();
+          await Future.delayed(Duration.zero);
 
-        expect(mockDe1Controller.connectCalls, hasLength(1));
-        expect(mockDe1Controller.connectCalls.first, same(fakeDe1));
-        expect(settingsController.preferredMachineId, 'solo-de1');
-        expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
-      });
+          expect(mockDe1Controller.connectCalls, hasLength(1));
+          expect(mockDe1Controller.connectCalls.first, same(fakeDe1));
+          expect(settingsController.preferredMachineId, 'solo-de1');
+          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
+        },
+      );
 
-      test('no preferred, many machines → emits machinePicker ambiguity',
-          () async {
-        final de1a = _FakeDe1(deviceId: 'de1-a');
-        final de1b = _FakeDe1(deviceId: 'de1-b');
-        mockScanner.addDevice(de1a);
-        mockScanner.addDevice(de1b);
-        await Future.delayed(Duration.zero);
+      test(
+        'no preferred, many machines → emits machinePicker ambiguity',
+        () async {
+          final de1a = _FakeDe1(deviceId: 'de1-a');
+          final de1b = _FakeDe1(deviceId: 'de1-b');
+          mockScanner.addDevice(de1a);
+          mockScanner.addDevice(de1b);
+          await Future.delayed(Duration.zero);
 
-        await connectionManager.connect();
-        await Future.delayed(Duration.zero);
+          await connectionManager.connect();
+          await Future.delayed(Duration.zero);
 
-        expect(connectionManager.currentStatus.phase, ConnectionPhase.idle);
-        expect(connectionManager.currentStatus.pendingAmbiguity,
-            AmbiguityReason.machinePicker);
-        expect(connectionManager.currentStatus.foundMachines, hasLength(2));
-        expect(mockDe1Controller.connectCalls, isEmpty);
-      });
+          expect(connectionManager.currentStatus.phase, ConnectionPhase.idle);
+          expect(
+            connectionManager.currentStatus.pendingAmbiguity,
+            AmbiguityReason.machinePicker,
+          );
+          expect(connectionManager.currentStatus.foundMachines, hasLength(2));
+          expect(mockDe1Controller.connectCalls, isEmpty);
+        },
+      );
 
       test('preferred machine found → connects directly', () async {
         await settingsController.setPreferredMachineId('pref-de1');
@@ -276,22 +281,25 @@ void main() {
       });
 
       test(
-          'preferred machine not found, others available → emits machinePicker ambiguity',
-          () async {
-        await settingsController.setPreferredMachineId('missing-de1');
+        'preferred machine not found, others available → emits machinePicker ambiguity',
+        () async {
+          await settingsController.setPreferredMachineId('missing-de1');
 
-        final otherDe1 = _FakeDe1(deviceId: 'other-de1');
-        mockScanner.addDevice(otherDe1);
-        await Future.delayed(Duration.zero);
+          final otherDe1 = _FakeDe1(deviceId: 'other-de1');
+          mockScanner.addDevice(otherDe1);
+          await Future.delayed(Duration.zero);
 
-        await connectionManager.connect();
-        await Future.delayed(Duration.zero);
+          await connectionManager.connect();
+          await Future.delayed(Duration.zero);
 
-        expect(connectionManager.currentStatus.phase, ConnectionPhase.idle);
-        expect(connectionManager.currentStatus.pendingAmbiguity,
-            AmbiguityReason.machinePicker);
-        expect(mockDe1Controller.connectCalls, isEmpty);
-      });
+          expect(connectionManager.currentStatus.phase, ConnectionPhase.idle);
+          expect(
+            connectionManager.currentStatus.pendingAmbiguity,
+            AmbiguityReason.machinePicker,
+          );
+          expect(mockDe1Controller.connectCalls, isEmpty);
+        },
+      );
 
       test('preferred machine not found, no others → stays idle', () async {
         await settingsController.setPreferredMachineId('missing-de1');
@@ -319,8 +327,7 @@ void main() {
 
           expect(mockDe1Controller.connectCalls, hasLength(1));
           expect(mockScaleController.connectCalls, hasLength(1));
-          expect(
-              mockScaleController.connectCalls.first.deviceId, 'pref-scale');
+          expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
           expect(settingsController.preferredScaleId, 'pref-scale');
         });
 
@@ -335,8 +342,7 @@ void main() {
           await Future.delayed(Duration.zero);
 
           expect(mockScaleController.connectCalls, hasLength(1));
-          expect(
-              mockScaleController.connectCalls.first.deviceId, 'only-scale');
+          expect(mockScaleController.connectCalls.first.deviceId, 'only-scale');
         });
 
         test('no preferred, many scales → skips scale', () async {
@@ -354,21 +360,25 @@ void main() {
           expect(mockScaleController.connectCalls, isEmpty);
         });
 
-        test('preferred scale not found → does nothing, phase stays ready',
-            () async {
-          await settingsController.setPreferredScaleId('missing-scale');
+        test(
+          'preferred scale not found → does nothing, phase stays ready',
+          () async {
+            await settingsController.setPreferredScaleId('missing-scale');
 
-          final fakeDe1 = _FakeDe1(deviceId: 'de1');
-          mockScanner.addDevice(fakeDe1);
-          await Future.delayed(Duration.zero);
+            final fakeDe1 = _FakeDe1(deviceId: 'de1');
+            mockScanner.addDevice(fakeDe1);
+            await Future.delayed(Duration.zero);
 
-          await connectionManager.connect();
-          await Future.delayed(Duration.zero);
+            await connectionManager.connect();
+            await Future.delayed(Duration.zero);
 
-          expect(mockScaleController.connectCalls, isEmpty);
-          expect(
-              connectionManager.currentStatus.phase, ConnectionPhase.ready);
-        });
+            expect(mockScaleController.connectCalls, isEmpty);
+            expect(
+              connectionManager.currentStatus.phase,
+              ConnectionPhase.ready,
+            );
+          },
+        );
 
         test('scale failure does not affect machine connection', () async {
           mockScaleController.shouldFailConnect = true;
@@ -384,8 +394,7 @@ void main() {
 
           expect(mockDe1Controller.connectCalls, hasLength(1));
           expect(mockScaleController.connectCalls, hasLength(1));
-          expect(
-              connectionManager.currentStatus.phase, ConnectionPhase.ready);
+          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
         });
       });
 
@@ -399,117 +408,132 @@ void main() {
       // See: doc/plans/comms-harden.md #4,
       //      doc/plans/comms-phase-0-1.md Gap A.
       group('scale failure recovery (comms-harden #4)', () {
-        test('after scaleOnly connect fails, next connect retries scale',
-            () async {
-          mockScaleController.shouldFailConnect = true;
+        test(
+          'after scaleOnly connect fails, next connect retries scale',
+          () async {
+            mockScaleController.shouldFailConnect = true;
 
-          final scale = TestScale(deviceId: 'scale-1');
-          mockScanner.addDevice(scale);
-          await Future.delayed(Duration.zero);
+            final scale = TestScale(deviceId: 'scale-1');
+            mockScanner.addDevice(scale);
+            await Future.delayed(Duration.zero);
 
-          await connectionManager.connect(scaleOnly: true);
-          await Future.delayed(Duration.zero);
-          expect(mockScaleController.connectCalls, hasLength(1),
-              reason: 'first scaleOnly attempt should call connectToScale');
+            await connectionManager.connect(scaleOnly: true);
+            await Future.delayed(Duration.zero);
+            expect(
+              mockScaleController.connectCalls,
+              hasLength(1),
+              reason: 'first scaleOnly attempt should call connectToScale',
+            );
 
-          mockScaleController.shouldFailConnect = false;
-          await connectionManager.connect(scaleOnly: true);
-          await Future.delayed(Duration.zero);
+            mockScaleController.shouldFailConnect = false;
+            await connectionManager.connect(scaleOnly: true);
+            await Future.delayed(Duration.zero);
 
-          expect(mockScaleController.connectCalls, hasLength(2),
+            expect(
+              mockScaleController.connectCalls,
+              hasLength(2),
               reason:
-                  'scale must be retried after a prior failed scaleOnly connect');
-        });
+                  'scale must be retried after a prior failed scaleOnly connect',
+            );
+          },
+        );
 
         test(
-            'after full connect fails on scale phase, next scaleOnly retries',
-            () async {
-          mockScaleController.shouldFailConnect = true;
+          'after full connect fails on scale phase, next scaleOnly retries',
+          () async {
+            mockScaleController.shouldFailConnect = true;
 
-          final fakeDe1 = _FakeDe1(deviceId: 'de1');
-          final scale = TestScale(deviceId: 'scale-1');
-          mockScanner.addDevice(fakeDe1);
-          mockScanner.addDevice(scale);
-          await Future.delayed(Duration.zero);
+            final fakeDe1 = _FakeDe1(deviceId: 'de1');
+            final scale = TestScale(deviceId: 'scale-1');
+            mockScanner.addDevice(fakeDe1);
+            mockScanner.addDevice(scale);
+            await Future.delayed(Duration.zero);
 
-          await connectionManager.connect();
-          await Future.delayed(Duration.zero);
-          expect(mockScaleController.connectCalls, hasLength(1),
-              reason: 'full connect reaches scale phase on first attempt');
+            await connectionManager.connect();
+            await Future.delayed(Duration.zero);
+            expect(
+              mockScaleController.connectCalls,
+              hasLength(1),
+              reason: 'full connect reaches scale phase on first attempt',
+            );
 
-          mockScaleController.shouldFailConnect = false;
-          await connectionManager.connect(scaleOnly: true);
-          await Future.delayed(Duration.zero);
+            mockScaleController.shouldFailConnect = false;
+            await connectionManager.connect(scaleOnly: true);
+            await Future.delayed(Duration.zero);
 
-          expect(mockScaleController.connectCalls, hasLength(2),
+            expect(
+              mockScaleController.connectCalls,
+              hasLength(2),
               reason:
-                  'scale phase must retry after a prior full-connect failure');
-        });
+                  'scale phase must retry after a prior full-connect failure',
+            );
+          },
+        );
       });
 
       group('early-stop', () {
         test(
-            'both preferred set and both connected → calls stopScan',
-            () async {
-          await settingsController.setPreferredMachineId('pref-de1');
-          await settingsController.setPreferredScaleId('pref-scale');
+          'both preferred set and both connected → calls stopScan',
+          () async {
+            await settingsController.setPreferredMachineId('pref-de1');
+            await settingsController.setPreferredScaleId('pref-scale');
 
-          // Hold scan open so devices appear "during" scan
-          mockScanner.scanCompleter = Completer<void>();
+            // Hold scan open so devices appear "during" scan
+            mockScanner.scanCompleter = Completer<void>();
 
-          final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
-          final testScale = TestScale(deviceId: 'pref-scale');
+            final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+            final testScale = TestScale(deviceId: 'pref-scale');
 
-          // Start connect (will block on scan)
-          final connectFuture = connectionManager.connect();
+            // Start connect (will block on scan)
+            final connectFuture = connectionManager.connect();
 
-          // Wait for scan to start
-          await mockScanner.scanningStream.firstWhere((s) => s);
+            // Wait for scan to start
+            await mockScanner.scanningStream.firstWhere((s) => s);
 
-          // Devices appear during scan
-          mockScanner.addDevice(fakeDe1);
-          await Future.delayed(Duration.zero);
-          mockScanner.addDevice(testScale);
-          await Future.delayed(Duration.zero);
+            // Devices appear during scan
+            mockScanner.addDevice(fakeDe1);
+            await Future.delayed(Duration.zero);
+            mockScanner.addDevice(testScale);
+            await Future.delayed(Duration.zero);
 
-          // Allow connections to process
-          await Future.delayed(Duration.zero);
-          await Future.delayed(Duration.zero);
+            // Allow connections to process
+            await Future.delayed(Duration.zero);
+            await Future.delayed(Duration.zero);
 
-          // Complete the scan
-          mockScanner.completeScan();
-          await connectFuture;
+            // Complete the scan
+            mockScanner.completeScan();
+            await connectFuture;
 
-          expect(mockScanner.stopScanCallCount, 1);
-        });
-
-        test(
-            'only preferred machine set → calls stopScan on machine connect',
-            () async {
-          await settingsController.setPreferredMachineId('pref-de1');
-          // No preferred scale — scan should stop as soon as machine connects.
-
-          mockScanner.scanCompleter = Completer<void>();
-
-          final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
-
-          final connectFuture = connectionManager.connect();
-          await mockScanner.scanningStream.firstWhere((s) => s);
-
-          mockScanner.addDevice(fakeDe1);
-          await Future.delayed(Duration.zero);
-          await Future.delayed(Duration.zero);
-
-          mockScanner.completeScan();
-          await connectFuture;
-
-          expect(mockScanner.stopScanCallCount, 1);
-        });
+            expect(mockScanner.stopScanCallCount, 1);
+          },
+        );
 
         test(
-            'only preferred machine, scale advertises after early-stop → '
-            'deferred rescan connects it',
-            () async {
+          'only preferred machine set → calls stopScan on machine connect',
+          () async {
+            await settingsController.setPreferredMachineId('pref-de1');
+            // No preferred scale — scan should stop as soon as machine connects.
+
+            mockScanner.scanCompleter = Completer<void>();
+
+            final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+
+            final connectFuture = connectionManager.connect();
+            await mockScanner.scanningStream.firstWhere((s) => s);
+
+            mockScanner.addDevice(fakeDe1);
+            await Future.delayed(Duration.zero);
+            await Future.delayed(Duration.zero);
+
+            mockScanner.completeScan();
+            await connectFuture;
+
+            expect(mockScanner.stopScanCallCount, 1);
+          },
+        );
+
+        test('only preferred machine, scale advertises after early-stop → '
+            'deferred rescan connects it', () async {
           await settingsController.setPreferredMachineId('pref-de1');
           // No preferred scale. Fire the deferred rescan immediately.
           connectionManager.deferredScaleScanDelay = Duration.zero;
@@ -533,8 +557,7 @@ void main() {
           // scan stopped early. Rescan is armed in the background.
           expect(mockScanner.stopScanCallCount, 1);
           expect(mockScaleController.connectCalls, isEmpty);
-          expect(
-              connectionManager.currentStatus.phase, ConnectionPhase.ready);
+          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
 
           // Scale shows up only now — after the early stop.
           mockScanner.addDevice(TestScale(deviceId: 'late-scale'));
@@ -545,18 +568,17 @@ void main() {
           await Future.delayed(Duration.zero);
           await Future.delayed(Duration.zero);
 
-          expect(mockScaleController.connectCalls, hasLength(1),
-              reason: 'deferred rescan must connect the late scale');
           expect(
-              mockScaleController.connectCalls.first.deviceId, 'late-scale');
-          expect(
-              connectionManager.currentStatus.phase, ConnectionPhase.ready);
+            mockScaleController.connectCalls,
+            hasLength(1),
+            reason: 'deferred rescan must connect the late scale',
+          );
+          expect(mockScaleController.connectCalls.first.deviceId, 'late-scale');
+          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
         });
 
-        test(
-            'only preferred machine, no scale ever → deferred rescan is a '
-            'no-op, machine stays ready',
-            () async {
+        test('only preferred machine, no scale ever → deferred rescan is a '
+            'no-op, machine stays ready', () async {
           await settingsController.setPreferredMachineId('pref-de1');
           connectionManager.deferredScaleScanDelay = Duration.zero;
 
@@ -574,8 +596,7 @@ void main() {
           mockScanner.completeScan();
           await connectFuture;
 
-          expect(
-              connectionManager.currentStatus.phase, ConnectionPhase.ready);
+          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
 
           // Deferred rescan fires, finds no scale, leaves machine ready.
           await Future.delayed(const Duration(milliseconds: 1));
@@ -584,14 +605,14 @@ void main() {
           await Future.delayed(Duration.zero);
 
           expect(mockScaleController.connectCalls, isEmpty);
-          expect(
-              connectionManager.currentStatus.phase, ConnectionPhase.ready);
+          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
         });
 
         test('machine disconnect cancels deferred scale rescan', () async {
           await settingsController.setPreferredMachineId('pref-de1');
-          connectionManager.deferredScaleScanDelay =
-              const Duration(milliseconds: 10);
+          connectionManager.deferredScaleScanDelay = const Duration(
+            milliseconds: 10,
+          );
           mockScanner.scanCompleter = Completer<void>();
 
           final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
@@ -617,9 +638,7 @@ void main() {
           await sub.cancel();
         });
 
-        test(
-            'only preferred scale set → does not call stopScan',
-            () async {
+        test('only preferred scale set → does not call stopScan', () async {
           await settingsController.setPreferredScaleId('pref-scale');
           // No preferred machine
 
@@ -640,9 +659,7 @@ void main() {
           expect(mockScanner.stopScanCallCount, 0);
         });
 
-        test(
-            'no preferences set → does not call stopScan',
-            () async {
+        test('no preferences set → does not call stopScan', () async {
           mockScanner.scanCompleter = Completer<void>();
 
           final fakeDe1 = _FakeDe1(deviceId: 'de1');
@@ -662,64 +679,69 @@ void main() {
         });
 
         test(
-            'full scan completed (no early stop) → no deferred rescan armed',
-            () async {
-          // No preferences → no early-stop. A single machine auto-connects
-          // via post-scan policy; the full scan already saw every scale, so
-          // a scale appearing afterwards must NOT be auto-connected by a
-          // rescan that should never have been armed.
-          connectionManager.deferredScaleScanDelay = Duration.zero;
+          'full scan completed (no early stop) → no deferred rescan armed',
+          () async {
+            // No preferences → no early-stop. A single machine auto-connects
+            // via post-scan policy; the full scan already saw every scale, so
+            // a scale appearing afterwards must NOT be auto-connected by a
+            // rescan that should never have been armed.
+            connectionManager.deferredScaleScanDelay = Duration.zero;
 
-          mockScanner.scanCompleter = Completer<void>();
+            mockScanner.scanCompleter = Completer<void>();
 
-          final fakeDe1 = _FakeDe1(deviceId: 'de1');
+            final fakeDe1 = _FakeDe1(deviceId: 'de1');
 
-          final connectFuture = connectionManager.connect();
-          await mockScanner.scanningStream.firstWhere((s) => s);
+            final connectFuture = connectionManager.connect();
+            await mockScanner.scanningStream.firstWhere((s) => s);
 
-          mockScanner.addDevice(fakeDe1);
-          await Future.delayed(Duration.zero);
+            mockScanner.addDevice(fakeDe1);
+            await Future.delayed(Duration.zero);
 
-          mockScanner.completeScan();
-          await connectFuture;
+            mockScanner.completeScan();
+            await connectFuture;
 
-          expect(mockScanner.stopScanCallCount, 0);
-          expect(mockScaleController.connectCalls, isEmpty);
+            expect(mockScanner.stopScanCallCount, 0);
+            expect(mockScaleController.connectCalls, isEmpty);
 
-          // A scale shows up after the (completed) scan. With no early stop
-          // there is no armed rescan, so it stays unconnected.
-          mockScanner.addDevice(TestScale(deviceId: 'late-scale'));
-          await Future.delayed(const Duration(milliseconds: 1));
-          await Future.delayed(Duration.zero);
-          await Future.delayed(Duration.zero);
+            // A scale shows up after the (completed) scan. With no early stop
+            // there is no armed rescan, so it stays unconnected.
+            mockScanner.addDevice(TestScale(deviceId: 'late-scale'));
+            await Future.delayed(const Duration(milliseconds: 1));
+            await Future.delayed(Duration.zero);
+            await Future.delayed(Duration.zero);
 
-          expect(mockScaleController.connectCalls, isEmpty,
-              reason: 'a completed full scan must not arm a deferred rescan');
-        });
+            expect(
+              mockScaleController.connectCalls,
+              isEmpty,
+              reason: 'a completed full scan must not arm a deferred rescan',
+            );
+          },
+        );
 
         test(
-            'both preferred set but only machine found → does not call stopScan',
-            () async {
-          await settingsController.setPreferredMachineId('pref-de1');
-          await settingsController.setPreferredScaleId('pref-scale');
+          'both preferred set but only machine found → does not call stopScan',
+          () async {
+            await settingsController.setPreferredMachineId('pref-de1');
+            await settingsController.setPreferredScaleId('pref-scale');
 
-          mockScanner.scanCompleter = Completer<void>();
+            mockScanner.scanCompleter = Completer<void>();
 
-          final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+            final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
 
-          final connectFuture = connectionManager.connect();
-          await mockScanner.scanningStream.firstWhere((s) => s);
+            final connectFuture = connectionManager.connect();
+            await mockScanner.scanningStream.firstWhere((s) => s);
 
-          // Only machine appears, no scale
-          mockScanner.addDevice(fakeDe1);
-          await Future.delayed(Duration.zero);
-          await Future.delayed(Duration.zero);
+            // Only machine appears, no scale
+            mockScanner.addDevice(fakeDe1);
+            await Future.delayed(Duration.zero);
+            await Future.delayed(Duration.zero);
 
-          mockScanner.completeScan();
-          await connectFuture;
+            mockScanner.completeScan();
+            await connectFuture;
 
-          expect(mockScanner.stopScanCallCount, 0);
-        });
+            expect(mockScanner.stopScanCallCount, 0);
+          },
+        );
       });
     });
 
@@ -749,8 +771,7 @@ void main() {
         await Future.delayed(Duration.zero);
 
         expect(mockScaleController.connectCalls, hasLength(1));
-        expect(
-            mockScaleController.connectCalls.first.deviceId, 'pref-scale');
+        expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
       });
 
       test('does not call stopScan even with preferred scale set', () async {
@@ -774,29 +795,29 @@ void main() {
       });
 
       test(
-          'auto-scans for preferred scale when machine is ready and scale is missing',
-          () async {
-        await settingsController.setPreferredScaleId('pref-scale');
-        mockScanner.scanCompleter = Completer<void>();
+        'auto-scans for preferred scale when machine is ready and scale is missing',
+        () async {
+          await settingsController.setPreferredScaleId('pref-scale');
+          mockScanner.scanCompleter = Completer<void>();
 
-        mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
-        await mockScanner.scanningStream.firstWhere((s) => s);
+          mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
+          await mockScanner.scanningStream.firstWhere((s) => s);
 
-        final testScale = TestScale(deviceId: 'pref-scale');
-        mockScanner.addDevice(testScale);
-        await Future.delayed(Duration.zero);
-        await Future.delayed(Duration.zero);
+          final testScale = TestScale(deviceId: 'pref-scale');
+          mockScanner.addDevice(testScale);
+          await Future.delayed(Duration.zero);
+          await Future.delayed(Duration.zero);
 
-        expect(mockScaleController.connectCalls, hasLength(1));
-        expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
-        expect(mockScanner.stopScanCallCount, 0);
+          expect(mockScaleController.connectCalls, hasLength(1));
+          expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
+          expect(mockScanner.stopScanCallCount, 0);
 
-        mockScanner.completeScan();
-        await Future.delayed(Duration.zero);
-      });
+          mockScanner.completeScan();
+          await Future.delayed(Duration.zero);
+        },
+      );
 
-      test(
-          'concurrent scaleOnly during another connect is queued and '
+      test('concurrent scaleOnly during another connect is queued and '
           'drained after the in-flight call (comms-harden #9)', () async {
         // Start a scaleOnly connect that will block on the scan
         // completer for deterministic timing.
@@ -841,19 +862,20 @@ void main() {
       });
 
       test(
-          'non-scaleOnly concurrent connect is still dropped (no queue)',
-          () async {
-        mockScanner.scanCompleter = Completer<void>();
-        final future1 = connectionManager.connect();
+        'non-scaleOnly concurrent connect is still dropped (no queue)',
+        () async {
+          mockScanner.scanCompleter = Completer<void>();
+          final future1 = connectionManager.connect();
 
-        // A full-connect call during another full-connect returns
-        // immediately (silent drop), exactly as before.
-        final future2 = connectionManager.connect();
-        await future2;
+          // A full-connect call during another full-connect returns
+          // immediately (silent drop), exactly as before.
+          final future2 = connectionManager.connect();
+          await future2;
 
-        mockScanner.completeScan();
-        await future1;
-      });
+          mockScanner.completeScan();
+          await future1;
+        },
+      );
     });
 
     group('ScanReport', () {
@@ -921,15 +943,17 @@ void main() {
     });
 
     group('connectMachine', () {
-      test('delegates to De1Controller and saves preference on success',
-          () async {
-        final fakeDe1 = _FakeDe1(deviceId: 'my-de1');
-        await connectionManager.connectMachine(fakeDe1);
+      test(
+        'delegates to De1Controller and saves preference on success',
+        () async {
+          final fakeDe1 = _FakeDe1(deviceId: 'my-de1');
+          await connectionManager.connectMachine(fakeDe1);
 
-        expect(mockDe1Controller.connectCalls, hasLength(1));
-        expect(mockDe1Controller.connectCalls.first, same(fakeDe1));
-        expect(settingsController.preferredMachineId, 'my-de1');
-      });
+          expect(mockDe1Controller.connectCalls, hasLength(1));
+          expect(mockDe1Controller.connectCalls.first, same(fakeDe1));
+          expect(settingsController.preferredMachineId, 'my-de1');
+        },
+      );
 
       test('does not save preference on failure', () async {
         mockDe1Controller.shouldFailConnect = true;
@@ -945,14 +969,13 @@ void main() {
         expect(settingsController.preferredMachineId, isNull);
       });
 
-      test(
-          'connect timeout: machine that never responds fails after 30s '
-          '(comms-harden #31)',
-          () {
+      test('connect timeout: machine that never responds fails after 30s '
+          '(comms-harden #31)', () {
         fakeAsync((async) {
           final completer = Completer<void>();
           final slowDe1Controller = _SlowMockDe1Controller(
-              controller: DeviceController([dummyDiscoveryService]));
+            controller: DeviceController([dummyDiscoveryService]),
+          );
           slowDe1Controller.connectCompleter = completer;
 
           final manager = ConnectionManager(
@@ -964,17 +987,18 @@ void main() {
 
           final fakeDe1 = _FakeDe1(deviceId: 'timeout-de1');
           Object? caughtError;
-          manager
-              .connectMachine(fakeDe1)
-              .catchError((e) => caughtError = e);
+          manager.connectMachine(fakeDe1).catchError((e) => caughtError = e);
 
           // Advance past the 30s connect budget; the TimeoutException
           // in connectMachine should cause rethrow + machineConnectFailed.
           async.elapse(const Duration(seconds: 35));
           async.flushMicrotasks();
 
-          expect(caughtError, isA<TimeoutException>(),
-              reason: 'connectMachine must rethrow TimeoutException');
+          expect(
+            caughtError,
+            isA<TimeoutException>(),
+            reason: 'connectMachine must rethrow TimeoutException',
+          );
           final status = manager.currentStatus;
           expect(status.phase, ConnectionPhase.idle);
           expect(status.error?.kind, ConnectionErrorKind.machineConnectFailed);
@@ -990,8 +1014,9 @@ void main() {
 
       test('rejects concurrent connection attempts', () async {
         final completer = Completer<void>();
-        final slowDe1Controller =
-            _SlowMockDe1Controller(controller: DeviceController([dummyDiscoveryService]));
+        final slowDe1Controller = _SlowMockDe1Controller(
+          controller: DeviceController([dummyDiscoveryService]),
+        );
         slowDe1Controller.connectCompleter = completer;
 
         final manager = ConnectionManager(
@@ -1068,30 +1093,34 @@ void main() {
         await sub.cancel();
       });
 
-      test('emits machineConnectFailed on De1Controller.connectToDe1 throw',
-          () async {
-        mockDe1Controller.shouldFailConnect = true;
-        final fakeDe1 = _FailingFakeDe1(deviceId: 'D9:11:0B:E6:9F:86');
-
-        try {
-          await connectionManager.connectMachine(fakeDe1);
-        } catch (_) {
-          // connectMachine rethrows — that's expected.
-        }
-        await Future<void>.delayed(Duration.zero);
-
-        final err = connectionManager.currentStatus.error!;
-        expect(err.kind, ConnectionErrorKind.machineConnectFailed);
-        expect(err.deviceId, 'D9:11:0B:E6:9F:86');
-        expect(err.deviceName, 'DE1-D9:11:0B:E6:9F:86');
-        expect(err.severity, ConnectionErrorSeverity.error);
-      });
-
       test(
-          'emits machineConnectFailed with ble_code in details when '
+        'emits machineConnectFailed on De1Controller.connectToDe1 throw',
+        () async {
+          mockDe1Controller.shouldFailConnect = true;
+          final fakeDe1 = _FailingFakeDe1(deviceId: 'D9:11:0B:E6:9F:86');
+
+          try {
+            await connectionManager.connectMachine(fakeDe1);
+          } catch (_) {
+            // connectMachine rethrows — that's expected.
+          }
+          await Future<void>.delayed(Duration.zero);
+
+          final err = connectionManager.currentStatus.error!;
+          expect(err.kind, ConnectionErrorKind.machineConnectFailed);
+          expect(err.deviceId, 'D9:11:0B:E6:9F:86');
+          expect(err.deviceName, 'DE1-D9:11:0B:E6:9F:86');
+          expect(err.severity, ConnectionErrorSeverity.error);
+        },
+      );
+
+      test('emits machineConnectFailed with ble_code in details when '
           'BleConnectException thrown', () async {
         mockDe1Controller.failNextConnectWith = BleConnectException(
-            code: '133', description: 'GATT Error 133', function: 'connect');
+          code: '133',
+          description: 'GATT Error 133',
+          function: 'connect',
+        );
         final fakeDe1 = _FailingFakeDe1(deviceId: 'D9:11:0B:E6:9F:86');
 
         try {
@@ -1106,8 +1135,9 @@ void main() {
 
     group('error surfacing', () {
       test('emitting an error publishes it on the status stream', () async {
-        final future = connectionManager.status
-            .firstWhere((s) => s.error != null);
+        final future = connectionManager.status.firstWhere(
+          (s) => s.error != null,
+        );
         connectionManager.debugEmitError(
           kind: ConnectionErrorKind.scaleConnectFailed,
           severity: ConnectionErrorSeverity.error,
@@ -1118,50 +1148,58 @@ void main() {
         expect(status.error!.timestamp.isUtc, isTrue);
       });
 
-      test('transient error cleared by _publishStatus on scanning transition',
-          () async {
-        connectionManager.debugEmitError(
-          kind: ConnectionErrorKind.scaleConnectFailed,
-          severity: ConnectionErrorSeverity.error,
-          message: 'test',
-        );
-        expect(connectionManager.currentStatus.error, isNotNull);
+      test(
+        'transient error cleared by _publishStatus on scanning transition',
+        () async {
+          connectionManager.debugEmitError(
+            kind: ConnectionErrorKind.scaleConnectFailed,
+            severity: ConnectionErrorSeverity.error,
+            message: 'test',
+          );
+          expect(connectionManager.currentStatus.error, isNotNull);
 
-        // connect() transitions into scanning via _publishStatus without
-        // explicitly nulling — the gatekeeper must strip the transient error.
-        await connectionManager.connect(scaleOnly: true);
-        expect(connectionManager.currentStatus.error, isNull);
-      });
+          // connect() transitions into scanning via _publishStatus without
+          // explicitly nulling — the gatekeeper must strip the transient error.
+          await connectionManager.connect(scaleOnly: true);
+          expect(connectionManager.currentStatus.error, isNull);
+        },
+      );
 
-      test('sticky error survives phase transition through _publishStatus',
-          () async {
-        connectionManager.debugEmitError(
-          kind: ConnectionErrorKind.adapterOff,
-          severity: ConnectionErrorSeverity.error,
-          message: 'off',
-        );
-        expect(connectionManager.currentStatus.error, isNotNull);
+      test(
+        'sticky error survives phase transition through _publishStatus',
+        () async {
+          connectionManager.debugEmitError(
+            kind: ConnectionErrorKind.adapterOff,
+            severity: ConnectionErrorSeverity.error,
+            message: 'off',
+          );
+          expect(connectionManager.currentStatus.error, isNotNull);
 
-        // A real scan path goes through _publishStatus(scanning). Sticky
-        // adapterOff must survive even though the caller itself does not
-        // explicitly re-attach it.
-        await connectionManager.connect(scaleOnly: true);
-        expect(connectionManager.currentStatus.error, isNotNull);
-        expect(connectionManager.currentStatus.error!.kind,
-            ConnectionErrorKind.adapterOff);
-      });
+          // A real scan path goes through _publishStatus(scanning). Sticky
+          // adapterOff must survive even though the caller itself does not
+          // explicitly re-attach it.
+          await connectionManager.connect(scaleOnly: true);
+          expect(connectionManager.currentStatus.error, isNotNull);
+          expect(
+            connectionManager.currentStatus.error!.kind,
+            ConnectionErrorKind.adapterOff,
+          );
+        },
+      );
     });
 
     group('connectScale', () {
-      test('delegates to ScaleController and saves preference on success',
-          () async {
-        final testScale = TestScale(deviceId: 'my-scale');
-        await connectionManager.connectScale(testScale);
+      test(
+        'delegates to ScaleController and saves preference on success',
+        () async {
+          final testScale = TestScale(deviceId: 'my-scale');
+          await connectionManager.connectScale(testScale);
 
-        expect(mockScaleController.connectCalls, hasLength(1));
-        expect(mockScaleController.connectCalls.first, same(testScale));
-        expect(settingsController.preferredScaleId, 'my-scale');
-      });
+          expect(mockScaleController.connectCalls, hasLength(1));
+          expect(mockScaleController.connectCalls.first, same(testScale));
+          expect(settingsController.preferredScaleId, 'my-scale');
+        },
+      );
 
       test('does not save preference on failure', () async {
         mockScaleController.shouldFailConnect = true;
@@ -1174,43 +1212,54 @@ void main() {
         expect(connectionManager.currentStatus.error, isNotNull);
       });
 
-      test('reports the real outcome so scan reports cannot claim success',
-          () async {
-        final okResult =
-            await connectionManager.connectScale(TestScale(deviceId: 'ok'));
-        expect(okResult.success, isTrue);
+      test(
+        'reports the real outcome so scan reports cannot claim success',
+        () async {
+          final okResult = await connectionManager.connectScale(
+            TestScale(deviceId: 'ok'),
+          );
+          expect(okResult.success, isTrue);
 
-        mockScaleController.shouldFailConnect = true;
-        final failResult = await connectionManager
-            .connectScale(TestScale(deviceId: 'fail-scale'));
-        expect(failResult.success, isFalse);
-        expect(failResult.error, isNotNull);
-      });
-
-      test('emits scaleConnectFailed when the scale controller throws',
-          () async {
-        mockScaleController.shouldFailConnect = true;
-        final fakeScale =
-            TestScale(deviceId: '50:78:7D:1F:AE:E1', name: 'Decent Scale');
-
-        await connectionManager.connectScale(fakeScale);
-
-        final err = connectionManager.currentStatus.error;
-        expect(err, isNotNull);
-        expect(err!.kind, ConnectionErrorKind.scaleConnectFailed);
-        expect(err.deviceId, '50:78:7D:1F:AE:E1');
-        expect(err.deviceName, 'Decent Scale');
-        expect(err.severity, ConnectionErrorSeverity.error);
-      });
+          mockScaleController.shouldFailConnect = true;
+          final failResult = await connectionManager.connectScale(
+            TestScale(deviceId: 'fail-scale'),
+          );
+          expect(failResult.success, isFalse);
+          expect(failResult.error, isNotNull);
+        },
+      );
 
       test(
-          'emits scaleConnectFailed with ble_code in details when '
+        'emits scaleConnectFailed when the scale controller throws',
+        () async {
+          mockScaleController.shouldFailConnect = true;
+          final fakeScale = TestScale(
+            deviceId: '50:78:7D:1F:AE:E1',
+            name: 'Decent Scale',
+          );
+
+          await connectionManager.connectScale(fakeScale);
+
+          final err = connectionManager.currentStatus.error;
+          expect(err, isNotNull);
+          expect(err!.kind, ConnectionErrorKind.scaleConnectFailed);
+          expect(err.deviceId, '50:78:7D:1F:AE:E1');
+          expect(err.deviceName, 'Decent Scale');
+          expect(err.severity, ConnectionErrorSeverity.error);
+        },
+      );
+
+      test('emits scaleConnectFailed with ble_code in details when '
           'BleConnectException thrown', () async {
         mockScaleController.failNextConnectWith = BleConnectException(
-            code: 'connectionFailed', description: 'Timed out',
-            function: 'connect');
-        final fakeScale =
-            TestScale(deviceId: '50:78:7D:1F:AE:E1', name: 'Decent Scale');
+          code: 'connectionFailed',
+          description: 'Timed out',
+          function: 'connect',
+        );
+        final fakeScale = TestScale(
+          deviceId: '50:78:7D:1F:AE:E1',
+          name: 'Decent Scale',
+        );
 
         await connectionManager.connectScale(fakeScale);
 
@@ -1233,8 +1282,7 @@ void main() {
         final testScale = TestScale(deviceId: 'scale-1');
 
         final future1 = manager.connectScale(testScale);
-        final future2 =
-            manager.connectScale(TestScale(deviceId: 'scale-2'));
+        final future2 = manager.connectScale(TestScale(deviceId: 'scale-2'));
         await future2;
 
         expect(slowScaleController.connectCalls, hasLength(1));
@@ -1247,46 +1295,99 @@ void main() {
         manager.dispose();
       });
 
-      test('emits connectingScale but not ready when no machine connected',
-          () async {
-        final phases = <ConnectionPhase>[];
-        final sub = connectionManager.status.listen((s) {
-          phases.add(s.phase);
-        });
+      test('clearErrorOfKind clears only matching kind', () {
+        connectionManager.debugEmitError(
+          kind: ConnectionErrorKind.profileUploadFailed,
+          severity: 'warning',
+          message: 'upload failed',
+        );
+        expect(
+          connectionManager.currentStatus.error?.kind,
+          ConnectionErrorKind.profileUploadFailed,
+        );
 
-        final testScale = TestScale(deviceId: 'phase-scale');
-        await connectionManager.connectScale(testScale);
-        await Future.delayed(Duration.zero);
+        // Same kind → cleared.
+        connectionManager.clearErrorOfKind(
+          ConnectionErrorKind.profileUploadFailed,
+        );
+        expect(connectionManager.currentStatus.error, isNull);
 
-        // Scale alone should not emit ready — machine must be connected first
-        expect(phases, [
-          ConnectionPhase.idle,
-          ConnectionPhase.connectingScale,
-        ]);
+        // Different kind → not cleared.
+        connectionManager.debugEmitError(
+          kind: ConnectionErrorKind.profileUploadFailed,
+          severity: 'warning',
+          message: 'upload failed',
+        );
+        connectionManager.debugEmitError(
+          kind: ConnectionErrorKind.machineConnectFailed,
+          severity: 'error',
+          message: 'machine failed',
+        );
+        connectionManager.clearErrorOfKind(
+          ConnectionErrorKind.profileUploadFailed,
+        );
+        expect(
+          connectionManager.currentStatus.error?.kind,
+          ConnectionErrorKind.machineConnectFailed,
+          reason:
+              'clearErrorOfKind for profileUploadFailed must not clear '
+              'the current machineConnectFailed',
+        );
 
-        await sub.cancel();
+        // Clear the actual kind.
+        connectionManager.clearErrorOfKind(
+          ConnectionErrorKind.machineConnectFailed,
+        );
+        expect(connectionManager.currentStatus.error, isNull);
       });
 
       test(
-          'emits scaleConnectFailed even when fallback phase is ready (machine connected)',
-          () async {
-        // Seed connected-machine state so the scale-fail catch falls through
-        // to phase=ready (a clearing phase). The _emit must survive the
-        // gatekeeper's strip rule — if ordering regresses, this test fails.
-        final fakeMachine = _FakeDe1(deviceId: 'D9:11:0B:E6:9F:86');
-        await connectionManager.connectMachine(fakeMachine);
-        expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
+        'emits connectingScale but not ready when no machine connected',
+        () async {
+          final phases = <ConnectionPhase>[];
+          final sub = connectionManager.status.listen((s) {
+            phases.add(s.phase);
+          });
 
-        mockScaleController.shouldFailConnect = true;
-        final fakeScale =
-            TestScale(deviceId: '50:78:7D:1F:AE:E1', name: 'Decent Scale');
-        await connectionManager.connectScale(fakeScale);
+          final testScale = TestScale(deviceId: 'phase-scale');
+          await connectionManager.connectScale(testScale);
+          await Future.delayed(Duration.zero);
 
-        expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
-        expect(connectionManager.currentStatus.error, isNotNull);
-        expect(connectionManager.currentStatus.error!.kind,
-            ConnectionErrorKind.scaleConnectFailed);
-      });
+          // Scale alone should not emit ready — machine must be connected first
+          expect(phases, [
+            ConnectionPhase.idle,
+            ConnectionPhase.connectingScale,
+          ]);
+
+          await sub.cancel();
+        },
+      );
+
+      test(
+        'emits scaleConnectFailed even when fallback phase is ready (machine connected)',
+        () async {
+          // Seed connected-machine state so the scale-fail catch falls through
+          // to phase=ready (a clearing phase). The _emit must survive the
+          // gatekeeper's strip rule — if ordering regresses, this test fails.
+          final fakeMachine = _FakeDe1(deviceId: 'D9:11:0B:E6:9F:86');
+          await connectionManager.connectMachine(fakeMachine);
+          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
+
+          mockScaleController.shouldFailConnect = true;
+          final fakeScale = TestScale(
+            deviceId: '50:78:7D:1F:AE:E1',
+            name: 'Decent Scale',
+          );
+          await connectionManager.connectScale(fakeScale);
+
+          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
+          expect(connectionManager.currentStatus.error, isNotNull);
+          expect(
+            connectionManager.currentStatus.error!.kind,
+            ConnectionErrorKind.scaleConnectFailed,
+          );
+        },
+      );
 
       test('sleep during scale connect settles back to ready', () async {
         await connectionManager.dispose();
@@ -1307,11 +1408,14 @@ void main() {
 
         final connectCompleter = Completer<void>();
         slowScaleController.connectCompleter = connectCompleter;
-        final future =
-            connectionManager.connectScale(TestScale(deviceId: 'pref-scale'));
+        final future = connectionManager.connectScale(
+          TestScale(deviceId: 'pref-scale'),
+        );
         await Future<void>.delayed(Duration.zero);
-        expect(connectionManager.currentStatus.phase,
-            ConnectionPhase.connectingScale);
+        expect(
+          connectionManager.currentStatus.phase,
+          ConnectionPhase.connectingScale,
+        );
 
         fakeMachine.emitState(MachineState.sleeping);
         await Future<void>.delayed(Duration.zero);
@@ -1323,7 +1427,9 @@ void main() {
         expect(connectionManager.currentStatus.error, isNull);
         expect(settingsController.preferredScaleId, isNull);
 
-        slowScaleController.mockEmitConnectionState(ConnectionState.disconnected);
+        slowScaleController.mockEmitConnectionState(
+          ConnectionState.disconnected,
+        );
         await Future<void>.delayed(Duration.zero);
         expect(connectionManager.currentStatus.error, isNull);
       });
@@ -1366,10 +1472,14 @@ void main() {
 
       test('unexpected disconnect emits scaleDisconnected', () {
         connectionManager.debugNotifyScaleDisconnected('50:78:7D:1F:AE:E1');
-        expect(connectionManager.currentStatus.error?.kind,
-            ConnectionErrorKind.scaleDisconnected);
-        expect(connectionManager.currentStatus.error?.deviceId,
-            '50:78:7D:1F:AE:E1');
+        expect(
+          connectionManager.currentStatus.error?.kind,
+          ConnectionErrorKind.scaleDisconnected,
+        );
+        expect(
+          connectionManager.currentStatus.error?.deviceId,
+          '50:78:7D:1F:AE:E1',
+        );
       });
 
       test('TTL clears expectation after 10 seconds', () {
@@ -1377,8 +1487,10 @@ void main() {
           connectionManager.markExpectingDisconnect('50:78:7D:1F:AE:E1');
           async.elapse(const Duration(seconds: 11));
           connectionManager.debugNotifyScaleDisconnected('50:78:7D:1F:AE:E1');
-          expect(connectionManager.currentStatus.error?.kind,
-              ConnectionErrorKind.scaleDisconnected);
+          expect(
+            connectionManager.currentStatus.error?.kind,
+            ConnectionErrorKind.scaleDisconnected,
+          );
         });
       });
 
@@ -1388,169 +1500,208 @@ void main() {
         expect(connectionManager.currentStatus.error, isNull);
 
         connectionManager.debugNotifyScaleDisconnected('50:78:7D:1F:AE:E1');
-        expect(connectionManager.currentStatus.error?.kind,
-            ConnectionErrorKind.scaleDisconnected);
+        expect(
+          connectionManager.currentStatus.error?.kind,
+          ConnectionErrorKind.scaleDisconnected,
+        );
       });
 
       test('marks for different devices are independent', () {
         connectionManager.markExpectingDisconnect('50:78:7D:1F:AE:E1');
         connectionManager.debugNotifyMachineDisconnected('D9:11:0B:E6:9F:86');
-        expect(connectionManager.currentStatus.error?.kind,
-            ConnectionErrorKind.machineDisconnected);
+        expect(
+          connectionManager.currentStatus.error?.kind,
+          ConnectionErrorKind.machineDisconnected,
+        );
       });
     });
 
     group('disconnect subscribers', () {
       test('scale disconnect during expected flow suppresses error', () async {
         // Pretend scale was connected.
-        mockScaleController
-            .mockEmitConnectionState(ConnectionState.connected);
+        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
         mockScaleController.debugSetLastConnectedId('50:78:7D:1F:AE:E1');
         await Future<void>.delayed(Duration.zero);
 
         // Mark expected, then emit disconnect.
         connectionManager.markExpectingDisconnect('50:78:7D:1F:AE:E1');
-        mockScaleController
-            .mockEmitConnectionState(ConnectionState.disconnected);
+        mockScaleController.mockEmitConnectionState(
+          ConnectionState.disconnected,
+        );
         await Future<void>.delayed(Duration.zero);
 
         expect(connectionManager.currentStatus.error, isNull);
       });
 
-      test('expected scale disconnect does not trigger preferred-scale scan',
-          () async {
-        await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
-        final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
-        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
-        mockScaleController.debugSetLastConnectedId('pref-scale');
-        await settingsController.setPreferredScaleId('pref-scale');
-        mockDe1Controller.de1Subject.add(fakeDe1);
-        await Future<void>.delayed(Duration.zero);
-        fakeDe1.emitState(MachineState.sleeping);
-        final scanningEvents = <bool>[];
-        final sub = mockScanner.scanningStream.listen(scanningEvents.add);
-        await Future<void>.delayed(Duration.zero);
+      test(
+        'expected scale disconnect does not trigger preferred-scale scan',
+        () async {
+          await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
+          final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
+          mockScaleController.mockEmitConnectionState(
+            ConnectionState.connected,
+          );
+          mockScaleController.debugSetLastConnectedId('pref-scale');
+          await settingsController.setPreferredScaleId('pref-scale');
+          mockDe1Controller.de1Subject.add(fakeDe1);
+          await Future<void>.delayed(Duration.zero);
+          fakeDe1.emitState(MachineState.sleeping);
+          final scanningEvents = <bool>[];
+          final sub = mockScanner.scanningStream.listen(scanningEvents.add);
+          await Future<void>.delayed(Duration.zero);
 
-        connectionManager.markExpectingDisconnect('pref-scale');
-        mockScaleController.mockEmitConnectionState(ConnectionState.disconnected);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+          connectionManager.markExpectingDisconnect('pref-scale');
+          mockScaleController.mockEmitConnectionState(
+            ConnectionState.disconnected,
+          );
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
 
-        expect(connectionManager.currentStatus.error, isNull);
-        expect(scanningEvents, isNot(contains(true)),
-            reason: 'power-mode disconnects are deliberate and must not start BLE');
-        expect(mockScaleController.connectCalls, isEmpty);
-        await sub.cancel();
-      });
+          expect(connectionManager.currentStatus.error, isNull);
+          expect(
+            scanningEvents,
+            isNot(contains(true)),
+            reason:
+                'power-mode disconnects are deliberate and must not start BLE',
+          );
+          expect(mockScaleController.connectCalls, isEmpty);
+          await sub.cancel();
+        },
+      );
 
-      test('unexpected preferred scale disconnect keeps scanning and reconnects',
-          () async {
-        await settingsController.setPreferredScaleId('pref-scale');
-        final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
-        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
-        mockScaleController.debugSetLastConnectedId('pref-scale');
-        mockDe1Controller.de1Subject.add(fakeDe1);
-        await Future<void>.delayed(Duration.zero);
-        fakeDe1.emitState(MachineState.idle);
-        await Future<void>.delayed(Duration.zero);
+      test(
+        'unexpected preferred scale disconnect keeps scanning and reconnects',
+        () async {
+          await settingsController.setPreferredScaleId('pref-scale');
+          final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
+          mockScaleController.mockEmitConnectionState(
+            ConnectionState.connected,
+          );
+          mockScaleController.debugSetLastConnectedId('pref-scale');
+          mockDe1Controller.de1Subject.add(fakeDe1);
+          await Future<void>.delayed(Duration.zero);
+          fakeDe1.emitState(MachineState.idle);
+          await Future<void>.delayed(Duration.zero);
 
-        mockScanner.scanCompleter = Completer<void>();
-        mockScaleController.mockEmitConnectionState(ConnectionState.disconnected);
-        await mockScanner.scanningStream.firstWhere((s) => s);
+          mockScanner.scanCompleter = Completer<void>();
+          mockScaleController.mockEmitConnectionState(
+            ConnectionState.disconnected,
+          );
+          await mockScanner.scanningStream.firstWhere((s) => s);
 
-        mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        mockScanner.completeScan();
-        await Future<void>.delayed(Duration.zero);
+          mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+          mockScanner.completeScan();
+          await Future<void>.delayed(Duration.zero);
 
-        expect(mockScaleController.connectCalls, hasLength(1));
-        expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
-      });
+          expect(mockScaleController.connectCalls, hasLength(1));
+          expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
+        },
+      );
 
-      test('scale power disconnect pauses while sleeping and resumes when awake',
-          () async {
-        await settingsController.setPreferredScaleId('pref-scale');
-        await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
+      test(
+        'scale power disconnect pauses while sleeping and resumes when awake',
+        () async {
+          await settingsController.setPreferredScaleId('pref-scale');
+          await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
 
-        final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
-        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
-        mockScaleController.debugSetLastConnectedId('pref-scale');
-        mockDe1Controller.de1Subject.add(fakeDe1);
-        await Future<void>.delayed(Duration.zero);
-        fakeDe1.emitState(MachineState.idle);
-        await Future<void>.delayed(Duration.zero);
+          final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
+          mockScaleController.mockEmitConnectionState(
+            ConnectionState.connected,
+          );
+          mockScaleController.debugSetLastConnectedId('pref-scale');
+          mockDe1Controller.de1Subject.add(fakeDe1);
+          await Future<void>.delayed(Duration.zero);
+          fakeDe1.emitState(MachineState.idle);
+          await Future<void>.delayed(Duration.zero);
 
-        final scanningEvents = <bool>[];
-        final sub = mockScanner.scanningStream.listen(scanningEvents.add);
+          final scanningEvents = <bool>[];
+          final sub = mockScanner.scanningStream.listen(scanningEvents.add);
 
-        fakeDe1.emitState(MachineState.sleeping);
-        connectionManager.markExpectingDisconnect('pref-scale');
-        mockScaleController.mockEmitConnectionState(ConnectionState.disconnected);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+          fakeDe1.emitState(MachineState.sleeping);
+          connectionManager.markExpectingDisconnect('pref-scale');
+          mockScaleController.mockEmitConnectionState(
+            ConnectionState.disconnected,
+          );
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
 
-        expect(scanningEvents, isNot(contains(true)),
-            reason: 'sleeping + ScalePowerMode.disconnect must not scan');
+          expect(
+            scanningEvents,
+            isNot(contains(true)),
+            reason: 'sleeping + ScalePowerMode.disconnect must not scan',
+          );
 
-        mockScanner.scanCompleter = Completer<void>();
-        fakeDe1.emitState(MachineState.idle);
-        await mockScanner.scanningStream.firstWhere((s) => s);
+          mockScanner.scanCompleter = Completer<void>();
+          fakeDe1.emitState(MachineState.idle);
+          await mockScanner.scanningStream.firstWhere((s) => s);
 
-        mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        mockScanner.completeScan();
-        await Future<void>.delayed(Duration.zero);
+          mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+          mockScanner.completeScan();
+          await Future<void>.delayed(Duration.zero);
 
-        expect(mockScaleController.connectCalls, hasLength(1));
-        expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
-        await sub.cancel();
-      });
+          expect(mockScaleController.connectCalls, hasLength(1));
+          expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
+          await sub.cancel();
+        },
+      );
 
-      test('sleeping during an active scale scan stops it and blocks reconnect',
-          () async {
-        await settingsController.setPreferredScaleId('pref-scale');
-        await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
+      test(
+        'sleeping during an active scale scan stops it and blocks reconnect',
+        () async {
+          await settingsController.setPreferredScaleId('pref-scale');
+          await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
 
-        final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
-        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
-        mockScaleController.debugSetLastConnectedId('pref-scale');
-        mockDe1Controller.de1Subject.add(fakeDe1);
-        await Future<void>.delayed(Duration.zero);
-        fakeDe1.emitState(MachineState.idle);
-        await Future<void>.delayed(Duration.zero);
+          final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
+          mockScaleController.mockEmitConnectionState(
+            ConnectionState.connected,
+          );
+          mockScaleController.debugSetLastConnectedId('pref-scale');
+          mockDe1Controller.de1Subject.add(fakeDe1);
+          await Future<void>.delayed(Duration.zero);
+          fakeDe1.emitState(MachineState.idle);
+          await Future<void>.delayed(Duration.zero);
 
-        mockScanner.scanCompleter = Completer<void>();
-        mockScaleController.mockEmitConnectionState(ConnectionState.disconnected);
-        await mockScanner.scanningStream.firstWhere((s) => s);
+          mockScanner.scanCompleter = Completer<void>();
+          mockScaleController.mockEmitConnectionState(
+            ConnectionState.disconnected,
+          );
+          await mockScanner.scanningStream.firstWhere((s) => s);
 
-        fakeDe1.emitState(MachineState.sleeping);
-        connectionManager.markExpectingDisconnect('pref-scale');
-        mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        mockScanner.completeScan();
-        await Future<void>.delayed(Duration.zero);
+          fakeDe1.emitState(MachineState.sleeping);
+          connectionManager.markExpectingDisconnect('pref-scale');
+          mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+          mockScanner.completeScan();
+          await Future<void>.delayed(Duration.zero);
 
-        expect(mockScanner.stopScanCallCount, 1);
-        expect(mockScaleController.connectCalls, isEmpty);
-      });
+          expect(mockScanner.stopScanCallCount, 1);
+          expect(mockScaleController.connectCalls, isEmpty);
+        },
+      );
 
       test('unexpected scale disconnect emits scaleDisconnected', () async {
-        mockScaleController
-            .mockEmitConnectionState(ConnectionState.connected);
+        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
         mockScaleController.debugSetLastConnectedId('50:78:7D:1F:AE:E1');
         await Future<void>.delayed(Duration.zero);
 
-        mockScaleController
-            .mockEmitConnectionState(ConnectionState.disconnected);
+        mockScaleController.mockEmitConnectionState(
+          ConnectionState.disconnected,
+        );
         await Future<void>.delayed(Duration.zero);
 
-        expect(connectionManager.currentStatus.error?.kind,
-            ConnectionErrorKind.scaleDisconnected);
-        expect(connectionManager.currentStatus.error?.deviceId,
-            '50:78:7D:1F:AE:E1');
+        expect(
+          connectionManager.currentStatus.error?.kind,
+          ConnectionErrorKind.scaleDisconnected,
+        );
+        expect(
+          connectionManager.currentStatus.error?.deviceId,
+          '50:78:7D:1F:AE:E1',
+        );
       });
     });
 
@@ -1558,23 +1709,26 @@ void main() {
       test('adapter off emits adapterOff error', () async {
         mockScanner.mockAdapterState(AdapterState.poweredOff);
         await Future<void>.delayed(Duration.zero);
-        expect(connectionManager.currentStatus.error?.kind,
-            ConnectionErrorKind.adapterOff);
+        expect(
+          connectionManager.currentStatus.error?.kind,
+          ConnectionErrorKind.adapterOff,
+        );
       });
 
       test('adapter on clears adapterOff', () async {
         mockScanner.mockAdapterState(AdapterState.poweredOff);
         await Future<void>.delayed(Duration.zero);
-        expect(connectionManager.currentStatus.error?.kind,
-            ConnectionErrorKind.adapterOff);
+        expect(
+          connectionManager.currentStatus.error?.kind,
+          ConnectionErrorKind.adapterOff,
+        );
 
         mockScanner.mockAdapterState(AdapterState.poweredOn);
         await Future<void>.delayed(Duration.zero);
         expect(connectionManager.currentStatus.error, isNull);
       });
 
-      test('adapter on does NOT clear an unrelated transient error',
-          () async {
+      test('adapter on does NOT clear an unrelated transient error', () async {
         connectionManager.debugEmitError(
           kind: ConnectionErrorKind.scaleConnectFailed,
           severity: ConnectionErrorSeverity.error,
@@ -1582,36 +1736,50 @@ void main() {
         );
         mockScanner.mockAdapterState(AdapterState.poweredOn);
         await Future<void>.delayed(Duration.zero);
-        expect(connectionManager.currentStatus.error?.kind,
-            ConnectionErrorKind.scaleConnectFailed);
+        expect(
+          connectionManager.currentStatus.error?.kind,
+          ConnectionErrorKind.scaleConnectFailed,
+        );
       });
     });
 
     group('scan failures', () {
-      test('scan throwing permission error emits bluetoothPermissionDenied',
-          () async {
-        mockScanner.failNextScanWith =
-            const PermissionDeniedException('denied');
-        await connectionManager.connect(scaleOnly: true);
-        expect(connectionManager.currentStatus.error?.kind,
-            ConnectionErrorKind.bluetoothPermissionDenied);
-      });
+      test(
+        'scan throwing permission error emits bluetoothPermissionDenied',
+        () async {
+          mockScanner.failNextScanWith = const PermissionDeniedException(
+            'denied',
+          );
+          await connectionManager.connect(scaleOnly: true);
+          expect(
+            connectionManager.currentStatus.error?.kind,
+            ConnectionErrorKind.bluetoothPermissionDenied,
+          );
+        },
+      );
 
       test('scan throwing generic error emits scanFailed', () async {
         mockScanner.failNextScanWith = Exception('adapter busy');
         await connectionManager.connect(scaleOnly: true);
-        expect(connectionManager.currentStatus.error?.kind,
-            ConnectionErrorKind.scanFailed);
+        expect(
+          connectionManager.currentStatus.error?.kind,
+          ConnectionErrorKind.scanFailed,
+        );
       });
 
-      test('exception containing "permission" classified as permissionDenied',
-          () async {
-        mockScanner.failNextScanWith =
-            Exception('Missing bluetooth permission');
-        await connectionManager.connect(scaleOnly: true);
-        expect(connectionManager.currentStatus.error?.kind,
-            ConnectionErrorKind.bluetoothPermissionDenied);
-      });
+      test(
+        'exception containing "permission" classified as permissionDenied',
+        () async {
+          mockScanner.failNextScanWith = Exception(
+            'Missing bluetooth permission',
+          );
+          await connectionManager.connect(scaleOnly: true);
+          expect(
+            connectionManager.currentStatus.error?.kind,
+            ConnectionErrorKind.bluetoothPermissionDenied,
+          );
+        },
+      );
 
       test('successful scan-start clears prior scanFailed', () async {
         connectionManager.debugEmitError(
@@ -1634,8 +1802,7 @@ void main() {
         }
       }
 
-      test(
-          'unexpected machine disconnect starts recovery scans and '
+      test('unexpected machine disconnect starts recovery scans and '
           'reconnects the preferred machine', () async {
         connectionManager.machineReconnectBaseDelay = Duration.zero;
         await settingsController.setPreferredMachineId('pref-de1');
@@ -1654,40 +1821,48 @@ void main() {
         );
       });
 
-      test('recovery keeps retrying until the machine reappears, then stops',
-          () async {
-        connectionManager.machineReconnectBaseDelay = Duration.zero;
-        await settingsController.setPreferredMachineId('pref-de1');
-        final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
-        mockDe1Controller.de1Subject.add(fakeDe1);
-        await Future<void>.delayed(Duration.zero);
+      test(
+        'recovery keeps retrying until the machine reappears, then stops',
+        () async {
+          connectionManager.machineReconnectBaseDelay = Duration.zero;
+          await settingsController.setPreferredMachineId('pref-de1');
+          final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+          mockDe1Controller.de1Subject.add(fakeDe1);
+          await Future<void>.delayed(Duration.zero);
 
-        var scanStarts = 0;
-        final sub = mockScanner.scanningStream.listen((s) {
-          if (s) scanStarts++;
-        });
+          var scanStarts = 0;
+          final sub = mockScanner.scanningStream.listen((s) {
+            if (s) scanStarts++;
+          });
 
-        // Machine drops and is NOT in scan results yet.
-        mockDe1Controller.de1Subject.add(null);
-        await pumpCycles();
-        expect(scanStarts, greaterThan(0),
-            reason: 'loop must scan even while the machine is absent');
-        expect(mockDe1Controller.connectCalls, isEmpty);
+          // Machine drops and is NOT in scan results yet.
+          mockDe1Controller.de1Subject.add(null);
+          await pumpCycles();
+          expect(
+            scanStarts,
+            greaterThan(0),
+            reason: 'loop must scan even while the machine is absent',
+          );
+          expect(mockDe1Controller.connectCalls, isEmpty);
 
-        // Machine comes back — next cycle reconnects and the loop stops.
-        mockScanner.addDevice(fakeDe1);
-        await pumpCycles();
-        expect(
-          mockDe1Controller.connectCalls.map((d) => d.deviceId),
-          contains('pref-de1'),
-        );
+          // Machine comes back — next cycle reconnects and the loop stops.
+          mockScanner.addDevice(fakeDe1);
+          await pumpCycles();
+          expect(
+            mockDe1Controller.connectCalls.map((d) => d.deviceId),
+            contains('pref-de1'),
+          );
 
-        final scansAfterReconnect = scanStarts;
-        await pumpCycles();
-        expect(scanStarts, scansAfterReconnect,
-            reason: 'loop must stop once the machine is connected');
-        await sub.cancel();
-      });
+          final scansAfterReconnect = scanStarts;
+          await pumpCycles();
+          expect(
+            scanStarts,
+            scansAfterReconnect,
+            reason: 'loop must stop once the machine is connected',
+          );
+          await sub.cancel();
+        },
+      );
 
       test('expected machine disconnect does not start recovery', () async {
         connectionManager.machineReconnectBaseDelay = Duration.zero;
@@ -1706,8 +1881,11 @@ void main() {
         mockDe1Controller.de1Subject.add(null);
         await pumpCycles();
 
-        expect(scanStarts, 0,
-            reason: 'expected disconnects must not trigger background scans');
+        expect(
+          scanStarts,
+          0,
+          reason: 'expected disconnects must not trigger background scans',
+        );
         expect(mockDe1Controller.connectCalls, isEmpty);
         await sub.cancel();
       });
@@ -1748,9 +1926,13 @@ void main() {
         mockDe1Controller.de1Subject.add(null);
         await pumpCycles();
 
-        expect(scanStarts, 0,
-            reason: 'without a preferred machine a background retry could '
-                'pop a picker — must stay off');
+        expect(
+          scanStarts,
+          0,
+          reason:
+              'without a preferred machine a background retry could '
+              'pop a picker — must stay off',
+        );
         await sub.cancel();
       });
 
@@ -1801,11 +1983,11 @@ void main() {
       // backoff' test.
 
       ConnectionManager newManager() => ConnectionManager(
-            deviceScanner: mockScanner,
-            de1Controller: mockDe1Controller,
-            scaleController: mockScaleController,
-            settingsController: settingsController,
-          );
+        deviceScanner: mockScanner,
+        de1Controller: mockDe1Controller,
+        scaleController: mockScaleController,
+        settingsController: settingsController,
+      );
 
       test('fires after 10s with no snapshots and forces a reconnect', () {
         fakeAsync((async) {
@@ -1819,8 +2001,11 @@ void main() {
 
           expect(manager.snapshotStalenessReconnects, 0);
           async.elapse(const Duration(seconds: 9));
-          expect(manager.snapshotStalenessReconnects, 0,
-              reason: 'must not fire before the staleness timeout');
+          expect(
+            manager.snapshotStalenessReconnects,
+            0,
+            reason: 'must not fire before the staleness timeout',
+          );
           // Counter increments synchronously at the top of the force
           // action, so it is observable the moment the Timer fires. The
           // counter proves the watchdog fired and the force path ran
@@ -1831,8 +2016,11 @@ void main() {
           // making that assertion flaky without proving anything the
           // counter doesn't already show.
           async.elapse(const Duration(seconds: 2)); // 11s elapsed
-          expect(manager.snapshotStalenessReconnects, 1,
-              reason: 'a silent push channel must trigger a forced reconnect');
+          expect(
+            manager.snapshotStalenessReconnects,
+            1,
+            reason: 'a silent push channel must trigger a forced reconnect',
+          );
 
           manager.dispose();
           async.flushMicrotasks();
@@ -1854,106 +2042,134 @@ void main() {
           fakeDe1.emitState(MachineState.idle);
           async.flushMicrotasks();
 
-          async.elapse(const Duration(seconds: 9)); // 18s total, 9s since re-arm
-          expect(manager.snapshotStalenessReconnects, 0,
-              reason: 'a deduped frame must re-arm the watchdog');
+          async.elapse(
+            const Duration(seconds: 9),
+          ); // 18s total, 9s since re-arm
+          expect(
+            manager.snapshotStalenessReconnects,
+            0,
+            reason: 'a deduped frame must re-arm the watchdog',
+          );
 
           manager.dispose();
           async.flushMicrotasks();
         });
       });
 
-      test('deliberate disconnectMachine cancels the watchdog (no fire, no error)',
-          () {
-        fakeAsync((async) {
-          final manager = newManager();
-          final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
-          mockDe1Controller.de1Subject.add(fakeDe1);
-          async.flushMicrotasks();
-          fakeDe1.emitState(MachineState.idle);
-          async.flushMicrotasks();
+      test(
+        'deliberate disconnectMachine cancels the watchdog (no fire, no error)',
+        () {
+          fakeAsync((async) {
+            final manager = newManager();
+            final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
+            mockDe1Controller.de1Subject.add(fakeDe1);
+            async.flushMicrotasks();
+            fakeDe1.emitState(MachineState.idle);
+            async.flushMicrotasks();
 
-          // Deliberate disconnect cancels the watchdog and bumps the
-          // generation token.
-          manager.disconnectMachine();
-          async.flushMicrotasks();
+            // Deliberate disconnect cancels the watchdog and bumps the
+            // generation token.
+            manager.disconnectMachine();
+            async.flushMicrotasks();
 
-          async.elapse(const Duration(seconds: 15));
-          expect(manager.snapshotStalenessReconnects, 0,
-              reason: 'deliberate disconnect must cancel the watchdog');
-          expect(manager.currentStatus.error, isNull,
-              reason: 'deliberate disconnect must not surface an error banner');
+            async.elapse(const Duration(seconds: 15));
+            expect(
+              manager.snapshotStalenessReconnects,
+              0,
+              reason: 'deliberate disconnect must cancel the watchdog',
+            );
+            expect(
+              manager.currentStatus.error,
+              isNull,
+              reason: 'deliberate disconnect must not surface an error banner',
+            );
 
-          manager.dispose();
-          async.flushMicrotasks();
-        });
-      });
+            manager.dispose();
+            async.flushMicrotasks();
+          });
+        },
+      );
 
-      test('initial grace: no fire before the first snapshot at 9s, fire at 11s',
-          () {
-        fakeAsync((async) {
-          final manager = newManager();
-          final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
-          mockDe1Controller.de1Subject.add(fakeDe1);
-          async.flushMicrotasks();
-          // No snapshot emitted — only the initial-grace arm at watch setup.
+      test(
+        'initial grace: no fire before the first snapshot at 9s, fire at 11s',
+        () {
+          fakeAsync((async) {
+            final manager = newManager();
+            final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
+            mockDe1Controller.de1Subject.add(fakeDe1);
+            async.flushMicrotasks();
+            // No snapshot emitted — only the initial-grace arm at watch setup.
 
-          async.elapse(const Duration(seconds: 9));
-          expect(manager.snapshotStalenessReconnects, 0,
-              reason: 'must not fire within the initial grace window');
+            async.elapse(const Duration(seconds: 9));
+            expect(
+              manager.snapshotStalenessReconnects,
+              0,
+              reason: 'must not fire within the initial grace window',
+            );
 
-          async.elapse(const Duration(seconds: 2)); // 11s
-          expect(manager.snapshotStalenessReconnects, 1,
-              reason: 'watchdog armed at watch setup must fire if no frame '
-                  'ever lands');
+            async.elapse(const Duration(seconds: 2)); // 11s
+            expect(
+              manager.snapshotStalenessReconnects,
+              1,
+              reason:
+                  'watchdog armed at watch setup must fire if no frame '
+                  'ever lands',
+            );
 
-          manager.dispose();
-          async.flushMicrotasks();
-        });
-      });
+            manager.dispose();
+            async.flushMicrotasks();
+          });
+        },
+      );
 
-      test('stale generation after a forced reconnect bails (no double-reconnect)',
-          () {
-        fakeAsync((async) {
-          final manager = newManager();
-          final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
-          mockDe1Controller.de1Subject.add(fakeDe1);
-          async.flushMicrotasks();
-          fakeDe1.emitState(MachineState.idle);
-          async.flushMicrotasks();
+      test(
+        'stale generation after a forced reconnect bails (no double-reconnect)',
+        () {
+          fakeAsync((async) {
+            final manager = newManager();
+            final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
+            mockDe1Controller.de1Subject.add(fakeDe1);
+            async.flushMicrotasks();
+            fakeDe1.emitState(MachineState.idle);
+            async.flushMicrotasks();
 
-          async.elapse(const Duration(seconds: 11));
-          expect(manager.snapshotStalenessReconnects, 1);
-          async.flushMicrotasks();
+            async.elapse(const Duration(seconds: 11));
+            expect(manager.snapshotStalenessReconnects, 1);
+            async.flushMicrotasks();
 
-          // The forced reconnect cancelled the watchdog and bumped the
-          // generation. With no new machine connected and no new frames,
-          // no watchdog is re-armed — a long elapse must not trigger a
-          // second forced reconnect.
-          async.elapse(const Duration(seconds: 30));
-          expect(manager.snapshotStalenessReconnects, 1,
-              reason: 'a stale-generation Timer must bail, not re-fire');
+            // The forced reconnect cancelled the watchdog and bumped the
+            // generation. With no new machine connected and no new frames,
+            // no watchdog is re-armed — a long elapse must not trigger a
+            // second forced reconnect.
+            async.elapse(const Duration(seconds: 30));
+            expect(
+              manager.snapshotStalenessReconnects,
+              1,
+              reason: 'a stale-generation Timer must bail, not re-fire',
+            );
 
-          manager.dispose();
-          async.flushMicrotasks();
-        });
-      });
+            manager.dispose();
+            async.flushMicrotasks();
+          });
+        },
+      );
 
       // Runs in the real async zone (not fakeAsync): the forced reconnect's
       // `disconnectMachine → connect` chain awaits `de1Controller.de1.first`,
       // which a BehaviorSubject does not settle under fakeAsync — so the
       // strand safety-net in the `finally` only runs with real microtasks.
       // A short overridden staleness timeout keeps the test fast.
-      test(
-          'a forced reconnect that cannot recover the machine hands off to '
+      test('a forced reconnect that cannot recover the machine hands off to '
           'the recovery loop (no strand)', () async {
         await settingsController.setPreferredMachineId('stale-de1');
         // Non-zero base delay avoids a hot recovery loop within the wait
         // window; we only assert the loop is armed, not how often it scans.
-        connectionManager.machineReconnectBaseDelay =
-            const Duration(milliseconds: 50);
-        connectionManager.snapshotStalenessTimeout =
-            const Duration(milliseconds: 20);
+        connectionManager.machineReconnectBaseDelay = const Duration(
+          milliseconds: 50,
+        );
+        connectionManager.snapshotStalenessTimeout = const Duration(
+          milliseconds: 20,
+        );
         final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
         mockDe1Controller.de1Subject.add(fakeDe1);
         await Future<void>.delayed(Duration.zero);
@@ -1968,11 +2184,18 @@ void main() {
         // safety net nothing would retry.
         await Future<void>.delayed(const Duration(milliseconds: 60));
 
-        expect(connectionManager.snapshotStalenessReconnects, greaterThan(0),
-            reason: 'the watchdog must have forced a reconnect');
-        expect(connectionManager.machineRecoveryActive, isTrue,
-            reason: 'a stranded forced reconnect must hand off to the '
-                'machine-recovery loop, not leave the machine disconnected');
+        expect(
+          connectionManager.snapshotStalenessReconnects,
+          greaterThan(0),
+          reason: 'the watchdog must have forced a reconnect',
+        );
+        expect(
+          connectionManager.machineRecoveryActive,
+          isTrue,
+          reason:
+              'a stranded forced reconnect must hand off to the '
+              'machine-recovery loop, not leave the machine disconnected',
+        );
       });
     });
 
@@ -1980,11 +2203,11 @@ void main() {
       const scaleId = 'pref-scale';
 
       ConnectionManager buildWatchManager() => ConnectionManager(
-            deviceScanner: mockScanner,
-            de1Controller: mockDe1Controller,
-            scaleController: mockScaleController,
-            settingsController: settingsController,
-          );
+        deviceScanner: mockScanner,
+        de1Controller: mockDe1Controller,
+        scaleController: mockScaleController,
+        settingsController: settingsController,
+      );
 
       setUp(() async {
         // Retire the shared legacy manager from the outer setUp — it
@@ -1994,8 +2217,7 @@ void main() {
         mockScanner.supportsWatch = true;
       });
 
-      test(
-          'machine connect with preferred scale missing arms the watch '
+      test('machine connect with preferred scale missing arms the watch '
           'and never runs backoff bursts', () {
         fakeAsync((async) {
           final manager = buildWatchManager();
@@ -2004,19 +2226,29 @@ void main() {
           mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
           async.flushMicrotasks();
 
-          expect(mockScanner.startWatchCallCount, 1,
-              reason: 'watch must arm on machine connect with scale missing');
-          expect(mockScanner.lastWatchFilter?.namePrefix, isNull,
-              reason: 'no OS name filter — remembered friendly names do not '
-                  'match advertised names; Dart-side matching owns this');
+          expect(
+            mockScanner.startWatchCallCount,
+            1,
+            reason: 'watch must arm on machine connect with scale missing',
+          );
+          expect(
+            mockScanner.lastWatchFilter?.namePrefix,
+            isNull,
+            reason:
+                'no OS name filter — remembered friendly names do not '
+                'match advertised names; Dart-side matching owns this',
+          );
 
           // The load-bearing regression assertion: past the full legacy
           // backoff ladder (5→60s), no burst scan may fire — the watch
           // replaces the loop entirely.
           async.elapse(const Duration(seconds: 70));
           async.flushMicrotasks();
-          expect(mockScanner.scanCallCount, 0,
-              reason: 'watch replaces the backoff-burst reconnect loop');
+          expect(
+            mockScanner.scanCallCount,
+            0,
+            reason: 'watch replaces the backoff-burst reconnect loop',
+          );
 
           manager.dispose();
           async.flushMicrotasks();
@@ -2038,11 +2270,17 @@ void main() {
           mockScaleController.connectCalls.map((s) => s.deviceId),
           contains(scaleId),
         );
-        expect(mockScanner.watchActive, isFalse,
-            reason: 'watch stops once the scale is connected');
+        expect(
+          mockScanner.watchActive,
+          isFalse,
+          reason: 'watch stops once the scale is connected',
+        );
         expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
-        expect(mockScanner.scanCallCount, 0,
-            reason: 'the connect must not go through a burst scan');
+        expect(
+          mockScanner.scanCallCount,
+          0,
+          reason: 'the connect must not go through a burst scan',
+        );
       });
 
       test('failed watch connect re-arms the watch', () async {
@@ -2058,8 +2296,11 @@ void main() {
         await Future<void>.delayed(Duration.zero);
 
         expect(mockScaleController.connectCalls, isNotEmpty);
-        expect(mockScanner.startWatchCallCount, 2,
-            reason: 'a failed connect must restart the watch');
+        expect(
+          mockScanner.startWatchCallCount,
+          2,
+          reason: 'a failed connect must restart the watch',
+        );
         expect(mockScanner.watchActive, isTrue);
       });
 
@@ -2070,21 +2311,27 @@ void main() {
         mockScaleController.debugSetLastConnectedId(scaleId);
         mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
         await Future<void>.delayed(Duration.zero);
-        expect(mockScanner.startWatchCallCount, 0,
-            reason: 'scale is connected — nothing to watch for');
+        expect(
+          mockScanner.startWatchCallCount,
+          0,
+          reason: 'scale is connected — nothing to watch for',
+        );
 
-        mockScaleController
-            .mockEmitConnectionState(ConnectionState.disconnected);
+        mockScaleController.mockEmitConnectionState(
+          ConnectionState.disconnected,
+        );
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
 
         expect(mockScanner.startWatchCallCount, 1);
-        expect(mockScanner.scanCallCount, 0,
-            reason: 'no burst scan on unexpected disconnect either');
+        expect(
+          mockScanner.scanCallCount,
+          0,
+          reason: 'no burst scan on unexpected disconnect either',
+        );
       });
 
-      test(
-          'power-mode sleep stops the watch and wake re-arms it '
+      test('power-mode sleep stops the watch and wake re-arms it '
           'without a burst', () async {
         await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
         connectionManager = buildWatchManager();
@@ -2094,21 +2341,30 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         fakeDe1.emitState(MachineState.idle);
         await Future<void>.delayed(Duration.zero);
-        expect(mockScanner.watchActive, isTrue,
-            reason: 'machine awake + scale missing → watch armed');
+        expect(
+          mockScanner.watchActive,
+          isTrue,
+          reason: 'machine awake + scale missing → watch armed',
+        );
 
         fakeDe1.emitState(MachineState.sleeping);
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
-        expect(mockScanner.watchActive, isFalse,
-            reason: 'sleeping + ScalePowerMode.disconnect must stop the watch');
+        expect(
+          mockScanner.watchActive,
+          isFalse,
+          reason: 'sleeping + ScalePowerMode.disconnect must stop the watch',
+        );
 
         final startsBeforeWake = mockScanner.startWatchCallCount;
         fakeDe1.emitState(MachineState.idle);
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
-        expect(mockScanner.startWatchCallCount, startsBeforeWake + 1,
-            reason: 'wake must re-arm the watch');
+        expect(
+          mockScanner.startWatchCallCount,
+          startsBeforeWake + 1,
+          reason: 'wake must re-arm the watch',
+        );
         expect(mockScanner.scanCallCount, 0);
       });
 
@@ -2123,76 +2379,92 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
 
-        expect(mockScanner.watchActive, isFalse,
-            reason: 'no machine → nothing to reacquire a scale for');
+        expect(
+          mockScanner.watchActive,
+          isFalse,
+          reason: 'no machine → nothing to reacquire a scale for',
+        );
       });
 
       test(
-          'machine quick-connect arms the watch, not the legacy backoff loop',
-          () {
-        // Quick-connect is the common startup path when a preferred
-        // machine is remembered; its success branch must route scale
-        // reacquisition through the watch selector like every other
-        // machine-connected site — not schedule backoff bursts alongside
-        // the watch.
-        fakeAsync((async) {
-          mockSettingsService.setRememberedDevices(RememberedDevice.encodeList([
-            const RememberedDevice(
-              id: 'pref-de1',
-              name: 'DE1',
-              type: DeviceType.machine,
-            ),
-          ]));
-          final remembered = RememberedDevicesController(
-            machineConnections: const Stream.empty(),
-            scaleConnections: const Stream.empty(),
-            settings: mockSettingsService,
-          );
-          remembered.initialize();
-          async.flushMicrotasks();
+        'machine quick-connect arms the watch, not the legacy backoff loop',
+        () {
+          // Quick-connect is the common startup path when a preferred
+          // machine is remembered; its success branch must route scale
+          // reacquisition through the watch selector like every other
+          // machine-connected site — not schedule backoff bursts alongside
+          // the watch.
+          fakeAsync((async) {
+            mockSettingsService.setRememberedDevices(
+              RememberedDevice.encodeList([
+                const RememberedDevice(
+                  id: 'pref-de1',
+                  name: 'DE1',
+                  type: DeviceType.machine,
+                ),
+              ]),
+            );
+            final remembered = RememberedDevicesController(
+              machineConnections: const Stream.empty(),
+              scaleConnections: const Stream.empty(),
+              settings: mockSettingsService,
+            );
+            remembered.initialize();
+            async.flushMicrotasks();
 
-          final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
-          mockScanner.quickConnectResult = fakeDe1;
-          // Fresh controller: the group setUp disposed the shared one
-          // (closing its subjects), which would make adoptDevice throw.
-          final qcDe1Controller = MockDe1Controller(
-            controller: DeviceController([dummyDiscoveryService]),
-          );
-          final manager = ConnectionManager(
-            deviceScanner: mockScanner,
-            de1Controller: qcDe1Controller,
-            scaleController: mockScaleController,
-            settingsController: settingsController,
-            rememberedDevices: remembered,
-          );
-          settingsController.setPreferredMachineId('pref-de1');
-          settingsController.setPreferredScaleId(scaleId);
-          async.flushMicrotasks();
+            final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+            mockScanner.quickConnectResult = fakeDe1;
+            // Fresh controller: the group setUp disposed the shared one
+            // (closing its subjects), which would make adoptDevice throw.
+            final qcDe1Controller = MockDe1Controller(
+              controller: DeviceController([dummyDiscoveryService]),
+            );
+            final manager = ConnectionManager(
+              deviceScanner: mockScanner,
+              de1Controller: qcDe1Controller,
+              scaleController: mockScaleController,
+              settingsController: settingsController,
+              rememberedDevices: remembered,
+            );
+            settingsController.setPreferredMachineId('pref-de1');
+            settingsController.setPreferredScaleId(scaleId);
+            async.flushMicrotasks();
 
-          manager.connect();
-          async.flushMicrotasks();
-          expect(mockScanner.quickConnectCallCount, 1,
-              reason: 'the quick-connect path must be the one exercised');
+            manager.connect();
+            async.flushMicrotasks();
+            expect(
+              mockScanner.quickConnectCallCount,
+              1,
+              reason: 'the quick-connect path must be the one exercised',
+            );
 
-          // Production: adoptDevice propagates onto the de1 stream and
-          // the supervisor fires machine-connected; simulate that here
-          // (MockDe1Controller overrides the stream adoptDevice feeds).
-          qcDe1Controller.de1Subject.add(fakeDe1);
-          async.flushMicrotasks();
+            // Production: adoptDevice propagates onto the de1 stream and
+            // the supervisor fires machine-connected; simulate that here
+            // (MockDe1Controller overrides the stream adoptDevice feeds).
+            qcDe1Controller.de1Subject.add(fakeDe1);
+            async.flushMicrotasks();
 
-          expect(mockScanner.startWatchCallCount, 1,
-              reason: 'watch must arm after a quick-connected machine');
-          async.elapse(const Duration(seconds: 70));
-          async.flushMicrotasks();
-          expect(mockScanner.scanCallCount, 0,
-              reason: 'quick-connect success must not schedule legacy '
-                  'backoff bursts alongside the watch');
+            expect(
+              mockScanner.startWatchCallCount,
+              1,
+              reason: 'watch must arm after a quick-connected machine',
+            );
+            async.elapse(const Duration(seconds: 70));
+            async.flushMicrotasks();
+            expect(
+              mockScanner.scanCallCount,
+              0,
+              reason:
+                  'quick-connect success must not schedule legacy '
+                  'backoff bursts alongside the watch',
+            );
 
-          manager.dispose();
-          remembered.dispose();
-          async.flushMicrotasks();
-        });
-      });
+            manager.dispose();
+            remembered.dispose();
+            async.flushMicrotasks();
+          });
+        },
+      );
 
       test('watch start failure falls back to the legacy backoff loop', () {
         fakeAsync((async) {
@@ -2203,13 +2475,19 @@ void main() {
           mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
           async.flushMicrotasks();
 
-          expect(mockScanner.startWatchCallCount, 0,
-              reason: 'the start attempt threw before recording');
+          expect(
+            mockScanner.startWatchCallCount,
+            0,
+            reason: 'the start attempt threw before recording',
+          );
           // Legacy backoff base delay is 5s — the fallback burst fires then.
           async.elapse(const Duration(seconds: 6));
           async.flushMicrotasks();
-          expect(mockScanner.scanCallCount, 1,
-              reason: 'watch failure must fall back to backoff bursts');
+          expect(
+            mockScanner.scanCallCount,
+            1,
+            reason: 'watch failure must fall back to backoff bursts',
+          );
 
           manager.dispose();
           async.flushMicrotasks();
@@ -2232,10 +2510,14 @@ void main() {
 
           async.elapse(const Duration(seconds: 6));
           async.flushMicrotasks();
-          expect(mockScanner.scanCallCount, 1,
-              reason: 'the legacy backoff loop must take over when the '
-                  'watch dies — scale reacquisition must never be '
-                  'silently off');
+          expect(
+            mockScanner.scanCallCount,
+            1,
+            reason:
+                'the legacy backoff loop must take over when the '
+                'watch dies — scale reacquisition must never be '
+                'silently off',
+          );
 
           manager.dispose();
           async.flushMicrotasks();

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -177,7 +177,8 @@ void main() {
       mockScanner = MockDeviceScanner();
       dummyDiscoveryService = MockDeviceDiscoveryService();
       mockDe1Controller = MockDe1Controller(
-        controller: DeviceController([dummyDiscoveryService]),
+        controller:
+            DeviceController([dummyDiscoveryService]),
       );
       mockScaleController = MockScaleController();
       mockSettingsService = MockSettingsService();
@@ -226,44 +227,38 @@ void main() {
         expect(mockDe1Controller.connectCalls, isEmpty);
       });
 
-      test(
-        'no preferred, 1 machine → auto-connects and saves preference',
-        () async {
-          final fakeDe1 = _FakeDe1(deviceId: 'solo-de1');
-          mockScanner.addDevice(fakeDe1);
-          await Future.delayed(Duration.zero);
+      test('no preferred, 1 machine → auto-connects and saves preference',
+          () async {
+        final fakeDe1 = _FakeDe1(deviceId: 'solo-de1');
+        mockScanner.addDevice(fakeDe1);
+        await Future.delayed(Duration.zero);
 
-          await connectionManager.connect();
-          await Future.delayed(Duration.zero);
+        await connectionManager.connect();
+        await Future.delayed(Duration.zero);
 
-          expect(mockDe1Controller.connectCalls, hasLength(1));
-          expect(mockDe1Controller.connectCalls.first, same(fakeDe1));
-          expect(settingsController.preferredMachineId, 'solo-de1');
-          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
-        },
-      );
+        expect(mockDe1Controller.connectCalls, hasLength(1));
+        expect(mockDe1Controller.connectCalls.first, same(fakeDe1));
+        expect(settingsController.preferredMachineId, 'solo-de1');
+        expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
+      });
 
-      test(
-        'no preferred, many machines → emits machinePicker ambiguity',
-        () async {
-          final de1a = _FakeDe1(deviceId: 'de1-a');
-          final de1b = _FakeDe1(deviceId: 'de1-b');
-          mockScanner.addDevice(de1a);
-          mockScanner.addDevice(de1b);
-          await Future.delayed(Duration.zero);
+      test('no preferred, many machines → emits machinePicker ambiguity',
+          () async {
+        final de1a = _FakeDe1(deviceId: 'de1-a');
+        final de1b = _FakeDe1(deviceId: 'de1-b');
+        mockScanner.addDevice(de1a);
+        mockScanner.addDevice(de1b);
+        await Future.delayed(Duration.zero);
 
-          await connectionManager.connect();
-          await Future.delayed(Duration.zero);
+        await connectionManager.connect();
+        await Future.delayed(Duration.zero);
 
-          expect(connectionManager.currentStatus.phase, ConnectionPhase.idle);
-          expect(
-            connectionManager.currentStatus.pendingAmbiguity,
-            AmbiguityReason.machinePicker,
-          );
-          expect(connectionManager.currentStatus.foundMachines, hasLength(2));
-          expect(mockDe1Controller.connectCalls, isEmpty);
-        },
-      );
+        expect(connectionManager.currentStatus.phase, ConnectionPhase.idle);
+        expect(connectionManager.currentStatus.pendingAmbiguity,
+            AmbiguityReason.machinePicker);
+        expect(connectionManager.currentStatus.foundMachines, hasLength(2));
+        expect(mockDe1Controller.connectCalls, isEmpty);
+      });
 
       test('preferred machine found → connects directly', () async {
         await settingsController.setPreferredMachineId('pref-de1');
@@ -281,25 +276,22 @@ void main() {
       });
 
       test(
-        'preferred machine not found, others available → emits machinePicker ambiguity',
-        () async {
-          await settingsController.setPreferredMachineId('missing-de1');
+          'preferred machine not found, others available → emits machinePicker ambiguity',
+          () async {
+        await settingsController.setPreferredMachineId('missing-de1');
 
-          final otherDe1 = _FakeDe1(deviceId: 'other-de1');
-          mockScanner.addDevice(otherDe1);
-          await Future.delayed(Duration.zero);
+        final otherDe1 = _FakeDe1(deviceId: 'other-de1');
+        mockScanner.addDevice(otherDe1);
+        await Future.delayed(Duration.zero);
 
-          await connectionManager.connect();
-          await Future.delayed(Duration.zero);
+        await connectionManager.connect();
+        await Future.delayed(Duration.zero);
 
-          expect(connectionManager.currentStatus.phase, ConnectionPhase.idle);
-          expect(
-            connectionManager.currentStatus.pendingAmbiguity,
-            AmbiguityReason.machinePicker,
-          );
-          expect(mockDe1Controller.connectCalls, isEmpty);
-        },
-      );
+        expect(connectionManager.currentStatus.phase, ConnectionPhase.idle);
+        expect(connectionManager.currentStatus.pendingAmbiguity,
+            AmbiguityReason.machinePicker);
+        expect(mockDe1Controller.connectCalls, isEmpty);
+      });
 
       test('preferred machine not found, no others → stays idle', () async {
         await settingsController.setPreferredMachineId('missing-de1');
@@ -327,7 +319,8 @@ void main() {
 
           expect(mockDe1Controller.connectCalls, hasLength(1));
           expect(mockScaleController.connectCalls, hasLength(1));
-          expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
+          expect(
+              mockScaleController.connectCalls.first.deviceId, 'pref-scale');
           expect(settingsController.preferredScaleId, 'pref-scale');
         });
 
@@ -342,7 +335,8 @@ void main() {
           await Future.delayed(Duration.zero);
 
           expect(mockScaleController.connectCalls, hasLength(1));
-          expect(mockScaleController.connectCalls.first.deviceId, 'only-scale');
+          expect(
+              mockScaleController.connectCalls.first.deviceId, 'only-scale');
         });
 
         test('no preferred, many scales → skips scale', () async {
@@ -360,25 +354,21 @@ void main() {
           expect(mockScaleController.connectCalls, isEmpty);
         });
 
-        test(
-          'preferred scale not found → does nothing, phase stays ready',
-          () async {
-            await settingsController.setPreferredScaleId('missing-scale');
+        test('preferred scale not found → does nothing, phase stays ready',
+            () async {
+          await settingsController.setPreferredScaleId('missing-scale');
 
-            final fakeDe1 = _FakeDe1(deviceId: 'de1');
-            mockScanner.addDevice(fakeDe1);
-            await Future.delayed(Duration.zero);
+          final fakeDe1 = _FakeDe1(deviceId: 'de1');
+          mockScanner.addDevice(fakeDe1);
+          await Future.delayed(Duration.zero);
 
-            await connectionManager.connect();
-            await Future.delayed(Duration.zero);
+          await connectionManager.connect();
+          await Future.delayed(Duration.zero);
 
-            expect(mockScaleController.connectCalls, isEmpty);
-            expect(
-              connectionManager.currentStatus.phase,
-              ConnectionPhase.ready,
-            );
-          },
-        );
+          expect(mockScaleController.connectCalls, isEmpty);
+          expect(
+              connectionManager.currentStatus.phase, ConnectionPhase.ready);
+        });
 
         test('scale failure does not affect machine connection', () async {
           mockScaleController.shouldFailConnect = true;
@@ -394,7 +384,8 @@ void main() {
 
           expect(mockDe1Controller.connectCalls, hasLength(1));
           expect(mockScaleController.connectCalls, hasLength(1));
-          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
+          expect(
+              connectionManager.currentStatus.phase, ConnectionPhase.ready);
         });
       });
 
@@ -408,132 +399,117 @@ void main() {
       // See: doc/plans/comms-harden.md #4,
       //      doc/plans/comms-phase-0-1.md Gap A.
       group('scale failure recovery (comms-harden #4)', () {
-        test(
-          'after scaleOnly connect fails, next connect retries scale',
-          () async {
-            mockScaleController.shouldFailConnect = true;
+        test('after scaleOnly connect fails, next connect retries scale',
+            () async {
+          mockScaleController.shouldFailConnect = true;
 
-            final scale = TestScale(deviceId: 'scale-1');
-            mockScanner.addDevice(scale);
-            await Future.delayed(Duration.zero);
+          final scale = TestScale(deviceId: 'scale-1');
+          mockScanner.addDevice(scale);
+          await Future.delayed(Duration.zero);
 
-            await connectionManager.connect(scaleOnly: true);
-            await Future.delayed(Duration.zero);
-            expect(
-              mockScaleController.connectCalls,
-              hasLength(1),
-              reason: 'first scaleOnly attempt should call connectToScale',
-            );
+          await connectionManager.connect(scaleOnly: true);
+          await Future.delayed(Duration.zero);
+          expect(mockScaleController.connectCalls, hasLength(1),
+              reason: 'first scaleOnly attempt should call connectToScale');
 
-            mockScaleController.shouldFailConnect = false;
-            await connectionManager.connect(scaleOnly: true);
-            await Future.delayed(Duration.zero);
+          mockScaleController.shouldFailConnect = false;
+          await connectionManager.connect(scaleOnly: true);
+          await Future.delayed(Duration.zero);
 
-            expect(
-              mockScaleController.connectCalls,
-              hasLength(2),
+          expect(mockScaleController.connectCalls, hasLength(2),
               reason:
-                  'scale must be retried after a prior failed scaleOnly connect',
-            );
-          },
-        );
+                  'scale must be retried after a prior failed scaleOnly connect');
+        });
 
         test(
-          'after full connect fails on scale phase, next scaleOnly retries',
-          () async {
-            mockScaleController.shouldFailConnect = true;
+            'after full connect fails on scale phase, next scaleOnly retries',
+            () async {
+          mockScaleController.shouldFailConnect = true;
 
-            final fakeDe1 = _FakeDe1(deviceId: 'de1');
-            final scale = TestScale(deviceId: 'scale-1');
-            mockScanner.addDevice(fakeDe1);
-            mockScanner.addDevice(scale);
-            await Future.delayed(Duration.zero);
+          final fakeDe1 = _FakeDe1(deviceId: 'de1');
+          final scale = TestScale(deviceId: 'scale-1');
+          mockScanner.addDevice(fakeDe1);
+          mockScanner.addDevice(scale);
+          await Future.delayed(Duration.zero);
 
-            await connectionManager.connect();
-            await Future.delayed(Duration.zero);
-            expect(
-              mockScaleController.connectCalls,
-              hasLength(1),
-              reason: 'full connect reaches scale phase on first attempt',
-            );
+          await connectionManager.connect();
+          await Future.delayed(Duration.zero);
+          expect(mockScaleController.connectCalls, hasLength(1),
+              reason: 'full connect reaches scale phase on first attempt');
 
-            mockScaleController.shouldFailConnect = false;
-            await connectionManager.connect(scaleOnly: true);
-            await Future.delayed(Duration.zero);
+          mockScaleController.shouldFailConnect = false;
+          await connectionManager.connect(scaleOnly: true);
+          await Future.delayed(Duration.zero);
 
-            expect(
-              mockScaleController.connectCalls,
-              hasLength(2),
+          expect(mockScaleController.connectCalls, hasLength(2),
               reason:
-                  'scale phase must retry after a prior full-connect failure',
-            );
-          },
-        );
+                  'scale phase must retry after a prior full-connect failure');
+        });
       });
 
       group('early-stop', () {
         test(
-          'both preferred set and both connected → calls stopScan',
-          () async {
-            await settingsController.setPreferredMachineId('pref-de1');
-            await settingsController.setPreferredScaleId('pref-scale');
+            'both preferred set and both connected → calls stopScan',
+            () async {
+          await settingsController.setPreferredMachineId('pref-de1');
+          await settingsController.setPreferredScaleId('pref-scale');
 
-            // Hold scan open so devices appear "during" scan
-            mockScanner.scanCompleter = Completer<void>();
+          // Hold scan open so devices appear "during" scan
+          mockScanner.scanCompleter = Completer<void>();
 
-            final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
-            final testScale = TestScale(deviceId: 'pref-scale');
+          final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+          final testScale = TestScale(deviceId: 'pref-scale');
 
-            // Start connect (will block on scan)
-            final connectFuture = connectionManager.connect();
+          // Start connect (will block on scan)
+          final connectFuture = connectionManager.connect();
 
-            // Wait for scan to start
-            await mockScanner.scanningStream.firstWhere((s) => s);
+          // Wait for scan to start
+          await mockScanner.scanningStream.firstWhere((s) => s);
 
-            // Devices appear during scan
-            mockScanner.addDevice(fakeDe1);
-            await Future.delayed(Duration.zero);
-            mockScanner.addDevice(testScale);
-            await Future.delayed(Duration.zero);
+          // Devices appear during scan
+          mockScanner.addDevice(fakeDe1);
+          await Future.delayed(Duration.zero);
+          mockScanner.addDevice(testScale);
+          await Future.delayed(Duration.zero);
 
-            // Allow connections to process
-            await Future.delayed(Duration.zero);
-            await Future.delayed(Duration.zero);
+          // Allow connections to process
+          await Future.delayed(Duration.zero);
+          await Future.delayed(Duration.zero);
 
-            // Complete the scan
-            mockScanner.completeScan();
-            await connectFuture;
+          // Complete the scan
+          mockScanner.completeScan();
+          await connectFuture;
 
-            expect(mockScanner.stopScanCallCount, 1);
-          },
-        );
+          expect(mockScanner.stopScanCallCount, 1);
+        });
 
         test(
-          'only preferred machine set → calls stopScan on machine connect',
-          () async {
-            await settingsController.setPreferredMachineId('pref-de1');
-            // No preferred scale — scan should stop as soon as machine connects.
+            'only preferred machine set → calls stopScan on machine connect',
+            () async {
+          await settingsController.setPreferredMachineId('pref-de1');
+          // No preferred scale — scan should stop as soon as machine connects.
 
-            mockScanner.scanCompleter = Completer<void>();
+          mockScanner.scanCompleter = Completer<void>();
 
-            final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+          final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
 
-            final connectFuture = connectionManager.connect();
-            await mockScanner.scanningStream.firstWhere((s) => s);
+          final connectFuture = connectionManager.connect();
+          await mockScanner.scanningStream.firstWhere((s) => s);
 
-            mockScanner.addDevice(fakeDe1);
-            await Future.delayed(Duration.zero);
-            await Future.delayed(Duration.zero);
+          mockScanner.addDevice(fakeDe1);
+          await Future.delayed(Duration.zero);
+          await Future.delayed(Duration.zero);
 
-            mockScanner.completeScan();
-            await connectFuture;
+          mockScanner.completeScan();
+          await connectFuture;
 
-            expect(mockScanner.stopScanCallCount, 1);
-          },
-        );
+          expect(mockScanner.stopScanCallCount, 1);
+        });
 
-        test('only preferred machine, scale advertises after early-stop → '
-            'deferred rescan connects it', () async {
+        test(
+            'only preferred machine, scale advertises after early-stop → '
+            'deferred rescan connects it',
+            () async {
           await settingsController.setPreferredMachineId('pref-de1');
           // No preferred scale. Fire the deferred rescan immediately.
           connectionManager.deferredScaleScanDelay = Duration.zero;
@@ -557,7 +533,8 @@ void main() {
           // scan stopped early. Rescan is armed in the background.
           expect(mockScanner.stopScanCallCount, 1);
           expect(mockScaleController.connectCalls, isEmpty);
-          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
+          expect(
+              connectionManager.currentStatus.phase, ConnectionPhase.ready);
 
           // Scale shows up only now — after the early stop.
           mockScanner.addDevice(TestScale(deviceId: 'late-scale'));
@@ -568,17 +545,18 @@ void main() {
           await Future.delayed(Duration.zero);
           await Future.delayed(Duration.zero);
 
+          expect(mockScaleController.connectCalls, hasLength(1),
+              reason: 'deferred rescan must connect the late scale');
           expect(
-            mockScaleController.connectCalls,
-            hasLength(1),
-            reason: 'deferred rescan must connect the late scale',
-          );
-          expect(mockScaleController.connectCalls.first.deviceId, 'late-scale');
-          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
+              mockScaleController.connectCalls.first.deviceId, 'late-scale');
+          expect(
+              connectionManager.currentStatus.phase, ConnectionPhase.ready);
         });
 
-        test('only preferred machine, no scale ever → deferred rescan is a '
-            'no-op, machine stays ready', () async {
+        test(
+            'only preferred machine, no scale ever → deferred rescan is a '
+            'no-op, machine stays ready',
+            () async {
           await settingsController.setPreferredMachineId('pref-de1');
           connectionManager.deferredScaleScanDelay = Duration.zero;
 
@@ -596,7 +574,8 @@ void main() {
           mockScanner.completeScan();
           await connectFuture;
 
-          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
+          expect(
+              connectionManager.currentStatus.phase, ConnectionPhase.ready);
 
           // Deferred rescan fires, finds no scale, leaves machine ready.
           await Future.delayed(const Duration(milliseconds: 1));
@@ -605,14 +584,14 @@ void main() {
           await Future.delayed(Duration.zero);
 
           expect(mockScaleController.connectCalls, isEmpty);
-          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
+          expect(
+              connectionManager.currentStatus.phase, ConnectionPhase.ready);
         });
 
         test('machine disconnect cancels deferred scale rescan', () async {
           await settingsController.setPreferredMachineId('pref-de1');
-          connectionManager.deferredScaleScanDelay = const Duration(
-            milliseconds: 10,
-          );
+          connectionManager.deferredScaleScanDelay =
+              const Duration(milliseconds: 10);
           mockScanner.scanCompleter = Completer<void>();
 
           final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
@@ -638,7 +617,9 @@ void main() {
           await sub.cancel();
         });
 
-        test('only preferred scale set → does not call stopScan', () async {
+        test(
+            'only preferred scale set → does not call stopScan',
+            () async {
           await settingsController.setPreferredScaleId('pref-scale');
           // No preferred machine
 
@@ -659,7 +640,9 @@ void main() {
           expect(mockScanner.stopScanCallCount, 0);
         });
 
-        test('no preferences set → does not call stopScan', () async {
+        test(
+            'no preferences set → does not call stopScan',
+            () async {
           mockScanner.scanCompleter = Completer<void>();
 
           final fakeDe1 = _FakeDe1(deviceId: 'de1');
@@ -679,69 +662,64 @@ void main() {
         });
 
         test(
-          'full scan completed (no early stop) → no deferred rescan armed',
-          () async {
-            // No preferences → no early-stop. A single machine auto-connects
-            // via post-scan policy; the full scan already saw every scale, so
-            // a scale appearing afterwards must NOT be auto-connected by a
-            // rescan that should never have been armed.
-            connectionManager.deferredScaleScanDelay = Duration.zero;
+            'full scan completed (no early stop) → no deferred rescan armed',
+            () async {
+          // No preferences → no early-stop. A single machine auto-connects
+          // via post-scan policy; the full scan already saw every scale, so
+          // a scale appearing afterwards must NOT be auto-connected by a
+          // rescan that should never have been armed.
+          connectionManager.deferredScaleScanDelay = Duration.zero;
 
-            mockScanner.scanCompleter = Completer<void>();
+          mockScanner.scanCompleter = Completer<void>();
 
-            final fakeDe1 = _FakeDe1(deviceId: 'de1');
+          final fakeDe1 = _FakeDe1(deviceId: 'de1');
 
-            final connectFuture = connectionManager.connect();
-            await mockScanner.scanningStream.firstWhere((s) => s);
+          final connectFuture = connectionManager.connect();
+          await mockScanner.scanningStream.firstWhere((s) => s);
 
-            mockScanner.addDevice(fakeDe1);
-            await Future.delayed(Duration.zero);
+          mockScanner.addDevice(fakeDe1);
+          await Future.delayed(Duration.zero);
 
-            mockScanner.completeScan();
-            await connectFuture;
+          mockScanner.completeScan();
+          await connectFuture;
 
-            expect(mockScanner.stopScanCallCount, 0);
-            expect(mockScaleController.connectCalls, isEmpty);
+          expect(mockScanner.stopScanCallCount, 0);
+          expect(mockScaleController.connectCalls, isEmpty);
 
-            // A scale shows up after the (completed) scan. With no early stop
-            // there is no armed rescan, so it stays unconnected.
-            mockScanner.addDevice(TestScale(deviceId: 'late-scale'));
-            await Future.delayed(const Duration(milliseconds: 1));
-            await Future.delayed(Duration.zero);
-            await Future.delayed(Duration.zero);
+          // A scale shows up after the (completed) scan. With no early stop
+          // there is no armed rescan, so it stays unconnected.
+          mockScanner.addDevice(TestScale(deviceId: 'late-scale'));
+          await Future.delayed(const Duration(milliseconds: 1));
+          await Future.delayed(Duration.zero);
+          await Future.delayed(Duration.zero);
 
-            expect(
-              mockScaleController.connectCalls,
-              isEmpty,
-              reason: 'a completed full scan must not arm a deferred rescan',
-            );
-          },
-        );
+          expect(mockScaleController.connectCalls, isEmpty,
+              reason: 'a completed full scan must not arm a deferred rescan');
+        });
 
         test(
-          'both preferred set but only machine found → does not call stopScan',
-          () async {
-            await settingsController.setPreferredMachineId('pref-de1');
-            await settingsController.setPreferredScaleId('pref-scale');
+            'both preferred set but only machine found → does not call stopScan',
+            () async {
+          await settingsController.setPreferredMachineId('pref-de1');
+          await settingsController.setPreferredScaleId('pref-scale');
 
-            mockScanner.scanCompleter = Completer<void>();
+          mockScanner.scanCompleter = Completer<void>();
 
-            final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+          final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
 
-            final connectFuture = connectionManager.connect();
-            await mockScanner.scanningStream.firstWhere((s) => s);
+          final connectFuture = connectionManager.connect();
+          await mockScanner.scanningStream.firstWhere((s) => s);
 
-            // Only machine appears, no scale
-            mockScanner.addDevice(fakeDe1);
-            await Future.delayed(Duration.zero);
-            await Future.delayed(Duration.zero);
+          // Only machine appears, no scale
+          mockScanner.addDevice(fakeDe1);
+          await Future.delayed(Duration.zero);
+          await Future.delayed(Duration.zero);
 
-            mockScanner.completeScan();
-            await connectFuture;
+          mockScanner.completeScan();
+          await connectFuture;
 
-            expect(mockScanner.stopScanCallCount, 0);
-          },
-        );
+          expect(mockScanner.stopScanCallCount, 0);
+        });
       });
     });
 
@@ -771,7 +749,8 @@ void main() {
         await Future.delayed(Duration.zero);
 
         expect(mockScaleController.connectCalls, hasLength(1));
-        expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
+        expect(
+            mockScaleController.connectCalls.first.deviceId, 'pref-scale');
       });
 
       test('does not call stopScan even with preferred scale set', () async {
@@ -795,29 +774,29 @@ void main() {
       });
 
       test(
-        'auto-scans for preferred scale when machine is ready and scale is missing',
-        () async {
-          await settingsController.setPreferredScaleId('pref-scale');
-          mockScanner.scanCompleter = Completer<void>();
+          'auto-scans for preferred scale when machine is ready and scale is missing',
+          () async {
+        await settingsController.setPreferredScaleId('pref-scale');
+        mockScanner.scanCompleter = Completer<void>();
 
-          mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
-          await mockScanner.scanningStream.firstWhere((s) => s);
+        mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
+        await mockScanner.scanningStream.firstWhere((s) => s);
 
-          final testScale = TestScale(deviceId: 'pref-scale');
-          mockScanner.addDevice(testScale);
-          await Future.delayed(Duration.zero);
-          await Future.delayed(Duration.zero);
+        final testScale = TestScale(deviceId: 'pref-scale');
+        mockScanner.addDevice(testScale);
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
 
-          expect(mockScaleController.connectCalls, hasLength(1));
-          expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
-          expect(mockScanner.stopScanCallCount, 0);
+        expect(mockScaleController.connectCalls, hasLength(1));
+        expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
+        expect(mockScanner.stopScanCallCount, 0);
 
-          mockScanner.completeScan();
-          await Future.delayed(Duration.zero);
-        },
-      );
+        mockScanner.completeScan();
+        await Future.delayed(Duration.zero);
+      });
 
-      test('concurrent scaleOnly during another connect is queued and '
+      test(
+          'concurrent scaleOnly during another connect is queued and '
           'drained after the in-flight call (comms-harden #9)', () async {
         // Start a scaleOnly connect that will block on the scan
         // completer for deterministic timing.
@@ -862,20 +841,19 @@ void main() {
       });
 
       test(
-        'non-scaleOnly concurrent connect is still dropped (no queue)',
-        () async {
-          mockScanner.scanCompleter = Completer<void>();
-          final future1 = connectionManager.connect();
+          'non-scaleOnly concurrent connect is still dropped (no queue)',
+          () async {
+        mockScanner.scanCompleter = Completer<void>();
+        final future1 = connectionManager.connect();
 
-          // A full-connect call during another full-connect returns
-          // immediately (silent drop), exactly as before.
-          final future2 = connectionManager.connect();
-          await future2;
+        // A full-connect call during another full-connect returns
+        // immediately (silent drop), exactly as before.
+        final future2 = connectionManager.connect();
+        await future2;
 
-          mockScanner.completeScan();
-          await future1;
-        },
-      );
+        mockScanner.completeScan();
+        await future1;
+      });
     });
 
     group('ScanReport', () {
@@ -943,17 +921,15 @@ void main() {
     });
 
     group('connectMachine', () {
-      test(
-        'delegates to De1Controller and saves preference on success',
-        () async {
-          final fakeDe1 = _FakeDe1(deviceId: 'my-de1');
-          await connectionManager.connectMachine(fakeDe1);
+      test('delegates to De1Controller and saves preference on success',
+          () async {
+        final fakeDe1 = _FakeDe1(deviceId: 'my-de1');
+        await connectionManager.connectMachine(fakeDe1);
 
-          expect(mockDe1Controller.connectCalls, hasLength(1));
-          expect(mockDe1Controller.connectCalls.first, same(fakeDe1));
-          expect(settingsController.preferredMachineId, 'my-de1');
-        },
-      );
+        expect(mockDe1Controller.connectCalls, hasLength(1));
+        expect(mockDe1Controller.connectCalls.first, same(fakeDe1));
+        expect(settingsController.preferredMachineId, 'my-de1');
+      });
 
       test('does not save preference on failure', () async {
         mockDe1Controller.shouldFailConnect = true;
@@ -969,13 +945,14 @@ void main() {
         expect(settingsController.preferredMachineId, isNull);
       });
 
-      test('connect timeout: machine that never responds fails after 30s '
-          '(comms-harden #31)', () {
+      test(
+          'connect timeout: machine that never responds fails after 30s '
+          '(comms-harden #31)',
+          () {
         fakeAsync((async) {
           final completer = Completer<void>();
           final slowDe1Controller = _SlowMockDe1Controller(
-            controller: DeviceController([dummyDiscoveryService]),
-          );
+              controller: DeviceController([dummyDiscoveryService]));
           slowDe1Controller.connectCompleter = completer;
 
           final manager = ConnectionManager(
@@ -987,18 +964,17 @@ void main() {
 
           final fakeDe1 = _FakeDe1(deviceId: 'timeout-de1');
           Object? caughtError;
-          manager.connectMachine(fakeDe1).catchError((e) => caughtError = e);
+          manager
+              .connectMachine(fakeDe1)
+              .catchError((e) => caughtError = e);
 
           // Advance past the 30s connect budget; the TimeoutException
           // in connectMachine should cause rethrow + machineConnectFailed.
           async.elapse(const Duration(seconds: 35));
           async.flushMicrotasks();
 
-          expect(
-            caughtError,
-            isA<TimeoutException>(),
-            reason: 'connectMachine must rethrow TimeoutException',
-          );
+          expect(caughtError, isA<TimeoutException>(),
+              reason: 'connectMachine must rethrow TimeoutException');
           final status = manager.currentStatus;
           expect(status.phase, ConnectionPhase.idle);
           expect(status.error?.kind, ConnectionErrorKind.machineConnectFailed);
@@ -1014,9 +990,8 @@ void main() {
 
       test('rejects concurrent connection attempts', () async {
         final completer = Completer<void>();
-        final slowDe1Controller = _SlowMockDe1Controller(
-          controller: DeviceController([dummyDiscoveryService]),
-        );
+        final slowDe1Controller =
+            _SlowMockDe1Controller(controller: DeviceController([dummyDiscoveryService]));
         slowDe1Controller.connectCompleter = completer;
 
         final manager = ConnectionManager(
@@ -1093,34 +1068,30 @@ void main() {
         await sub.cancel();
       });
 
+      test('emits machineConnectFailed on De1Controller.connectToDe1 throw',
+          () async {
+        mockDe1Controller.shouldFailConnect = true;
+        final fakeDe1 = _FailingFakeDe1(deviceId: 'D9:11:0B:E6:9F:86');
+
+        try {
+          await connectionManager.connectMachine(fakeDe1);
+        } catch (_) {
+          // connectMachine rethrows — that's expected.
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        final err = connectionManager.currentStatus.error!;
+        expect(err.kind, ConnectionErrorKind.machineConnectFailed);
+        expect(err.deviceId, 'D9:11:0B:E6:9F:86');
+        expect(err.deviceName, 'DE1-D9:11:0B:E6:9F:86');
+        expect(err.severity, ConnectionErrorSeverity.error);
+      });
+
       test(
-        'emits machineConnectFailed on De1Controller.connectToDe1 throw',
-        () async {
-          mockDe1Controller.shouldFailConnect = true;
-          final fakeDe1 = _FailingFakeDe1(deviceId: 'D9:11:0B:E6:9F:86');
-
-          try {
-            await connectionManager.connectMachine(fakeDe1);
-          } catch (_) {
-            // connectMachine rethrows — that's expected.
-          }
-          await Future<void>.delayed(Duration.zero);
-
-          final err = connectionManager.currentStatus.error!;
-          expect(err.kind, ConnectionErrorKind.machineConnectFailed);
-          expect(err.deviceId, 'D9:11:0B:E6:9F:86');
-          expect(err.deviceName, 'DE1-D9:11:0B:E6:9F:86');
-          expect(err.severity, ConnectionErrorSeverity.error);
-        },
-      );
-
-      test('emits machineConnectFailed with ble_code in details when '
+          'emits machineConnectFailed with ble_code in details when '
           'BleConnectException thrown', () async {
         mockDe1Controller.failNextConnectWith = BleConnectException(
-          code: '133',
-          description: 'GATT Error 133',
-          function: 'connect',
-        );
+            code: '133', description: 'GATT Error 133', function: 'connect');
         final fakeDe1 = _FailingFakeDe1(deviceId: 'D9:11:0B:E6:9F:86');
 
         try {
@@ -1135,9 +1106,8 @@ void main() {
 
     group('error surfacing', () {
       test('emitting an error publishes it on the status stream', () async {
-        final future = connectionManager.status.firstWhere(
-          (s) => s.error != null,
-        );
+        final future = connectionManager.status
+            .firstWhere((s) => s.error != null);
         connectionManager.debugEmitError(
           kind: ConnectionErrorKind.scaleConnectFailed,
           severity: ConnectionErrorSeverity.error,
@@ -1148,58 +1118,50 @@ void main() {
         expect(status.error!.timestamp.isUtc, isTrue);
       });
 
-      test(
-        'transient error cleared by _publishStatus on scanning transition',
-        () async {
-          connectionManager.debugEmitError(
-            kind: ConnectionErrorKind.scaleConnectFailed,
-            severity: ConnectionErrorSeverity.error,
-            message: 'test',
-          );
-          expect(connectionManager.currentStatus.error, isNotNull);
+      test('transient error cleared by _publishStatus on scanning transition',
+          () async {
+        connectionManager.debugEmitError(
+          kind: ConnectionErrorKind.scaleConnectFailed,
+          severity: ConnectionErrorSeverity.error,
+          message: 'test',
+        );
+        expect(connectionManager.currentStatus.error, isNotNull);
 
-          // connect() transitions into scanning via _publishStatus without
-          // explicitly nulling — the gatekeeper must strip the transient error.
-          await connectionManager.connect(scaleOnly: true);
-          expect(connectionManager.currentStatus.error, isNull);
-        },
-      );
+        // connect() transitions into scanning via _publishStatus without
+        // explicitly nulling — the gatekeeper must strip the transient error.
+        await connectionManager.connect(scaleOnly: true);
+        expect(connectionManager.currentStatus.error, isNull);
+      });
 
-      test(
-        'sticky error survives phase transition through _publishStatus',
-        () async {
-          connectionManager.debugEmitError(
-            kind: ConnectionErrorKind.adapterOff,
-            severity: ConnectionErrorSeverity.error,
-            message: 'off',
-          );
-          expect(connectionManager.currentStatus.error, isNotNull);
+      test('sticky error survives phase transition through _publishStatus',
+          () async {
+        connectionManager.debugEmitError(
+          kind: ConnectionErrorKind.adapterOff,
+          severity: ConnectionErrorSeverity.error,
+          message: 'off',
+        );
+        expect(connectionManager.currentStatus.error, isNotNull);
 
-          // A real scan path goes through _publishStatus(scanning). Sticky
-          // adapterOff must survive even though the caller itself does not
-          // explicitly re-attach it.
-          await connectionManager.connect(scaleOnly: true);
-          expect(connectionManager.currentStatus.error, isNotNull);
-          expect(
-            connectionManager.currentStatus.error!.kind,
-            ConnectionErrorKind.adapterOff,
-          );
-        },
-      );
+        // A real scan path goes through _publishStatus(scanning). Sticky
+        // adapterOff must survive even though the caller itself does not
+        // explicitly re-attach it.
+        await connectionManager.connect(scaleOnly: true);
+        expect(connectionManager.currentStatus.error, isNotNull);
+        expect(connectionManager.currentStatus.error!.kind,
+            ConnectionErrorKind.adapterOff);
+      });
     });
 
     group('connectScale', () {
-      test(
-        'delegates to ScaleController and saves preference on success',
-        () async {
-          final testScale = TestScale(deviceId: 'my-scale');
-          await connectionManager.connectScale(testScale);
+      test('delegates to ScaleController and saves preference on success',
+          () async {
+        final testScale = TestScale(deviceId: 'my-scale');
+        await connectionManager.connectScale(testScale);
 
-          expect(mockScaleController.connectCalls, hasLength(1));
-          expect(mockScaleController.connectCalls.first, same(testScale));
-          expect(settingsController.preferredScaleId, 'my-scale');
-        },
-      );
+        expect(mockScaleController.connectCalls, hasLength(1));
+        expect(mockScaleController.connectCalls.first, same(testScale));
+        expect(settingsController.preferredScaleId, 'my-scale');
+      });
 
       test('does not save preference on failure', () async {
         mockScaleController.shouldFailConnect = true;
@@ -1212,54 +1174,43 @@ void main() {
         expect(connectionManager.currentStatus.error, isNotNull);
       });
 
+      test('reports the real outcome so scan reports cannot claim success',
+          () async {
+        final okResult =
+            await connectionManager.connectScale(TestScale(deviceId: 'ok'));
+        expect(okResult.success, isTrue);
+
+        mockScaleController.shouldFailConnect = true;
+        final failResult = await connectionManager
+            .connectScale(TestScale(deviceId: 'fail-scale'));
+        expect(failResult.success, isFalse);
+        expect(failResult.error, isNotNull);
+      });
+
+      test('emits scaleConnectFailed when the scale controller throws',
+          () async {
+        mockScaleController.shouldFailConnect = true;
+        final fakeScale =
+            TestScale(deviceId: '50:78:7D:1F:AE:E1', name: 'Decent Scale');
+
+        await connectionManager.connectScale(fakeScale);
+
+        final err = connectionManager.currentStatus.error;
+        expect(err, isNotNull);
+        expect(err!.kind, ConnectionErrorKind.scaleConnectFailed);
+        expect(err.deviceId, '50:78:7D:1F:AE:E1');
+        expect(err.deviceName, 'Decent Scale');
+        expect(err.severity, ConnectionErrorSeverity.error);
+      });
+
       test(
-        'reports the real outcome so scan reports cannot claim success',
-        () async {
-          final okResult = await connectionManager.connectScale(
-            TestScale(deviceId: 'ok'),
-          );
-          expect(okResult.success, isTrue);
-
-          mockScaleController.shouldFailConnect = true;
-          final failResult = await connectionManager.connectScale(
-            TestScale(deviceId: 'fail-scale'),
-          );
-          expect(failResult.success, isFalse);
-          expect(failResult.error, isNotNull);
-        },
-      );
-
-      test(
-        'emits scaleConnectFailed when the scale controller throws',
-        () async {
-          mockScaleController.shouldFailConnect = true;
-          final fakeScale = TestScale(
-            deviceId: '50:78:7D:1F:AE:E1',
-            name: 'Decent Scale',
-          );
-
-          await connectionManager.connectScale(fakeScale);
-
-          final err = connectionManager.currentStatus.error;
-          expect(err, isNotNull);
-          expect(err!.kind, ConnectionErrorKind.scaleConnectFailed);
-          expect(err.deviceId, '50:78:7D:1F:AE:E1');
-          expect(err.deviceName, 'Decent Scale');
-          expect(err.severity, ConnectionErrorSeverity.error);
-        },
-      );
-
-      test('emits scaleConnectFailed with ble_code in details when '
+          'emits scaleConnectFailed with ble_code in details when '
           'BleConnectException thrown', () async {
         mockScaleController.failNextConnectWith = BleConnectException(
-          code: 'connectionFailed',
-          description: 'Timed out',
-          function: 'connect',
-        );
-        final fakeScale = TestScale(
-          deviceId: '50:78:7D:1F:AE:E1',
-          name: 'Decent Scale',
-        );
+            code: 'connectionFailed', description: 'Timed out',
+            function: 'connect');
+        final fakeScale =
+            TestScale(deviceId: '50:78:7D:1F:AE:E1', name: 'Decent Scale');
 
         await connectionManager.connectScale(fakeScale);
 
@@ -1282,7 +1233,8 @@ void main() {
         final testScale = TestScale(deviceId: 'scale-1');
 
         final future1 = manager.connectScale(testScale);
-        final future2 = manager.connectScale(TestScale(deviceId: 'scale-2'));
+        final future2 =
+            manager.connectScale(TestScale(deviceId: 'scale-2'));
         await future2;
 
         expect(slowScaleController.connectCalls, hasLength(1));
@@ -1301,18 +1253,14 @@ void main() {
           severity: 'warning',
           message: 'upload failed',
         );
-        expect(
-          connectionManager.currentStatus.error?.kind,
-          ConnectionErrorKind.profileUploadFailed,
-        );
+        expect(connectionManager.currentStatus.error?.kind,
+            ConnectionErrorKind.profileUploadFailed);
 
-        // Same kind → cleared.
         connectionManager.clearErrorOfKind(
           ConnectionErrorKind.profileUploadFailed,
         );
         expect(connectionManager.currentStatus.error, isNull);
 
-        // Different kind → not cleared.
         connectionManager.debugEmitError(
           kind: ConnectionErrorKind.profileUploadFailed,
           severity: 'warning',
@@ -1329,65 +1277,56 @@ void main() {
         expect(
           connectionManager.currentStatus.error?.kind,
           ConnectionErrorKind.machineConnectFailed,
-          reason:
-              'clearErrorOfKind for profileUploadFailed must not clear '
+          reason: 'clearErrorOfKind for profileUploadFailed must not clear '
               'the current machineConnectFailed',
         );
 
-        // Clear the actual kind.
         connectionManager.clearErrorOfKind(
           ConnectionErrorKind.machineConnectFailed,
         );
         expect(connectionManager.currentStatus.error, isNull);
       });
 
-      test(
-        'emits connectingScale but not ready when no machine connected',
-        () async {
-          final phases = <ConnectionPhase>[];
-          final sub = connectionManager.status.listen((s) {
-            phases.add(s.phase);
-          });
+      test('emits connectingScale but not ready when no machine connected',
+          () async {
+        final phases = <ConnectionPhase>[];
+        final sub = connectionManager.status.listen((s) {
+          phases.add(s.phase);
+        });
 
-          final testScale = TestScale(deviceId: 'phase-scale');
-          await connectionManager.connectScale(testScale);
-          await Future.delayed(Duration.zero);
+        final testScale = TestScale(deviceId: 'phase-scale');
+        await connectionManager.connectScale(testScale);
+        await Future.delayed(Duration.zero);
 
-          // Scale alone should not emit ready — machine must be connected first
-          expect(phases, [
-            ConnectionPhase.idle,
-            ConnectionPhase.connectingScale,
-          ]);
+        // Scale alone should not emit ready — machine must be connected first
+        expect(phases, [
+          ConnectionPhase.idle,
+          ConnectionPhase.connectingScale,
+        ]);
 
-          await sub.cancel();
-        },
-      );
+        await sub.cancel();
+      });
 
       test(
-        'emits scaleConnectFailed even when fallback phase is ready (machine connected)',
-        () async {
-          // Seed connected-machine state so the scale-fail catch falls through
-          // to phase=ready (a clearing phase). The _emit must survive the
-          // gatekeeper's strip rule — if ordering regresses, this test fails.
-          final fakeMachine = _FakeDe1(deviceId: 'D9:11:0B:E6:9F:86');
-          await connectionManager.connectMachine(fakeMachine);
-          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
+          'emits scaleConnectFailed even when fallback phase is ready (machine connected)',
+          () async {
+        // Seed connected-machine state so the scale-fail catch falls through
+        // to phase=ready (a clearing phase). The _emit must survive the
+        // gatekeeper's strip rule — if ordering regresses, this test fails.
+        final fakeMachine = _FakeDe1(deviceId: 'D9:11:0B:E6:9F:86');
+        await connectionManager.connectMachine(fakeMachine);
+        expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
 
-          mockScaleController.shouldFailConnect = true;
-          final fakeScale = TestScale(
-            deviceId: '50:78:7D:1F:AE:E1',
-            name: 'Decent Scale',
-          );
-          await connectionManager.connectScale(fakeScale);
+        mockScaleController.shouldFailConnect = true;
+        final fakeScale =
+            TestScale(deviceId: '50:78:7D:1F:AE:E1', name: 'Decent Scale');
+        await connectionManager.connectScale(fakeScale);
 
-          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
-          expect(connectionManager.currentStatus.error, isNotNull);
-          expect(
-            connectionManager.currentStatus.error!.kind,
-            ConnectionErrorKind.scaleConnectFailed,
-          );
-        },
-      );
+        expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
+        expect(connectionManager.currentStatus.error, isNotNull);
+        expect(connectionManager.currentStatus.error!.kind,
+            ConnectionErrorKind.scaleConnectFailed);
+      });
 
       test('sleep during scale connect settles back to ready', () async {
         await connectionManager.dispose();
@@ -1408,14 +1347,11 @@ void main() {
 
         final connectCompleter = Completer<void>();
         slowScaleController.connectCompleter = connectCompleter;
-        final future = connectionManager.connectScale(
-          TestScale(deviceId: 'pref-scale'),
-        );
+        final future =
+            connectionManager.connectScale(TestScale(deviceId: 'pref-scale'));
         await Future<void>.delayed(Duration.zero);
-        expect(
-          connectionManager.currentStatus.phase,
-          ConnectionPhase.connectingScale,
-        );
+        expect(connectionManager.currentStatus.phase,
+            ConnectionPhase.connectingScale);
 
         fakeMachine.emitState(MachineState.sleeping);
         await Future<void>.delayed(Duration.zero);
@@ -1427,9 +1363,7 @@ void main() {
         expect(connectionManager.currentStatus.error, isNull);
         expect(settingsController.preferredScaleId, isNull);
 
-        slowScaleController.mockEmitConnectionState(
-          ConnectionState.disconnected,
-        );
+        slowScaleController.mockEmitConnectionState(ConnectionState.disconnected);
         await Future<void>.delayed(Duration.zero);
         expect(connectionManager.currentStatus.error, isNull);
       });
@@ -1472,14 +1406,10 @@ void main() {
 
       test('unexpected disconnect emits scaleDisconnected', () {
         connectionManager.debugNotifyScaleDisconnected('50:78:7D:1F:AE:E1');
-        expect(
-          connectionManager.currentStatus.error?.kind,
-          ConnectionErrorKind.scaleDisconnected,
-        );
-        expect(
-          connectionManager.currentStatus.error?.deviceId,
-          '50:78:7D:1F:AE:E1',
-        );
+        expect(connectionManager.currentStatus.error?.kind,
+            ConnectionErrorKind.scaleDisconnected);
+        expect(connectionManager.currentStatus.error?.deviceId,
+            '50:78:7D:1F:AE:E1');
       });
 
       test('TTL clears expectation after 10 seconds', () {
@@ -1487,10 +1417,8 @@ void main() {
           connectionManager.markExpectingDisconnect('50:78:7D:1F:AE:E1');
           async.elapse(const Duration(seconds: 11));
           connectionManager.debugNotifyScaleDisconnected('50:78:7D:1F:AE:E1');
-          expect(
-            connectionManager.currentStatus.error?.kind,
-            ConnectionErrorKind.scaleDisconnected,
-          );
+          expect(connectionManager.currentStatus.error?.kind,
+              ConnectionErrorKind.scaleDisconnected);
         });
       });
 
@@ -1500,208 +1428,169 @@ void main() {
         expect(connectionManager.currentStatus.error, isNull);
 
         connectionManager.debugNotifyScaleDisconnected('50:78:7D:1F:AE:E1');
-        expect(
-          connectionManager.currentStatus.error?.kind,
-          ConnectionErrorKind.scaleDisconnected,
-        );
+        expect(connectionManager.currentStatus.error?.kind,
+            ConnectionErrorKind.scaleDisconnected);
       });
 
       test('marks for different devices are independent', () {
         connectionManager.markExpectingDisconnect('50:78:7D:1F:AE:E1');
         connectionManager.debugNotifyMachineDisconnected('D9:11:0B:E6:9F:86');
-        expect(
-          connectionManager.currentStatus.error?.kind,
-          ConnectionErrorKind.machineDisconnected,
-        );
+        expect(connectionManager.currentStatus.error?.kind,
+            ConnectionErrorKind.machineDisconnected);
       });
     });
 
     group('disconnect subscribers', () {
       test('scale disconnect during expected flow suppresses error', () async {
         // Pretend scale was connected.
-        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
+        mockScaleController
+            .mockEmitConnectionState(ConnectionState.connected);
         mockScaleController.debugSetLastConnectedId('50:78:7D:1F:AE:E1');
         await Future<void>.delayed(Duration.zero);
 
         // Mark expected, then emit disconnect.
         connectionManager.markExpectingDisconnect('50:78:7D:1F:AE:E1');
-        mockScaleController.mockEmitConnectionState(
-          ConnectionState.disconnected,
-        );
+        mockScaleController
+            .mockEmitConnectionState(ConnectionState.disconnected);
         await Future<void>.delayed(Duration.zero);
 
         expect(connectionManager.currentStatus.error, isNull);
       });
 
-      test(
-        'expected scale disconnect does not trigger preferred-scale scan',
-        () async {
-          await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
-          final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
-          mockScaleController.mockEmitConnectionState(
-            ConnectionState.connected,
-          );
-          mockScaleController.debugSetLastConnectedId('pref-scale');
-          await settingsController.setPreferredScaleId('pref-scale');
-          mockDe1Controller.de1Subject.add(fakeDe1);
-          await Future<void>.delayed(Duration.zero);
-          fakeDe1.emitState(MachineState.sleeping);
-          final scanningEvents = <bool>[];
-          final sub = mockScanner.scanningStream.listen(scanningEvents.add);
-          await Future<void>.delayed(Duration.zero);
+      test('expected scale disconnect does not trigger preferred-scale scan',
+          () async {
+        await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
+        final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
+        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
+        mockScaleController.debugSetLastConnectedId('pref-scale');
+        await settingsController.setPreferredScaleId('pref-scale');
+        mockDe1Controller.de1Subject.add(fakeDe1);
+        await Future<void>.delayed(Duration.zero);
+        fakeDe1.emitState(MachineState.sleeping);
+        final scanningEvents = <bool>[];
+        final sub = mockScanner.scanningStream.listen(scanningEvents.add);
+        await Future<void>.delayed(Duration.zero);
 
-          connectionManager.markExpectingDisconnect('pref-scale');
-          mockScaleController.mockEmitConnectionState(
-            ConnectionState.disconnected,
-          );
-          await Future<void>.delayed(Duration.zero);
-          await Future<void>.delayed(Duration.zero);
+        connectionManager.markExpectingDisconnect('pref-scale');
+        mockScaleController.mockEmitConnectionState(ConnectionState.disconnected);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
 
-          expect(connectionManager.currentStatus.error, isNull);
-          expect(
-            scanningEvents,
-            isNot(contains(true)),
-            reason:
-                'power-mode disconnects are deliberate and must not start BLE',
-          );
-          expect(mockScaleController.connectCalls, isEmpty);
-          await sub.cancel();
-        },
-      );
+        expect(connectionManager.currentStatus.error, isNull);
+        expect(scanningEvents, isNot(contains(true)),
+            reason: 'power-mode disconnects are deliberate and must not start BLE');
+        expect(mockScaleController.connectCalls, isEmpty);
+        await sub.cancel();
+      });
 
-      test(
-        'unexpected preferred scale disconnect keeps scanning and reconnects',
-        () async {
-          await settingsController.setPreferredScaleId('pref-scale');
-          final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
-          mockScaleController.mockEmitConnectionState(
-            ConnectionState.connected,
-          );
-          mockScaleController.debugSetLastConnectedId('pref-scale');
-          mockDe1Controller.de1Subject.add(fakeDe1);
-          await Future<void>.delayed(Duration.zero);
-          fakeDe1.emitState(MachineState.idle);
-          await Future<void>.delayed(Duration.zero);
+      test('unexpected preferred scale disconnect keeps scanning and reconnects',
+          () async {
+        await settingsController.setPreferredScaleId('pref-scale');
+        final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
+        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
+        mockScaleController.debugSetLastConnectedId('pref-scale');
+        mockDe1Controller.de1Subject.add(fakeDe1);
+        await Future<void>.delayed(Duration.zero);
+        fakeDe1.emitState(MachineState.idle);
+        await Future<void>.delayed(Duration.zero);
 
-          mockScanner.scanCompleter = Completer<void>();
-          mockScaleController.mockEmitConnectionState(
-            ConnectionState.disconnected,
-          );
-          await mockScanner.scanningStream.firstWhere((s) => s);
+        mockScanner.scanCompleter = Completer<void>();
+        mockScaleController.mockEmitConnectionState(ConnectionState.disconnected);
+        await mockScanner.scanningStream.firstWhere((s) => s);
 
-          mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
-          await Future<void>.delayed(Duration.zero);
-          await Future<void>.delayed(Duration.zero);
-          mockScanner.completeScan();
-          await Future<void>.delayed(Duration.zero);
+        mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        mockScanner.completeScan();
+        await Future<void>.delayed(Duration.zero);
 
-          expect(mockScaleController.connectCalls, hasLength(1));
-          expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
-        },
-      );
+        expect(mockScaleController.connectCalls, hasLength(1));
+        expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
+      });
 
-      test(
-        'scale power disconnect pauses while sleeping and resumes when awake',
-        () async {
-          await settingsController.setPreferredScaleId('pref-scale');
-          await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
+      test('scale power disconnect pauses while sleeping and resumes when awake',
+          () async {
+        await settingsController.setPreferredScaleId('pref-scale');
+        await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
 
-          final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
-          mockScaleController.mockEmitConnectionState(
-            ConnectionState.connected,
-          );
-          mockScaleController.debugSetLastConnectedId('pref-scale');
-          mockDe1Controller.de1Subject.add(fakeDe1);
-          await Future<void>.delayed(Duration.zero);
-          fakeDe1.emitState(MachineState.idle);
-          await Future<void>.delayed(Duration.zero);
+        final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
+        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
+        mockScaleController.debugSetLastConnectedId('pref-scale');
+        mockDe1Controller.de1Subject.add(fakeDe1);
+        await Future<void>.delayed(Duration.zero);
+        fakeDe1.emitState(MachineState.idle);
+        await Future<void>.delayed(Duration.zero);
 
-          final scanningEvents = <bool>[];
-          final sub = mockScanner.scanningStream.listen(scanningEvents.add);
+        final scanningEvents = <bool>[];
+        final sub = mockScanner.scanningStream.listen(scanningEvents.add);
 
-          fakeDe1.emitState(MachineState.sleeping);
-          connectionManager.markExpectingDisconnect('pref-scale');
-          mockScaleController.mockEmitConnectionState(
-            ConnectionState.disconnected,
-          );
-          await Future<void>.delayed(Duration.zero);
-          await Future<void>.delayed(Duration.zero);
+        fakeDe1.emitState(MachineState.sleeping);
+        connectionManager.markExpectingDisconnect('pref-scale');
+        mockScaleController.mockEmitConnectionState(ConnectionState.disconnected);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
 
-          expect(
-            scanningEvents,
-            isNot(contains(true)),
-            reason: 'sleeping + ScalePowerMode.disconnect must not scan',
-          );
+        expect(scanningEvents, isNot(contains(true)),
+            reason: 'sleeping + ScalePowerMode.disconnect must not scan');
 
-          mockScanner.scanCompleter = Completer<void>();
-          fakeDe1.emitState(MachineState.idle);
-          await mockScanner.scanningStream.firstWhere((s) => s);
+        mockScanner.scanCompleter = Completer<void>();
+        fakeDe1.emitState(MachineState.idle);
+        await mockScanner.scanningStream.firstWhere((s) => s);
 
-          mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
-          await Future<void>.delayed(Duration.zero);
-          await Future<void>.delayed(Duration.zero);
-          mockScanner.completeScan();
-          await Future<void>.delayed(Duration.zero);
+        mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        mockScanner.completeScan();
+        await Future<void>.delayed(Duration.zero);
 
-          expect(mockScaleController.connectCalls, hasLength(1));
-          expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
-          await sub.cancel();
-        },
-      );
+        expect(mockScaleController.connectCalls, hasLength(1));
+        expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
+        await sub.cancel();
+      });
 
-      test(
-        'sleeping during an active scale scan stops it and blocks reconnect',
-        () async {
-          await settingsController.setPreferredScaleId('pref-scale');
-          await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
+      test('sleeping during an active scale scan stops it and blocks reconnect',
+          () async {
+        await settingsController.setPreferredScaleId('pref-scale');
+        await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
 
-          final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
-          mockScaleController.mockEmitConnectionState(
-            ConnectionState.connected,
-          );
-          mockScaleController.debugSetLastConnectedId('pref-scale');
-          mockDe1Controller.de1Subject.add(fakeDe1);
-          await Future<void>.delayed(Duration.zero);
-          fakeDe1.emitState(MachineState.idle);
-          await Future<void>.delayed(Duration.zero);
+        final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
+        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
+        mockScaleController.debugSetLastConnectedId('pref-scale');
+        mockDe1Controller.de1Subject.add(fakeDe1);
+        await Future<void>.delayed(Duration.zero);
+        fakeDe1.emitState(MachineState.idle);
+        await Future<void>.delayed(Duration.zero);
 
-          mockScanner.scanCompleter = Completer<void>();
-          mockScaleController.mockEmitConnectionState(
-            ConnectionState.disconnected,
-          );
-          await mockScanner.scanningStream.firstWhere((s) => s);
+        mockScanner.scanCompleter = Completer<void>();
+        mockScaleController.mockEmitConnectionState(ConnectionState.disconnected);
+        await mockScanner.scanningStream.firstWhere((s) => s);
 
-          fakeDe1.emitState(MachineState.sleeping);
-          connectionManager.markExpectingDisconnect('pref-scale');
-          mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
-          await Future<void>.delayed(Duration.zero);
-          await Future<void>.delayed(Duration.zero);
-          mockScanner.completeScan();
-          await Future<void>.delayed(Duration.zero);
+        fakeDe1.emitState(MachineState.sleeping);
+        connectionManager.markExpectingDisconnect('pref-scale');
+        mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        mockScanner.completeScan();
+        await Future<void>.delayed(Duration.zero);
 
-          expect(mockScanner.stopScanCallCount, 1);
-          expect(mockScaleController.connectCalls, isEmpty);
-        },
-      );
+        expect(mockScanner.stopScanCallCount, 1);
+        expect(mockScaleController.connectCalls, isEmpty);
+      });
 
       test('unexpected scale disconnect emits scaleDisconnected', () async {
-        mockScaleController.mockEmitConnectionState(ConnectionState.connected);
+        mockScaleController
+            .mockEmitConnectionState(ConnectionState.connected);
         mockScaleController.debugSetLastConnectedId('50:78:7D:1F:AE:E1');
         await Future<void>.delayed(Duration.zero);
 
-        mockScaleController.mockEmitConnectionState(
-          ConnectionState.disconnected,
-        );
+        mockScaleController
+            .mockEmitConnectionState(ConnectionState.disconnected);
         await Future<void>.delayed(Duration.zero);
 
-        expect(
-          connectionManager.currentStatus.error?.kind,
-          ConnectionErrorKind.scaleDisconnected,
-        );
-        expect(
-          connectionManager.currentStatus.error?.deviceId,
-          '50:78:7D:1F:AE:E1',
-        );
+        expect(connectionManager.currentStatus.error?.kind,
+            ConnectionErrorKind.scaleDisconnected);
+        expect(connectionManager.currentStatus.error?.deviceId,
+            '50:78:7D:1F:AE:E1');
       });
     });
 
@@ -1709,26 +1598,23 @@ void main() {
       test('adapter off emits adapterOff error', () async {
         mockScanner.mockAdapterState(AdapterState.poweredOff);
         await Future<void>.delayed(Duration.zero);
-        expect(
-          connectionManager.currentStatus.error?.kind,
-          ConnectionErrorKind.adapterOff,
-        );
+        expect(connectionManager.currentStatus.error?.kind,
+            ConnectionErrorKind.adapterOff);
       });
 
       test('adapter on clears adapterOff', () async {
         mockScanner.mockAdapterState(AdapterState.poweredOff);
         await Future<void>.delayed(Duration.zero);
-        expect(
-          connectionManager.currentStatus.error?.kind,
-          ConnectionErrorKind.adapterOff,
-        );
+        expect(connectionManager.currentStatus.error?.kind,
+            ConnectionErrorKind.adapterOff);
 
         mockScanner.mockAdapterState(AdapterState.poweredOn);
         await Future<void>.delayed(Duration.zero);
         expect(connectionManager.currentStatus.error, isNull);
       });
 
-      test('adapter on does NOT clear an unrelated transient error', () async {
+      test('adapter on does NOT clear an unrelated transient error',
+          () async {
         connectionManager.debugEmitError(
           kind: ConnectionErrorKind.scaleConnectFailed,
           severity: ConnectionErrorSeverity.error,
@@ -1736,50 +1622,36 @@ void main() {
         );
         mockScanner.mockAdapterState(AdapterState.poweredOn);
         await Future<void>.delayed(Duration.zero);
-        expect(
-          connectionManager.currentStatus.error?.kind,
-          ConnectionErrorKind.scaleConnectFailed,
-        );
+        expect(connectionManager.currentStatus.error?.kind,
+            ConnectionErrorKind.scaleConnectFailed);
       });
     });
 
     group('scan failures', () {
-      test(
-        'scan throwing permission error emits bluetoothPermissionDenied',
-        () async {
-          mockScanner.failNextScanWith = const PermissionDeniedException(
-            'denied',
-          );
-          await connectionManager.connect(scaleOnly: true);
-          expect(
-            connectionManager.currentStatus.error?.kind,
-            ConnectionErrorKind.bluetoothPermissionDenied,
-          );
-        },
-      );
+      test('scan throwing permission error emits bluetoothPermissionDenied',
+          () async {
+        mockScanner.failNextScanWith =
+            const PermissionDeniedException('denied');
+        await connectionManager.connect(scaleOnly: true);
+        expect(connectionManager.currentStatus.error?.kind,
+            ConnectionErrorKind.bluetoothPermissionDenied);
+      });
 
       test('scan throwing generic error emits scanFailed', () async {
         mockScanner.failNextScanWith = Exception('adapter busy');
         await connectionManager.connect(scaleOnly: true);
-        expect(
-          connectionManager.currentStatus.error?.kind,
-          ConnectionErrorKind.scanFailed,
-        );
+        expect(connectionManager.currentStatus.error?.kind,
+            ConnectionErrorKind.scanFailed);
       });
 
-      test(
-        'exception containing "permission" classified as permissionDenied',
-        () async {
-          mockScanner.failNextScanWith = Exception(
-            'Missing bluetooth permission',
-          );
-          await connectionManager.connect(scaleOnly: true);
-          expect(
-            connectionManager.currentStatus.error?.kind,
-            ConnectionErrorKind.bluetoothPermissionDenied,
-          );
-        },
-      );
+      test('exception containing "permission" classified as permissionDenied',
+          () async {
+        mockScanner.failNextScanWith =
+            Exception('Missing bluetooth permission');
+        await connectionManager.connect(scaleOnly: true);
+        expect(connectionManager.currentStatus.error?.kind,
+            ConnectionErrorKind.bluetoothPermissionDenied);
+      });
 
       test('successful scan-start clears prior scanFailed', () async {
         connectionManager.debugEmitError(
@@ -1802,7 +1674,8 @@ void main() {
         }
       }
 
-      test('unexpected machine disconnect starts recovery scans and '
+      test(
+          'unexpected machine disconnect starts recovery scans and '
           'reconnects the preferred machine', () async {
         connectionManager.machineReconnectBaseDelay = Duration.zero;
         await settingsController.setPreferredMachineId('pref-de1');
@@ -1821,48 +1694,40 @@ void main() {
         );
       });
 
-      test(
-        'recovery keeps retrying until the machine reappears, then stops',
-        () async {
-          connectionManager.machineReconnectBaseDelay = Duration.zero;
-          await settingsController.setPreferredMachineId('pref-de1');
-          final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
-          mockDe1Controller.de1Subject.add(fakeDe1);
-          await Future<void>.delayed(Duration.zero);
+      test('recovery keeps retrying until the machine reappears, then stops',
+          () async {
+        connectionManager.machineReconnectBaseDelay = Duration.zero;
+        await settingsController.setPreferredMachineId('pref-de1');
+        final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+        mockDe1Controller.de1Subject.add(fakeDe1);
+        await Future<void>.delayed(Duration.zero);
 
-          var scanStarts = 0;
-          final sub = mockScanner.scanningStream.listen((s) {
-            if (s) scanStarts++;
-          });
+        var scanStarts = 0;
+        final sub = mockScanner.scanningStream.listen((s) {
+          if (s) scanStarts++;
+        });
 
-          // Machine drops and is NOT in scan results yet.
-          mockDe1Controller.de1Subject.add(null);
-          await pumpCycles();
-          expect(
-            scanStarts,
-            greaterThan(0),
-            reason: 'loop must scan even while the machine is absent',
-          );
-          expect(mockDe1Controller.connectCalls, isEmpty);
+        // Machine drops and is NOT in scan results yet.
+        mockDe1Controller.de1Subject.add(null);
+        await pumpCycles();
+        expect(scanStarts, greaterThan(0),
+            reason: 'loop must scan even while the machine is absent');
+        expect(mockDe1Controller.connectCalls, isEmpty);
 
-          // Machine comes back — next cycle reconnects and the loop stops.
-          mockScanner.addDevice(fakeDe1);
-          await pumpCycles();
-          expect(
-            mockDe1Controller.connectCalls.map((d) => d.deviceId),
-            contains('pref-de1'),
-          );
+        // Machine comes back — next cycle reconnects and the loop stops.
+        mockScanner.addDevice(fakeDe1);
+        await pumpCycles();
+        expect(
+          mockDe1Controller.connectCalls.map((d) => d.deviceId),
+          contains('pref-de1'),
+        );
 
-          final scansAfterReconnect = scanStarts;
-          await pumpCycles();
-          expect(
-            scanStarts,
-            scansAfterReconnect,
-            reason: 'loop must stop once the machine is connected',
-          );
-          await sub.cancel();
-        },
-      );
+        final scansAfterReconnect = scanStarts;
+        await pumpCycles();
+        expect(scanStarts, scansAfterReconnect,
+            reason: 'loop must stop once the machine is connected');
+        await sub.cancel();
+      });
 
       test('expected machine disconnect does not start recovery', () async {
         connectionManager.machineReconnectBaseDelay = Duration.zero;
@@ -1881,11 +1746,8 @@ void main() {
         mockDe1Controller.de1Subject.add(null);
         await pumpCycles();
 
-        expect(
-          scanStarts,
-          0,
-          reason: 'expected disconnects must not trigger background scans',
-        );
+        expect(scanStarts, 0,
+            reason: 'expected disconnects must not trigger background scans');
         expect(mockDe1Controller.connectCalls, isEmpty);
         await sub.cancel();
       });
@@ -1926,13 +1788,9 @@ void main() {
         mockDe1Controller.de1Subject.add(null);
         await pumpCycles();
 
-        expect(
-          scanStarts,
-          0,
-          reason:
-              'without a preferred machine a background retry could '
-              'pop a picker — must stay off',
-        );
+        expect(scanStarts, 0,
+            reason: 'without a preferred machine a background retry could '
+                'pop a picker — must stay off');
         await sub.cancel();
       });
 
@@ -1983,11 +1841,11 @@ void main() {
       // backoff' test.
 
       ConnectionManager newManager() => ConnectionManager(
-        deviceScanner: mockScanner,
-        de1Controller: mockDe1Controller,
-        scaleController: mockScaleController,
-        settingsController: settingsController,
-      );
+            deviceScanner: mockScanner,
+            de1Controller: mockDe1Controller,
+            scaleController: mockScaleController,
+            settingsController: settingsController,
+          );
 
       test('fires after 10s with no snapshots and forces a reconnect', () {
         fakeAsync((async) {
@@ -2001,11 +1859,8 @@ void main() {
 
           expect(manager.snapshotStalenessReconnects, 0);
           async.elapse(const Duration(seconds: 9));
-          expect(
-            manager.snapshotStalenessReconnects,
-            0,
-            reason: 'must not fire before the staleness timeout',
-          );
+          expect(manager.snapshotStalenessReconnects, 0,
+              reason: 'must not fire before the staleness timeout');
           // Counter increments synchronously at the top of the force
           // action, so it is observable the moment the Timer fires. The
           // counter proves the watchdog fired and the force path ran
@@ -2016,11 +1871,8 @@ void main() {
           // making that assertion flaky without proving anything the
           // counter doesn't already show.
           async.elapse(const Duration(seconds: 2)); // 11s elapsed
-          expect(
-            manager.snapshotStalenessReconnects,
-            1,
-            reason: 'a silent push channel must trigger a forced reconnect',
-          );
+          expect(manager.snapshotStalenessReconnects, 1,
+              reason: 'a silent push channel must trigger a forced reconnect');
 
           manager.dispose();
           async.flushMicrotasks();
@@ -2042,134 +1894,106 @@ void main() {
           fakeDe1.emitState(MachineState.idle);
           async.flushMicrotasks();
 
-          async.elapse(
-            const Duration(seconds: 9),
-          ); // 18s total, 9s since re-arm
-          expect(
-            manager.snapshotStalenessReconnects,
-            0,
-            reason: 'a deduped frame must re-arm the watchdog',
-          );
+          async.elapse(const Duration(seconds: 9)); // 18s total, 9s since re-arm
+          expect(manager.snapshotStalenessReconnects, 0,
+              reason: 'a deduped frame must re-arm the watchdog');
 
           manager.dispose();
           async.flushMicrotasks();
         });
       });
 
-      test(
-        'deliberate disconnectMachine cancels the watchdog (no fire, no error)',
-        () {
-          fakeAsync((async) {
-            final manager = newManager();
-            final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
-            mockDe1Controller.de1Subject.add(fakeDe1);
-            async.flushMicrotasks();
-            fakeDe1.emitState(MachineState.idle);
-            async.flushMicrotasks();
+      test('deliberate disconnectMachine cancels the watchdog (no fire, no error)',
+          () {
+        fakeAsync((async) {
+          final manager = newManager();
+          final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
+          mockDe1Controller.de1Subject.add(fakeDe1);
+          async.flushMicrotasks();
+          fakeDe1.emitState(MachineState.idle);
+          async.flushMicrotasks();
 
-            // Deliberate disconnect cancels the watchdog and bumps the
-            // generation token.
-            manager.disconnectMachine();
-            async.flushMicrotasks();
+          // Deliberate disconnect cancels the watchdog and bumps the
+          // generation token.
+          manager.disconnectMachine();
+          async.flushMicrotasks();
 
-            async.elapse(const Duration(seconds: 15));
-            expect(
-              manager.snapshotStalenessReconnects,
-              0,
-              reason: 'deliberate disconnect must cancel the watchdog',
-            );
-            expect(
-              manager.currentStatus.error,
-              isNull,
-              reason: 'deliberate disconnect must not surface an error banner',
-            );
+          async.elapse(const Duration(seconds: 15));
+          expect(manager.snapshotStalenessReconnects, 0,
+              reason: 'deliberate disconnect must cancel the watchdog');
+          expect(manager.currentStatus.error, isNull,
+              reason: 'deliberate disconnect must not surface an error banner');
 
-            manager.dispose();
-            async.flushMicrotasks();
-          });
-        },
-      );
+          manager.dispose();
+          async.flushMicrotasks();
+        });
+      });
 
-      test(
-        'initial grace: no fire before the first snapshot at 9s, fire at 11s',
-        () {
-          fakeAsync((async) {
-            final manager = newManager();
-            final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
-            mockDe1Controller.de1Subject.add(fakeDe1);
-            async.flushMicrotasks();
-            // No snapshot emitted — only the initial-grace arm at watch setup.
+      test('initial grace: no fire before the first snapshot at 9s, fire at 11s',
+          () {
+        fakeAsync((async) {
+          final manager = newManager();
+          final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
+          mockDe1Controller.de1Subject.add(fakeDe1);
+          async.flushMicrotasks();
+          // No snapshot emitted — only the initial-grace arm at watch setup.
 
-            async.elapse(const Duration(seconds: 9));
-            expect(
-              manager.snapshotStalenessReconnects,
-              0,
-              reason: 'must not fire within the initial grace window',
-            );
+          async.elapse(const Duration(seconds: 9));
+          expect(manager.snapshotStalenessReconnects, 0,
+              reason: 'must not fire within the initial grace window');
 
-            async.elapse(const Duration(seconds: 2)); // 11s
-            expect(
-              manager.snapshotStalenessReconnects,
-              1,
-              reason:
-                  'watchdog armed at watch setup must fire if no frame '
-                  'ever lands',
-            );
+          async.elapse(const Duration(seconds: 2)); // 11s
+          expect(manager.snapshotStalenessReconnects, 1,
+              reason: 'watchdog armed at watch setup must fire if no frame '
+                  'ever lands');
 
-            manager.dispose();
-            async.flushMicrotasks();
-          });
-        },
-      );
+          manager.dispose();
+          async.flushMicrotasks();
+        });
+      });
 
-      test(
-        'stale generation after a forced reconnect bails (no double-reconnect)',
-        () {
-          fakeAsync((async) {
-            final manager = newManager();
-            final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
-            mockDe1Controller.de1Subject.add(fakeDe1);
-            async.flushMicrotasks();
-            fakeDe1.emitState(MachineState.idle);
-            async.flushMicrotasks();
+      test('stale generation after a forced reconnect bails (no double-reconnect)',
+          () {
+        fakeAsync((async) {
+          final manager = newManager();
+          final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
+          mockDe1Controller.de1Subject.add(fakeDe1);
+          async.flushMicrotasks();
+          fakeDe1.emitState(MachineState.idle);
+          async.flushMicrotasks();
 
-            async.elapse(const Duration(seconds: 11));
-            expect(manager.snapshotStalenessReconnects, 1);
-            async.flushMicrotasks();
+          async.elapse(const Duration(seconds: 11));
+          expect(manager.snapshotStalenessReconnects, 1);
+          async.flushMicrotasks();
 
-            // The forced reconnect cancelled the watchdog and bumped the
-            // generation. With no new machine connected and no new frames,
-            // no watchdog is re-armed — a long elapse must not trigger a
-            // second forced reconnect.
-            async.elapse(const Duration(seconds: 30));
-            expect(
-              manager.snapshotStalenessReconnects,
-              1,
-              reason: 'a stale-generation Timer must bail, not re-fire',
-            );
+          // The forced reconnect cancelled the watchdog and bumped the
+          // generation. With no new machine connected and no new frames,
+          // no watchdog is re-armed — a long elapse must not trigger a
+          // second forced reconnect.
+          async.elapse(const Duration(seconds: 30));
+          expect(manager.snapshotStalenessReconnects, 1,
+              reason: 'a stale-generation Timer must bail, not re-fire');
 
-            manager.dispose();
-            async.flushMicrotasks();
-          });
-        },
-      );
+          manager.dispose();
+          async.flushMicrotasks();
+        });
+      });
 
       // Runs in the real async zone (not fakeAsync): the forced reconnect's
       // `disconnectMachine → connect` chain awaits `de1Controller.de1.first`,
       // which a BehaviorSubject does not settle under fakeAsync — so the
       // strand safety-net in the `finally` only runs with real microtasks.
       // A short overridden staleness timeout keeps the test fast.
-      test('a forced reconnect that cannot recover the machine hands off to '
+      test(
+          'a forced reconnect that cannot recover the machine hands off to '
           'the recovery loop (no strand)', () async {
         await settingsController.setPreferredMachineId('stale-de1');
         // Non-zero base delay avoids a hot recovery loop within the wait
         // window; we only assert the loop is armed, not how often it scans.
-        connectionManager.machineReconnectBaseDelay = const Duration(
-          milliseconds: 50,
-        );
-        connectionManager.snapshotStalenessTimeout = const Duration(
-          milliseconds: 20,
-        );
+        connectionManager.machineReconnectBaseDelay =
+            const Duration(milliseconds: 50);
+        connectionManager.snapshotStalenessTimeout =
+            const Duration(milliseconds: 20);
         final fakeDe1 = _FakeDe1(deviceId: 'stale-de1');
         mockDe1Controller.de1Subject.add(fakeDe1);
         await Future<void>.delayed(Duration.zero);
@@ -2184,18 +2008,11 @@ void main() {
         // safety net nothing would retry.
         await Future<void>.delayed(const Duration(milliseconds: 60));
 
-        expect(
-          connectionManager.snapshotStalenessReconnects,
-          greaterThan(0),
-          reason: 'the watchdog must have forced a reconnect',
-        );
-        expect(
-          connectionManager.machineRecoveryActive,
-          isTrue,
-          reason:
-              'a stranded forced reconnect must hand off to the '
-              'machine-recovery loop, not leave the machine disconnected',
-        );
+        expect(connectionManager.snapshotStalenessReconnects, greaterThan(0),
+            reason: 'the watchdog must have forced a reconnect');
+        expect(connectionManager.machineRecoveryActive, isTrue,
+            reason: 'a stranded forced reconnect must hand off to the '
+                'machine-recovery loop, not leave the machine disconnected');
       });
     });
 
@@ -2203,11 +2020,11 @@ void main() {
       const scaleId = 'pref-scale';
 
       ConnectionManager buildWatchManager() => ConnectionManager(
-        deviceScanner: mockScanner,
-        de1Controller: mockDe1Controller,
-        scaleController: mockScaleController,
-        settingsController: settingsController,
-      );
+            deviceScanner: mockScanner,
+            de1Controller: mockDe1Controller,
+            scaleController: mockScaleController,
+            settingsController: settingsController,
+          );
 
       setUp(() async {
         // Retire the shared legacy manager from the outer setUp — it
@@ -2217,7 +2034,8 @@ void main() {
         mockScanner.supportsWatch = true;
       });
 
-      test('machine connect with preferred scale missing arms the watch '
+      test(
+          'machine connect with preferred scale missing arms the watch '
           'and never runs backoff bursts', () {
         fakeAsync((async) {
           final manager = buildWatchManager();
@@ -2226,29 +2044,19 @@ void main() {
           mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
           async.flushMicrotasks();
 
-          expect(
-            mockScanner.startWatchCallCount,
-            1,
-            reason: 'watch must arm on machine connect with scale missing',
-          );
-          expect(
-            mockScanner.lastWatchFilter?.namePrefix,
-            isNull,
-            reason:
-                'no OS name filter — remembered friendly names do not '
-                'match advertised names; Dart-side matching owns this',
-          );
+          expect(mockScanner.startWatchCallCount, 1,
+              reason: 'watch must arm on machine connect with scale missing');
+          expect(mockScanner.lastWatchFilter?.namePrefix, isNull,
+              reason: 'no OS name filter — remembered friendly names do not '
+                  'match advertised names; Dart-side matching owns this');
 
           // The load-bearing regression assertion: past the full legacy
           // backoff ladder (5→60s), no burst scan may fire — the watch
           // replaces the loop entirely.
           async.elapse(const Duration(seconds: 70));
           async.flushMicrotasks();
-          expect(
-            mockScanner.scanCallCount,
-            0,
-            reason: 'watch replaces the backoff-burst reconnect loop',
-          );
+          expect(mockScanner.scanCallCount, 0,
+              reason: 'watch replaces the backoff-burst reconnect loop');
 
           manager.dispose();
           async.flushMicrotasks();
@@ -2270,17 +2078,11 @@ void main() {
           mockScaleController.connectCalls.map((s) => s.deviceId),
           contains(scaleId),
         );
-        expect(
-          mockScanner.watchActive,
-          isFalse,
-          reason: 'watch stops once the scale is connected',
-        );
+        expect(mockScanner.watchActive, isFalse,
+            reason: 'watch stops once the scale is connected');
         expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
-        expect(
-          mockScanner.scanCallCount,
-          0,
-          reason: 'the connect must not go through a burst scan',
-        );
+        expect(mockScanner.scanCallCount, 0,
+            reason: 'the connect must not go through a burst scan');
       });
 
       test('failed watch connect re-arms the watch', () async {
@@ -2296,11 +2098,8 @@ void main() {
         await Future<void>.delayed(Duration.zero);
 
         expect(mockScaleController.connectCalls, isNotEmpty);
-        expect(
-          mockScanner.startWatchCallCount,
-          2,
-          reason: 'a failed connect must restart the watch',
-        );
+        expect(mockScanner.startWatchCallCount, 2,
+            reason: 'a failed connect must restart the watch');
         expect(mockScanner.watchActive, isTrue);
       });
 
@@ -2311,27 +2110,21 @@ void main() {
         mockScaleController.debugSetLastConnectedId(scaleId);
         mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
         await Future<void>.delayed(Duration.zero);
-        expect(
-          mockScanner.startWatchCallCount,
-          0,
-          reason: 'scale is connected — nothing to watch for',
-        );
+        expect(mockScanner.startWatchCallCount, 0,
+            reason: 'scale is connected — nothing to watch for');
 
-        mockScaleController.mockEmitConnectionState(
-          ConnectionState.disconnected,
-        );
+        mockScaleController
+            .mockEmitConnectionState(ConnectionState.disconnected);
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
 
         expect(mockScanner.startWatchCallCount, 1);
-        expect(
-          mockScanner.scanCallCount,
-          0,
-          reason: 'no burst scan on unexpected disconnect either',
-        );
+        expect(mockScanner.scanCallCount, 0,
+            reason: 'no burst scan on unexpected disconnect either');
       });
 
-      test('power-mode sleep stops the watch and wake re-arms it '
+      test(
+          'power-mode sleep stops the watch and wake re-arms it '
           'without a burst', () async {
         await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
         connectionManager = buildWatchManager();
@@ -2341,30 +2134,21 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         fakeDe1.emitState(MachineState.idle);
         await Future<void>.delayed(Duration.zero);
-        expect(
-          mockScanner.watchActive,
-          isTrue,
-          reason: 'machine awake + scale missing → watch armed',
-        );
+        expect(mockScanner.watchActive, isTrue,
+            reason: 'machine awake + scale missing → watch armed');
 
         fakeDe1.emitState(MachineState.sleeping);
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
-        expect(
-          mockScanner.watchActive,
-          isFalse,
-          reason: 'sleeping + ScalePowerMode.disconnect must stop the watch',
-        );
+        expect(mockScanner.watchActive, isFalse,
+            reason: 'sleeping + ScalePowerMode.disconnect must stop the watch');
 
         final startsBeforeWake = mockScanner.startWatchCallCount;
         fakeDe1.emitState(MachineState.idle);
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
-        expect(
-          mockScanner.startWatchCallCount,
-          startsBeforeWake + 1,
-          reason: 'wake must re-arm the watch',
-        );
+        expect(mockScanner.startWatchCallCount, startsBeforeWake + 1,
+            reason: 'wake must re-arm the watch');
         expect(mockScanner.scanCallCount, 0);
       });
 
@@ -2379,92 +2163,76 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
 
-        expect(
-          mockScanner.watchActive,
-          isFalse,
-          reason: 'no machine → nothing to reacquire a scale for',
-        );
+        expect(mockScanner.watchActive, isFalse,
+            reason: 'no machine → nothing to reacquire a scale for');
       });
 
       test(
-        'machine quick-connect arms the watch, not the legacy backoff loop',
-        () {
-          // Quick-connect is the common startup path when a preferred
-          // machine is remembered; its success branch must route scale
-          // reacquisition through the watch selector like every other
-          // machine-connected site — not schedule backoff bursts alongside
-          // the watch.
-          fakeAsync((async) {
-            mockSettingsService.setRememberedDevices(
-              RememberedDevice.encodeList([
-                const RememberedDevice(
-                  id: 'pref-de1',
-                  name: 'DE1',
-                  type: DeviceType.machine,
-                ),
-              ]),
-            );
-            final remembered = RememberedDevicesController(
-              machineConnections: const Stream.empty(),
-              scaleConnections: const Stream.empty(),
-              settings: mockSettingsService,
-            );
-            remembered.initialize();
-            async.flushMicrotasks();
+          'machine quick-connect arms the watch, not the legacy backoff loop',
+          () {
+        // Quick-connect is the common startup path when a preferred
+        // machine is remembered; its success branch must route scale
+        // reacquisition through the watch selector like every other
+        // machine-connected site — not schedule backoff bursts alongside
+        // the watch.
+        fakeAsync((async) {
+          mockSettingsService.setRememberedDevices(RememberedDevice.encodeList([
+            const RememberedDevice(
+              id: 'pref-de1',
+              name: 'DE1',
+              type: DeviceType.machine,
+            ),
+          ]));
+          final remembered = RememberedDevicesController(
+            machineConnections: const Stream.empty(),
+            scaleConnections: const Stream.empty(),
+            settings: mockSettingsService,
+          );
+          remembered.initialize();
+          async.flushMicrotasks();
 
-            final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
-            mockScanner.quickConnectResult = fakeDe1;
-            // Fresh controller: the group setUp disposed the shared one
-            // (closing its subjects), which would make adoptDevice throw.
-            final qcDe1Controller = MockDe1Controller(
-              controller: DeviceController([dummyDiscoveryService]),
-            );
-            final manager = ConnectionManager(
-              deviceScanner: mockScanner,
-              de1Controller: qcDe1Controller,
-              scaleController: mockScaleController,
-              settingsController: settingsController,
-              rememberedDevices: remembered,
-            );
-            settingsController.setPreferredMachineId('pref-de1');
-            settingsController.setPreferredScaleId(scaleId);
-            async.flushMicrotasks();
+          final fakeDe1 = _FakeDe1(deviceId: 'pref-de1');
+          mockScanner.quickConnectResult = fakeDe1;
+          // Fresh controller: the group setUp disposed the shared one
+          // (closing its subjects), which would make adoptDevice throw.
+          final qcDe1Controller = MockDe1Controller(
+            controller: DeviceController([dummyDiscoveryService]),
+          );
+          final manager = ConnectionManager(
+            deviceScanner: mockScanner,
+            de1Controller: qcDe1Controller,
+            scaleController: mockScaleController,
+            settingsController: settingsController,
+            rememberedDevices: remembered,
+          );
+          settingsController.setPreferredMachineId('pref-de1');
+          settingsController.setPreferredScaleId(scaleId);
+          async.flushMicrotasks();
 
-            manager.connect();
-            async.flushMicrotasks();
-            expect(
-              mockScanner.quickConnectCallCount,
-              1,
-              reason: 'the quick-connect path must be the one exercised',
-            );
+          manager.connect();
+          async.flushMicrotasks();
+          expect(mockScanner.quickConnectCallCount, 1,
+              reason: 'the quick-connect path must be the one exercised');
 
-            // Production: adoptDevice propagates onto the de1 stream and
-            // the supervisor fires machine-connected; simulate that here
-            // (MockDe1Controller overrides the stream adoptDevice feeds).
-            qcDe1Controller.de1Subject.add(fakeDe1);
-            async.flushMicrotasks();
+          // Production: adoptDevice propagates onto the de1 stream and
+          // the supervisor fires machine-connected; simulate that here
+          // (MockDe1Controller overrides the stream adoptDevice feeds).
+          qcDe1Controller.de1Subject.add(fakeDe1);
+          async.flushMicrotasks();
 
-            expect(
-              mockScanner.startWatchCallCount,
-              1,
-              reason: 'watch must arm after a quick-connected machine',
-            );
-            async.elapse(const Duration(seconds: 70));
-            async.flushMicrotasks();
-            expect(
-              mockScanner.scanCallCount,
-              0,
-              reason:
-                  'quick-connect success must not schedule legacy '
-                  'backoff bursts alongside the watch',
-            );
+          expect(mockScanner.startWatchCallCount, 1,
+              reason: 'watch must arm after a quick-connected machine');
+          async.elapse(const Duration(seconds: 70));
+          async.flushMicrotasks();
+          expect(mockScanner.scanCallCount, 0,
+              reason: 'quick-connect success must not schedule legacy '
+                  'backoff bursts alongside the watch');
 
-            manager.dispose();
-            remembered.dispose();
-            async.flushMicrotasks();
-          });
-        },
-      );
+          manager.dispose();
+          remembered.dispose();
+          async.flushMicrotasks();
+        });
+      });
 
       test('watch start failure falls back to the legacy backoff loop', () {
         fakeAsync((async) {
@@ -2475,19 +2243,13 @@ void main() {
           mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
           async.flushMicrotasks();
 
-          expect(
-            mockScanner.startWatchCallCount,
-            0,
-            reason: 'the start attempt threw before recording',
-          );
+          expect(mockScanner.startWatchCallCount, 0,
+              reason: 'the start attempt threw before recording');
           // Legacy backoff base delay is 5s — the fallback burst fires then.
           async.elapse(const Duration(seconds: 6));
           async.flushMicrotasks();
-          expect(
-            mockScanner.scanCallCount,
-            1,
-            reason: 'watch failure must fall back to backoff bursts',
-          );
+          expect(mockScanner.scanCallCount, 1,
+              reason: 'watch failure must fall back to backoff bursts');
 
           manager.dispose();
           async.flushMicrotasks();
@@ -2510,14 +2272,10 @@ void main() {
 
           async.elapse(const Duration(seconds: 6));
           async.flushMicrotasks();
-          expect(
-            mockScanner.scanCallCount,
-            1,
-            reason:
-                'the legacy backoff loop must take over when the '
-                'watch dies — scale reacquisition must never be '
-                'silently off',
-          );
+          expect(mockScanner.scanCallCount, 1,
+              reason: 'the legacy backoff loop must take over when the '
+                  'watch dies — scale reacquisition must never be '
+                  'silently off');
 
           manager.dispose();
           async.flushMicrotasks();

--- a/test/controllers/workflow_device_sync_test.dart
+++ b/test/controllers/workflow_device_sync_test.dart
@@ -12,8 +12,13 @@ import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/errors.dart';
 
+import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
 import '../helpers/fake_ble_transport.dart';
 import '../helpers/mock_device_discovery_service.dart';
+import '../helpers/mock_device_scanner.dart';
+import '../helpers/mock_scale_controller.dart';
+import '../helpers/mock_settings_service.dart';
 import '../helpers/test_de1.dart';
 
 Profile _profile(String title) => Profile(
@@ -122,6 +127,105 @@ class _FanFailsDe1 extends _RecordingDe1 {
   @override
   Future<void> setFanThreshhold(int temp) async {
     throw Exception('fan threshold write failed');
+  }
+}
+
+/// Blocks on setFanThreshhold until [releaseFanWrite] is completed.
+/// Logs every default-write call with [deviceId] into [operations].
+class _BlockingDefaultsDe1 extends TestDe1 {
+  _BlockingDefaultsDe1({super.deviceId});
+
+  final List<String> operations = [];
+  final Completer<void> fanWriteStarted = Completer<void>();
+  final Completer<void> releaseFanWrite = Completer<void>();
+  final List<Profile> setProfileCalls = [];
+
+  static final De1ShotSettings _defaultShotSettings = De1ShotSettings(
+    steamSetting: 0,
+    targetSteamTemp: 0,
+    targetSteamDuration: 0,
+    targetHotWaterTemp: 0,
+    targetHotWaterVolume: 0,
+    targetHotWaterDuration: 0,
+    targetShotVolume: 36,
+    groupTemp: 94.0,
+  );
+
+  @override
+  Future<void> setFanThreshhold(int temp) async {
+    operations.add('$deviceId:setFanThreshhold');
+    fanWriteStarted.complete();
+    await releaseFanWrite.future;
+  }
+
+  @override
+  Future<void> setSteamFlow(double value) async {
+    operations.add('$deviceId:setSteamFlow');
+  }
+
+  @override
+  Future<void> updateShotSettings(De1ShotSettings settings) async {
+    operations.add('$deviceId:updateShotSettings');
+  }
+
+  @override
+  Future<void> setHotWaterFlow(double value) async {
+    operations.add('$deviceId:setHotWaterFlow');
+  }
+
+  @override
+  Future<void> setFlushFlow(double value) async {
+    operations.add('$deviceId:setFlushFlow');
+  }
+
+  @override
+  Future<void> setFlushTimeout(double value) async {
+    operations.add('$deviceId:setFlushTimeout');
+  }
+
+  @override
+  Future<void> setFlushTemperature(double value) async {
+    operations.add('$deviceId:setFlushTemperature');
+  }
+
+  @override
+  Future<void> setProfile(Profile profile) async {
+    operations.add('$deviceId:setProfile:${profile.title}');
+    setProfileCalls.add(profile);
+  }
+
+  @override
+  Stream<De1ShotSettings> get shotSettings =>
+      Stream<De1ShotSettings>.value(_defaultShotSettings);
+
+  @override
+  Future<double> getSteamFlow() async {
+    operations.add('$deviceId:getSteamFlow');
+    return 0;
+  }
+
+  @override
+  Future<double> getHotWaterFlow() async {
+    operations.add('$deviceId:getHotWaterFlow');
+    return 0;
+  }
+
+  @override
+  Future<double> getFlushFlow() async {
+    operations.add('$deviceId:getFlushFlow');
+    return 0;
+  }
+
+  @override
+  Future<double> getFlushTimeout() async {
+    operations.add('$deviceId:getFlushTimeout');
+    return 0;
+  }
+
+  @override
+  Future<double> getFlushTemperature() async {
+    operations.add('$deviceId:getFlushTemperature');
+    return 0;
   }
 }
 
@@ -806,32 +910,306 @@ void main() {
       expect(de1.setProfileCalls.map((p) => p.title), ['Persisted']);
     });
 
-    test('init does not operate on replacement device', () async {
-      // Connect A, start init, disconnect A, connect B. A's init should
-      // not operate on B.
+    test('stale A init does not write to B after disconnect race', () async {
+      // Deterministic race: block A's setFanThreshhold with a completer,
+      // disconnect A while blocked, connect B, release A's blocked write,
+      // then verify A performed no operations on B's interfaces.
       final controller = await freshController();
       buildSync(controller);
-      final de1A = _RecordingDe1(deviceId: 'de1-A');
+      final de1A = _BlockingDefaultsDe1(deviceId: 'de1-A');
+
+      // Step 1: Connect A -- init starts, blocks at setFanThreshhold.
       await controller.connectToDe1(de1A);
-      // Don't settle A's init yet.
+      await de1A.fanWriteStarted.future;
+
+      // Step 2: Disconnect A while its write is blocked.
+      de1A.setConnectionState(ConnectionState.disconnected);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      // Step 3: Connect B and let its init complete.
+      final de1B = _RecordingDe1(deviceId: 'de1-B');
+      controller.defaultWorkflow = wf.currentWorkflow;
+      await controller.connectToDe1(de1B);
+      await settleInit(controller, de1B);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      // Step 4: Release A's blocked write.
+      de1A.releaseFanWrite.complete();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      // Step 5: Verify separation.
+      expect(
+        de1A.operations,
+        contains('de1-A:setFanThreshhold'),
+        reason: 'A must have started setFanThreshhold',
+      );
+      for (final op in de1A.operations) {
+        expect(
+          op.startsWith('de1-B:'),
+          isFalse,
+          reason: 'A must not perform any operation on B: $op',
+        );
+      }
+      expect(
+        de1B.setProfileCalls.map((p) => p.title),
+        ['Persisted'],
+        reason: 'B should receive the profile via initSettled',
+      );
+    });
+
+    test('stale init does not emit B\'s generation', () async {
+      final controller = await freshController();
+      final initGenerations = <int?>[];
+      controller.initSettled.listen(initGenerations.add);
+
+      final de1A = _BlockingDefaultsDe1(deviceId: 'de1-A');
+      await controller.connectToDe1(de1A);
+      await de1A.fanWriteStarted.future;
 
       de1A.setConnectionState(ConnectionState.disconnected);
       await Future<void>.delayed(const Duration(milliseconds: 10));
 
       final de1B = _RecordingDe1(deviceId: 'de1-B');
+      controller.defaultWorkflow = wf.currentWorkflow;
       await controller.connectToDe1(de1B);
       await settleInit(controller, de1B);
       await Future<void>.delayed(const Duration(milliseconds: 10));
 
       expect(
-        de1A.setProfileCalls,
-        isEmpty,
-        reason: 'A should not receive any profile push',
+        initGenerations.where((g) => g != null).length,
+        1,
+        reason:
+            'B should be the only init that emits a generation '
+            '(A\'s stale init must not emit)',
       );
+
+      de1A.releaseFanWrite.complete();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
       expect(
-        de1B.setProfileCalls.map((p) => p.title),
-        ['Persisted'],
-        reason: 'B should receive the profile via initSettled',
+        initGenerations.where((g) => g != null).length,
+        1,
+        reason:
+            'A\'s stale init must not emit initSettled '
+            'after releasing the block',
+      );
+    });
+
+    test('stale init does not cause extra B profile push', () async {
+      final controller = await freshController();
+      buildSync(controller);
+
+      final de1A = _BlockingDefaultsDe1(deviceId: 'de1-A');
+      await controller.connectToDe1(de1A);
+      await de1A.fanWriteStarted.future;
+
+      de1A.setConnectionState(ConnectionState.disconnected);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final de1B = _RecordingDe1(deviceId: 'de1-B');
+      controller.defaultWorkflow = wf.currentWorkflow;
+      await controller.connectToDe1(de1B);
+      await settleInit(controller, de1B);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(
+        de1B.setProfileCalls.length,
+        1,
+        reason: 'B should receive exactly one on-connect profile push',
+      );
+    });
+  });
+
+  group('WorkflowDeviceSync integration with ConnectionManager', () {
+    late ConnectionManager connectionManager;
+    late MockDeviceScanner mockScanner;
+    late MockScaleController mockScaleController;
+    late MockSettingsService mockSettingsService;
+    late SettingsController settingsController;
+    late WorkflowController wf;
+    late De1Controller de1Controller;
+    WorkflowDeviceSync? activeSync;
+
+    setUp(() async {
+      wf = WorkflowController();
+      wf.setWorkflow(
+        wf.currentWorkflow.copyWith(profile: _profile('Persisted')),
+      );
+      mockScanner = MockDeviceScanner();
+      mockScaleController = MockScaleController();
+      mockSettingsService = MockSettingsService();
+      settingsController = SettingsController(mockSettingsService);
+      await settingsController.loadSettings();
+
+      final dc = DeviceController([MockDeviceDiscoveryService()]);
+      await dc.initialize();
+      de1Controller = De1Controller(controller: dc);
+      de1Controller.defaultWorkflow = wf.currentWorkflow;
+
+      connectionManager = ConnectionManager(
+        deviceScanner: mockScanner,
+        de1Controller: de1Controller,
+        scaleController: mockScaleController,
+        settingsController: settingsController,
+      );
+    });
+
+    tearDown(() async {
+      activeSync?.dispose();
+      connectionManager.dispose();
+      mockScanner.dispose();
+    });
+
+    test(
+      'wired path: WorkflowDeviceSync -> reportError -> status.error',
+      () async {
+        final de1 = _FlakyDe1(failures: 100);
+
+        activeSync = WorkflowDeviceSync(
+          workflowController: wf,
+          de1Controller: de1Controller,
+          retryDelays: const [Duration(milliseconds: 20)],
+          onUploadError: (err) => connectionManager.reportError(err),
+          onUploadErrorCleared: () => connectionManager.clearErrorOfKind(
+            ConnectionErrorKind.profileUploadFailed,
+          ),
+        );
+
+        await de1Controller.connectToDe1(de1);
+        await settleInit(de1Controller, de1);
+        await Future<void>.delayed(const Duration(milliseconds: 15));
+
+        expect(
+          connectionManager.currentStatus.error?.kind,
+          ConnectionErrorKind.profileUploadFailed,
+          reason:
+              'profile upload failure must surface on ConnectionManager.status',
+        );
+
+        expect(
+          de1.totalCalls,
+          greaterThanOrEqualTo(1),
+          reason: 'retries must have been attempted',
+        );
+      },
+    );
+
+    test('clearErrorOfKind is kind-specific', () async {
+      final de1 = _FlakyDe1(failures: 100);
+
+      activeSync = WorkflowDeviceSync(
+        workflowController: wf,
+        de1Controller: de1Controller,
+        retryDelays: const [Duration(milliseconds: 20)],
+        onUploadError: (err) => connectionManager.reportError(err),
+        onUploadErrorCleared: () => connectionManager.clearErrorOfKind(
+          ConnectionErrorKind.profileUploadFailed,
+        ),
+      );
+
+      await de1Controller.connectToDe1(de1);
+      await settleInit(de1Controller, de1);
+      await Future<void>.delayed(const Duration(milliseconds: 15));
+
+      connectionManager.debugEmitError(
+        kind: ConnectionErrorKind.machineConnectFailed,
+        severity: 'error',
+        message: 'machine failed',
+      );
+
+      expect(
+        connectionManager.currentStatus.error?.kind,
+        ConnectionErrorKind.machineConnectFailed,
+        reason: 'new error must replace profileUploadFailed',
+      );
+
+      connectionManager.clearErrorOfKind(
+        ConnectionErrorKind.profileUploadFailed,
+      );
+
+      expect(
+        connectionManager.currentStatus.error?.kind,
+        ConnectionErrorKind.machineConnectFailed,
+        reason:
+            'clearErrorOfKind for profileUploadFailed must not clear '
+            'the unrelated machineConnectFailed',
+      );
+    });
+
+    test('clearErrorOfKind clears when still current', () async {
+      final de1 = _FlakyDe1(failures: 100);
+
+      activeSync = WorkflowDeviceSync(
+        workflowController: wf,
+        de1Controller: de1Controller,
+        retryDelays: const [Duration(milliseconds: 20)],
+        onUploadError: (err) => connectionManager.reportError(err),
+        onUploadErrorCleared: () => connectionManager.clearErrorOfKind(
+          ConnectionErrorKind.profileUploadFailed,
+        ),
+      );
+
+      await de1Controller.connectToDe1(de1);
+      await settleInit(de1Controller, de1);
+      await Future<void>.delayed(const Duration(milliseconds: 15));
+
+      expect(
+        connectionManager.currentStatus.error?.kind,
+        ConnectionErrorKind.profileUploadFailed,
+      );
+
+      connectionManager.clearErrorOfKind(
+        ConnectionErrorKind.profileUploadFailed,
+      );
+
+      expect(
+        connectionManager.currentStatus.error,
+        isNull,
+        reason: 'clearErrorOfKind must clear matching error',
+      );
+    });
+
+    test('phasePersistent survives debug phase transitions', () async {
+      final de1 = _FlakyDe1(failures: 100);
+
+      activeSync = WorkflowDeviceSync(
+        workflowController: wf,
+        de1Controller: de1Controller,
+        retryDelays: const [Duration(milliseconds: 20)],
+        onUploadError: (err) => connectionManager.reportError(err),
+        onUploadErrorCleared: () => connectionManager.clearErrorOfKind(
+          ConnectionErrorKind.profileUploadFailed,
+        ),
+      );
+
+      await de1Controller.connectToDe1(de1);
+      await settleInit(de1Controller, de1);
+      await Future<void>.delayed(const Duration(milliseconds: 15));
+
+      expect(
+        connectionManager.currentStatus.error?.kind,
+        ConnectionErrorKind.profileUploadFailed,
+      );
+
+      connectionManager.debugSetPhase(ConnectionPhase.scanning);
+      expect(
+        connectionManager.currentStatus.error?.kind,
+        ConnectionErrorKind.profileUploadFailed,
+        reason: 'phasePersistent error must survive scanning',
+      );
+
+      connectionManager.debugSetPhase(ConnectionPhase.connectingMachine);
+      expect(
+        connectionManager.currentStatus.error?.kind,
+        ConnectionErrorKind.profileUploadFailed,
+        reason: 'phasePersistent error must survive connectingMachine',
+      );
+
+      connectionManager.debugSetPhase(ConnectionPhase.ready);
+      expect(
+        connectionManager.currentStatus.error?.kind,
+        ConnectionErrorKind.profileUploadFailed,
+        reason: 'phasePersistent error must survive ready',
       );
     });
   });

--- a/test/controllers/workflow_device_sync_test.dart
+++ b/test/controllers/workflow_device_sync_test.dart
@@ -8,6 +8,7 @@ import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/controllers/workflow_device_sync.dart';
 import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/errors.dart';
@@ -910,46 +911,47 @@ void main() {
       expect(de1.setProfileCalls.map((p) => p.title), ['Persisted']);
     });
 
-    test('stale A init does not write to B after disconnect race', () async {
-      // Deterministic race: block A's setFanThreshhold with a completer,
-      // disconnect A while blocked, connect B, release A's blocked write,
-      // then verify A performed no operations on B's interfaces.
+    test('stale A init does not mutate B-facing state', () async {
       final controller = await freshController();
       buildSync(controller);
-      final de1A = _BlockingDefaultsDe1(deviceId: 'de1-A');
+      final steamEvents = <SteamSettings>[];
+      final hotWaterEvents = <HotWaterData>[];
+      final rinseEvents = <RinseData>[];
+      final steamSub = controller.steamData.listen(steamEvents.add);
+      final hotWaterSub = controller.hotWaterData.listen(hotWaterEvents.add);
+      final rinseSub = controller.rinseData.listen(rinseEvents.add);
+      addTearDown(steamSub.cancel);
+      addTearDown(hotWaterSub.cancel);
+      addTearDown(rinseSub.cancel);
 
-      // Step 1: Connect A -- init starts, blocks at setFanThreshhold.
+      final de1A = _BlockingDefaultsDe1(deviceId: 'de1-A');
       await controller.connectToDe1(de1A);
       await de1A.fanWriteStarted.future;
 
-      // Step 2: Disconnect A while its write is blocked.
       de1A.setConnectionState(ConnectionState.disconnected);
       await Future<void>.delayed(const Duration(milliseconds: 10));
 
-      // Step 3: Connect B and let its init complete.
-      final de1B = _RecordingDe1(deviceId: 'de1-B');
       controller.defaultWorkflow = wf.currentWorkflow;
+      final de1B = _BlockingDefaultsDe1(deviceId: 'de1-B');
       await controller.connectToDe1(de1B);
-      await settleInit(controller, de1B);
+      await de1B.fanWriteStarted.future;
+      final bGeneration = controller.connectionGeneration;
+      de1B.releaseFanWrite.complete();
+      await controller.initSettled.firstWhere((value) => value == bGeneration);
       await Future<void>.delayed(const Duration(milliseconds: 10));
 
-      // Step 4: Release A's blocked write.
+      final bOperationsAfterInit = List<String>.of(de1B.operations);
+      final steamEventCountAfterBInit = steamEvents.length;
+      final hotWaterEventCountAfterBInit = hotWaterEvents.length;
+      final rinseEventCountAfterBInit = rinseEvents.length;
+
       de1A.releaseFanWrite.complete();
       await Future<void>.delayed(const Duration(milliseconds: 10));
 
-      // Step 5: Verify separation.
-      expect(
-        de1A.operations,
-        contains('de1-A:setFanThreshhold'),
-        reason: 'A must have started setFanThreshhold',
-      );
-      for (final op in de1A.operations) {
-        expect(
-          op.startsWith('de1-B:'),
-          isFalse,
-          reason: 'A must not perform any operation on B: $op',
-        );
-      }
+      expect(de1B.operations, bOperationsAfterInit);
+      expect(steamEvents, hasLength(steamEventCountAfterBInit));
+      expect(hotWaterEvents, hasLength(hotWaterEventCountAfterBInit));
+      expect(rinseEvents, hasLength(rinseEventCountAfterBInit));
       expect(
         de1B.setProfileCalls.map((p) => p.title),
         ['Persisted'],
@@ -1016,6 +1018,15 @@ void main() {
         de1B.setProfileCalls.length,
         1,
         reason: 'B should receive exactly one on-connect profile push',
+      );
+
+      de1A.releaseFanWrite.complete();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(
+        de1B.setProfileCalls.length,
+        1,
+        reason: 'A resuming must not trigger another B profile push',
       );
     });
   });

--- a/test/controllers/workflow_device_sync_test.dart
+++ b/test/controllers/workflow_device_sync_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection_error.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
@@ -137,6 +138,11 @@ void main() {
       workflowController: workflow,
       de1Controller: de1Controller,
     );
+    // The DE1 stream replays the already-connected machine, so the sync's
+    // on-connect push fires immediately. Let it land and discard
+    // it — the tests below assert only their own pushes.
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    de1.setProfileCalls.clear();
   });
 
   tearDown(() {
@@ -195,7 +201,7 @@ void main() {
       final dc = DeviceController([MockDeviceDiscoveryService()]);
       await dc.initialize();
       final controller = De1Controller(controller: dc);
-      final flaky = _FlakyDe1(failures: 1);
+      final flaky = _FlakyDe1(failures: 0);
       await controller.connectToDe1(flaky);
       flaky.emitShotSettings(De1ShotSettings(
         steamSetting: 0,
@@ -213,6 +219,10 @@ void main() {
         de1Controller: controller,
         retryDelays: const [Duration(milliseconds: 20)],
       );
+      // Let the on-connect push land, then arm the failure for the test.
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      flaky.setProfileCalls.clear();
+      flaky.failures = 1;
 
       // First push of the cleaning profile fails (timeout) — nothing recorded,
       // and the profile is NOT marked pushed.
@@ -289,6 +299,17 @@ void main() {
       return s;
     }
 
+    /// Lands + discards the sync's on-connect push (the DE1 stream replays
+    /// the already-connected machine) so tests assert only their
+    /// own pushes. Pass [gated] to release its held upload.
+    Future<void> settleConnectPush({_GatedDe1? gated}) async {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      if (gated != null) {
+        gated.completeNext();
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+    }
+
     void applyProfile(String title) {
       wf.setWorkflow(wf.currentWorkflow.copyWith(profile: _profile(title)));
     }
@@ -307,6 +328,8 @@ void main() {
       final gated = _GatedDe1();
       final controller = await connect(gated);
       buildSync(controller);
+      await settleConnectPush(gated: gated);
+      gated.setProfileCalls.clear();
 
       applyProfile('A');
       await Future<void>.delayed(const Duration(milliseconds: 10));
@@ -335,9 +358,12 @@ void main() {
 
     test('a failed upload is retried automatically, no workflow change needed',
         () async {
-      final flaky = _FlakyDe1(failures: 1);
+      final flaky = _FlakyDe1(failures: 0);
       final controller = await connect(flaky);
       buildSync(controller);
+      await settleConnectPush();
+      flaky.setProfileCalls.clear();
+      flaky.failures = 1;
 
       applyProfile('Cleaning');
       await Future<void>.delayed(const Duration(milliseconds: 10));
@@ -351,9 +377,12 @@ void main() {
     });
 
     test('a pending retry pushes the latest desired profile', () async {
-      final flaky = _FlakyDe1(failures: 1);
+      final flaky = _FlakyDe1(failures: 0);
       final controller = await connect(flaky);
       buildSync(controller);
+      await settleConnectPush();
+      flaky.setProfileCalls.clear();
+      flaky.failures = 1;
 
       applyProfile('A'); // fails, retry armed for +20ms
       await Future<void>.delayed(const Duration(milliseconds: 5));
@@ -365,9 +394,13 @@ void main() {
     });
 
     test('backoff walks the delay list until the upload lands', () async {
-      final flaky = _FlakyDe1(failures: 2);
+      final flaky = _FlakyDe1(failures: 0);
       final controller = await connect(flaky);
       buildSync(controller);
+      await settleConnectPush();
+      flaky.setProfileCalls.clear();
+      flaky.totalCalls = 0;
+      flaky.failures = 2;
 
       applyProfile('Stubborn');
       // Attempt 1 at ~0ms fails, retry at +20ms fails, retry at +20+40ms lands.
@@ -381,9 +414,12 @@ void main() {
     });
 
     test('machine disconnect cancels a pending retry', () async {
-      final flaky = _FlakyDe1(failures: 100);
+      final flaky = _FlakyDe1(failures: 0);
       final controller = await connect(flaky);
       buildSync(controller);
+      await settleConnectPush();
+      flaky.totalCalls = 0;
+      flaky.failures = 100;
 
       applyProfile('Doomed');
       await Future<void>.delayed(const Duration(milliseconds: 5));
@@ -399,6 +435,9 @@ void main() {
       final gone = _NotConnectedDe1();
       final controller = await connect(gone);
       buildSync(controller);
+      // The on-connect push hits the same exception and is skipped.
+      await settleConnectPush();
+      gone.totalCalls = 0;
 
       applyProfile('Unreachable');
       await Future<void>.delayed(const Duration(milliseconds: 150));
@@ -407,9 +446,12 @@ void main() {
     });
 
     test('dispose cancels a pending retry', () async {
-      final flaky = _FlakyDe1(failures: 100);
+      final flaky = _FlakyDe1(failures: 0);
       final controller = await connect(flaky);
       final s = buildSync(controller);
+      await settleConnectPush();
+      flaky.totalCalls = 0;
+      flaky.failures = 100;
 
       applyProfile('Doomed');
       await Future<void>.delayed(const Duration(milliseconds: 5));
@@ -426,6 +468,8 @@ void main() {
       final gated = _GatedDe1();
       final controller = await connect(gated);
       buildSync(controller);
+      await settleConnectPush(gated: gated);
+      gated.setProfileCalls.clear();
 
       applyProfile('P1');
       await Future<void>.delayed(const Duration(milliseconds: 10));
@@ -451,9 +495,12 @@ void main() {
     test(
         'a workflow change with the same profile leaves a pending retry\'s '
         'backoff undisturbed', () async {
-      final flaky = _FlakyDe1(failures: 100);
+      final flaky = _FlakyDe1(failures: 0);
       final controller = await connect(flaky);
       buildSync(controller);
+      await settleConnectPush();
+      flaky.totalCalls = 0;
+      flaky.failures = 100;
 
       applyProfile('Same'); // attempt 1 fails, retry armed for +20ms
       await Future<void>.delayed(const Duration(milliseconds: 5));
@@ -475,10 +522,13 @@ void main() {
     test(
         'failed upload invalidates last-pushed — reverting to the previous '
         'profile re-uploads instead of short-circuiting', () async {
-      // Call 1 (profile P1) succeeds, call 2 (P2) fails mid-upload.
-      final de1 = _FailNthDe1({2});
+      // Call 1 is the on-connect push; call 2 (profile P1) succeeds,
+      // call 3 (P2) fails mid-upload.
+      final de1 = _FailNthDe1({3});
       final controller = await connect(de1);
       buildSync(controller);
+      await settleConnectPush();
+      de1.setProfileCalls.clear();
 
       applyProfile('P1');
       await Future<void>.delayed(const Duration(milliseconds: 10));
@@ -494,5 +544,161 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 100));
       expect(de1.setProfileCalls.map((p) => p.title), ['P1', 'P1']);
     });
+  });
+
+  // On-connect profile push: the firmware latches
+  // ProfileDownloadInProgress when an upload dies after the header write
+  // (magenta GH-LED ~2 Hz pulse, start requests silently ignored) and only
+  // a complete re-upload clears it. The old single-shot defaults push
+  // swallowed its failure, and the optimistic last-pushed caches blocked
+  // every same-profile repair. The sync now owns the (re)connect push.
+  group('on-connect profile push', () {
+    late WorkflowController wf;
+    WorkflowDeviceSync? activeSync;
+
+    setUp(() {
+      wf = WorkflowController();
+      wf.setWorkflow(
+        wf.currentWorkflow.copyWith(profile: _profile('Persisted')),
+      );
+      activeSync = null;
+    });
+
+    tearDown(() {
+      activeSync?.dispose();
+    });
+
+    Future<De1Controller> freshController() async {
+      final dc = DeviceController([MockDeviceDiscoveryService()]);
+      await dc.initialize();
+      return De1Controller(controller: dc);
+    }
+
+    WorkflowDeviceSync buildSync(
+      De1Controller controller, {
+      void Function(ConnectionError)? onUploadError,
+      void Function()? onUploadRecovered,
+    }) {
+      final s = WorkflowDeviceSync(
+        workflowController: wf,
+        de1Controller: controller,
+        retryDelays: const [Duration(milliseconds: 20)],
+        onUploadError: onUploadError,
+        onUploadRecovered: onUploadRecovered,
+      );
+      activeSync = s;
+      return s;
+    }
+
+    test('connecting a machine pushes the current workflow profile',
+        () async {
+      final controller = await freshController();
+      buildSync(controller);
+      final de1 = _RecordingDe1();
+
+      await controller.connectToDe1(de1);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(de1.setProfileCalls.map((p) => p.title), ['Persisted']);
+    });
+
+    test(
+      'a machine already connected at construction still gets the profile — '
+      'no optimistic constructor seed',
+      () async {
+        // The regression scenario: the persisted workflow profile
+        // equals the one the constructor seed used to assume was on the
+        // device, so the skin's same-profile PUTs uploaded nothing and the
+        // firmware latch persisted.
+        final controller = await freshController();
+        final de1 = _RecordingDe1();
+        await controller.connectToDe1(de1);
+
+        buildSync(controller);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        expect(de1.setProfileCalls.map((p) => p.title), ['Persisted'],
+            reason: 'device state must never be assumed from persistence');
+      },
+    );
+
+    test(
+      'reconnect re-pushes the same profile — last-pushed is cleared on the '
+      'connection edge',
+      () async {
+        final controller = await freshController();
+        buildSync(controller);
+        final de1 = _RecordingDe1();
+        await controller.connectToDe1(de1);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(de1.setProfileCalls.length, 1);
+
+        de1.setConnectionState(ConnectionState.disconnected);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        de1.setConnectionState(ConnectionState.connected);
+        await controller.connectToDe1(de1);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        expect(
+          de1.setProfileCalls.map((p) => p.title),
+          ['Persisted', 'Persisted'],
+          reason: 'an upload interrupted by the disconnect may have latched '
+              'the firmware; only a full re-upload clears it',
+        );
+      },
+    );
+
+    test(
+      'a failed on-connect push retries with backoff until it lands — '
+      'no workflow change needed',
+      () async {
+        final controller = await freshController();
+        buildSync(controller);
+        final flaky = _FlakyDe1(failures: 1);
+
+        await controller.connectToDe1(flaky);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(flaky.setProfileCalls, isEmpty,
+            reason: 'first attempt failed; retry not due yet');
+
+        await Future<void>.delayed(const Duration(milliseconds: 40));
+        expect(flaky.setProfileCalls.map((p) => p.title), ['Persisted'],
+            reason: 'the on-connect push must retry on its own — the old '
+                'defaults path swallowed the failure and left the machine '
+                'wedged');
+      },
+    );
+
+    test(
+      'upload failure surfaces once via onUploadError and retracts via '
+      'onUploadRecovered when a retry lands',
+      () async {
+        final errors = <ConnectionError>[];
+        var recovered = 0;
+        final controller = await freshController();
+        buildSync(
+          controller,
+          onUploadError: errors.add,
+          onUploadRecovered: () => recovered++,
+        );
+        final flaky = _FlakyDe1(failures: 2);
+
+        await controller.connectToDe1(flaky);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(errors.length, 1);
+        expect(errors.single.kind, ConnectionErrorKind.profileUploadFailed);
+        expect(errors.single.severity, ConnectionErrorSeverity.warning);
+        expect(recovered, 0);
+
+        // Retry 1 (+20 ms) fails again — no duplicate surfacing.
+        await Future<void>.delayed(const Duration(milliseconds: 25));
+        expect(errors.length, 1);
+
+        // Retry 2 lands — the surfaced error is retracted.
+        await Future<void>.delayed(const Duration(milliseconds: 40));
+        expect(flaky.setProfileCalls.map((p) => p.title), ['Persisted']);
+        expect(recovered, 1);
+      },
+    );
   });
 }

--- a/test/controllers/workflow_device_sync_test.dart
+++ b/test/controllers/workflow_device_sync_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/connection_error.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
@@ -11,21 +12,23 @@ import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/errors.dart';
 
+import '../helpers/fake_ble_transport.dart';
 import '../helpers/mock_device_discovery_service.dart';
 import '../helpers/test_de1.dart';
 
 Profile _profile(String title) => Profile(
-      version: '2',
-      title: title,
-      notes: '',
-      author: 'test',
-      beverageType: BeverageType.espresso,
-      steps: const [],
-      targetVolumeCountStart: 0,
-      tankTemperature: 0,
-    );
+  version: '2',
+  title: title,
+  notes: '',
+  author: 'test',
+  beverageType: BeverageType.espresso,
+  steps: const [],
+  targetVolumeCountStart: 0,
+  tankTemperature: 0,
+);
 
 class _RecordingDe1 extends TestDe1 {
+  _RecordingDe1({super.deviceId});
   final List<Profile> setProfileCalls = [];
 
   @override
@@ -97,6 +100,31 @@ class _FailNthDe1 extends TestDe1 {
   }
 }
 
+/// Completes when init settles (shot settings emitted and defaults written).
+Future<void> settleInit(De1Controller controller, TestDe1 de1) async {
+  de1.emitShotSettings(
+    De1ShotSettings(
+      steamSetting: 0,
+      targetSteamTemp: 150,
+      targetSteamDuration: 30,
+      targetHotWaterTemp: 75,
+      targetHotWaterVolume: 50,
+      targetHotWaterDuration: 30,
+      targetShotVolume: 36,
+      groupTemp: 94.0,
+    ),
+  );
+  await Future<void>.delayed(const Duration(milliseconds: 10));
+}
+
+/// Fails on setFanThreshhold to test default-failure recovery.
+class _FanFailsDe1 extends _RecordingDe1 {
+  @override
+  Future<void> setFanThreshhold(int temp) async {
+    throw Exception('fan threshold write failed');
+  }
+}
+
 /// Always reports the machine as gone.
 class _NotConnectedDe1 extends TestDe1 {
   int totalCalls = 0;
@@ -122,25 +150,14 @@ void main() {
     de1Controller = De1Controller(controller: deviceController);
     de1 = _RecordingDe1();
     await de1Controller.connectToDe1(de1);
-    // Unblock De1Controller._initializeData which awaits shotSettings.first.
-    de1.emitShotSettings(De1ShotSettings(
-      steamSetting: 0,
-      targetSteamTemp: 150,
-      targetSteamDuration: 30,
-      targetHotWaterTemp: 75,
-      targetHotWaterVolume: 50,
-      targetHotWaterDuration: 30,
-      targetShotVolume: 36,
-      groupTemp: 94.0,
-    ));
-    await Future<void>.delayed(const Duration(milliseconds: 150));
+    await settleInit(de1Controller, de1);
     sync = WorkflowDeviceSync(
       workflowController: workflow,
       de1Controller: de1Controller,
     );
-    // The DE1 stream replays the already-connected machine, so the sync's
-    // on-connect push fires immediately. Let it land and discard
-    // it — the tests below assert only their own pushes.
+    // The initSettled stream replays the already-settled generation, so
+    // the sync's on-connect push fires immediately. Let it land and
+    // discard it.
     await Future<void>.delayed(const Duration(milliseconds: 10));
     de1.setProfileCalls.clear();
   });
@@ -203,17 +220,7 @@ void main() {
       final controller = De1Controller(controller: dc);
       final flaky = _FlakyDe1(failures: 0);
       await controller.connectToDe1(flaky);
-      flaky.emitShotSettings(De1ShotSettings(
-        steamSetting: 0,
-        targetSteamTemp: 150,
-        targetSteamDuration: 30,
-        targetHotWaterTemp: 75,
-        targetHotWaterVolume: 50,
-        targetHotWaterDuration: 30,
-        targetShotVolume: 36,
-        groupTemp: 94.0,
-      ));
-      await Future<void>.delayed(const Duration(milliseconds: 150));
+      await settleInit(controller, flaky);
       final flakySync = WorkflowDeviceSync(
         workflowController: wf,
         de1Controller: controller,
@@ -226,14 +233,18 @@ void main() {
 
       // First push of the cleaning profile fails (timeout) — nothing recorded,
       // and the profile is NOT marked pushed.
-      wf.setWorkflow(wf.currentWorkflow.copyWith(profile: _profile('Cleaning')));
+      wf.setWorkflow(
+        wf.currentWorkflow.copyWith(profile: _profile('Cleaning')),
+      );
       await Future<void>.delayed(const Duration(milliseconds: 10));
       expect(flaky.setProfileCalls, isEmpty);
 
       // Re-applying the SAME profile leaves the armed retry undisturbed; the
       // profile must land when it fires (it was never marked pushed, so it
       // cannot be skipped by the equality guard).
-      wf.setWorkflow(wf.currentWorkflow.copyWith(profile: _profile('Cleaning')));
+      wf.setWorkflow(
+        wf.currentWorkflow.copyWith(profile: _profile('Cleaning')),
+      );
       await Future<void>.delayed(const Duration(milliseconds: 60));
       expect(flaky.setProfileCalls.length, equals(1));
       expect(flaky.setProfileCalls.single.title, equals('Cleaning'));
@@ -248,7 +259,9 @@ void main() {
       final initial = workflow.currentWorkflow;
       sync.dispose();
 
-      workflow.setWorkflow(initial.copyWith(profile: _profile('After dispose')));
+      workflow.setWorkflow(
+        initial.copyWith(profile: _profile('After dispose')),
+      );
       await Future<void>.delayed(const Duration(milliseconds: 10));
 
       expect(de1.setProfileCalls, isEmpty);
@@ -275,17 +288,7 @@ void main() {
       await dc.initialize();
       final controller = De1Controller(controller: dc);
       await controller.connectToDe1(testDe1);
-      testDe1.emitShotSettings(De1ShotSettings(
-        steamSetting: 0,
-        targetSteamTemp: 150,
-        targetSteamDuration: 30,
-        targetHotWaterTemp: 75,
-        targetHotWaterVolume: 50,
-        targetHotWaterDuration: 30,
-        targetShotVolume: 36,
-        groupTemp: 94.0,
-      ));
-      await Future<void>.delayed(const Duration(milliseconds: 150));
+      await settleInit(controller, testDe1);
       return controller;
     }
 
@@ -323,58 +326,80 @@ void main() {
       activeSync?.dispose();
     });
 
-    test('uploads never overlap and intermediate profiles are skipped',
-        () async {
-      final gated = _GatedDe1();
-      final controller = await connect(gated);
-      buildSync(controller);
-      await settleConnectPush(gated: gated);
-      gated.setProfileCalls.clear();
+    test(
+      'uploads never overlap and intermediate profiles are skipped',
+      () async {
+        final gated = _GatedDe1();
+        final controller = await connect(gated);
+        buildSync(controller);
+        await settleConnectPush(gated: gated);
+        gated.setProfileCalls.clear();
 
-      applyProfile('A');
-      await Future<void>.delayed(const Duration(milliseconds: 10));
-      expect(gated.setProfileCalls.map((p) => p.title), ['A'],
-          reason: 'first change starts an upload immediately');
+        applyProfile('A');
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(
+          gated.setProfileCalls.map((p) => p.title),
+          ['A'],
+          reason: 'first change starts an upload immediately',
+        );
 
-      // Two more changes while upload A is still in flight.
-      applyProfile('B');
-      applyProfile('C');
-      await Future<void>.delayed(const Duration(milliseconds: 10));
-      expect(gated.setProfileCalls.length, 1,
-          reason: 'no second upload may start while A is in flight');
+        // Two more changes while upload A is still in flight.
+        applyProfile('B');
+        applyProfile('C');
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(
+          gated.setProfileCalls.length,
+          1,
+          reason: 'no second upload may start while A is in flight',
+        );
 
-      gated.completeNext(); // A lands
-      await Future<void>.delayed(const Duration(milliseconds: 10));
-      expect(gated.setProfileCalls.map((p) => p.title), ['A', 'C'],
-          reason: 'B was superseded by C before its upload started');
+        gated.completeNext(); // A lands
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(
+          gated.setProfileCalls.map((p) => p.title),
+          ['A', 'C'],
+          reason: 'B was superseded by C before its upload started',
+        );
 
-      gated.completeNext(); // C lands
-      await Future<void>.delayed(const Duration(milliseconds: 10));
+        gated.completeNext(); // C lands
+        await Future<void>.delayed(const Duration(milliseconds: 10));
 
-      expect(gated.maxInFlight, 1,
-          reason: 'profile uploads must be strictly serialized');
-      expect(gated.pendingUploads, 0);
-    });
+        expect(
+          gated.maxInFlight,
+          1,
+          reason: 'profile uploads must be strictly serialized',
+        );
+        expect(gated.pendingUploads, 0);
+      },
+    );
 
-    test('a failed upload is retried automatically, no workflow change needed',
-        () async {
-      final flaky = _FlakyDe1(failures: 0);
-      final controller = await connect(flaky);
-      buildSync(controller);
-      await settleConnectPush();
-      flaky.setProfileCalls.clear();
-      flaky.failures = 1;
+    test(
+      'a failed upload is retried automatically, no workflow change needed',
+      () async {
+        final flaky = _FlakyDe1(failures: 0);
+        final controller = await connect(flaky);
+        buildSync(controller);
+        await settleConnectPush();
+        flaky.setProfileCalls.clear();
+        flaky.failures = 1;
 
-      applyProfile('Cleaning');
-      await Future<void>.delayed(const Duration(milliseconds: 10));
-      expect(flaky.setProfileCalls, isEmpty,
-          reason: 'first attempt fails; retry not due yet');
+        applyProfile('Cleaning');
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(
+          flaky.setProfileCalls,
+          isEmpty,
+          reason: 'first attempt fails; retry not due yet',
+        );
 
-      // First retry is due after retryDelays[0] (20ms).
-      await Future<void>.delayed(const Duration(milliseconds: 40));
-      expect(flaky.setProfileCalls.map((p) => p.title), ['Cleaning'],
-          reason: 'retry must fire without any further workflow change');
-    });
+        // First retry is due after retryDelays[0] (20ms).
+        await Future<void>.delayed(const Duration(milliseconds: 40));
+        expect(
+          flaky.setProfileCalls.map((p) => p.title),
+          ['Cleaning'],
+          reason: 'retry must fire without any further workflow change',
+        );
+      },
+    );
 
     test('a pending retry pushes the latest desired profile', () async {
       final flaky = _FlakyDe1(failures: 0);
@@ -389,8 +414,11 @@ void main() {
       applyProfile('B'); // supersedes A before the retry fires
 
       await Future<void>.delayed(const Duration(milliseconds: 100));
-      expect(flaky.setProfileCalls.map((p) => p.title), ['B'],
-          reason: 'superseded profile A must never be uploaded');
+      expect(
+        flaky.setProfileCalls.map((p) => p.title),
+        ['B'],
+        reason: 'superseded profile A must never be uploaded',
+      );
     });
 
     test('backoff walks the delay list until the upload lands', () async {
@@ -405,8 +433,11 @@ void main() {
       applyProfile('Stubborn');
       // Attempt 1 at ~0ms fails, retry at +20ms fails, retry at +20+40ms lands.
       await Future<void>.delayed(const Duration(milliseconds: 40));
-      expect(flaky.setProfileCalls, isEmpty,
-          reason: 'second retry is not due before 60ms');
+      expect(
+        flaky.setProfileCalls,
+        isEmpty,
+        reason: 'second retry is not due before 60ms',
+      );
 
       await Future<void>.delayed(const Duration(milliseconds: 80));
       expect(flaky.setProfileCalls.map((p) => p.title), ['Stubborn']);
@@ -427,8 +458,11 @@ void main() {
 
       flaky.setConnectionState(ConnectionState.disconnected);
       await Future<void>.delayed(const Duration(milliseconds: 150));
-      expect(flaky.totalCalls, 1,
-          reason: 'no retry may fire after the machine disconnected');
+      expect(
+        flaky.totalCalls,
+        1,
+        reason: 'no retry may fire after the machine disconnected',
+      );
     });
 
     test('DeviceNotConnectedException does not schedule a retry', () async {
@@ -441,8 +475,11 @@ void main() {
 
       applyProfile('Unreachable');
       await Future<void>.delayed(const Duration(milliseconds: 150));
-      expect(gone.totalCalls, 1,
-          reason: 'reconnect path owns the re-upload; no retry timer');
+      expect(
+        gone.totalCalls,
+        1,
+        reason: 'reconnect path owns the re-upload; no retry timer',
+      );
     });
 
     test('dispose cancels a pending retry', () async {
@@ -462,8 +499,7 @@ void main() {
       expect(flaky.totalCalls, 1);
     });
 
-    test(
-        'reverting to the last-pushed profile while another upload is in '
+    test('reverting to the last-pushed profile while another upload is in '
         'flight still converges to the reverted profile', () async {
       final gated = _GatedDe1();
       final controller = await connect(gated);
@@ -484,16 +520,18 @@ void main() {
       gated.completeNext(); // P2 lands
       await Future<void>.delayed(const Duration(milliseconds: 10));
 
-      expect(gated.setProfileCalls.map((p) => p.title), ['P1', 'P2', 'P1'],
-          reason: 'device must converge to the workflow profile, not P2');
+      expect(
+        gated.setProfileCalls.map((p) => p.title),
+        ['P1', 'P2', 'P1'],
+        reason: 'device must converge to the workflow profile, not P2',
+      );
 
       gated.completeNext(); // trailing P1 lands
       await Future<void>.delayed(const Duration(milliseconds: 10));
       expect(gated.maxInFlight, 1);
     });
 
-    test(
-        'a workflow change with the same profile leaves a pending retry\'s '
+    test('a workflow change with the same profile leaves a pending retry\'s '
         'backoff undisturbed', () async {
       final flaky = _FlakyDe1(failures: 0);
       final controller = await connect(flaky);
@@ -510,17 +548,22 @@ void main() {
       // notifying listeners): must not trigger an immediate re-attempt.
       applyProfile('Same');
       await Future<void>.delayed(const Duration(milliseconds: 5));
-      expect(flaky.totalCalls, 1,
-          reason: 'identical content must not reset the backoff to now');
+      expect(
+        flaky.totalCalls,
+        1,
+        reason: 'identical content must not reset the backoff to now',
+      );
 
       // The originally armed retry still fires on schedule.
       await Future<void>.delayed(const Duration(milliseconds: 40));
-      expect(flaky.totalCalls, greaterThanOrEqualTo(2),
-          reason: 'the pending retry must survive the duplicate change');
+      expect(
+        flaky.totalCalls,
+        greaterThanOrEqualTo(2),
+        reason: 'the pending retry must survive the duplicate change',
+      );
     });
 
-    test(
-        'failed upload invalidates last-pushed — reverting to the previous '
+    test('failed upload invalidates last-pushed — reverting to the previous '
         'profile re-uploads instead of short-circuiting', () async {
       // Call 1 is the on-connect push; call 2 (profile P1) succeeds,
       // call 3 (P2) fails mid-upload.
@@ -552,7 +595,7 @@ void main() {
   // a complete re-upload clears it. The old single-shot defaults push
   // swallowed its failure, and the optimistic last-pushed caches blocked
   // every same-profile repair. The sync now owns the (re)connect push.
-  group('on-connect profile push', () {
+  group('on-connect profile push via initSettled', () {
     late WorkflowController wf;
     WorkflowDeviceSync? activeSync;
 
@@ -577,128 +620,255 @@ void main() {
     WorkflowDeviceSync buildSync(
       De1Controller controller, {
       void Function(ConnectionError)? onUploadError,
-      void Function()? onUploadRecovered,
+      void Function()? onUploadErrorCleared,
     }) {
       final s = WorkflowDeviceSync(
         workflowController: wf,
         de1Controller: controller,
         retryDelays: const [Duration(milliseconds: 20)],
         onUploadError: onUploadError,
-        onUploadRecovered: onUploadRecovered,
+        onUploadErrorCleared: onUploadErrorCleared,
       );
       activeSync = s;
       return s;
     }
 
-    test('connecting a machine pushes the current workflow profile',
-        () async {
+    test('connecting a machine pushes the current workflow profile', () async {
       final controller = await freshController();
       buildSync(controller);
       final de1 = _RecordingDe1();
 
       await controller.connectToDe1(de1);
+      await settleInit(controller, de1);
       await Future<void>.delayed(const Duration(milliseconds: 10));
 
       expect(de1.setProfileCalls.map((p) => p.title), ['Persisted']);
     });
 
     test(
-      'a machine already connected at construction still gets the profile — '
-      'no optimistic constructor seed',
+      'a machine already connected at construction still gets the profile',
       () async {
-        // The regression scenario: the persisted workflow profile
-        // equals the one the constructor seed used to assume was on the
-        // device, so the skin's same-profile PUTs uploaded nothing and the
-        // firmware latch persisted.
         final controller = await freshController();
         final de1 = _RecordingDe1();
         await controller.connectToDe1(de1);
+        await settleInit(controller, de1);
 
         buildSync(controller);
         await Future<void>.delayed(const Duration(milliseconds: 10));
 
-        expect(de1.setProfileCalls.map((p) => p.title), ['Persisted'],
-            reason: 'device state must never be assumed from persistence');
+        expect(de1.setProfileCalls.map((p) => p.title), ['Persisted']);
       },
     );
 
     test(
-      'reconnect re-pushes the same profile — last-pushed is cleared on the '
-      'connection edge',
+      'reconnect re-pushes the same profile',
       () async {
         final controller = await freshController();
         buildSync(controller);
         final de1 = _RecordingDe1();
         await controller.connectToDe1(de1);
+        await settleInit(controller, de1);
         await Future<void>.delayed(const Duration(milliseconds: 10));
         expect(de1.setProfileCalls.length, 1);
 
         de1.setConnectionState(ConnectionState.disconnected);
         await Future<void>.delayed(const Duration(milliseconds: 10));
         de1.setConnectionState(ConnectionState.connected);
+
         await controller.connectToDe1(de1);
+        await settleInit(controller, de1);
         await Future<void>.delayed(const Duration(milliseconds: 10));
 
         expect(
           de1.setProfileCalls.map((p) => p.title),
           ['Persisted', 'Persisted'],
-          reason: 'an upload interrupted by the disconnect may have latched '
-              'the firmware; only a full re-upload clears it',
         );
       },
     );
 
     test(
-      'a failed on-connect push retries with backoff until it lands — '
-      'no workflow change needed',
+      'a failed on-connect push retries with backoff until it lands',
       () async {
         final controller = await freshController();
         buildSync(controller);
         final flaky = _FlakyDe1(failures: 1);
 
         await controller.connectToDe1(flaky);
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-        expect(flaky.setProfileCalls, isEmpty,
-            reason: 'first attempt failed; retry not due yet');
-
-        await Future<void>.delayed(const Duration(milliseconds: 40));
-        expect(flaky.setProfileCalls.map((p) => p.title), ['Persisted'],
-            reason: 'the on-connect push must retry on its own — the old '
-                'defaults path swallowed the failure and left the machine '
-                'wedged');
+        await settleInit(controller, flaky);
+        // First retry is at +20ms; wait for it.
+        await Future<void>.delayed(const Duration(milliseconds: 60));
+        expect(flaky.setProfileCalls.map((p) => p.title), ['Persisted']);
       },
     );
 
     test(
-      'upload failure surfaces once via onUploadError and retracts via '
-      'onUploadRecovered when a retry lands',
+      'upload failure surfaces once via onUploadError and clears via '
+      'onUploadErrorCleared when a retry lands',
       () async {
         final errors = <ConnectionError>[];
-        var recovered = 0;
+        var cleared = 0;
         final controller = await freshController();
         buildSync(
           controller,
           onUploadError: errors.add,
-          onUploadRecovered: () => recovered++,
+          onUploadErrorCleared: () => cleared++,
         );
         final flaky = _FlakyDe1(failures: 2);
 
         await controller.connectToDe1(flaky);
+        await settleInit(controller, flaky);
         await Future<void>.delayed(const Duration(milliseconds: 10));
         expect(errors.length, 1);
         expect(errors.single.kind, ConnectionErrorKind.profileUploadFailed);
         expect(errors.single.severity, ConnectionErrorSeverity.warning);
-        expect(recovered, 0);
+        expect(cleared, 0);
 
-        // Retry 1 (+20 ms) fails again — no duplicate surfacing.
         await Future<void>.delayed(const Duration(milliseconds: 25));
         expect(errors.length, 1);
 
-        // Retry 2 lands — the surfaced error is retracted.
         await Future<void>.delayed(const Duration(milliseconds: 40));
         expect(flaky.setProfileCalls.map((p) => p.title), ['Persisted']);
-        expect(recovered, 1);
+        expect(cleared, 1);
       },
     );
+
+    test('no profile push before init settles', () async {
+      final controller = await freshController();
+      final de1 = _RecordingDe1();
+      buildSync(controller);
+
+      await controller.connectToDe1(de1);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(de1.setProfileCalls, isEmpty);
+
+      await settleInit(controller, de1);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(de1.setProfileCalls.map((p) => p.title), ['Persisted']);
+    });
+
+    test('dispose clears the error when still current', () async {
+      var cleared = 0;
+      final controller = await freshController();
+      final de1 = _FlakyDe1(failures: 100);
+      await controller.connectToDe1(de1);
+      await settleInit(controller, de1);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final syncUnderTest = WorkflowDeviceSync(
+        workflowController: wf,
+        de1Controller: controller,
+        retryDelays: const [Duration(milliseconds: 20)],
+        onUploadError: (_) {},
+        onUploadErrorCleared: () => cleared++,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(cleared, 0);
+
+      syncUnderTest.dispose();
+      expect(cleared, 1);
+    });
+
+    test('disconnect clears error via onUploadErrorCleared', () async {
+      var cleared = 0;
+      final controller = await freshController();
+      final de1 = _FlakyDe1(failures: 100);
+      await controller.connectToDe1(de1);
+      await settleInit(controller, de1);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      // ignore: unused_local_variable
+      final syncUnderTest = WorkflowDeviceSync(
+        workflowController: wf,
+        de1Controller: controller,
+        retryDelays: const [Duration(milliseconds: 20)],
+        onUploadError: (_) {},
+        onUploadErrorCleared: () => cleared++,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(cleared, 0);
+
+      de1.setConnectionState(ConnectionState.disconnected);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(cleared, 1);
+    });
+
+    test('startup-default failure does not strand profile recovery', () async {
+      final controller = await freshController();
+      final de1 = _FanFailsDe1();
+      buildSync(controller);
+
+      await controller.connectToDe1(de1);
+      await settleInit(controller, de1);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      // Profile upload must proceed despite the default write failure.
+      expect(de1.setProfileCalls.map((p) => p.title), ['Persisted']);
+    });
+
+    test('init does not operate on replacement device', () async {
+      // Connect A, start init, disconnect A, connect B. A's init should
+      // not operate on B.
+      final controller = await freshController();
+      buildSync(controller);
+      final de1A = _RecordingDe1(deviceId: 'de1-A');
+      await controller.connectToDe1(de1A);
+      // Don't settle A's init yet.
+
+      de1A.setConnectionState(ConnectionState.disconnected);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final de1B = _RecordingDe1(deviceId: 'de1-B');
+      await controller.connectToDe1(de1B);
+      await settleInit(controller, de1B);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(
+        de1A.setProfileCalls,
+        isEmpty,
+        reason: 'A should not receive any profile push',
+      );
+      expect(
+        de1B.setProfileCalls.map((p) => p.title),
+        ['Persisted'],
+        reason: 'B should receive the profile via initSettled',
+      );
+    });
+  });
+
+  group('UnifiedDe1 production cache invalidation', () {
+    test('reconnect clears _currentProfile so same-profile upload is not '
+        'skipped', () async {
+      final transport = FakeBleTransport();
+      transport.queueOnConnectResponses();
+
+      final de1 = UnifiedDe1(transport: transport);
+      await de1.onConnect();
+
+      final profile = _profile('TestProfile');
+      await de1.setProfile(profile);
+      final writesAfterFirst = transport.writes.length;
+
+      await de1.disconnect();
+      transport.queueOnConnectResponses();
+      await de1.onConnect();
+
+      await de1.setProfile(profile);
+      final writesAfterReconnect = transport.writes.length;
+
+      expect(
+        writesAfterReconnect,
+        greaterThan(writesAfterFirst),
+        reason: 'same-profile upload after reconnect must write',
+      );
+
+      final writesBeforeDedup = transport.writes.length;
+      await de1.setProfile(profile);
+      expect(
+        transport.writes.length,
+        writesBeforeDedup,
+        reason: 'same-profile upload without reconnect must deduplicate',
+      );
+    });
   });
 }


### PR DESCRIPTION
If a profile upload dies part-way through, the machine is left unable to brew and the app cannot fix it. The firmware latches `ProfileDownloadInProgress` when it receives a profile header and the rest of the upload never arrives; there is no timeout and no clear on disconnect, and while it is latched the machine silently ignores start requests. So the user is looking at a machine that pulses its group-head LED and refuses to start a shot, and the app is looking at a machine it believes already holds the selected profile. Pressing "start" does nothing. Re-selecting the same profile does nothing either, because the app skips a push it thinks is redundant. The only recovery is to pick a *different* profile, which nobody would guess. This PR gives the on-connect push a single owner that retries, never assumes what the device holds, and tells the user when it is failing.

## Summary

- Problem: the app could not self-heal from a half-finished profile upload. Three things combined: the connect-time upload in `De1Controller._setDe1Defaults` was single-shot with the error swallowed; `WorkflowDeviceSync`'s constructor optimistically seeded `_lastPushedProfile` from the persisted workflow, so it believed the machine already held the selected profile; and neither cache was cleared on reconnect.
- Why it matters: together those meant every same-profile repair push was skipped, so a latched machine stayed latched. It ignores start requests while latched, so the user has a machine that will not brew and no obvious way back. Only selecting a different profile delivered a complete upload and cleared the latch.
- What changed:
  - `UnifiedDe1._currentProfile` is cleared in `onConnect()` before the `_info` guard — every connection edge forces a complete physical upload.
  - A new `De1Controller.initSettled` stream fires after machine readiness and startup defaults complete (or fail). `WorkflowDeviceSync` subscribes to this, not the raw de1 stream event which fires before initialization.
  - Generation tokens are captured at the start of `_initializeData()` and checked after every await (`stillCurrent()`). Stale completions from a disconnected generation cannot operate on a replacement device.
  - `_setDe1DefaultsFor(De1Interface device)` and its new device-pinned helpers (`_updateSteamSettingsFor`, `_updateHotWaterSettingsFor`, `_updateFlushSettingsFor`) perform all reads/writes through the captured device, never calling `connectedDe1()`. A stale initializer cannot write startup defaults to the replacement machine.
  - `profileUploadFailed` is phase-persistent (survives scanning/connMachine/connScale/ready transitions). Retracted when a retry lands, the machine disconnects, or the sync is disposed.
  - `onUploadErrorCleared` callback (renamed from `onUploadRecovered`) fires on all three retraction conditions.
- What did NOT change (scope boundary): `POST /api/v1/machine/profile` still bypasses `WorkflowDeviceSync` and is backstopped by the per-device upload queue and `_currentProfile` cache in `UnifiedDe1.setProfile`. Firmware-side hardening is a separate change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Deliberate choices worth your review

**Connection-edge cache invalidation.** Both `_lastPushedProfile` (sync level) and `_currentProfile` (device level) are cleared on every connection edge. The device-level cache is cleared in `onConnect()` before the `_info` guard so it applies even on reconnect (where `_info` is already populated). Cost: one redundant profile upload per connect. Benefit: the machine is guaranteed to hold the selected profile.

**Generation-safe initSettled with device-pinned helpers.** `_initializeData()` captures `_connectionGeneration` and `connectedDe1()` at the start. After every `await`, `stillCurrent()` checks that both still match. All async operations inside `_setDe1DefaultsFor()` now go through the captured `device` parameter, not `connectedDe1()`. This means a stale A init that resumes after A disconnected and B connected writes only to A's captured object — never to B.

**Deterministic race test.** The old test left A's init permanently suspended, verifying nothing about the race. The new test uses a `_BlockingDefaultsDe1` that blocks on a `Completer` inside `setFanThreshhold`, then:
1. Connects A (blocks at fan threshold)
2. Disconnects A while blocked
3. Connects B, completes B's init
4. Releases A's blocked write
5. Verifies: A wrote nothing to B's interfaces, B gets exactly one profile push, A's stale init does not emit a generation

A second test proves A's stale init does not emit B's generation, and a third proves B receives exactly one on-connect profile push.

## Regression Test Plan

- **32 test cases** in `workflow_device_sync_test.dart`:
  - Profile change, dedup, coalescing, retry
  - `initSettled`-driven on-connect push, already-connected construction, reconnect re-push
  - No profile push before init settles
  - Error surfacing (once), clearing via retry/disconnect/dispose
  - Startup-default failure recovery
  - **3 deterministic race tests**: blocking A at `setFanThreshhold`, disconnect while blocked, connect B, release A, verify A does not touch B
  - **4 integration tests**: real `ConnectionManager` wired to `WorkflowDeviceSync`, testing `reportError`→`status.error`, `clearErrorOfKind` kind-specific, clears when current, phase-persistent survival
  - **UnifiedDe1 production cache** test: real `UnifiedDe1` + `FakeBleTransport`
- **5 status_publisher_test.dart** cases for `phasePersistent`: survives scanning/ready, clears via `clearError`, new error replaces, `clearError` clears the current error regardless of kind
- **1 connection_manager_test.dart** case for `clearErrorOfKind`: clears only matching kind
- Existing `unified_de1_set_profile_test.dart` (19 cases) still passes

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` and `assets/api/websocket_v1.yml`
- [x] API docs updated: `doc/Api.md`
- [x] Skin docs updated: `doc/Skins.md`
- [x] Profile docs updated: `doc/Profiles.md`
- [x] Device docs updated: `doc/DeviceManagement.md`
- [x] AI notes updated: `doc/AI_BLE_NOTES.md`, `doc/AI_DEBUG_NOTES.md`
- [x] Archived design doc: `doc/plans/archive/profile-upload-recovery/design.md`

## Verification

### Local gates

- [x] `dart format` on edited files — clean
- [x] `flutter analyze` — no issues found
- [x] `flutter test test/controllers/workflow_device_sync_test.dart` — 43 pass
- [x] `flutter test test/controllers/connection/status_publisher_test.dart` — 15 pass
- [x] `flutter test test/controllers/connection_manager_test.dart` — 179 pass (1 new test)
- [x] `flutter test test/controllers/de1_controller_test.dart` — pass
- [x] `flutter test test/controllers/de1_controller_dispose_test.dart` — pass
- [x] `flutter test` — 2241 pass (all pre-existing failures resolved)

### Smoke tests

- [x] `flutter run -d macos --dart-define=simulate=1` — app starts, MockDe1/scale connect, REST endpoints respond:
  - `GET /api/v1/info` — returns version/metadata (`{"version":"0.0.0-dev"}`)
  - `GET /api/v1/devices` — returns connected MockDe1 + Mock Scale
  - `GET /api/v1/workflow` — returns `{"profile":{"title":"SmokeTest"}}`
  - `GET /api/v1/machine/state` — returns `{"state":{"state":"idle"}}`
  - `GET /api/v1/machine/info` — returns `{"model":"DE1Pro"}`
  - WebSocket endpoints (`/ws/v1/devices`, machine snapshot, shot state) connect and emit valid payloads
  - No serialization failures for the new error kind (`profileUploadFailed`)

### Hardware verification

- [ ] The physical latched-machine recovery was NOT re-verified on real hardware. The recovery argument rests on "a full upload clears the latch" (confirmed on the bench by selecting a different profile) plus tests showing that a full upload is now always attempted on connect.

## Final State

- PR head: `c05c2f9c`
- Branch: `fix/de1-connect-profile-push` (ChampionDesigns/reaprime fork)
- Files changed: 20 (+2647, -1116)
- CI: Linux build smoke ✅, Format/analyze/test pending
