### PR TITLE
fix(presence): derive the keep-awake window instead of latching it

### DIFF
--- a/doc/plans/archive/presence-derived-keep-awake/2026-07-17-design.md
+++ b/doc/plans/archive/presence-derived-keep-awake/2026-07-17-design.md
@@ -1,0 +1,21 @@
+# Derived keep-awake occurrences
+
+## Problem
+
+`PresenceController` previously stored `keepAwakeUntil` as a latch. The schedule checker set that latch only when it ran during the scheduled start minute while the machine was sleeping. Starting the app mid-window, reconnecting mid-window, missing the start-minute callback, or already having an awake machine at the start could therefore leave or clear the latch even though the configured keep-awake interval was still active.
+
+## Design
+
+The controller now parses the existing schedule JSON and derives the concrete occurrence covering the current time. Each enabled schedule with an explicit positive `keepAwakeFor` is evaluated for today and the previous day. The concrete end remains `start.add(Duration(minutes: keepAwakeFor))`, preserving elapsed-duration and DST behavior. Start is inclusive and end is exclusive. When occurrences overlap, the latest end wins.
+
+The derivation is independent of connection and callback history, so restart, reconnect, and missed-callback cases recover naturally. `keepAwakeUntil` still reports null when no machine is connected or no explicit occurrence is active. The idle-sleep timer is re-armed when an occurrence suppresses an expiry.
+
+## Manual sleep
+
+Derivation alone would restore suppression after a user manually slept and woke the machine during the same occurrence. To preserve existing behavior, `PresenceController` records cancellation by schedule ID and concrete scheduled start. A sleeping transition cancels the active occurrence; reconnecting, waking again, or editing that schedule does not remove the cancellation. Records are pruned after the occurrence ends or when that schedule is removed, allowing later occurrences to work normally.
+
+## Scope boundaries
+
+Schedules without a positive `keepAwakeFor` remain wake-only and create no occurrence. Stored JSON and REST request and response shapes are unchanged. Scheduled waking remains owned by the existing schedule checker.
+
+Firmware table capacity, register packing, firmware weekday conversion, Bengle synchronization, default durations, and DST changes are outside this fix. Firmware wake-schedule synchronization belongs to PR #467.

--- a/lib/src/controllers/presence_controller.dart
+++ b/lib/src/controllers/presence_controller.dart
@@ -4,6 +4,7 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/keep_awake_occurrence.dart';
 import 'package:reaprime/src/models/wake_schedule.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 
@@ -60,11 +61,32 @@ class PresenceController {
   final Set<String> _firedScheduleIds = {};
   int? _lastCheckedMinute;
 
-  /// Timestamp when the current keep-awake window expires. Null = no active window.
-  DateTime? _keepAwakeUntil;
+  String? _cachedSchedulesJson;
+  List<WakeSchedule> _cachedSchedules = const [];
+  final Set<KeepAwakeOccurrence> _cancelledOccurrences = {};
 
-  /// Exposes the keep-awake expiry for API/UI. Null if no window is active.
-  DateTime? get keepAwakeUntil => _keepAwakeUntil;
+  List<WakeSchedule> get _wakeSchedules {
+    final json = _settingsController.wakeSchedules;
+    if (json != _cachedSchedulesJson) {
+      _cachedSchedulesJson = json;
+      _cachedSchedules = keepAwakeSchedulesFromJson(json);
+      _pruneRemovedCancelledOccurrences();
+    }
+    return _cachedSchedules;
+  }
+
+  KeepAwakeOccurrence? get _activeKeepAwakeOccurrence {
+    if (_de1 == null) return null;
+    final schedules = _wakeSchedules;
+    final occurrence = activeKeepAwakeOccurrence(schedules, _clock());
+    _pruneCancelledOccurrences(occurrence);
+    if (occurrence == null || _cancelledOccurrences.contains(occurrence)) {
+      return null;
+    }
+    return occurrence;
+  }
+
+  DateTime? get keepAwakeUntil => _activeKeepAwakeOccurrence?.end;
 
   PresenceController({
     required De1Controller de1Controller,
@@ -95,7 +117,7 @@ class PresenceController {
     _pendingUserPresent = false;
     _pendingUserPresentTimer?.cancel();
     _pendingUserPresentTimer = null;
-    _keepAwakeUntil = null;
+    _cancelledOccurrences.clear();
     _settingsController.removeListener(_onSettingsChanged);
   }
 
@@ -135,7 +157,6 @@ class PresenceController {
     _pendingUserPresent = false;
     _pendingUserPresentTimer?.cancel();
     _pendingUserPresentTimer = null;
-    _keepAwakeUntil = null;
     _de1 = de1;
 
     if (de1 != null) {
@@ -165,10 +186,13 @@ class PresenceController {
     }
 
     if (newState == MachineState.sleeping &&
-        _currentMachineState != MachineState.sleeping &&
-        _keepAwakeUntil != null) {
-      _log.info('Machine went to sleep during keep-awake window, clearing');
-      _keepAwakeUntil = null;
+        _currentMachineState != null &&
+        _currentMachineState != MachineState.sleeping) {
+      final occurrence = _activeKeepAwakeOccurrence;
+      if (occurrence != null) {
+        _cancelledOccurrences.add(occurrence);
+        _log.info('Machine went to sleep during keep-awake occurrence');
+      }
     }
 
     // An activity (espresso/steam/hot water/flush/clean) just finished: restart
@@ -202,6 +226,25 @@ class PresenceController {
     } else {
       _sleepTimer?.cancel();
       _sleepTimer = null;
+    }
+  }
+
+  void _pruneRemovedCancelledOccurrences() {
+    final scheduleIds = _cachedSchedules.map((schedule) => schedule.id).toSet();
+    _cancelledOccurrences.removeWhere(
+      (occurrence) => !scheduleIds.contains(occurrence.scheduleId),
+    );
+  }
+
+  void _pruneCancelledOccurrences(KeepAwakeOccurrence? activeOccurrence) {
+    final now = _clock();
+    _cancelledOccurrences.removeWhere(
+      (occurrence) =>
+          occurrence != activeOccurrence && !now.isBefore(occurrence.end),
+    );
+    if (activeOccurrence != null &&
+        _cancelledOccurrences.remove(activeOccurrence)) {
+      _cancelledOccurrences.add(activeOccurrence);
     }
   }
 
@@ -263,17 +306,13 @@ class PresenceController {
   void _onSleepTimeout() {
     if (_de1 == null) return;
 
-    if (_keepAwakeUntil != null && _clock().isBefore(_keepAwakeUntil!)) {
+    final occurrence = _activeKeepAwakeOccurrence;
+    if (occurrence != null) {
       _log.info(
-        'Sleep timeout suppressed by keep-awake (until $_keepAwakeUntil)',
+        'Sleep timeout suppressed by keep-awake (until ${occurrence.end})',
       );
       _resetSleepTimer();
       return;
-    }
-
-    if (_keepAwakeUntil != null) {
-      _log.info('Keep-awake window expired');
-      _keepAwakeUntil = null;
     }
 
     // If machine is in an active state, restart the timer instead of sleeping
@@ -366,16 +405,6 @@ class PresenceController {
           _de1!.requestState(MachineState.schedIdle).catchError((Object e) {
             _log.warning('Failed to request schedIdle', e);
           });
-          if (schedule.keepAwakeFor != null) {
-            final newExpiry = now.add(
-              Duration(minutes: schedule.keepAwakeFor!),
-            );
-            if (_keepAwakeUntil == null ||
-                newExpiry.isAfter(_keepAwakeUntil!)) {
-              _keepAwakeUntil = newExpiry;
-              _log.info('Keep-awake window set until $_keepAwakeUntil');
-            }
-          }
           break; // One wake per check cycle
         }
       }

--- a/lib/src/models/keep_awake_occurrence.dart
+++ b/lib/src/models/keep_awake_occurrence.dart
@@ -1,0 +1,93 @@
+import 'package:reaprime/src/models/wake_schedule.dart';
+
+class KeepAwakeOccurrence {
+  const KeepAwakeOccurrence({
+    required this.scheduleId,
+    required this.start,
+    required this.end,
+  });
+
+  final String scheduleId;
+  final DateTime start;
+  final DateTime end;
+
+  @override
+  bool operator ==(Object other) =>
+      other is KeepAwakeOccurrence &&
+      other.scheduleId == scheduleId &&
+      other.start == start;
+
+  @override
+  int get hashCode => Object.hash(scheduleId, start);
+}
+
+KeepAwakeOccurrence? activeKeepAwakeOccurrence(
+  List<WakeSchedule> schedules,
+  DateTime now,
+) {
+  KeepAwakeOccurrence? latest;
+
+  for (final schedule in schedules) {
+    final occurrence = _activeOccurrenceForSchedule(schedule, now);
+    if (occurrence == null) continue;
+    if (latest == null ||
+        occurrence.end.isAfter(latest.end) ||
+        (occurrence.end == latest.end &&
+            occurrence.start.isAfter(latest.start))) {
+      latest = occurrence;
+    }
+  }
+
+  return latest;
+}
+
+List<WakeSchedule> keepAwakeSchedulesFromJson(String json) {
+  if (json.isEmpty || json == '[]') return const [];
+  try {
+    return WakeSchedule.deserializeList(json);
+  } catch (_) {
+    return const [];
+  }
+}
+
+KeepAwakeOccurrence? _activeOccurrenceForSchedule(
+  WakeSchedule schedule,
+  DateTime now,
+) {
+  final durationMinutes = schedule.keepAwakeFor;
+  if (!schedule.enabled ||
+      durationMinutes == null ||
+      durationMinutes <= 0 ||
+      schedule.hour < 0 ||
+      schedule.hour > 23 ||
+      schedule.minute < 0 ||
+      schedule.minute > 59) {
+    return null;
+  }
+
+  for (var daysAgo = 0; daysAgo <= 1; daysAgo++) {
+    final day = DateTime(now.year, now.month, now.day - daysAgo);
+    if (schedule.daysOfWeek.isNotEmpty &&
+        !schedule.daysOfWeek.contains(day.weekday)) {
+      continue;
+    }
+
+    final start = DateTime(
+      day.year,
+      day.month,
+      day.day,
+      schedule.hour,
+      schedule.minute,
+    );
+    final end = start.add(Duration(minutes: durationMinutes));
+    if (!now.isBefore(start) && now.isBefore(end)) {
+      return KeepAwakeOccurrence(
+        scheduleId: schedule.id,
+        start: start,
+        end: end,
+      );
+    }
+  }
+
+  return null;
+}

--- a/test/controllers/presence_controller_test.dart
+++ b/test/controllers/presence_controller_test.dart
@@ -441,48 +441,51 @@ void main() {
       });
     });
 
-    test('sleep countdown restarts when a shot ends, not from the last heartbeat', () {
-      fakeAsync((async) {
-        settingsController.setSleepTimeoutMinutes(5);
-        async.flushMicrotasks();
+    test(
+      'sleep countdown restarts when a shot ends, not from the last heartbeat',
+      () {
+        fakeAsync((async) {
+          settingsController.setSleepTimeoutMinutes(5);
+          async.flushMicrotasks();
 
-        final controller = PresenceController(
-          de1Controller: de1Controller,
-          settingsController: settingsController,
-          clock: () => clock.now(),
-        );
-        controller.initialize();
-        de1Controller.setDe1(testDe1);
-        async.flushMicrotasks();
+          final controller = PresenceController(
+            de1Controller: de1Controller,
+            settingsController: settingsController,
+            clock: () => clock.now(),
+          );
+          controller.initialize();
+          de1Controller.setDe1(testDe1);
+          async.flushMicrotasks();
 
-        controller.heartbeat();
-        async.flushMicrotasks();
+          controller.heartbeat();
+          async.flushMicrotasks();
 
-        // A hands-off pull that begins and ends well within the timeout window,
-        // with no further heartbeats (the user never touches the screen).
-        async.elapse(const Duration(minutes: 1));
-        testDe1.emitState(MachineState.espresso);
-        async.flushMicrotasks();
-        async.elapse(const Duration(minutes: 1));
-        testDe1.emitState(MachineState.idle);
-        async.flushMicrotasks();
+          // A hands-off pull that begins and ends well within the timeout window,
+          // with no further heartbeats (the user never touches the screen).
+          async.elapse(const Duration(minutes: 1));
+          testDe1.emitState(MachineState.espresso);
+          async.flushMicrotasks();
+          async.elapse(const Duration(minutes: 1));
+          testDe1.emitState(MachineState.idle);
+          async.flushMicrotasks();
 
-        // Past the ORIGINAL heartbeat-anchored timeout (5m after the heartbeat):
-        // must NOT sleep, because the shot ending restarted the countdown.
-        async.elapse(const Duration(minutes: 3, seconds: 30));
-        expect(
-          testDe1.requestedStates.where((s) => s == MachineState.sleeping),
-          isEmpty,
-          reason: 'Shot end should have restarted the sleep countdown',
-        );
+          // Past the ORIGINAL heartbeat-anchored timeout (5m after the heartbeat):
+          // must NOT sleep, because the shot ending restarted the countdown.
+          async.elapse(const Duration(minutes: 3, seconds: 30));
+          expect(
+            testDe1.requestedStates.where((s) => s == MachineState.sleeping),
+            isEmpty,
+            reason: 'Shot end should have restarted the sleep countdown',
+          );
 
-        // A full timeout after the shot ended: now it sleeps.
-        async.elapse(const Duration(minutes: 2));
-        expect(testDe1.requestedStates, contains(MachineState.sleeping));
+          // A full timeout after the shot ended: now it sleeps.
+          async.elapse(const Duration(minutes: 2));
+          expect(testDe1.requestedStates, contains(MachineState.sleeping));
 
-        controller.dispose();
-      });
-    });
+          controller.dispose();
+        });
+      },
+    );
   });
 
   group('scheduled wake', () {
@@ -887,6 +890,265 @@ void main() {
         expect(secondExpiry, isNotNull);
         expect(secondExpiry!.isAfter(firstExpiry!), isTrue);
 
+        controller.dispose();
+      });
+    });
+
+    test(
+      'already-awake machine keeps the occurrence after its start minute',
+      () {
+        fakeAsync((async) {
+          settingsController.setSleepTimeoutMinutes(30);
+          settingsController.setWakeSchedules(
+            WakeSchedule.serializeList([
+              const WakeSchedule(
+                id: 'already-awake',
+                hour: 5,
+                minute: 30,
+                daysOfWeek: {1, 2, 3, 4, 5},
+                enabled: true,
+                keepAwakeFor: 90,
+              ),
+            ]),
+          );
+          async.flushMicrotasks();
+
+          final controller = PresenceController(
+            de1Controller: de1Controller,
+            settingsController: settingsController,
+            clock: () => DateTime(2026, 1, 15, 6),
+          );
+          controller.initialize();
+          de1Controller.setDe1(testDe1);
+          async.flushMicrotasks();
+
+          controller.heartbeat();
+          async.elapse(const Duration(minutes: 30, seconds: 1));
+
+          expect(controller.keepAwakeUntil, DateTime(2026, 1, 15, 7));
+          expect(
+            testDe1.requestedStates,
+            isNot(contains(MachineState.sleeping)),
+          );
+
+          controller.clockOverride = () => DateTime(2026, 1, 15, 7, 1);
+          async.elapse(const Duration(minutes: 30, seconds: 1));
+
+          expect(testDe1.requestedStates, contains(MachineState.sleeping));
+          controller.dispose();
+        });
+      },
+    );
+
+    test('reconnecting during an occurrence preserves keep-awake', () {
+      fakeAsync((async) {
+        settingsController.setWakeSchedules(
+          WakeSchedule.serializeList([
+            const WakeSchedule(
+              id: 'reconnect',
+              hour: 7,
+              minute: 0,
+              daysOfWeek: {},
+              enabled: true,
+              keepAwakeFor: 60,
+            ),
+          ]),
+        );
+        async.flushMicrotasks();
+
+        final controller = PresenceController(
+          de1Controller: de1Controller,
+          settingsController: settingsController,
+          clock: () => DateTime(2026, 1, 15, 7, 30),
+        );
+        controller.initialize();
+        de1Controller.setDe1(testDe1);
+        async.flushMicrotasks();
+        de1Controller.setDe1(null);
+        async.flushMicrotasks();
+
+        expect(controller.keepAwakeUntil, isNull);
+
+        final reconnected = _TestDe1();
+        de1Controller.setDe1(reconnected);
+        async.flushMicrotasks();
+
+        expect(controller.keepAwakeUntil, DateTime(2026, 1, 15, 8));
+        controller.dispose();
+      });
+    });
+
+    test('new controller derives an occurrence already in progress', () {
+      fakeAsync((async) {
+        settingsController.setWakeSchedules(
+          WakeSchedule.serializeList([
+            const WakeSchedule(
+              id: 'restart',
+              hour: 7,
+              minute: 0,
+              daysOfWeek: {},
+              enabled: true,
+              keepAwakeFor: 60,
+            ),
+          ]),
+        );
+        async.flushMicrotasks();
+
+        final controller = PresenceController(
+          de1Controller: de1Controller,
+          settingsController: settingsController,
+          clock: () => DateTime(2026, 1, 15, 7, 30),
+        );
+        controller.initialize();
+        de1Controller.setDe1(testDe1);
+        async.flushMicrotasks();
+
+        expect(controller.keepAwakeUntil, DateTime(2026, 1, 15, 8));
+        controller.dispose();
+      });
+    });
+
+    test('waking again does not restore a manually cancelled occurrence', () {
+      fakeAsync((async) {
+        settingsController.setWakeSchedules(
+          WakeSchedule.serializeList([
+            const WakeSchedule(
+              id: 'manual-cancel',
+              hour: 7,
+              minute: 0,
+              daysOfWeek: {},
+              enabled: true,
+              keepAwakeFor: 60,
+            ),
+          ]),
+        );
+        async.flushMicrotasks();
+
+        final controller = PresenceController(
+          de1Controller: de1Controller,
+          settingsController: settingsController,
+          clock: () => DateTime(2026, 1, 15, 7, 30),
+        );
+        controller.initialize();
+        de1Controller.setDe1(testDe1);
+        async.flushMicrotasks();
+
+        testDe1.emitState(MachineState.sleeping);
+        async.flushMicrotasks();
+        expect(controller.keepAwakeUntil, isNull);
+
+        testDe1.emitState(MachineState.idle);
+        async.flushMicrotasks();
+        expect(controller.keepAwakeUntil, isNull);
+
+        controller.dispose();
+      });
+    });
+
+    test('changing a schedule does not restore a cancelled occurrence', () {
+      fakeAsync((async) {
+        const schedule = WakeSchedule(
+          id: 'changed',
+          hour: 7,
+          minute: 0,
+          daysOfWeek: {},
+          enabled: true,
+          keepAwakeFor: 60,
+        );
+        settingsController.setWakeSchedules(
+          WakeSchedule.serializeList([schedule]),
+        );
+        async.flushMicrotasks();
+
+        final controller = PresenceController(
+          de1Controller: de1Controller,
+          settingsController: settingsController,
+          clock: () => DateTime(2026, 1, 15, 7, 30),
+        );
+        controller.initialize();
+        de1Controller.setDe1(testDe1);
+        async.flushMicrotasks();
+
+        testDe1.emitState(MachineState.sleeping);
+        async.flushMicrotasks();
+        expect(controller.keepAwakeUntil, isNull);
+
+        settingsController.setWakeSchedules(
+          WakeSchedule.serializeList([
+            schedule.copyWith(keepAwakeFor: 120),
+          ]),
+        );
+        async.flushMicrotasks();
+
+        testDe1.emitState(MachineState.idle);
+        async.flushMicrotasks();
+        expect(controller.keepAwakeUntil, isNull);
+        controller.dispose();
+      });
+    });
+
+    test('a later concrete occurrence works after cancellation', () {
+      fakeAsync((async) {
+        const schedule = WakeSchedule(
+          id: 'recurring',
+          hour: 7,
+          minute: 0,
+          daysOfWeek: {},
+          enabled: true,
+          keepAwakeFor: 60,
+        );
+        settingsController.setWakeSchedules(
+          WakeSchedule.serializeList([schedule]),
+        );
+        async.flushMicrotasks();
+
+        final controller = PresenceController(
+          de1Controller: de1Controller,
+          settingsController: settingsController,
+          clock: () => DateTime(2026, 1, 15, 7, 30),
+        );
+        controller.initialize();
+        de1Controller.setDe1(testDe1);
+        async.flushMicrotasks();
+
+        testDe1.emitState(MachineState.sleeping);
+        async.flushMicrotasks();
+        expect(controller.keepAwakeUntil, isNull);
+
+        controller.clockOverride = () => DateTime(2026, 1, 16, 7, 30);
+        testDe1.emitState(MachineState.idle);
+        async.flushMicrotasks();
+
+        expect(controller.keepAwakeUntil, DateTime(2026, 1, 16, 8));
+        controller.dispose();
+      });
+    });
+
+    test('keepAwakeUntil is null without a connected machine', () {
+      fakeAsync((async) {
+        settingsController.setWakeSchedules(
+          WakeSchedule.serializeList([
+            const WakeSchedule(
+              id: 'disconnected',
+              hour: 7,
+              minute: 0,
+              daysOfWeek: {},
+              enabled: true,
+              keepAwakeFor: 60,
+            ),
+          ]),
+        );
+        async.flushMicrotasks();
+
+        final controller = PresenceController(
+          de1Controller: de1Controller,
+          settingsController: settingsController,
+          clock: () => DateTime(2026, 1, 15, 7, 30),
+        );
+        controller.initialize();
+        async.flushMicrotasks();
+
+        expect(controller.keepAwakeUntil, isNull);
         controller.dispose();
       });
     });

--- a/test/models/keep_awake_occurrence_test.dart
+++ b/test/models/keep_awake_occurrence_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/keep_awake_occurrence.dart';
+import 'package:reaprime/src/models/wake_schedule.dart';
+
+WakeSchedule schedule({
+  String id = 'schedule',
+  int hour = 7,
+  int minute = 0,
+  Set<int> daysOfWeek = const {},
+  bool enabled = true,
+  int? keepAwakeFor = 60,
+}) => WakeSchedule(
+  id: id,
+  hour: hour,
+  minute: minute,
+  daysOfWeek: daysOfWeek,
+  enabled: enabled,
+  keepAwakeFor: keepAwakeFor,
+);
+
+void main() {
+  group('activeKeepAwakeOccurrence', () {
+    test('start is inclusive', () {
+      final occurrence = activeKeepAwakeOccurrence(
+        [schedule()],
+        DateTime(2026, 1, 15, 7),
+      );
+
+      expect(occurrence?.start, DateTime(2026, 1, 15, 7));
+      expect(occurrence?.end, DateTime(2026, 1, 15, 8));
+    });
+
+    test('end is exclusive', () {
+      final occurrence = activeKeepAwakeOccurrence(
+        [schedule()],
+        DateTime(2026, 1, 15, 8),
+      );
+
+      expect(occurrence, isNull);
+    });
+
+    test('null and zero durations remain wake-only', () {
+      expect(
+        activeKeepAwakeOccurrence(
+          [schedule(keepAwakeFor: null)],
+          DateTime(2026, 1, 15, 7),
+        ),
+        isNull,
+      );
+      expect(
+        activeKeepAwakeOccurrence(
+          [schedule(keepAwakeFor: 0)],
+          DateTime(2026, 1, 15, 7),
+        ),
+        isNull,
+      );
+    });
+
+    test('checks the previous day for a duration crossing midnight', () {
+      final occurrence = activeKeepAwakeOccurrence(
+        [
+          schedule(hour: 23, keepAwakeFor: 120, daysOfWeek: {3}),
+        ],
+        DateTime(2026, 1, 15, 0, 30),
+      );
+
+      expect(occurrence?.start, DateTime(2026, 1, 14, 23));
+      expect(occurrence?.end, DateTime(2026, 1, 15, 1));
+    });
+
+    test('empty days means every day and explicit days are respected', () {
+      final now = DateTime(2026, 1, 15, 7, 30);
+
+      expect(activeKeepAwakeOccurrence([schedule()], now), isNotNull);
+      expect(
+        activeKeepAwakeOccurrence(
+          [
+            schedule(daysOfWeek: {DateTime.friday}),
+          ],
+          now,
+        ),
+        isNull,
+      );
+    });
+
+    test('overlapping occurrences return the latest end', () {
+      final occurrence = activeKeepAwakeOccurrence(
+        [
+          schedule(id: 'short', keepAwakeFor: 60),
+          schedule(id: 'long', minute: 30, keepAwakeFor: 120),
+        ],
+        DateTime(2026, 1, 15, 7, 45),
+      );
+
+      expect(occurrence?.scheduleId, 'long');
+      expect(occurrence?.end, DateTime(2026, 1, 15, 9, 30));
+    });
+
+    test('more than 32 occurrences do not affect app-side evaluation', () {
+      final schedules = [
+        for (var i = 0; i < 40; i++)
+          schedule(id: '$i', minute: i, keepAwakeFor: 120),
+      ];
+
+      final occurrence = activeKeepAwakeOccurrence(
+        schedules,
+        DateTime(2026, 1, 15, 7, 45),
+      );
+
+      expect(occurrence?.scheduleId, '39');
+      expect(occurrence?.end, DateTime(2026, 1, 15, 9, 39));
+    });
+
+    test('uses elapsed duration from the concrete start', () {
+      final start = DateTime(2026, 1, 15, 7);
+      final occurrence = activeKeepAwakeOccurrence(
+        [schedule(keepAwakeFor: 90)],
+        start,
+      );
+
+      expect(occurrence?.end, start.add(const Duration(minutes: 90)));
+    });
+  });
+
+  group('keepAwakeSchedulesFromJson', () {
+    test('malformed JSON produces no schedules and does not throw', () {
+      expect(keepAwakeSchedulesFromJson('{not json'), isEmpty);
+      expect(keepAwakeSchedulesFromJson('[{"id":"missing-fields"}]'), isEmpty);
+    });
+
+    test('valid stored schedule JSON remains readable', () {
+      final json = WakeSchedule.serializeList([schedule()]);
+
+      expect(keepAwakeSchedulesFromJson(json), hasLength(1));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Explicit keep-awake occurrences are now recovered after app restart, machine reconnect, or a missed start-minute callback.
- Wake-only schedules remain wake-only.
- Manual sleep still cancels the active concrete occurrence; waking again during that occurrence does not restore it.
- No API, storage, firmware, UI, scheduled-wake, heartbeat, default-duration, or DST behavior changed.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [x] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Root Cause

`keepAwakeUntil` was a latch set only by the sleeping-machine branch of the schedule checker during the exact scheduled start minute. Restart, reconnect, an already-awake machine, or a missed callback could therefore lose the configured window.

## Regression Test Plan

- [x] Unit test
- [ ] Integration test (mock transport edge)
- [ ] End-to-end test (`simulate=1` + curl/websocat)

Added focused coverage in:

- `test/models/keep_awake_occurrence_test.dart`: wake-only null/zero durations, inclusive start, exclusive end, weekday filtering, midnight crossing, elapsed-duration end, overlap selection, more than 32 schedules, and malformed JSON.
- `test/controllers/presence_controller_test.dart`: already-awake, reconnect, new-controller mid-occurrence, no connected machine, manual cancellation, wake-after-cancellation, schedule-edit cancellation retention, later concrete occurrence recovery, timer suppression, and timer re-arming.

## Documentation Obligations

- [x] N/A — no API or product documentation changed. Design rationale is archived in `doc/plans/archive/presence-derived-keep-awake/2026-07-17-design.md`.

## Security Impact

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `No`
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`

## User-Visible Changes

A configured explicit keep-awake occurrence is no longer lost after restart, reconnect, or a missed start-minute callback. All other behavior is unchanged.

## Verification

Rebased onto current `origin/main` before implementation.

- [x] `dart format` on the four changed Dart files
- [x] `flutter test test/models/keep_awake_occurrence_test.dart` — 10 passed
- [x] `flutter test test/controllers/presence_controller_test.dart` — 24 passed
- [x] `./bundle_skins.sh`
- [x] `flutter test` — 2286 passed
- [x] `flutter analyze --no-pub` — no issues after removing generated Apple SPM build artifacts
- [x] `(cd packages/dye2-plugin && npm run build)`
- [x] `git diff --check`

No simulated-device or real-hardware smoke test was needed because no API or device communication path changed.

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`

Existing REST shapes and stored schedule JSON are unchanged.

## Risks & Mitigations

- Risk: deriving state could accidentally restore a manually cancelled occurrence.
  - Mitigation: cancellations use schedule ID plus concrete start time and have focused regression coverage.
