### PR TITLE
feat(serial): DE1-family USB-serial parity, and let a wired-only setup reach its machine

### DIFF
--- a/assets/api/bengle_hw_v1.yml
+++ b/assets/api/bengle_hw_v1.yml
@@ -1,0 +1,757 @@
+# =============================================================================
+# Bengle firmware <-> app hardware contract (bengle_hw_v1.yml)
+# =============================================================================
+# contract_version: 1
+#
+# Generated from firmware the firmware register table at:
+#
+#
+# Change protocol: firmware changes a register -> regenerate this file from the
+# new the firmware register table -> bump contract_version -> update the app enums (BengleMmr /
+# BengleSteamMmr / BengleScaleMmr / BengleCalMmr / BengleLedMmr / MMRItem) ->
+# the mmr_contract_test checker enforces agreement; firmware and app PRs both
+# cite the contract_version.
+#
+# Normalization rules applied (binding):
+#   * mult / min / max are only meaningful on firmware register-table rows with auto > 0 (the
+#     macro read/write path). auto = 0 rows are served by hand-written firmware
+#     cases; for those, `mult` below records the VERIFIED behaviour of the
+#     hand-written path (which matches the the firmware register table column everywhere except
+#     v13Model, whose mult=1000 column is inert -- recorded as mult: 1).
+#   * min / max below are RAW WIRE UNITS (the little-endian int32 actually on
+#     the wire). Where the firmware register table used post-divide engineering units, the original
+#     engineering values are kept in a trailing comment.
+#   * min/max encoding: where the firmware register table declares the full-u32 column
+#     0..0xFFFFFFFF it is retained verbatim (for a u32 wire value that is
+#     identical to "no constraint"); ScaleTare alone is normalized to
+#     null/null because its written value is ignored entirely (pure trigger).
+#     Deliberate, not drift -- a subset checker passes either encoding.
+#   * Read-back resolution on FLOAT-backed rows (EndOfShotWeight, LastTARE,
+#     ScaleCalWeight, TargetMilkTemp, V24CurrentBudget, MatCurrentTemp): the
+#     firmware macro read path truncates BEFORE scaling
+#     (the firmware the firmware read path),
+#     so wire READS return floor(engineering) x mult -- whole engineering
+#     units -- while writes keep full x-mult resolution. The same U32(float)
+#     cast saturates a negative stored value to 0 on Cortex-M, so these rows
+#     can never read back negative. Affected rows carry a "Read-back" note.
+#     (MatSetPoint is float-backed too but exact: mult 1, whole-degC writes.)
+#   * The firmware does NOT enforce min/max on Bengle macro-path writes
+#     the firmware write path never range-checks): bounds here are documentation and the app
+#     is the sole guard. Checker semantics: app range must be a SUBSET of the
+#     contract range (not equal) -- e.g. calFlowEst app min raw 130 vs FW 125.
+#   * perms are canonicalized from the the firmware register table ENTRY column:
+#     PERM_READ -> R, PERM_RT -> RT, PERM_RW -> RW, PERM_RWD -> RWD (persisted
+#     to disk), PERM_RWT -> RWT (write triggers an action). The ENTRY column is
+#     AUTHORITATIVE: the firmware register table's own header comment block disagrees with it on
+#     row 33 (comment "RW" vs ENTRY PERM_READ) and rows 34/35/37 (comment "W"
+#     vs ENTRY PERM_RWT); the firmware write macro verifiably enforces the
+#     ENTRY perms. App enums carry no perms today, so the checker must NOT
+#     assert perms in v1.
+#   * `app_alias` is present only where the app's declared description string
+#     differs from the firmware register name (TargetMilkTemp is the only
+#     case). Rows are keyed by FIRMWARE name, so the alias records the
+#     app-side name.
+#   * Rows 12 (PrefGHCMCI) and 13 (MaxShotPres) are omitted: PERM_NONE TODO
+#     stubs in firmware, unreachable and irrelevant to the app.
+#   * All len=4 registers are little-endian int32 on the MMR wire. Addresses in
+#     frames are 24-bit big-endian (the 0x00 top byte of 0x008038xx-style
+#     addresses is discarded).
+# =============================================================================
+
+contract_version: 1
+firmware:
+  commit: 0381e7ab58eb5b5ee36c14b0bef123ea3cfe4f2e
+  build: 90
+  source: the firmware register table
+generated: 2026-07-11
+
+# -----------------------------------------------------------------------------
+# MMR register table
+# name = firmware register name; fw_row = the firmware register table RangeNum; address as it
+# appears in a read/write frame (before the 24-bit truncation); length in
+# bytes; mult = raw wire value / engineering value.
+# -----------------------------------------------------------------------------
+registers:
+  # --- Shared DE1-family rows the app's MMRItem enum declares -----------------
+  - name: ExternalFlash
+    fw_row: 0
+    address: "0x00000000"
+    length: 1048575 # 0xFFFFF -- first 1 MB mapped to external flash
+    perms: RW
+    mult: 1
+    value_kind: bytes
+    min: null
+    max: null
+    unit: null
+    semantics: "External-flash window (disk operations, firmware images); not a scalar register."
+
+  - name: HWConfig
+    fw_row: 1
+    address: "0x00800000"
+    length: 4
+    perms: R
+    mult: 1
+    value_kind: int32
+    min: null
+    max: null
+    unit: bitmask
+    semantics: "Hardware configuration word."
+
+  - name: Model
+    fw_row: 2
+    address: "0x00800004"
+    length: 4
+    perms: R
+    mult: 1
+    value_kind: int32
+    min: null
+    max: null
+    unit: null
+    semantics: "Legacy machine model."
+
+  - name: CPUBoardModel
+    fw_row: 19
+    address: "0x00800008"
+    length: 4
+    perms: R
+    mult: 1
+    value_kind: int32
+    min: null
+    max: null
+    unit: "model x 1000"
+    semantics: "CPU board model x 1000 by convention (e.g. 1100 = 1.1); served raw, no mult column."
+
+  - name: v13Model
+    fw_row: 20
+    address: "0x0080000C"
+    length: 4
+    perms: R
+    # the firmware register table's mult column says 1000 but the row is auto=0 and served UNSCALED
+    # by a hand-written case (a hand-written firmware case) -- the column is inert. A
+    # generator that trusted it would declare v13Model x1000 and break Bengle
+    # detection. HW-verified: a live Bengle answers 128 raw.
+    mult: 1
+    value_kind: int32
+    min: null
+    max: null
+    unit: null
+    semantics: "v1.3+ firmware model: Unset=0, DE1=1, DE1Plus=2, DE1Pro=3, DE1XL=4, DE1Cafe=5, DE1XXL=6, DE1XXXL=7, Bengle=128. Bengle identity gate is value >= 128."
+
+  - name: CPUFirmwareBuild
+    fw_row: 21
+    address: "0x00800010"
+    length: 4
+    perms: R
+    mult: 1
+    value_kind: int32
+    min: null
+    max: null
+    unit: build
+    semantics: "CPU board firmware build number (starts at 1000 for v1.3, +1 per build). This contract pins the validated firmware build on a firmware development branch
+
+  - name: DebugLen
+    fw_row: 3
+    address: "0x00802800"
+    length: 4
+    perms: RT
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 4096
+    unit: chars
+    semantics: "Valid characters in the debug buffer; accessing pauses BLE debug logging."
+
+  - name: DebugBuffer
+    fw_row: 4
+    address: "0x00802804"
+    length: 4096 # 0x1000
+    perms: RT
+    mult: 1
+    value_kind: bytes
+    min: null
+    max: null
+    unit: null
+    semantics: "Last 4 K of debug output; zero-terminated if not full. Pauses BLE debug logging."
+
+  - name: DebugConfig
+    fw_row: 5
+    address: "0x00803804"
+    length: 4
+    perms: RT
+    mult: 1
+    value_kind: int32
+    min: null
+    max: null
+    unit: bitmask
+    semantics: "BLE debug config; reading restarts logging into the BLE log."
+
+  - name: FanThreshold
+    fw_row: 6
+    address: "0x00803808"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 50
+    unit: degC
+    semantics: "Fan threshold temperature."
+
+  - name: TankTemp
+    fw_row: 7
+    address: "0x0080380C"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 60
+    unit: degC
+    semantics: "Tank water temperature threshold."
+
+  - name: HeaterUp1Flow
+    fw_row: 8
+    address: "0x00803810"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 5 # the firmware register table 0.5 ml/s (post-divide)
+    max: 80 # the firmware register table 8.0 ml/s
+    unit: "ml/s x 10"
+    semantics: "HeaterUp phase-1 flow rate."
+
+  - name: HeaterUp2Flow
+    fw_row: 9
+    address: "0x00803814"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 5 # the firmware register table 0.5 ml/s
+    max: 80 # the firmware register table 8.0 ml/s
+    unit: "ml/s x 10"
+    semantics: "HeaterUp phase-2 flow rate."
+
+  - name: WaterHeaterIdleTemp
+    fw_row: 10
+    address: "0x00803818"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 5 # the firmware register table 0.5 degC
+    max: 1000 # the firmware register table 100.0 degC
+    unit: "degC x 10"
+    semantics: "Water heater idle temperature."
+
+  - name: GHCInfo
+    fw_row: 11
+    address: "0x0080381C"
+    length: 4
+    perms: R
+    mult: 1
+    value_kind: int32
+    min: null
+    max: 4294967295 # 0xFFFFFFFF
+    unit: bitmask
+    semantics: "GHC info bitmask: 0x1 LED controller, 0x2 touch controller, 0x4 GHC active, 0x80000000 factory mode."
+
+  - name: TargetSteamFlow
+    fw_row: 14
+    address: "0x00803828"
+    length: 4
+    perms: RW
+    mult: 100
+    value_kind: scaledFloat
+    min: 40 # the firmware register table 0.4 ml/s
+    max: 400 # the firmware register table 4.0 ml/s
+    unit: "ml/s x 100"
+    semantics: "Target steam flow rate."
+
+  - name: SteamStartSecs
+    fw_row: 15
+    address: "0x0080382C"
+    length: 4
+    perms: RW
+    # KNOWN DECLARATION MISMATCH (D5): this scaledFloat was previously declared
+    # with scales 1.0 while the firmware mult is 100. Latent (nothing reads/writes
+    # it today); the declaration is corrected to readScale 0.01 / writeScale 100.0.
+    mult: 100
+    value_kind: scaledFloat
+    min: 10 # the firmware register table 0.1 s
+    max: 400 # the firmware register table 4.0 s
+    unit: "seconds x 100"
+    semantics: "Seconds of high steam flow; 0 may overheat the heater."
+
+  - name: SerialN
+    fw_row: 16
+    address: "0x00803830"
+    length: 4
+    perms: R
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 4294967295 # 0xFFFFFFFF
+    unit: null
+    semantics: "Current machine serial number."
+
+  - name: HeaterV
+    fw_row: 17
+    address: "0x00803834"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 1230
+    unit: volts
+    semantics: "Nominal heater voltage (0, 120 or 230); +1000 when it is a set value."
+
+  - name: HeaterUp2Timeout
+    fw_row: 18
+    address: "0x00803838"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 5 # the firmware register table 0.5 s
+    max: 300 # the firmware register table 30.0 s
+    unit: "seconds x 10"
+    semantics: "HeaterUp phase-2 timeout."
+
+  - name: CalFlowEst
+    fw_row: 22
+    address: "0x0080383C"
+    length: 4
+    perms: RW
+    mult: 1000
+    value_kind: scaledFloat
+    min: 125 # the firmware register table 0.125 (post-divide). App declares min raw 130 -- narrower is legal (app range must be a subset of this range).
+    max: 2000 # the firmware register table 2.0
+    unit: "ratio x 1000"
+    semantics: "Flow-estimation calibration multiplier."
+
+  - name: FlushFlowRate
+    fw_row: 23
+    address: "0x00803840"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 10 # the firmware register table 1 ml/s
+    max: 80 # the firmware register table 8.0 ml/s
+    unit: "ml/s x 10"
+    semantics: "Flush flow rate."
+
+  - name: FlushTemp
+    fw_row: 24
+    address: "0x00803844"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 10 # the firmware register table 1 degC
+    max: 990 # the firmware register table 99.0 degC
+    unit: "degC x 10"
+    semantics: "Flush temperature."
+
+  - name: FlushTimeout
+    fw_row: 25
+    address: "0x00803848"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 10 # the firmware register table 1 s
+    max: 2500 # the firmware register table 250.0 s
+    unit: "seconds x 10"
+    semantics: "Flush timeout."
+
+  - name: HotWaterFlowRate
+    fw_row: 26
+    address: "0x0080384C"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 0
+    max: 80 # the firmware register table 8.0 ml/s
+    unit: "ml/s x 10"
+    semantics: "Hot water flow rate."
+
+  - name: SteamPurgeMode
+    fw_row: 27
+    address: "0x00803850"
+    length: 4
+    perms: RWD
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 1
+    unit: enum
+    semantics: "Steam purge mode."
+
+  - name: AllowUSBCharging
+    fw_row: 28
+    address: "0x00803854"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: boolean
+    min: 0
+    max: 1
+    unit: bool
+    semantics: "Allow USB charging."
+
+  - name: AppFeatureFlags
+    fw_row: 29
+    address: "0x00803858"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 2147483647 # 0x7FFFFFFF -- top bit unavailable (parts of FW treat it as signed)
+    unit: bitmask
+    semantics: "App-reported feature flags; bit0 = app supports the UserNotPresent substate (app writes 1 on connect)."
+
+  - name: RefillKitPresent
+    fw_row: 30
+    address: "0x0080385C"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 2147483647 # 0x7FFFFFFF
+    unit: enum
+    semantics: "Refill kit presence -- TRI-STATE 0/1/2, not a boolean."
+
+  - name: UserPresent
+    fw_row: 31
+    address: "0x00803860"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: boolean
+    min: 0
+    max: 1
+    unit: bool
+    semantics: "Is the user present."
+
+  # --- Bengle scale / stop-at-weight (app: BengleScaleMmr) --------------------
+  - name: EndOfShotWeight
+    fw_row: 32
+    address: "0x00803864"
+    length: 4
+    perms: RWD
+    mult: 100
+    value_kind: scaledFloat
+    min: 0
+    max: 1000000 # the firmware register table 10000.0 g (post-divide) -- the 10000 g WIRE clamp the app enforces (grams clamped 0..10000 before x100).
+    # Footnote: the firmware's internal model table
+    # gives EOSW a model range of 0..3000 g -- targets above 3000 g are
+    # wire-legal but outside the firmware's model range.
+    unit: "g x 100"
+    semantics: "Stop-at-weight target: firmware ends the shot autonomously at this weight; 0 = disabled. App writes round(grams x 100) -- rounding, not truncation. Read-back is whole grams only (firmware truncates before scaling: floor(g) x 100)."
+
+  - name: MatSetPoint
+    fw_row: 36
+    address: "0x00803874"
+    length: 4
+    perms: RWD
+    mult: 1 # WHOLE degrees C -- not deci-degC, not float32 
+    value_kind: scaledFloat
+    min: 0
+    max: 4294967295 # the firmware register table column is unbounded (0..0xFFFFFFFF); firmware never clamps -- the app is the sole guard, clamping 0..80 degC.
+    unit: degC
+    semantics: "Cup-warmer target in whole degC; 0 = off. Inert unless CupWarmerMode=1; app re-sends both on every connect."
+
+  - name: ScaleCalCmd
+    fw_row: 39
+    address: "0x00803880"
+    length: 4
+    perms: RWT
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 5
+    unit: enum
+    semantics: "Start a non-blocking cal step: 0=abort 1=zero 3=tare 4=latch point 1 (LEFT half) 5=latch point 2 (RIGHT half); 2 = retired auto-detect (errors, never send). Non-zero cmd while busy OR during Espresso is ignored (a cal step would move the mass reference the running shot's stop-at-weight gate depends on; the step stays Idle)."
+
+  - name: ScaleCalState
+    fw_row: 40
+    address: "0x00803884"
+    length: 4
+    perms: R
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 4294967295 # 0xFFFFFFFF
+    unit: packed
+    semantics: "Packed cal state: Step[31:24] SubState[23:16] Remaining[15:8] CalStatus[7:0]. SubState: 0=settling 1=averaging 2=done 3=error. Step at THIS pin (two-point cal): Idle=0 Zeroing=1 CalPoint1=2 CalPoint2=3 Taring=4 Complete=5 Error=6; the FIELD single-point variant numbers Complete=4 / Error=5 (colliding with two-point Taring/Complete). Terminal detection MUST therefore key off SubState (done=2 / error=3), never Step."
+
+  - name: ScaleCalWeight
+    fw_row: 41
+    address: "0x00803888"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 0
+    max: 100000 # the firmware register table 10000 g (post-divide)
+    unit: "g x 10"
+    semantics: "Known reference calibration mass; write and read-back-confirm (within 0.1 g) before ScaleCalCmd 4/5. Read-back is whole grams only (firmware truncates before scaling: floor(g) x 10), so the 0.1 g confirm round-trips ONLY integer-gram references -- use whole-gram masses."
+
+  - name: ScaleTare
+    fw_row: 42
+    address: "0x0080388C"
+    length: 4
+    perms: RWT
+    mult: 1
+    value_kind: int32
+    min: null # trigger -- value ignored, never clamped
+    max: null
+    unit: trigger
+    semantics: "Quick tare: writing any value performs an immediate tare; app writes 1 (de1plus parity). Confirm by watching Weight drop, not by the 0xA013 Flags bit."
+
+  # --- LED strip (app: BengleLedMmr); all packed 0x00RRGGBB -------------------
+  # 16-bit app channels map DOWN by taking each channel's high byte and UP by
+  # byte-replication (0xAB -> 0xABAB). There is NO switch-LED register: the
+  # firmware mirrors the front strip to the switch.
+  - name: FrontLEDColor
+    fw_row: 43
+    address: "0x00803890"
+    length: 4
+    perms: RWD
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 16777215 # 0x00FFFFFF
+    unit: rgb24
+    semantics: "Live/preview front strip colour 0x00RRGGBB: shows immediately regardless of awake/sleep without touching the stored palette; FW refreshes it when a stored palette is applied."
+
+  - name: RearLEDColor
+    fw_row: 44
+    address: "0x00803894"
+    length: 4
+    perms: RWD
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 16777215 # 0x00FFFFFF
+    unit: rgb24
+    semantics: "Live/preview rear strip colour 0x00RRGGBB (as FrontLEDColor)."
+
+  - name: FrontLEDAwake
+    fw_row: 45
+    address: "0x00803898"
+    length: 4
+    perms: RWD
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 16777215 # 0x00FFFFFF
+    unit: rgb24
+    semantics: "Stored front awake palette 0x00RRGGBB; FW applies on wake and immediately when written while awake."
+
+  - name: RearLEDAwake
+    fw_row: 46
+    address: "0x0080389C"
+    length: 4
+    perms: RWD
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 16777215 # 0x00FFFFFF
+    unit: rgb24
+    semantics: "Stored rear awake palette 0x00RRGGBB."
+
+  - name: FrontLEDSleep
+    fw_row: 47
+    address: "0x008038A0"
+    length: 4
+    perms: RWD
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 16777215 # 0x00FFFFFF
+    unit: rgb24
+    semantics: "Stored front sleep palette 0x00RRGGBB; FW applies on sleep."
+
+  - name: RearLEDSleep
+    fw_row: 48
+    address: "0x008038A4"
+    length: 4
+    perms: RWD
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 16777215 # 0x00FFFFFF
+    unit: rgb24
+    semantics: "Stored rear sleep palette 0x00RRGGBB."
+
+  # --- Milk auto-stop (app: BengleSteamMmr) -----------------------------------
+  - name: TargetMilkTemp
+    fw_row: 49
+    address: "0x008038A8"
+    length: 4
+    perms: RWD
+    mult: 10
+    value_kind: scaledFloat
+    min: 0
+    max: 850 # ALREADY RAW (= 85.0 degC): the firmware register table lists 850 in violation of its own post-divide convention (desc says "Range 0-85").
+    unit: "degC x 10"
+    semantics: "Milk-probe steam auto-stop target; 0 = disabled. App clamps 0..85 degC before scaling; live probe reading rides 0xA013 MilkTemp, not an MMR. Read-back resolution is whole degC (floor(degC) x 10) -- writes keep deci-degC."
+    app_alias: StopAtTemperatureTarget # app desc string differs from the FW name (BengleSteamMmr.stopAtTemperatureTarget)
+
+  # --- Cup warmer mode + status (app: BengleMmr.cupWarmerMode + thermal reads) -
+  - name: CupWarmerMode
+    fw_row: 50
+    address: "0x008038AC"
+    length: 4
+    perms: RW # deliberately NOT RWD: resets to 0 every boot so the heater cannot auto-activate after a power cut -- app must re-send on every connect
+    mult: 1
+    value_kind: boolean
+    min: 0
+    max: 1
+    unit: bool
+    semantics: "Cup-warmer enable 0=Off 1=On; RAM-only by design. App writes 1 iff target > 0 and re-asserts (with MatSetPoint) on reconnect."
+
+  - name: InactivitySleepTimeout
+    fw_row: 54
+    address: "0x008038BC"
+    length: 4
+    perms: RWD
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 240
+    unit: minutes
+    semantics: "Minutes of inactivity before autonomous sleep when no tablet is connected; 0 = disabled, default 60. While a tablet is connected the tablet owns sleep."
+
+  - name: SetLocalTimeOfWeek
+    fw_row: 55
+    address: "0x008038C0"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 604800
+    unit: seconds
+    semantics: "Local time as seconds since Sunday 00:00:00; sets the firmware wall-clock. RAM-only, re-push on connect."
+
+  - name: ScheduleEntry
+    fw_row: 56
+    address: "0x008038C4"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 2147483647 # 0x7FFFFFFF
+    unit: packed
+    semantics: "One wake window, packed (dow<<22)|(startMin<<11)|endMin; appended to the schedule table."
+
+  - name: ScheduleControl
+    fw_row: 57
+    address: "0x008038C8"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 255
+    unit: enum
+    semantics: "Schedule control: 0 = clear table + disable, 1 = enable. Write 0, then entries, then 1."
+
+  - name: MatCurrentTemp
+    fw_row: 58
+    address: "0x008038CC"
+    length: 4
+    perms: R
+    mult: 10
+    value_kind: scaledFloat
+    min: 0
+    max: 1600 # ALREADY RAW (= 160.0 degC): second the firmware register table post-divide convention violation, like TargetMilkTemp.
+    unit: "degC x 10"
+    semantics: "Cup-warmer current mat temperature; 0 = no valid reading (NTC open/short) -- app maps 0 to null ('no reading'), never fake data. Read resolution is whole degC despite the x10 unit (firmware truncates before scaling) -- wire values are always multiples of 10."
+
+# -----------------------------------------------------------------------------
+# 0xA013 BengleShotSample -- the sole shot/telemetry source on a Bengle
+# -----------------------------------------------------------------------------
+# BLE: additive characteristic 0xA013 on service 0xA000 (never present on a
+# plain DE1; requires large ATT MTU -- app requests 517). Serial: CID letter S
+# ("<+S>" / "<-S>" / "[S]hex"). 28 bytes, size-locked in firmware
+# (static_assert on T_BengleShotSample), streamed at 15 Hz.
+#
+# ALL multi-byte fields are BIG-endian -- the opposite of the little-endian MMR
+# payloads. It is a reorganised superset of 0xA00D, not 0xA00D + a tail: field
+# order, widths and scaling all differ; never reuse the 0xA00D parser.
+#
+# DROP RULE: frames shorter than 28 bytes are dropped (decoder returns null,
+# transport drops + warns) -- never a RangeError, never a snapshot. Bytes
+# beyond 28 are ignored.
+#
+# Golden frame (hand-computed, cross-checked vs firmware + de1plus):
+#   03E8 0384 0258 00FA 00C8 00B4 2422 2260 2454 2328 0490 07 34BC 0000 00
+#   -> time 1000, pressure 9.00, setPressure 6.00, flow 2.50, setFlow 2.00,
+#      gFlow 1.80, mix 92.50, head 88.00, setMix 93.00, setHead 90.00,
+#      weight 1168/32 = 36.5 g, frame 7, steam 135.00, milk 0.00, flags 0
+packet_0xA013:
+  size_bytes: 28
+  endianness: big
+  ble_characteristic: "A013"
+  ble_service: "A000"
+  serial_cid: S
+  rate_hz: 15
+  drop_rule: "Frames < 28 bytes are dropped at both the transport and the decoder (null, no RangeError); trailing bytes beyond 28 are ignored."
+  fields:
+    - { offset: 0,  size: 2, name: SampleTime,       type: u16, scale: 1,    unit: halfcycles, semantics: "Half-cycles since shot start (same basis as 0xA00D SampleTime)." }
+    - { offset: 2,  size: 2, name: GroupPressure,    type: u16, scale: 0.01, unit: bar,  semantics: "Pressure at group (u16 / 100)." }
+    - { offset: 4,  size: 2, name: SetGroupPressure, type: u16, scale: 0.01, unit: bar,  semantics: "Set pressure; 0 if no target." }
+    - { offset: 6,  size: 2, name: GroupFlow,        type: u16, scale: 0.01, unit: ml/s, semantics: "Estimated flow at group." }
+    - { offset: 8,  size: 2, name: SetGroupFlow,     type: u16, scale: 0.01, unit: ml/s, semantics: "Set flow; 0 if no target." }
+    - { offset: 10, size: 2, name: GFlow,            type: u16, scale: 0.01, unit: g/s,  semantics: "Gravimetric flow from the integrated scale -> MachineSnapshot.weightFlow." }
+    - { offset: 12, size: 2, name: MixTemp,          type: u16, scale: 0.01, unit: degC, semantics: "Water temperature entering the group." }
+    - { offset: 14, size: 2, name: HeadTemp,         type: u16, scale: 0.01, unit: degC, semantics: "Showerhead water temperature (u16/100 here; 0xA00D used 3-byte U24P16 -- layout differs)." }
+    - { offset: 16, size: 2, name: SetMixTemp,       type: u16, scale: 0.01, unit: degC, semantics: "Mix temperature target; 0 if no target." }
+    - { offset: 18, size: 2, name: SetHeadTemp,      type: u16, scale: 0.01, unit: degC, semantics: "Showerhead temperature target; 0 if no target." }
+    - { offset: 20, size: 2, name: Weight,           type: u16, scale: 0.03125, unit: g, semantics: "Integrated-scale weight, U16P5 (u16 / 32 -- NOT / 100): max 2048 g, step 0.03125 g. ALREADY net of tare (firmware serializes CurrW - LastTARE, the exact stop-at-weight control expression). A negative net weight (platform unloaded after a tare) clamps to 0 on the wire -- U16P5 has no sign bit." }
+    - { offset: 22, size: 1, name: FrameNumber,      type: u8,  scale: 1,    unit: index, semantics: "Profile frame currently executing." }
+    - { offset: 23, size: 2, name: SteamTemp,        type: u16, scale: 0.01, unit: degC, semantics: "Steam metal temperature (unaligned offset -- the struct is packed)." }
+    - { offset: 25, size: 2, name: MilkTemp,         type: u16, scale: 0.01, unit: degC, semantics: "Milk-probe temperature (u16 / 100). 0 = no probe / no fresh reading: at this firmware pin the value is a refreshed only while the probe reports live data." }
+    - { offset: 27, size: 1, name: Flags,            type: u8,  scale: 1,    unit: bitmask, semantics: "Newer FW (this pin): bit0 = LastTARE != 0.0f; app must never gate on it. (Older firmware wrote 0 unconditionally; it is a value proxy, not a tare event.)" }
+
+# -----------------------------------------------------------------------------
+# Serial (USB) ASCII view -- shared with the firmware BLE module
+# -----------------------------------------------------------------------------
+serial_verbs:
+  framing:
+    write: '"<X>" + lowercase hex (2 chars/byte) + newline -- write payload to endpoint letter X'
+    subscribe: '"<+X>" + newline -- add-notify for endpoint letter X; firmware add-notify ALWAYS provokes one immediate [X] frame even if the value is unchanged'
+    unsubscribe: '"<-X>" + newline -- remove-notify'
+    reply: '"[X]" + HEX -- one inbound frame; a message is complete when followed by the next "[" or a newline'
+    notes: "No checksum, no retransmit; leading junk before the first '[' is discarded; a receive buffer past 4096 chars with no complete message is dumped with a warning. Resync relies on the keepalive and on MMR-read retries."
+  mmr_read: # <E> = readFromMMR (BLE 0xA005). Reads go over E, never F.
+    request: '"<E>" + 40 hex chars: 20-byte T_ReadFromMMR -- byte[0] Len (firmware reads (Len+1)*4 bytes; app sends 0 => 4 bytes), byte[1..3] 24-bit address BIG-endian, byte[4..19] zeros'
+    response: '"[E]" + hex: byte[0] length, byte[1..3] address BIG-endian (match the request triplet), byte[4..7] value LITTLE-endian int32, echo padded to the 20-byte frame'
+    round_trip: "Arm the [E] listener BEFORE writing the request (address-triplet match closes the race); bounded 4 s timeout, 2 retries with 300 ms settle; readFromMMR is continuously subscribed on serial (<+E> at connect). Addresses must be 4-aligned or the firmware silently drops the frame."
+    probe_example: 'v13Model probe: "<E>0080000c" + 32 zero chars -> "[E]0480000C80000000..." (len 4, LE value 0x00000080 = 128 = Bengle)'
+  mmr_write: # <F> = writeToMMR (BLE 0xA006). Write-only: no [F] frame ever exists.
+    frame: '"<F>" + EXACTLY 40 hex chars: 20-byte the MMR write frame -- byte[0] Len = TRUE payload byte count (firmware requires 1..16), byte[1..3] 24-bit address BIG-endian, byte[4..19] data (int values LE int32 at offset 4, unused tail zeros)'
+    zero_pad_rule: "The firmware serial parser consumes exactly sizeof(the MMR write frame) = 20 bytes (40 hex chars) per <F> frame before accepting the newline; a short frame desyncs it. The app zero-pads ONLY writeToMMR frames shorter than 20 bytes (the DFU uploader's final chunk is the sole short-frame producer). The Len byte carries the true length so padding is inert; the BLE path is unchanged and other endpoints are never padded."
+  one_shot_read: 'Endpoints without a continuous subscription (versions "A", temperatures "J", calibration "R") read as a round trip: "<+X>" -> await the fresh "[X]" (listener armed before the write) -> "<-X>" sent even on failure; bounded timeout (default 2 s). Continuously-subscribed endpoints serve their latest-received frame; endpoints the firmware cannot emit throw a descriptive UnsupportedError.'
+  keepalive: 'A 5 s periodic "<+N>" actively drives the shared BLE/USB serial view: the firmware source arbitration is last-writer-wins (any byte on the BLE-module UART silently steals the notify stream from a passive USB listener), so the client must keep writing; because add-notify forces an immediate [N], it doubles as a resync for the checksum-less ASCII framing.'
+  throughput: "Downlink ceiling ~1920 B/s: the firmware main loop drains at most 16 bytes per ~120 Hz tick and polls for input only on ticks where it sent nothing (half-duplex, downlink-prioritised). Dual 15 Hz [M]+[S] streams (~42 + ~60 chars/frame) overrun the budget -- hardware-confirmed truncated frames and weight flicker -- so on a confirmed Bengle the app unsubscribes 0xA00D over serial with <-M> (BLE has headroom and keeps 0xA00D subscribed, parse-and-dropped)."
+  bengle_specifics:
+    - '"<+S>" is sent unconditionally at serial connect (a plain DE1 simply never emits [S]); "[S]" + 56 hex chars = one 0xA013 frame; the <28-byte drop rule applies on serial too.'
+    - '"<-M>" is sent after Bengle identity is confirmed (v13Model >= 128) -- see throughput.'
+    - '"<-S>" mirrors at disconnect.'
+  usb_identity: # the USB half of brief-Section-5 invariant 11
+    enumeration: 'The Bengle enumerates with the pico-sdk DEFAULT VID:PID 0x2E8A:0x000A and product string "TinyUSB Device" (the device ships TinyUSB default descriptors). Captured from hardware.'
+    app_dispatch: 'The defaults are too generic for the direct-instantiation shortcut: bengleUsbIds stays deliberately EMPTY and 0x2E8A:0x000A rides bengleProbeCandidateIds into the identification PROBE path instead -- the serial v13Model read (>= 128) remains the sole authority on Bengle identity.'
+    android_name_gate: 'serialProbeAllowsProductName() admits a port to the probe when the USB product name is null/unknown, contains "Serial", or is exactly one of "DE1" / "Bengle" / "Half Decent Scale"; every other name is skipped without probing. Desktop has NO name gate.'
+    android_auto_permission: 'android/app/src/main/res/xml/device_filter.xml grants USB permission without a user prompt for vendor-id 11914 (0x2E8A) / product-id 10 (0x000A).'

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -4914,7 +4914,7 @@ components:
           type: array
           items:
             type: string
-            enum: [machine, scale, sensor]
+            enum: [machine, scale, sensor, bengle]
           nullable: true
         themeMode:
           description: App theme mode
@@ -5004,7 +5004,7 @@ components:
           type: array
           items:
             type: string
-            enum: [machine, scale, sensor]
+            enum: [machine, scale, sensor, bengle]
         themeMode:
           description: App theme mode
           type: string

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -109,6 +109,39 @@ Discovery services are responsible for scanning and creating device instances. E
   (`0x2E8A:0x000A`) comes from
   `android/app/src/main/res/xml/device_filter.xml`.
 
+  **USB/serial transport behaviour (DE1 family).** The wire protocol is the
+  DE1 ASCII serial view (uplink `<X>hex` / `<+X>` / `<-X>`, downlink
+  `[X]hex`), shared with the firmware's BLE module. Constraints the client
+  designs around (`UnifiedDe1Transport`):
+
+  - **Reads.** The serial view has no read verb. Continuously-subscribed
+    frames (state, shot sample, water levels, MMR, FW map) are served from
+    the latest received frame; `versions`, `temperatures` and `calibration`
+    are one-shot `<+X>` → `[X]` → `<-X>` round trips with a 2 s timeout
+    (firmware that never emits the char fails fast instead of hanging).
+    Endpoints the firmware cannot emit (`setTime`, `shotDirectory`,
+    `headerWrite`, `frameWrite`, …) throw `UnsupportedError`. Shot settings
+    (`[K]`) are accepted as writes by the the Bengle firmware but not yet
+    emitted — a serial read returns the seeded zero frame until the
+    firmware gains `[K]` support.
+  - **Length-exact frames.** The firmware parser consumes exactly
+    `sizeof(struct)` hex bytes per `<X>` frame; a short frame is dropped and
+    desyncs the parser to the next `<`. The only short-frame producer — the
+    DFU uploader's final image chunk — is zero-padded to the 20-byte
+    the MMR write frame size on serial (the `Len` byte keeps the true length).
+  - **Throughput.** The firmware serial downlink is capped at ~1920 B/s
+    (16 bytes per 120 Hz tick), half-duplex and downlink-prioritised.
+    Subscriptions are budgeted accordingly, and truncated frames from a
+    momentary overrun are dropped with a warning rather than crashing the
+    parser.
+  - **Link arbitration.** BLE and USB are mutually exclusive in the
+    firmware (last-writer-wins source flag): a passively-listening USB
+    client can silently lose its notify stream to a stray BLE-module byte.
+    The transport actively drives the link with a 5 s `<+N>` keepalive,
+    which re-asserts the USB source and re-syncs subscribed frames (the
+    ASCII framing has no checksum/retransmit; MMR reads additionally carry
+    their own timeout+retry).
+
 #### 3. SimulatedDeviceService
 - **Platform:** All
 - **File:** `lib/src/services/simulated_device_service.dart`

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -142,6 +142,18 @@ Discovery services are responsible for scanning and creating device instances. E
     ASCII framing has no checksum/retransmit; MMR reads additionally carry
     their own timeout+retry).
 
+  **Bluetooth-off operation.** USB/serial discovery keeps running with the
+  Bluetooth adapter off (the scan runs every discovery service in parallel
+  and records per-service failures instead of failing the whole scan). The
+  scan-flow UI demotes only the `adapterOff` error while non-Bluetooth
+  results are in flight — found machines, an active connect, a pending
+  picker — so a wired-only setup still reaches its picker; genuine connect
+  failures still surface, and the adapter-off view tells the user USB keeps
+  working. The preferred machine is stored per transport id (a serial
+  device's `usb-…` stable id vs a BLE MAC), so the first wired session ends
+  at the picker; picking the wired machine once makes later launches
+  auto-connect over USB.
+
 #### 3. SimulatedDeviceService
 - **Platform:** All
 - **File:** `lib/src/services/simulated_device_service.dart`

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -89,11 +89,25 @@ Discovery services are responsible for scanning and creating device instances. E
   1. `productName == "DE1"` → `UnifiedDe1`. `productName == "Bengle"` →
      `Bengle`. Cheapest path.
   2. VID:PID match against `lib/src/services/serial/usb_ids.dart`.
-     Tables empty until concrete pairs are captured from hardware.
+     Direct-instantiation tables stay empty: the Bengle's captured pair
+     (`0x2E8A:0x000A`, product string "TinyUSB Device") is the pico-sdk
+     default that any hobby CDC board also uses, so it only *qualifies
+     the port for the probe* (`bengleProbeCandidateIds`) — the `v13Model`
+     read decides what the device actually is.
   3. Fallback: open the port, send `<+M>` and the v13Model MMR-read
      request, wait for `[M]` (DE1-protocol baseline) plus an `[E]…`
      reply at addr `0x0080000C`. v13Model `>= 128` → `Bengle`, else
      `UnifiedDe1`. Encoded via `lib/src/services/serial/mmr_codec.dart`.
+
+  On Android the enumeration is pre-filtered by USB `productName`
+  (`serialProbeAllowsProductName` in `lib/src/services/serial/utils.dart`):
+  `DE1`, `Bengle`, `Half Decent Scale`, anything containing `Serial`, and
+  unknown (null) names are probed; everything else is skipped so the
+  3-second probe never opens unrelated USB devices. A port whose VID:PID is
+  in `bengleProbeCandidateIds` passes the gate regardless of its name.
+  Desktop has no name gate. Auto-permission for the Bengle VID:PID
+  (`0x2E8A:0x000A`) comes from
+  `android/app/src/main/res/xml/device_filter.xml`.
 
 #### 3. SimulatedDeviceService
 - **Platform:** All

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -131,6 +131,31 @@ Discovery services use name-based matching via `DeviceMatcher` to create appropr
 - Service verification happens during `onConnect()` using `BleServiceIdentifier`
 - DiFluid R2 reflectometers are matched separately from DiFluid scales by advertised name and the R2 BLE service UUID, then exposed as `Sensor` devices with a `measure` command
 
+#### Bengle: name is a hint, `v13Model` is authoritative
+
+The BLE advertised name only *selects the class at scan time* — it must not
+decide the DE1-vs-Bengle protocol, because the authoritative identity is the
+`v13Model` MMR register (`0x0080000C`), which is readable only **after**
+connecting: `model >= 128` ⇒ Bengle (the DE1 family is `1..7`; served
+unscaled). `UnifiedDe1.onConnect` reads it and sets the `isBengle` flag.
+
+So `DeviceMatcher` stays name-based, and `De1Controller.connectToDe1`
+re-resolves the machine class from the connected model
+(`resolveMachineForModel`, `lib/src/models/device/impl/de1/de1_resolver.dart`):
+
+- if the name-picked class already agrees with the model (the common case —
+  real Bengle hardware advertises `"Bengle"`), the same instance is used, with
+  no reconnect;
+- otherwise a fresh instance of the correct class (`Bengle` / `UnifiedDe1`) is
+  built over the **same live transport**, carrying the connect-time identity
+  across, and re-connected (which only re-subscribes + runs capability init —
+  no MMR re-read).
+
+This mirrors the serial path (`serial_service_*`), which already instantiates
+`Bengle` vs `UnifiedDe1` from `v13Model >= 128` at detection time. Net effect:
+a Bengle presenting any advertised name still gets Bengle features, and a DE1
+mis-advertising `"Bengle"` is driven as a plain DE1.
+
 ### Service Lifecycle
 
 1. **Initialization:** `service.initialize()`

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -10,6 +10,9 @@ import 'package:reaprime/src/models/data/shot_state_event.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1_resolver.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/errors.dart';
 import 'package:rxdart/subjects.dart';
 
@@ -141,14 +144,57 @@ class De1Controller {
   }
 
   Future<void> connectToDe1(De1Interface de1Interface) async {
-    if (de1Interface == _de1) {
-        _log.fine("trying to connect to existing de1, exit early");
-        return;
-      }
+    // Guard on deviceId, not object identity: after a model-based class swap
+    // (resolveMachineForModel below) `_de1` is a rebuilt instance, so a
+    // caller re-passing the name-picked interim (same physical machine)
+    // would otherwise fall through and needlessly tear down + rebuild the
+    // live connection.
+    if (_de1 != null &&
+        (identical(de1Interface, _de1) ||
+            de1Interface.deviceId == _de1!.deviceId)) {
+      _log.fine("trying to connect to existing de1, exit early");
+      return;
+    }
     _onDisconnect(); // just in case
     _log.fine("found de1, connecting");
+    var machine = de1Interface;
     try {
-      await de1Interface.onConnect();
+      await machine.onConnect();
+      // BLE discovery picks the class by advertised name, but the v13Model
+      // read in onConnect is authoritative. If they disagree, re-resolve to
+      // the correct class over the same live transport and finish connecting
+      // it (the re-connect only (re)subscribes + runs capability init —
+      // identity was carried over, so no MMR re-read).
+      final resolved = resolveMachineForModel(machine);
+      if (!identical(resolved, machine)) {
+        _log.info(
+          'v13Model disagrees with name-picked class: re-resolved '
+          '${machine.name} -> ${resolved.name} over the same transport',
+        );
+        await resolved.onConnect();
+        // The name-picked interim is discarded but shares the live transport
+        // with `resolved`; detach its wrapper (stop listening + close its
+        // subjects) WITHOUT disposing the shared transport, which `resolved`
+        // now owns. Prevents a lingering serial readStream listener and
+        // leaked subjects.
+        //
+        // A *demoted* Bengle interim (name-picked "Bengle" that reads
+        // v13Model < 128) ran its capability init in onConnect, attaching
+        // capability subjects to itself that only Bengle.onDisconnect would
+        // release — and the discarded interim never sees a disconnect.
+        // Dispose EVERY capability Bengle.onConnect initialises; when a new
+        // capability mixin is added to Bengle, extend this teardown or the
+        // demotion path leaks its subjects
+        // (test/controllers/de1_controller_resolve_test.dart locks this).
+        if (machine is Bengle) {
+          await machine.disposeIntegratedScale();
+          await machine.disposeLedStrip();
+        }
+        if (machine is UnifiedDe1) {
+          await machine.detachTransport();
+        }
+        machine = resolved;
+      }
     } catch (e, st) {
       _log.warning(
         'Failed to connect to ${de1Interface.name} '
@@ -159,7 +205,7 @@ class De1Controller {
       _onDisconnect();
       rethrow;
     }
-    _de1 = de1Interface;
+    _de1 = machine;
     _de1Controller.add(_de1);
 
     _subscriptions.add(

--- a/lib/src/device_discovery_feature/scan_flow_view.dart
+++ b/lib/src/device_discovery_feature/scan_flow_view.dart
@@ -5,6 +5,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:reaprime/src/controllers/connection_error.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/scan_state_guardian.dart';
@@ -252,12 +253,29 @@ class ScanFlowViewState extends State<ScanFlowView> {
   Widget build(BuildContext context) {
     final Widget content;
 
-    // Adapter error takes precedence
-    if (_adapterError != null) {
+    // Adapter error takes precedence -- but only while nothing that works
+    // WITHOUT Bluetooth is in flight. USB/serial discovery keeps running
+    // with the adapter off, so found machines, an active
+    // connect, or a pending picker keep the normal flow visible and a
+    // wired-only setup can reach the skin. `ready` navigates away above
+    // regardless.
+    final busyWithoutBle =
+        _status.phase == ConnectionPhase.connectingMachine ||
+        _status.phase == ConnectionPhase.connectingScale ||
+        _status.pendingAmbiguity != null ||
+        _status.foundMachines.isNotEmpty ||
+        _discoveredMachines.isNotEmpty;
+    if (_adapterError != null && !busyWithoutBle) {
       content = _adapterErrorView(context);
     }
-    // Error state from connection manager
-    else if (_status.error != null && _status.phase == ConnectionPhase.idle) {
+    // Error state from connection manager. The sticky adapter-off error
+    // gets the same treatment as the guardian view above: it must not
+    // hide machines that were found WITHOUT Bluetooth (USB/serial), or
+    // a wired-only setup can never reach its picker.
+    else if (_status.error != null &&
+        _status.phase == ConnectionPhase.idle &&
+        !(busyWithoutBle &&
+            _status.error!.kind == ConnectionErrorKind.adapterOff)) {
       content = _errorView(context);
     }
     // Scanning
@@ -610,6 +628,12 @@ class ScanFlowViewState extends State<ScanFlowView> {
           Text('Bluetooth Unavailable', style: theme.textTheme.h4),
           Text(
             _adapterError!,
+            style: theme.textTheme.muted,
+            textAlign: TextAlign.center,
+          ),
+          Text(
+            'USB connections keep working: plug the machine in over USB '
+            'and it will be found without Bluetooth.',
             style: theme.textTheme.muted,
             textAlign: TextAlign.center,
           ),

--- a/lib/src/models/device/impl/de1/de1.models.dart
+++ b/lib/src/models/device/impl/de1/de1.models.dart
@@ -291,11 +291,17 @@ enum MMRItem implements MmrAddress {
     readScale: 0.01,
     writeScale: 100.0,
   ),
+  // Scales fixed against firmware the firmware register table (mult = 100, seconds ×100 on the
+  // wire): this entry used to carry the default 1.0 scales, which was latent
+  // (nothing reads/writes it yet) but the first wired setter would have
+  // written 100× low. Pinned by the bengle_hw_v1.yml contract checker.
   steamStartSecs(
     0x0080382C,
     4,
     MmrValueKind.scaledFloat,
     "Seconds of high steam flow * 100. Valid range 0.0 - 4.0. 0 may result in an overheated heater. Be careful.",
+    readScale: 0.01,
+    writeScale: 100.0,
   ),
   serialN(0x00803830, 4, MmrValueKind.int32, "Current serial number"),
   heaterV(

--- a/lib/src/models/device/impl/de1/de1.models.dart
+++ b/lib/src/models/device/impl/de1/de1.models.dart
@@ -415,10 +415,13 @@ enum DecentMachineModel {
         return DecentMachineModel.DE1XXL;
       case 6:
         return DecentMachineModel.DE1XXXL;
-      case 128:
-        return DecentMachineModel.Bengle;
       default:
-        return DecentMachineModel.Unknown;
+        // v13Model >= 128 => Bengle; the DE1 family is 1..7. Matches the
+        // detection gate (unified_de1 / serial_service both use `>= 128`),
+        // so a future Bengle model number resolves to Bengle, not Unknown.
+        return model >= 128
+            ? DecentMachineModel.Bengle
+            : DecentMachineModel.Unknown;
     }
   }
 }

--- a/lib/src/models/device/impl/de1/de1_resolver.dart
+++ b/lib/src/models/device/impl/de1/de1_resolver.dart
@@ -1,0 +1,42 @@
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+
+/// Model-authoritative machine class selection.
+///
+/// BLE discovery instantiates the machine class from the advertised name
+/// (`DeviceMatcher`), before a connection exists. But the authoritative
+/// identity is `v13Model` (`>= 128` ⇒ Bengle), which is only readable after
+/// connecting. So the name-picked class can be wrong: a Bengle advertising a
+/// DE1-style name lands as a plain [UnifiedDe1] (Bengle features dark), and a
+/// DE1 mis-advertising "Bengle" lands as a [Bengle].
+///
+/// Call this **after** [UnifiedDe1.onConnect] (which sets [UnifiedDe1.isBengle]
+/// from the read model). It returns:
+///  - the same instance when the name-picked class already matches the model
+///    (the common case — real Bengle hardware advertises "Bengle"), or
+///  - a fresh instance of the correct class built over the **same live
+///    transport**, with the connect-time identity carried over
+///    ([UnifiedDe1.adoptIdentityFrom]). The caller runs `onConnect` on the
+///    returned instance; because its identity is pre-populated, that call
+///    skips the MMR re-reads and only (re)subscribes + runs capability init.
+///
+/// This mirrors the serial path, which already picks `Bengle` vs `UnifiedDe1`
+/// from `v13Model >= 128` at detection time (`serial_service_*`). The BLE
+/// transport's per-characteristic subscriptions are replaced (not stacked) on
+/// the re-`connect`, so rebuilding over the shared transport is safe.
+De1Interface resolveMachineForModel(De1Interface machine) {
+  // Only DE1-family machines carry the v13Model gate; anything else is
+  // returned untouched.
+  if (machine is! UnifiedDe1) return machine;
+
+  final wantsBengle = machine.isBengle;
+  if (wantsBengle && machine is! Bengle) {
+    return Bengle(transport: machine.dataTransport)..adoptIdentityFrom(machine);
+  }
+  if (!wantsBengle && machine is Bengle) {
+    return UnifiedDe1(transport: machine.dataTransport)
+      ..adoptIdentityFrom(machine);
+  }
+  return machine;
+}

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -807,7 +807,11 @@ class UnifiedDe1 implements De1Interface {
   @protected
   Future<void> writeMmrScaled(MmrAddress addr, double value) async {
     _assertKind(addr, const {MmrValueKind.scaledFloat}, 'writeMmrScaled');
-    final scaled = (value * addr.writeScale).toInt();
+    // round(), not toInt(): floating error (e.g. 2.3 * 100 == 229.999…)
+    // truncates a whole unit low. Matches de1plus, which rounds this write
+    // class. (Bengle path — every Bengle capability scaled write routes
+    // through here.)
+    final scaled = (value * addr.writeScale).round();
     if (addr is MMRItem) return _writeMMRInt(addr, scaled);
     final clamped = (addr.min != null && addr.max != null)
         ? scaled.clamp(addr.min!, addr.max!)

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -193,6 +193,48 @@ class UnifiedDe1 implements De1Interface {
   int _refillKit = -1;
   double? _cachedFlowEstimation;
 
+  bool _isBengle = false;
+
+  /// Authoritative Bengle identity, established on [onConnect] from the
+  /// `v13Model` MMR (`0x0080000C`): `model >= 128` ⇒ Bengle (the DE1 family
+  /// is 1..7; the register is served unscaled).
+  ///
+  /// The BLE advertised name is only a scan hint — `DeviceMatcher` picks the
+  /// class by name before a connection exists — so this runtime flag, read
+  /// from the wire, is authoritative. `resolveMachineForModel` uses it at
+  /// connect time to re-resolve the machine to the correct class over the
+  /// same transport, so a Bengle advertising a DE1-style name still presents
+  /// Bengle features. `false` until `onConnect` has read the model; the
+  /// serial path gates the same way (`serial_service_*`).
+  bool get isBengle => _isBengle;
+
+  /// The underlying [DataTransport], exposed for connect-time model-based
+  /// class resolution (`resolveMachineForModel`): when `v13Model` disagrees
+  /// with the name-picked class, a fresh instance is built over this same
+  /// live transport. Not intended for direct I/O.
+  DataTransport get dataTransport => _transport.dataTransport;
+
+  /// Copies the connect-time identity that [onConnect] reads (machine info,
+  /// heater voltage, refill-kit state, flow-cal cache, Bengle flag) from
+  /// [other] onto this instance. Used by `resolveMachineForModel` so a
+  /// re-resolved machine's [onConnect] short-circuits the MMR re-reads (its
+  /// `_info` is already populated) and only (re)subscribes + runs capability
+  /// init over the shared transport.
+  void adoptIdentityFrom(UnifiedDe1 other) {
+    _info = other._info;
+    _voltage = other._voltage;
+    _refillKit = other._refillKit;
+    _cachedFlowEstimation = other._cachedFlowEstimation;
+    _isBengle = other._isBengle;
+  }
+
+  /// Releases this instance's transport wrapper (its subjects + serial read
+  /// subscription) WITHOUT disposing the underlying transport, which a
+  /// re-resolved replacement now owns. Used by `De1Controller.connectToDe1`
+  /// to tear down the discarded name-picked interim after a model-based
+  /// class swap. See `resolveMachineForModel`.
+  Future<void> detachTransport() => _transport.detach();
+
   @override
   Future<void> onConnect() async {
     initRawStream();
@@ -203,10 +245,17 @@ class UnifiedDe1 implements De1Interface {
     }
 
     final model = _unpackMMRInt(await _mmrRead(MMRItem.v13Model));
-    if (model >= 128) {
-      _log.warning(
-        'Device model $model indicates non-DE1 hardware '
-        '(Bengle or similar). Advertised name may be misleading.',
+    // v13Model (0x0080000C) is the authoritative Bengle identity —
+    // model >= 128 ⇒ Bengle (DE1 family is 1..7), served unscaled. The BLE
+    // advertised name is only a scan hint (DeviceMatcher picks the class by
+    // name); De1Controller.connectToDe1 re-resolves the class from this flag
+    // afterwards (resolveMachineForModel), so a mis-named Bengle still gets
+    // Bengle features.
+    _isBengle = model >= 128;
+    if (_isBengle) {
+      _log.info(
+        'v13Model=$model (>=128): Bengle hardware detected. Advertised '
+        'name is a hint only.',
       );
     }
     final ghcInfo = _unpackMMRInt(await _mmrRead(MMRItem.ghcInfo));
@@ -448,7 +497,7 @@ class UnifiedDe1 implements De1Interface {
     await _sendProfile(profile);
     _currentProfile = profile;
     // Guard against firmware ProfileDownloadInProgress race: the DE1 writes
-    // the shot descriptor to internal flash inside APIView::write for the
+    // the shot descriptor to internal flash inside the firmware for the
     // final frame and tail, and only clears ProfileDownloadInProgress when
     // that flash write returns. If a state=espresso request hits the
     // firmware task loop before the flag clears, doEspresso() aborts to

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart
@@ -151,6 +151,13 @@ extension UnifiedDe1MMR on UnifiedDe1 {
   }
 
   Future<void> _writeMMRScaled(MMRItem item, double value) async {
+    // toInt() (truncate), NOT round(): these base-DE1 setters
+    // (flush/hot-water/steam/heater/cal flow) must stay byte-identical to a
+    // plain DE1 as shipped, and de1plus truncates them via int(...) —
+    // e.g. set_flush_flow_rate `int(10*rate)`, set_steam_flow (de1_comms.tcl).
+    // The Bengle-only ×100 weight case that genuinely needs rounding (floating
+    // error: 2.3*100 == 229.999… truncates low) rides the SEPARATE public
+    // writeMmrScaled() helper, which de1plus also rounds — not this one.
     final scaledValue = (value * item.writeScale).toInt();
     await _writeMMRInt(item, scaledValue);
   }

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -26,6 +26,43 @@ class UnifiedDe1Transport {
   // serial branch never runs.
   StreamSubscription<String>? _transportSubscription;
 
+  /// period of the serial keepalive that actively drives the
+  /// shared firmware link. BLE and USB share one serial view in the
+  /// firmware, arbitrated by a last-writer-wins `Source` flag — any stray
+  /// byte from the BLE module silently steals the notify stream from a
+  /// passively-listening USB client (the firmware its BLE input path vs
+  /// the BLE-UART RX path). A periodic `<+N>` re-add re-asserts
+  /// Source=USB, and — because the firmware treats an add-notify as a
+  /// force-update — also re-syncs any subscribed frame a silently-dropped
+  /// byte corrupted (the ASCII framing has no checksum/retransmit). 5 s
+  /// bounds the worst-case stolen-stream window at negligible cost (one
+  /// ~8-char command up, one [N] frame + changed frames down).
+  static const defaultSerialKeepaliveInterval = Duration(seconds: 5);
+
+  /// Test seam: keepalive cadence, injectable so the timer tests can run
+  /// on real (shortened) time — fakeAsync stalls on the root-zone
+  /// `_nullFuture` that broadcast-subscription cancels return.
+  final Duration serialKeepaliveInterval;
+  Timer? _serialKeepalive;
+
+  /// bounded wait for a single-notify serial read. The firmware
+  /// answers a `<+X>` with one `[X]` frame within a notify tick, so 2 s is
+  /// generous; firmware that never emits the char (e.g. a pre-parity
+  /// the firmware asked for `[A]`) fails fast with a [TimeoutException] instead
+  /// of hanging the raw-API caller.
+  static const defaultSerialSingleReadTimeout = Duration(seconds: 2);
+
+  /// Test seam: see [serialKeepaliveInterval].
+  final Duration serialSingleReadTimeout;
+
+  /// the firmware serial parser consumes exactly
+  /// the frame length is 20 bytes per `<F>`
+  /// frame (the firmware serial view counts hex pairs before accepting
+  /// the newline). BLE tolerates a short final DFU chunk; serial drops the
+  /// whole frame and resyncs on the next `<`. The `Len` byte (`data[0]`)
+  /// carries the true payload length, so trailing zeros are inert.
+  static const _writeToMmrFrameBytes = 20;
+
   // True while `_handleBleTimeout` is doing a deliberate disconnect→reconnect
   // to recover from a BLE timeout. The disconnect it issues must stay
   // invisible to upstream (De1Controller would otherwise null the machine on
@@ -68,6 +105,17 @@ class UnifiedDe1Transport {
     ByteData(7),
   );
 
+  // single-notify serial read channels ([A] Versions,
+  // [J] Temperatures, [R] Calibration). Plain broadcast controllers, NOT
+  // BehaviorSubjects: a read must resolve with the fresh frame provoked by
+  // its own `<+X>`, never a cached one.
+  final StreamController<ByteData> _versionsController =
+      StreamController.broadcast();
+  final StreamController<ByteData> _temperaturesController =
+      StreamController.broadcast();
+  final StreamController<ByteData> _calibrationController =
+      StreamController.broadcast();
+
   Stream<ByteData> get state => _stateSubject.asBroadcastStream();
   Stream<ByteData> get shotSample => _shotSampleSubject.asBroadcastStream();
   Stream<ByteData> get shotSettings => shotSettingsSubject.asBroadcastStream();
@@ -78,7 +126,11 @@ class UnifiedDe1Transport {
   // Serial only
   String _currentBuffer = "";
 
-  UnifiedDe1Transport({required DataTransport transport})
+  UnifiedDe1Transport({
+    required DataTransport transport,
+    this.serialKeepaliveInterval = defaultSerialKeepaliveInterval,
+    this.serialSingleReadTimeout = defaultSerialSingleReadTimeout,
+  })
     : _transport = transport,
       transportType =
           transport is BLETransport
@@ -200,6 +252,20 @@ class UnifiedDe1Transport {
 
     // needed to know which state we're at - request idle state
     await _transport.writeCommand("<B>02");
+
+    // actively drive the shared BLE/USB link — see
+    // [serialKeepaliveInterval] for why a passive USB client loses its
+    // notify stream. Fire-and-forget: a failed keepalive write means the
+    // port is dying, which the read-side onError/onDone paths already
+    // handle; it must not become an unhandled async error.
+    _serialKeepalive?.cancel();
+    _serialKeepalive = Timer.periodic(serialKeepaliveInterval, (_) {
+      _transport
+          .writeCommand("<+${Endpoint.stateInfo.representation}>")
+          .catchError(
+            (Object e) => _log.fine('serial keepalive write failed', e),
+          );
+    });
   }
 
   /// End-of-life cleanup. Closes all subjects, cancels the serial
@@ -209,6 +275,8 @@ class UnifiedDe1Transport {
     // Cancel serial subscription if active
     await _transportSubscription?.cancel();
     _transportSubscription = null;
+    _serialKeepalive?.cancel();
+    _serialKeepalive = null;
 
     // Close all BehaviorSubjects so downstream listeners see onDone
     if (!_stateSubject.isClosed) _stateSubject.close();
@@ -217,6 +285,9 @@ class UnifiedDe1Transport {
     if (!_waterLevelsSubject.isClosed) _waterLevelsSubject.close();
     if (!_mmrSubject.isClosed) _mmrSubject.close();
     if (!_fwMapRequestSubject.isClosed) _fwMapRequestSubject.close();
+    if (!_versionsController.isClosed) _versionsController.close();
+    if (!_temperaturesController.isClosed) _temperaturesController.close();
+    if (!_calibrationController.isClosed) _calibrationController.close();
 
     await _transport.dispose();
   }
@@ -232,12 +303,17 @@ class UnifiedDe1Transport {
   Future<void> detach() async {
     await _transportSubscription?.cancel();
     _transportSubscription = null;
+    _serialKeepalive?.cancel();
+    _serialKeepalive = null;
     if (!_stateSubject.isClosed) _stateSubject.close();
     if (!_shotSampleSubject.isClosed) _shotSampleSubject.close();
     if (!shotSettingsSubject.isClosed) shotSettingsSubject.close();
     if (!_waterLevelsSubject.isClosed) _waterLevelsSubject.close();
     if (!_mmrSubject.isClosed) _mmrSubject.close();
     if (!_fwMapRequestSubject.isClosed) _fwMapRequestSubject.close();
+    if (!_versionsController.isClosed) _versionsController.close();
+    if (!_temperaturesController.isClosed) _temperaturesController.close();
+    if (!_calibrationController.isClosed) _calibrationController.close();
   }
 
   Future<void> disconnect() async {
@@ -253,6 +329,8 @@ class UnifiedDe1Transport {
         }
         await _transportSubscription?.cancel();
         _transportSubscription = null;
+        _serialKeepalive?.cancel();
+        _serialKeepalive = null;
         // Start notifications - regular setup
         await _transport.writeCommand(
           "<-${Endpoint.stateInfo.representation}>",
@@ -375,6 +453,15 @@ class UnifiedDe1Transport {
           _mmrNotification(data);
         case "[I]":
           _fwMapNotification(data);
+        // single-notify read replies. Only ever solicited by
+        // _serialSingleNotifyRead's own `<+X>`, so no length guard here —
+        // the awaiting reader owns interpretation.
+        case "[A]":
+          _versionsController.add(data);
+        case "[J]":
+          _temperaturesController.add(data);
+        case "[R]":
+          _calibrationController.add(data);
         default:
           _log.warning("unhandled de1 message: $input");
           break;
@@ -497,49 +584,98 @@ class UnifiedDe1Transport {
     return response;
   }
 
+  /// Serial reads come in three shapes:
+  ///
+  /// 1. **Continuously-subscribed streams** (`<+X>` sent in
+  ///    `_serialConnect`) — the BehaviorSubject's current value *is* the
+  ///    latest frame; return it.
+  /// 2. **Single-notify round trips** — the DE1 serial view has no read
+  ///    verb; an add-notify (`<+X>`) makes the firmware emit one `[X]`
+  ///    frame immediately, so a read is `<+X>` → await fresh frame →
+  ///    `<-X>` ([_serialSingleNotifyRead]).
+  /// 3. **No read path** — the firmware never emits the char (its
+  ///    the firmware notify loop serves only N/M/Q/I/E/R — plus J/K with the
+  ///    serial-parity firmware; the firmware has no version-frame support,
+  ///    so a `versions` read times out cleanly on every firmware today —
+  ///    and F/G/H are write-only commands). A descriptive
+  ///    [UnsupportedError] beats `UnimplementedError`: the raw WS API
+  ///    surfaces it to the client instead of crashing the read.
   Future<ByteData> _serialRead(Endpoint e) async {
     if (transportType != TransportType.serial) {
       throw "Invalid transport type, expected Serial";
     }
 
     switch (e) {
-      case Endpoint.versions:
-        throw UnimplementedError();
+      // -- continuously subscribed: current value is the latest frame.
       case Endpoint.requestedState:
-        return _stateSubject.first;
-      case Endpoint.setTime:
-        throw UnimplementedError();
-      case Endpoint.shotDirectory:
-        throw UnimplementedError();
-      case Endpoint.readFromMMR:
-        return _mmrSubject.first;
-      case Endpoint.writeToMMR:
-        throw UnimplementedError();
-      case Endpoint.shotMapRequest:
-        throw UnimplementedError();
-      case Endpoint.deleteShotRange:
-        throw UnimplementedError();
-      case Endpoint.fwMapRequest:
-        return _fwMapRequestSubject.first;
-      case Endpoint.temperatures:
-        throw UnimplementedError();
-      case Endpoint.shotSettings:
-        return shotSettingsSubject.first;
-      case Endpoint.deprecatedShotDesc:
-        throw UnimplementedError();
-      case Endpoint.shotSample:
-        return _shotSampleSubject.first;
       case Endpoint.stateInfo:
         return _stateSubject.first;
-      case Endpoint.headerWrite:
-        throw UnimplementedError();
-      case Endpoint.frameWrite:
-        throw UnimplementedError();
+      case Endpoint.readFromMMR:
+        return _mmrSubject.first;
+      case Endpoint.fwMapRequest:
+        return _fwMapRequestSubject.first;
+      case Endpoint.shotSettings:
+        // Note: the the Bengle firmware accepts <K> writes but does not emit
+        // [K] frames (no the firmware notify loop block), so on serial this stays the
+        // seeded zero frame until the firmware gains [K] support.
+        return shotSettingsSubject.first;
+      case Endpoint.shotSample:
+        return _shotSampleSubject.first;
       case Endpoint.waterLevels:
         return _waterLevelsSubject.first;
+
+      // -- single-notify round trips.
+      case Endpoint.versions:
+        return _serialSingleNotifyRead(e, _versionsController.stream);
+      case Endpoint.temperatures:
+        return _serialSingleNotifyRead(e, _temperaturesController.stream);
       case Endpoint.calibration:
-        // TODO: Handle this case.
-        throw UnimplementedError();
+        return _serialSingleNotifyRead(e, _calibrationController.stream);
+
+      // -- no serial read path.
+      case Endpoint.setTime:
+      case Endpoint.shotDirectory:
+      case Endpoint.writeToMMR:
+      case Endpoint.shotMapRequest:
+      case Endpoint.deleteShotRange:
+      case Endpoint.deprecatedShotDesc:
+      case Endpoint.headerWrite:
+      case Endpoint.frameWrite:
+        throw UnsupportedError(
+          'Endpoint ${e.name} has no serial read path: the DE1 serial view '
+          'never emits [${e.representation}] frames',
+        );
+    }
+  }
+
+  /// One-shot serial read of a characteristic that is not continuously
+  /// subscribed: arm a listener, provoke a single notify with
+  /// `<+X>`, await the fresh frame, then `<-X>` so the read leaves no
+  /// stream subscription behind. Bounded by [serialSingleReadTimeout] so
+  /// firmware that never emits the char yields a clean [TimeoutException]
+  /// instead of a hang.
+  Future<ByteData> _serialSingleNotifyRead(
+    Endpoint e,
+    Stream<ByteData> frames,
+  ) async {
+    final t = _transport;
+    if (t is! SerialTransport) {
+      throw StateError(
+        '_serialSingleNotifyRead(${e.name}) requires a serial transport',
+      );
+    }
+    // Arm BEFORE requesting so the reply can't slip between the write
+    // completing and the listener attaching (same race `_mmrReadRaw`
+    // guards against).
+    final response = frames.first.timeout(serialSingleReadTimeout);
+    // If the request write throws, nothing awaits `response` and its later
+    // timeout would surface as an unhandled async error — mark it handled.
+    response.ignore();
+    try {
+      await t.writeCommand('<+${e.representation}>');
+      return await response;
+    } finally {
+      await t.writeCommand('<-${e.representation}>');
     }
   }
 
@@ -662,7 +798,16 @@ class UnifiedDe1Transport {
     if (_transport is! SerialTransport) {
       throw "Invalid transport type, expected Serial";
     }
-    final payload = data
+    var frame = data;
+    // length-exact framing. Only writeToMMR has a short-frame
+    // producer (the DFU uploader's final image chunk); every other caller
+    // already emits struct-sized frames (`_mmrWriteRaw` pads to 20,
+    // Header/Frame writes are 5 B / 8 B by construction). See
+    // [_writeToMmrFrameBytes] for why the firmware requires this.
+    if (e == Endpoint.writeToMMR && data.length < _writeToMmrFrameBytes) {
+      frame = Uint8List(_writeToMmrFrameBytes)..setRange(0, data.length, data);
+    }
+    final payload = frame
         .map((e) => e.toRadixString(16).padLeft(2, '0'))
         .join('');
     await _transport.writeCommand('<${e.representation!}>$payload');

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -42,6 +42,12 @@ class UnifiedDe1Transport {
 
   String get id => _transport.id;
 
+  /// The underlying [DataTransport], exposed for connect-time model-based
+  /// class resolution only (see `resolveMachineForModel`): a re-resolved
+  /// machine is rebuilt over this same live transport. Not for I/O — use the
+  /// typed read/write/subscribe surface.
+  DataTransport get dataTransport => _transport;
+
   final BehaviorSubject<ByteData> _stateSubject = BehaviorSubject.seeded(
     ByteData(4),
   );
@@ -213,6 +219,25 @@ class UnifiedDe1Transport {
     if (!_fwMapRequestSubject.isClosed) _fwMapRequestSubject.close();
 
     await _transport.dispose();
+  }
+
+  /// Releases this wrapper's own resources (serial read subscription + local
+  /// subjects) WITHOUT disposing the underlying [dataTransport]. Used when a
+  /// machine is re-resolved to a different class over the same live transport
+  /// (`resolveMachineForModel`): the discarded interim wrapper must stop
+  /// listening — else a serial `readStream` listener lingers and
+  /// double-parses every line — but must NOT tear down the shared transport,
+  /// which the replacement wrapper now owns. Not for normal teardown; use
+  /// [dispose] for that.
+  Future<void> detach() async {
+    await _transportSubscription?.cancel();
+    _transportSubscription = null;
+    if (!_stateSubject.isClosed) _stateSubject.close();
+    if (!_shotSampleSubject.isClosed) _shotSampleSubject.close();
+    if (!shotSettingsSubject.isClosed) shotSettingsSubject.close();
+    if (!_waterLevelsSubject.isClosed) _waterLevelsSubject.close();
+    if (!_mmrSubject.isClosed) _mmrSubject.close();
+    if (!_fwMapRequestSubject.isClosed) _fwMapRequestSubject.close();
   }
 
   Future<void> disconnect() async {

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io' show Platform;
 import 'dart:typed_data';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart' as device;
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
@@ -58,9 +59,17 @@ class UniversalBleTransport implements BLETransport {
   static const int _bluezDiscoveryRetries = 3;
   static const Duration _bluezDiscoveryRetryDelay = Duration(seconds: 1);
 
-  bool get _isLinux => Platform.isLinux;
+  bool get _isLinux => isLinuxOverride ?? Platform.isLinux;
 
-  UniversalBleTransport({required BleDevice device}) : _device = device {
+  /// Test seam for the Linux-vs-rest platform gate (`dart:io Platform` is
+  /// not fakeable in unit tests). Production code never sets it.
+  @visibleForTesting
+  final bool? isLinuxOverride;
+
+  UniversalBleTransport({
+    required BleDevice device,
+    @visibleForTesting this.isLinuxOverride,
+  }) : _device = device {
     _log = Logger("BLETransport-${device.deviceId}");
   }
 
@@ -105,12 +114,22 @@ class UniversalBleTransport implements BLETransport {
     }
     _startAdvertWatch();
 
-    // Android: post-connect settle + MTU bump.
-    // The 200ms settle avoids service-discovery races on tablet SoCs
-    // where the BLE stack finalises GATT setup asynchronously after
-    // connect. MTU 517 reduces GATT round-trips for reads/writes.
-    if (!_isLinux && Platform.isAndroid) {
-      await Future.delayed(_androidPostConnectDelay);
+    // Post-connect MTU bump: request a large ATT MTU on ALL platforms, not
+    // just Android. The 28-byte Bengle 0xA013 shot-sample notification needs
+    // an MTU above the 23-byte ATT default (else the notification truncates),
+    // and MTU 517 also reduces GATT round-trips for every read/write. The
+    // DE1/Bengle module self-negotiates up to 247 on connect regardless, so
+    // this client request is a belt-and-suspenders complement. Skipped on
+    // Linux — BlueZ manages the MTU itself and universal_ble does not expose
+    // requestMtu there. MTU is a BLE-only concept; the serial transport
+    // neither has nor needs one.
+    if (!_isLinux) {
+      // The 200ms settle avoids a service-discovery race on Android tablet
+      // SoCs that finalise GATT setup asynchronously after connect. Only
+      // needed there, so keep it Android-scoped.
+      if (Platform.isAndroid) {
+        await Future.delayed(_androidPostConnectDelay);
+      }
       try {
         await UniversalBle.requestMtu(
           _device.deviceId,

--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
@@ -187,11 +188,22 @@ class SerialServiceAndroid implements DeviceDiscoveryService {
     _machineSubject.add(_devices);
   }
 
+  /// 3 admission gate for [_detectDevice]: the old inline name check
+  /// dropped `productName == "Bengle"` before the v13Model probe ever ran,
+  /// making the Bengle shortcut below unreachable. A known Bengle VID:PID
+  /// also passes (current firmware enumerates with the TinyUSB default
+  /// strings, so the name alone says nothing); the probe stays the
+  /// authority on what the device actually is. Extracted as a static seam
+  /// so the OR-combination — the actual fix — is unit-testable; the
+  /// predicates alone don't lock the call-site wiring.
+  @visibleForTesting
+  static bool shouldProbeUsbDevice(UsbDevice device) =>
+      serialProbeAllowsProductName(device.productName) ||
+      isBengleProbeCandidate(vid: device.vid, pid: device.pid);
+
   Future<Device?> _detectDevice(UsbDevice device) async {
     _log.info("device name: ${device.productName}");
-    if (device.productName?.contains('Serial') == false &&
-        !(device.productName == 'DE1') &&
-        !(device.productName == 'Half Decent Scale')) {
+    if (!shouldProbeUsbDevice(device)) {
       return null;
     }
     UsbPort? port;
@@ -213,8 +225,8 @@ class SerialServiceAndroid implements DeviceDiscoveryService {
       return UnifiedDe1(transport: transport);
     }
 
-    // Bengle shortcut (productName likely lands as "Bengle" once FW
-    // exposes it; trivial future-proofing).
+    // Bengle shortcut — reachable now that the name gate admits "Bengle"
+    //.
     if (device.productName == "Bengle") {
       _log.info("short circuit to bengle");
       return Bengle(transport: transport);

--- a/lib/src/services/serial/usb_ids.dart
+++ b/lib/src/services/serial/usb_ids.dart
@@ -19,8 +19,26 @@ typedef UsbIdPair = (int vid, int pid);
 /// DE1 USB ID pairs. See doc on [UsbDeviceModel] for caveats.
 const List<UsbIdPair> de1UsbIds = [];
 
-/// Bengle USB ID pairs. Populated once captured from hardware.
+/// Bengle USB ID pairs. Deliberately EMPTY: the Bengle's TinyUSB stack
+/// currently enumerates with the pico-sdk DEFAULT ids (`0x2E8A:0x000A`,
+/// product string "TinyUSB Device" — captured from hardware),
+/// which any default pico-sdk CDC device also uses. Too generic for the
+/// direct-instantiation shortcut; see [bengleProbeCandidateIds] instead.
 const List<UsbIdPair> bengleUsbIds = [];
+
+/// VID:PID pairs that qualify a port for the identification PROBE (the
+/// v13Model read stays the authority on what the device is), without
+/// requiring the product-name gate to pass. This is how a Bengle whose
+/// firmware still ships the TinyUSB default descriptors ("TinyUSB
+/// Device") gets probed at all on Android.
+const List<UsbIdPair> bengleProbeCandidateIds = [(0x2E8A, 0x000A)];
+
+/// True when `(vid, pid)` is worth a DE1-protocol probe even though the
+/// product name says nothing useful. Null inputs yield false.
+bool isBengleProbeCandidate({required int? vid, required int? pid}) {
+  if (vid == null || pid == null) return false;
+  return bengleProbeCandidateIds.contains((vid, pid));
+}
 
 /// Default table consulted by serial services.
 const Map<UsbDeviceModel, List<UsbIdPair>> usbDeviceTable = {

--- a/lib/src/services/serial/utils.dart
+++ b/lib/src/services/serial/utils.dart
@@ -32,6 +32,19 @@ bool isDE1(List<String> data, List<int> bytes) {
   return data.any((e) => e.startsWith("[M]"));
 }
 
+/// Android USB product-name pre-filter for the serial probe.
+///
+/// The gate exists so the 3-second identification probe doesn't open every
+/// USB device on the bus, but it used to drop a board named `Bengle` before
+/// the v13Model probe ever ran (the auto-permission `device_filter.xml`
+/// already holds the Bengle VID:PID). Unknown (null) names stay allowed —
+/// the probe is the authority there. Desktop has no such gate.
+bool serialProbeAllowsProductName(String? productName) {
+  if (productName == null) return true;
+  if (productName.contains('Serial')) return true;
+  return const {'DE1', 'Bengle', 'Half Decent Scale'}.contains(productName);
+}
+
 /// Non-blocking replacement for the native `sp_drain`, which has no timeout
 /// and blocks the calling isolate forever when a USB-serial device never
 /// transmits the buffered bytes (observed when scan probes a non-Decent

--- a/test/controllers/connection_manager_wired_preferred_test.dart
+++ b/test/controllers/connection_manager_wired_preferred_test.dart
@@ -1,0 +1,161 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+
+import '../helpers/mock_de1_controller.dart';
+import '../helpers/mock_device_discovery_service.dart';
+import '../helpers/mock_device_scanner.dart';
+import '../helpers/mock_scale_controller.dart';
+import '../helpers/mock_settings_service.dart';
+
+/// Minimal De1Interface stub (mirrors connection_manager_test.dart's
+/// _FakeDe1) whose deviceId can look like a USB stable id or a BLE MAC.
+class _FakeDe1 implements De1Interface {
+  @override
+  final String deviceId;
+
+  @override
+  final String name;
+
+  @override
+  DeviceType get type => DeviceType.machine;
+
+  @override
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.connected);
+
+  @override
+  Stream<MachineSnapshot> get currentSnapshot => const Stream.empty();
+
+  _FakeDe1({required this.deviceId, String? name})
+    : name = name ?? 'DE1-$deviceId';
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// invariant 12f: the preferred machine is stored per TRANSPORT id
+/// (`connectMachine` saves `machine.deviceId`; a serial device's id is the
+/// `usb-<vid>-<pid>-<serial>` stable id, a BLE device's is its MAC).
+/// Nothing maps a BLE preference onto the same physical machine's USB
+/// identity — deliberately. So the first wired session ends at the picker;
+/// picking the USB machine once makes IT the preference, and later
+/// launches auto-connect over the wire. Do not "fix" this by aliasing
+/// identities.
+void main() {
+  const bleMac = 'AA:BB:CC:DD:EE:FF';
+  const usbStableId = 'usb-2e8a-a-unknown';
+
+  late MockDeviceScanner mockScanner;
+  late MockDe1Controller mockDe1Controller;
+  late MockScaleController mockScaleController;
+  late SettingsController settingsController;
+
+  ConnectionManager buildManager() => ConnectionManager(
+    deviceScanner: mockScanner,
+    de1Controller: mockDe1Controller,
+    scaleController: mockScaleController,
+    settingsController: settingsController,
+  );
+
+  setUp(() async {
+    mockScanner = MockDeviceScanner();
+    mockDe1Controller = MockDe1Controller(
+      controller: DeviceController([MockDeviceDiscoveryService()]),
+    );
+    mockScaleController = MockScaleController();
+    settingsController = SettingsController(MockSettingsService());
+    await settingsController.loadSettings();
+  });
+
+  tearDown(() {
+    mockScanner.dispose();
+  });
+
+  test('first wired session ends at the picker (BLE preference does not '
+      'match the USB identity)', () async {
+    // The user has been connecting over BLE — the stored preference is
+    // the machine's BLE MAC.
+    await settingsController.setPreferredMachineId(bleMac);
+
+    // Today only the wire finds the machine (e.g. Bluetooth off): the
+    // same physical machine appears under its USB stable id.
+    final wiredDe1 = _FakeDe1(deviceId: usbStableId, name: 'Bengle');
+    mockScanner.addDevice(wiredDe1);
+    await Future.delayed(Duration.zero);
+
+    final manager = buildManager();
+    addTearDown(manager.dispose);
+    await manager.connect();
+    await Future.delayed(Duration.zero);
+
+    expect(
+      mockDe1Controller.connectCalls,
+      isEmpty,
+      reason: 'the BLE preference must not auto-claim the USB identity',
+    );
+    expect(manager.currentStatus.phase, ConnectionPhase.idle);
+    expect(
+      manager.currentStatus.pendingAmbiguity,
+      AmbiguityReason.machinePicker,
+      reason: 'the wired-only first session must surface the picker',
+    );
+    expect(manager.currentStatus.foundMachines, [wiredDe1]);
+  });
+
+  test(
+    'picking the USB machine stores its stable id as the preference',
+    () async {
+      await settingsController.setPreferredMachineId(bleMac);
+      final wiredDe1 = _FakeDe1(deviceId: usbStableId, name: 'Bengle');
+
+      final manager = buildManager();
+      addTearDown(manager.dispose);
+      await manager.connectMachine(wiredDe1);
+
+      expect(mockDe1Controller.connectCalls, [same(wiredDe1)]);
+      expect(
+        settingsController.preferredMachineId,
+        usbStableId,
+        reason:
+            'the preference is per transport id — picking the wired '
+            'machine replaces the BLE MAC with the USB stable id',
+      );
+      expect(manager.currentStatus.phase, ConnectionPhase.ready);
+    },
+  );
+
+  test('a later launch auto-connects the preferred wired machine', () async {
+    // The previous session picked the USB machine; its stable id is now
+    // the preference.
+    await settingsController.setPreferredMachineId(usbStableId);
+
+    final wiredDe1 = _FakeDe1(deviceId: usbStableId, name: 'Bengle');
+    mockScanner.addDevice(wiredDe1);
+    await Future.delayed(Duration.zero);
+
+    // A fresh manager, as on app launch.
+    final manager = buildManager();
+    addTearDown(manager.dispose);
+    await manager.connect();
+    await Future.delayed(Duration.zero);
+
+    expect(mockDe1Controller.connectCalls, hasLength(1));
+    expect(mockDe1Controller.connectCalls.single.deviceId, usbStableId);
+    expect(manager.currentStatus.phase, ConnectionPhase.ready);
+    expect(
+      manager.currentStatus.pendingAmbiguity,
+      isNull,
+      reason: 'no picker on later launches — the wire auto-connects',
+    );
+  });
+}

--- a/test/controllers/de1_controller_resolve_test.dart
+++ b/test/controllers/de1_controller_resolve_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+
+import '../helpers/fake_ble_transport.dart';
+import '../helpers/mock_device_discovery_service.dart';
+
+/// Controller-level locks for the connect-time class re-resolution in
+/// `De1Controller.connectToDe1` (model-authoritative selection):
+///
+///  1. the controller finishes connecting the RE-RESOLVED machine, not the
+///     name-picked interim;
+///  2. a *demoted* Bengle interim has every capability its `onConnect`
+///     initialised disposed by the controller (the discarded interim never
+///     sees `Bengle.onDisconnect`, so leaving any capability out leaks its
+///     subjects — an earlier implementation shipped exactly that bug);
+///  3. the connect idempotency guard keys on deviceId, not object identity
+///     (post-swap `_de1` is a different object for the same machine).
+void main() {
+  late FakeBleTransport transport;
+  late De1Controller controller;
+
+  setUp(() async {
+    transport = FakeBleTransport();
+    transport.queueMmrResponseInt(MMRItem.calFlowEst, 100);
+    final deviceController = DeviceController([MockDeviceDiscoveryService()]);
+    await deviceController.initialize();
+    controller = De1Controller(controller: deviceController);
+  });
+
+  tearDown(() async {
+    await controller.dispose();
+    await transport.dispose();
+  });
+
+  test('connectToDe1 re-resolves a DE1-named machine reporting a Bengle model '
+      'and publishes the promoted instance', () async {
+    transport.queueOnConnectResponses(v13Model: 128);
+    final interim = UnifiedDe1(transport: transport);
+
+    await controller.connectToDe1(interim);
+
+    final connected = await controller.de1.first;
+    expect(connected, isA<Bengle>());
+    expect(
+      identical(connected, interim),
+      isFalse,
+      reason:
+          'the name-picked interim must be replaced by the resolved '
+          'Bengle',
+    );
+  });
+
+  test('a demoted Bengle interim has ALL its capability subjects disposed '
+      '(none may leak)', () async {
+    transport.queueOnConnectResponses(v13Model: 1);
+    final interim = Bengle(transport: transport);
+
+    await controller.connectToDe1(interim);
+
+    final connected = await controller.de1.first;
+    expect(connected, isA<UnifiedDe1>());
+    expect(connected, isNot(isA<Bengle>()));
+
+    // Every capability `Bengle.onConnect` initialises must be disposed on
+    // the discarded interim — its `Bengle.onDisconnect` never runs. A
+    // disposed capability closes its subjects, so each stream below must
+    // complete; a leaked (still-open) subject makes `toList()` hang and the
+    // bounded timeout fails the test. When a new capability mixin is added
+    // to Bengle, register its stream(s) here alongside the teardown in
+    // `De1Controller.connectToDe1`.
+    Future<void> expectDisposed(Stream<Object?> stream, String what) {
+      return expectLater(
+        stream.toList().timeout(const Duration(seconds: 2)),
+        completes,
+        reason: '$what subject leaked on the demoted Bengle interim',
+      );
+    }
+
+    await expectDisposed(interim.weightSnapshot, 'IntegratedScale.weight');
+    await expectDisposed(interim.stopAtWeightTarget, 'IntegratedScale.saw');
+    await expectDisposed(interim.ledStripState, 'LedStrip.state');
+  });
+
+  test('connectToDe1 is idempotent by deviceId after a class swap', () async {
+    transport.queueOnConnectResponses(v13Model: 128);
+    final interim = UnifiedDe1(transport: transport);
+    await controller.connectToDe1(interim);
+    final connected = await controller.de1.first;
+    expect(connected, isA<Bengle>());
+
+    // Re-passing the (discarded) name-picked interim: same physical
+    // deviceId, but a DIFFERENT object from the resolved machine. An
+    // object-identity guard would fall through and tear down + rebuild the
+    // live connection; the deviceId guard must exit early instead.
+    final events = <De1Interface?>[];
+    final sub = controller.de1.skip(1).listen(events.add);
+
+    await controller.connectToDe1(interim);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    expect(
+      events,
+      isEmpty,
+      reason:
+          'idempotency guard must key on deviceId, not identity — the '
+          'live connection was torn down',
+    );
+    expect(identical(await controller.de1.first, connected), isTrue);
+    await sub.cancel();
+  });
+}

--- a/test/device_discovery_feature/scan_flow_ble_off_test.dart
+++ b/test/device_discovery_feature/scan_flow_ble_off_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection_error.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/scan_state_guardian.dart';
+import 'package:reaprime/src/device_discovery_feature/scan_flow_view.dart';
+import 'package:reaprime/src/models/adapter_state.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+import '../helpers/mock_connection_manager.dart';
+import '../helpers/mock_de1_controller.dart';
+import '../helpers/mock_device_discovery_service.dart';
+import '../helpers/mock_device_scanner.dart';
+import '../helpers/mock_scale_controller.dart';
+import '../helpers/mock_settings_service.dart';
+import '../helpers/test_de1.dart';
+
+/// USB/serial discovery works with Bluetooth off, so the
+/// adapter-off error may only replace the scan flow while nothing that
+/// works WITHOUT Bluetooth is in flight. A wired-only setup must be able
+/// to reach the skin.
+void main() {
+  late MockConnectionManager mockConnectionManager;
+  late MockBleDiscoveryService mockBleService;
+  late ScanStateGuardian scanStateGuardian;
+  late SettingsController settingsController;
+  late MockDeviceScanner mockDeviceScanner;
+
+  setUp(() async {
+    mockDeviceScanner = MockDeviceScanner();
+    settingsController = SettingsController(MockSettingsService());
+    await settingsController.loadSettings();
+
+    mockConnectionManager = MockConnectionManager(
+      deviceScanner: mockDeviceScanner,
+      de1Controller: MockDe1Controller(controller: DeviceController([])),
+      scaleController: MockScaleController(),
+      settingsController: settingsController,
+    );
+
+    mockBleService = MockBleDiscoveryService();
+    scanStateGuardian = ScanStateGuardian(bleService: mockBleService);
+  });
+
+  tearDown(() {
+    mockConnectionManager.dispose();
+    scanStateGuardian.dispose();
+    mockBleService.dispose();
+    mockDeviceScanner.dispose();
+  });
+
+  Widget buildSubject() {
+    return ShadApp(
+      home: ScanFlowView(
+        connectionManager: mockConnectionManager,
+        deviceController: DeviceController([]),
+        settingsController: settingsController,
+        scanStateGuardian: scanStateGuardian,
+        onConnected: () {},
+        onExit: () {},
+      ),
+    );
+  }
+
+  Future<void> turnAdapterOff(WidgetTester tester) async {
+    mockBleService.setAdapterState(AdapterState.poweredOn);
+    await tester.runAsync(() => Future.delayed(Duration.zero));
+    await tester.pumpWidget(buildSubject());
+    await tester.pump();
+    mockBleService.setAdapterState(AdapterState.poweredOff);
+    await tester.runAsync(() => Future.delayed(Duration.zero));
+    await tester.pump();
+  }
+
+  testWidgets('adapter-off with nothing else in flight shows the error', (
+    tester,
+  ) async {
+    await turnAdapterOff(tester);
+
+    expect(find.text('Bluetooth Unavailable'), findsOneWidget);
+    expect(
+      find.textContaining('USB connections keep working'),
+      findsOneWidget,
+      reason: 'the error must tell wired users they are not blocked',
+    );
+  });
+
+  testWidgets('adapter-off with a found (serial) machine keeps the flow '
+      'visible', (tester) async {
+    await turnAdapterOff(tester);
+    expect(find.text('Bluetooth Unavailable'), findsOneWidget);
+
+    // A serial machine found with Bluetooth off — e.g. the Bengle over
+    // its USB port — must surface the normal flow, not the error.
+    mockConnectionManager.emitStatus(
+      ConnectionStatus(
+        phase: ConnectionPhase.idle,
+        foundMachines: [TestDe1()],
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Bluetooth Unavailable'), findsNothing);
+  });
+
+  testWidgets('sticky adapter-off ConnectionError does not hide a found '
+      'machine', (tester) async {
+    await turnAdapterOff(tester);
+
+    // The connection manager's sticky idle error (what the UI renders as
+    // "Connection error: Bluetooth is turned off.") must not out-rank a
+    // machine found over USB — the wired flow ends at the picker.
+    mockConnectionManager.emitStatus(
+      ConnectionStatus(
+        phase: ConnectionPhase.idle,
+        foundMachines: [TestDe1()],
+        error: ConnectionError(
+          kind: ConnectionErrorKind.adapterOff,
+          severity: ConnectionErrorSeverity.error,
+          timestamp: DateTime.now().toUtc(),
+          message: 'Bluetooth is turned off.',
+          suggestion: 'Turn Bluetooth on to scan for devices.',
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Bluetooth Unavailable'), findsNothing);
+    expect(
+      find.textContaining('Bluetooth is turned off'),
+      findsNothing,
+      reason: 'the picker, not the error view, must be shown',
+    );
+  });
+
+  testWidgets('adapter-off during a machine connect keeps the flow visible', (
+    tester,
+  ) async {
+    mockBleService.setAdapterState(AdapterState.poweredOn);
+    await tester.runAsync(() => Future.delayed(Duration.zero));
+    await tester.pumpWidget(buildSubject());
+    await tester.pump();
+
+    mockConnectionManager.emitStatus(
+      const ConnectionStatus(phase: ConnectionPhase.connectingMachine),
+    );
+    await tester.pump();
+
+    mockBleService.setAdapterState(AdapterState.poweredOff);
+    await tester.runAsync(() => Future.delayed(Duration.zero));
+    await tester.pump();
+
+    expect(find.text('Bluetooth Unavailable'), findsNothing);
+  });
+}

--- a/test/helpers/fake_serial_transport.dart
+++ b/test/helpers/fake_serial_transport.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/transport/serial_port.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// Inbound-capable fake [SerialTransport] for transport-level tests.
+///
+/// The repo's older recording fake is write-only (`readStream` never emits),
+/// so it can't exercise the serial RX parser. This one drives [readStream]
+/// from a broadcast controller via [injectSerial] and records every outbound
+/// [writeCommand] string in [writes] — the serial analogue of
+/// `FakeBleTransport`'s `writes` capture. Added for the serial-transport work
+/// serial-parity suite.
+class FakeSerialTransport extends SerialTransport {
+  final _connState = BehaviorSubject<ConnectionState>.seeded(
+    ConnectionState.connected,
+  );
+  final _readCtl = StreamController<String>.broadcast();
+
+  /// Outbound `writeCommand` strings, in order (e.g. `<+N>`, `<-M>`).
+  final List<String> writes = [];
+
+  @override
+  String get id => 'fake-serial';
+  @override
+  String get name => 'FakeSerial';
+  @override
+  Stream<ConnectionState> get connectionState => _connState.stream;
+  @override
+  Future<void> connect() async {}
+  @override
+  Future<void> disconnect() async {}
+  @override
+  Stream<String> get readStream => _readCtl.stream;
+  @override
+  Stream<Uint8List> get rawStream => const Stream.empty();
+  @override
+  Future<void> writeHexCommand(Uint8List command) async {}
+  @override
+  Future<void> writeCommand(String command) async => writes.add(command);
+
+  /// Feed a raw serial chunk into the transport's input parser.
+  void injectSerial(String chunk) => _readCtl.add(chunk);
+
+  @override
+  Future<void> dispose() async {
+    await _connState.close();
+    await _readCtl.close();
+  }
+}

--- a/test/models/device/de1_resolver_test.dart
+++ b/test/models/device/de1_resolver_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1_resolver.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+
+import '../../helpers/fake_ble_transport.dart';
+
+/// Model-authoritative class selection — BLE discovery picks the machine
+/// class by advertised name (`DeviceMatcher`), but `v13Model`, read on
+/// connect, is authoritative. `resolveMachineForModel` runs after
+/// `onConnect` and returns the concrete machine matching the detected model:
+/// the same instance when the name-picked class already agrees, otherwise a
+/// fresh instance of the right class over the same connected transport with
+/// the read identity carried over. This mirrors the serial path, which
+/// already instantiates `Bengle` vs `UnifiedDe1` from `v13Model >= 128`.
+void main() {
+  group('resolveMachineForModel', () {
+    late FakeBleTransport transport;
+
+    setUp(() {
+      transport = FakeBleTransport();
+      // onConnect warms the flow-cal cache (calFlowEst); queue it so onConnect
+      // returns immediately instead of eating the MMR read-retry timeout.
+      transport.queueMmrResponseInt(MMRItem.calFlowEst, 100);
+    });
+
+    tearDown(() => transport.dispose());
+
+    test(
+      'DE1-named device reporting v13Model >= 128 resolves to Bengle',
+      () async {
+        transport.queueOnConnectResponses(v13Model: 128, serialN: 4242);
+        final machine = UnifiedDe1(transport: transport);
+        await machine.onConnect();
+
+        final resolved = resolveMachineForModel(machine);
+
+        expect(resolved, isA<Bengle>());
+        expect(
+          identical(resolved, machine),
+          isFalse,
+          reason: 'must be a fresh Bengle, not the name-picked UnifiedDe1',
+        );
+        // Identity read on connect is carried over (no MMR re-read needed).
+        expect(resolved.machineInfo.serialNumber, '4242');
+        expect((resolved as Bengle).isBengle, isTrue);
+      },
+    );
+
+    test(
+      'plain DE1 (model 1) stays UnifiedDe1 — no swap, same instance',
+      () async {
+        transport.queueOnConnectResponses(v13Model: 1);
+        final machine = UnifiedDe1(transport: transport);
+        await machine.onConnect();
+
+        final resolved = resolveMachineForModel(machine);
+
+        expect(identical(resolved, machine), isTrue);
+        expect(resolved, isA<UnifiedDe1>());
+        expect(resolved, isNot(isA<Bengle>()));
+      },
+    );
+
+    test(
+      'Bengle-named device reporting model >= 128 stays Bengle — no swap',
+      () async {
+        transport.queueOnConnectResponses(v13Model: 128);
+        final machine = Bengle(transport: transport);
+        await machine.onConnect();
+
+        final resolved = resolveMachineForModel(machine);
+
+        expect(identical(resolved, machine), isTrue);
+        expect(resolved, isA<Bengle>());
+      },
+    );
+
+    test(
+      'Bengle-named device reporting a DE1 model demotes to UnifiedDe1',
+      () async {
+        transport.queueOnConnectResponses(v13Model: 1);
+        final machine = Bengle(transport: transport);
+        await machine.onConnect();
+
+        final resolved = resolveMachineForModel(machine);
+
+        expect(resolved, isA<UnifiedDe1>());
+        expect(resolved, isNot(isA<Bengle>()));
+        expect(identical(resolved, machine), isFalse);
+        expect((resolved as UnifiedDe1).isBengle, isFalse);
+      },
+    );
+
+    test(
+      'a re-resolved Bengle completes onConnect over the shared transport '
+      'after the MMR queue is drained (identity short-circuits re-reads)',
+      () async {
+        // The interim onConnect consumes the queued MMR responses. The crux of
+        // the design: the re-resolved instance carries the identity over, so its
+        // onConnect must short-circuit the MMR reads (its `_info` is set) and
+        // still complete — NOT hang on the now-empty queue.
+        transport.queueOnConnectResponses(v13Model: 128, serialN: 7);
+        final machine = UnifiedDe1(transport: transport);
+        await machine.onConnect();
+
+        final resolved = resolveMachineForModel(machine) as Bengle;
+        // Mirrors De1Controller.connectToDe1: finish connecting the resolved
+        // instance. With no re-queued responses this would time out (~12s) and
+        // throw if it re-read MMRs.
+        await resolved.onConnect().timeout(const Duration(seconds: 8));
+
+        expect(resolved.isBengle, isTrue);
+        expect(resolved.machineInfo.serialNumber, '7');
+      },
+    );
+
+    test(
+      'detaching the interim after a promotion leaves the resolved instance '
+      'working over the shared transport (detach must not dispose it)',
+      () async {
+        transport.queueOnConnectResponses(v13Model: 128, serialN: 9);
+        final interim = UnifiedDe1(transport: transport);
+        await interim.onConnect();
+        final resolved = resolveMachineForModel(interim) as Bengle;
+        await resolved.onConnect();
+
+        // Mirror De1Controller.connectToDe1: tear down the discarded interim.
+        await interim.detachTransport();
+
+        // The shared transport must still be alive — the resolved instance can
+        // still round-trip an MMR read. (If detach had disposed the transport,
+        // this would hang/throw.)
+        transport.queueMmrResponseInt(MMRItem.fanThreshold, 55);
+        expect(
+          await resolved.getFanThreshhold().timeout(const Duration(seconds: 8)),
+          55,
+        );
+      },
+    );
+  });
+}

--- a/test/services/ble/universal_ble_transport_mtu_test.dart
+++ b/test/services/ble/universal_ble_transport_mtu_test.dart
@@ -79,8 +79,7 @@ class _MtuRecordingBlePlatform extends UniversalBlePlatform {
   Future<List<BleService>> discoverServices(
     String deviceId,
     bool withDescriptors,
-  ) async =>
-      [];
+  ) async => [];
 
   @override
   Future<void> setNotifiable(
@@ -96,8 +95,7 @@ class _MtuRecordingBlePlatform extends UniversalBlePlatform {
     String service,
     String characteristic, {
     Duration? timeout,
-  }) async =>
-      Uint8List(0);
+  }) async => Uint8List(0);
 
   @override
   Future<void> writeValue(
@@ -133,8 +131,7 @@ class _MtuRecordingBlePlatform extends UniversalBlePlatform {
   @override
   Future<List<BleDevice>> getSystemDevices(
     List<String>? withServices,
-  ) async =>
-      [];
+  ) async => [];
 }
 
 void main() {
@@ -161,29 +158,35 @@ void main() {
     expect(
       platform.mtuRequests,
       [(deviceId, 517)],
-      reason: 'exactly one MTU request, value 517 — required for the '
+      reason:
+          'exactly one MTU request, value 517 — required for the '
           '28-byte 0xA013 notification (ATT default is 23)',
     );
     await transport.dispose();
   });
 
-  test('connect() skips the MTU request on Linux (BlueZ owns the MTU)',
-      () async {
-    final transport = UniversalBleTransport(
-      device: BleDevice(deviceId: deviceId, name: 'Bengle'),
-      isLinuxOverride: true,
-    );
+  test(
+    'connect() skips the MTU request on Linux (BlueZ owns the MTU)',
+    () async {
+      final transport = UniversalBleTransport(
+        device: BleDevice(deviceId: deviceId, name: 'Bengle'),
+        isLinuxOverride: true,
+      );
 
-    await transport.connect();
+      await transport.connect();
 
-    expect(platform.mtuRequests, isEmpty,
-        reason: 'universal_ble exposes no requestMtu on Linux; BlueZ '
-            'negotiates the MTU itself');
-    await transport.dispose();
-  });
+      expect(
+        platform.mtuRequests,
+        isEmpty,
+        reason:
+            'universal_ble exposes no requestMtu on Linux; BlueZ '
+            'negotiates the MTU itself',
+      );
+      await transport.dispose();
+    },
+  );
 
-  test('a failed MTU negotiation is non-fatal — connect() completes',
-      () async {
+  test('a failed MTU negotiation is non-fatal — connect() completes', () async {
     platform.throwOnRequestMtu = true;
     final transport = UniversalBleTransport(
       device: BleDevice(deviceId: deviceId, name: 'Bengle'),
@@ -195,8 +198,11 @@ void main() {
     // the larger MTU.
     await transport.connect();
 
-    expect(platform.mtuRequests, hasLength(1),
-        reason: 'the request must still be attempted');
+    expect(
+      platform.mtuRequests,
+      hasLength(1),
+      reason: 'the request must still be attempted',
+    );
     await transport.dispose();
   });
 }

--- a/test/services/ble/universal_ble_transport_mtu_test.dart
+++ b/test/services/ble/universal_ble_transport_mtu_test.dart
@@ -1,0 +1,202 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/ble/universal_ble_transport.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+/// Locks the post-connect large-ATT-MTU request in
+/// `UniversalBleTransport.connect()`:
+///
+///  * MTU **517** is requested on every non-Linux platform (it used to be
+///    Android-only; the 28-byte Bengle 0xA013 shot-sample notification
+///    truncates at the 23-byte ATT default, so the request must be attempted
+///    everywhere BLE runs);
+///  * **Linux is skipped** — BlueZ manages the MTU itself and universal_ble
+///    does not expose `requestMtu` there;
+///  * a **failed negotiation is non-fatal** — the DE1/Bengle BLE module
+///    self-negotiates up to 247 on connect regardless, so `connect()` must
+///    log-and-continue, never throw.
+///
+/// The platform gate itself (`Platform.isLinux`) is not fakeable in a unit
+/// test, so the transport exposes an `isLinuxOverride` test seam.
+class _MtuRecordingBlePlatform extends UniversalBlePlatform {
+  /// Recorded (deviceId, expectedMtu) pairs from [requestMtu].
+  final List<(String, int)> mtuRequests = [];
+
+  /// When true, [requestMtu] throws — simulating a stack that rejects the
+  /// negotiation.
+  bool throwOnRequestMtu = false;
+
+  @override
+  Future<int> requestMtu(String deviceId, int expectedMtu) async {
+    mtuRequests.add((deviceId, expectedMtu));
+    if (throwOnRequestMtu) {
+      throw UniversalBleException(
+        code: UniversalBleErrorCode.failed,
+        message: 'simulated MTU negotiation failure',
+      );
+    }
+    return expectedMtu;
+  }
+
+  @override
+  Future<AvailabilityState> getBluetoothAvailabilityState() async =>
+      AvailabilityState.poweredOn;
+
+  @override
+  Future<bool> enableBluetooth() async => true;
+
+  @override
+  Future<bool> disableBluetooth() async => false;
+
+  @override
+  Future<void> startScan({
+    ScanFilter? scanFilter,
+    PlatformConfig? platformConfig,
+  }) async {}
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  Future<bool> isScanning() async => false;
+
+  @override
+  Future<void> connect(
+    String deviceId, {
+    Duration? connectionTimeout,
+    bool autoConnect = false,
+  }) async {
+    updateConnection(deviceId, true);
+  }
+
+  @override
+  Future<void> disconnect(String deviceId) async {
+    updateConnection(deviceId, false);
+  }
+
+  @override
+  Future<List<BleService>> discoverServices(
+    String deviceId,
+    bool withDescriptors,
+  ) async =>
+      [];
+
+  @override
+  Future<void> setNotifiable(
+    String deviceId,
+    String service,
+    String characteristic,
+    BleInputProperty bleInputProperty,
+  ) async {}
+
+  @override
+  Future<Uint8List> readValue(
+    String deviceId,
+    String service,
+    String characteristic, {
+    Duration? timeout,
+  }) async =>
+      Uint8List(0);
+
+  @override
+  Future<void> writeValue(
+    String deviceId,
+    String service,
+    String characteristic,
+    Uint8List value,
+    BleOutputProperty bleOutputProperty,
+  ) async {}
+
+  @override
+  Future<int> readRssi(String deviceId) async => -50;
+
+  @override
+  Future<void> requestConnectionPriority(
+    String deviceId,
+    BleConnectionPriority priority,
+  ) async {}
+
+  @override
+  Future<bool> isPaired(String deviceId) async => false;
+
+  @override
+  Future<bool> pair(String deviceId) async => true;
+
+  @override
+  Future<void> unpair(String deviceId) async {}
+
+  @override
+  Future<BleConnectionState> getConnectionState(String deviceId) async =>
+      BleConnectionState.connected;
+
+  @override
+  Future<List<BleDevice>> getSystemDevices(
+    List<String>? withServices,
+  ) async =>
+      [];
+}
+
+void main() {
+  late _MtuRecordingBlePlatform platform;
+  var deviceCounter = 0;
+  late String deviceId;
+
+  setUp(() {
+    platform = _MtuRecordingBlePlatform();
+    UniversalBle.setInstance(platform);
+    UniversalBle.clearQueue();
+    // Unique id per test so per-device queue state can't bleed over.
+    deviceId = 'AA:BB:CC:DD:FF:${(deviceCounter++).toString().padLeft(2, '0')}';
+  });
+
+  test('connect() requests MTU 517 on non-Linux platforms', () async {
+    final transport = UniversalBleTransport(
+      device: BleDevice(deviceId: deviceId, name: 'Bengle'),
+      isLinuxOverride: false,
+    );
+
+    await transport.connect();
+
+    expect(
+      platform.mtuRequests,
+      [(deviceId, 517)],
+      reason: 'exactly one MTU request, value 517 — required for the '
+          '28-byte 0xA013 notification (ATT default is 23)',
+    );
+    await transport.dispose();
+  });
+
+  test('connect() skips the MTU request on Linux (BlueZ owns the MTU)',
+      () async {
+    final transport = UniversalBleTransport(
+      device: BleDevice(deviceId: deviceId, name: 'Bengle'),
+      isLinuxOverride: true,
+    );
+
+    await transport.connect();
+
+    expect(platform.mtuRequests, isEmpty,
+        reason: 'universal_ble exposes no requestMtu on Linux; BlueZ '
+            'negotiates the MTU itself');
+    await transport.dispose();
+  });
+
+  test('a failed MTU negotiation is non-fatal — connect() completes',
+      () async {
+    platform.throwOnRequestMtu = true;
+    final transport = UniversalBleTransport(
+      device: BleDevice(deviceId: deviceId, name: 'Bengle'),
+      isLinuxOverride: false,
+    );
+
+    // Must not throw: the module self-negotiates up to 247 on connect, so
+    // the client request is belt-and-suspenders and a rejection only costs
+    // the larger MTU.
+    await transport.connect();
+
+    expect(platform.mtuRequests, hasLength(1),
+        reason: 'the request must still be attempted');
+    await transport.dispose();
+  });
+}

--- a/test/services/serial/usb_ids_test.dart
+++ b/test/services/serial/usb_ids_test.dart
@@ -49,4 +49,25 @@ void main() {
       expect(matchUsbDevice(usbDeviceTable, vid: 0xFFFF, pid: 0xFFFF), isNull);
     });
   });
+
+  group('Bengle probe-candidate pair', () {
+    test('bengleUsbIds stays empty — TinyUSB defaults are too generic', () {
+      // 0x2E8A:0x000A is EVERY default pico-sdk CDC device. It may only
+      // qualify a port for the v13Model probe (bengleProbeCandidateIds),
+      // never identify one. Adding it here would claim random hobby
+      // boards as espresso machines.
+      expect(bengleUsbIds, isEmpty);
+      expect(bengleProbeCandidateIds, contains((0x2E8A, 0x000A)));
+    });
+
+    test('the TinyUSB-default pair never direct-instantiates', () {
+      expect(
+        matchUsbDevice(usbDeviceTable, vid: 0x2E8A, pid: 0x000A),
+        isNull,
+        reason:
+            'the pair feeds the probe path only — the v13Model read '
+            'stays the authority on what the device is',
+      );
+    });
+  });
 }

--- a/test/unit/models/device/impl/bengle/mmr_contract_test.dart
+++ b/test/unit/models/device/impl/bengle/mmr_contract_test.dart
@@ -1,0 +1,531 @@
+// Firmware <-> app MMR contract checker (CI drift gate).
+//
+// Validates every app-declared MMR register against the machine-readable
+// firmware contract `assets/api/bengle_hw_v1.yml` (contract_version 1,
+// distilled from firmware the firmware register table @ a firmware development branch
+// The MMR layout is hand-declared twice (firmware C, app Dart); this test is
+// the machine check that the two copies cannot silently drift apart.
+//
+// Run: flutter test test/unit/models/device/impl/bengle/mmr_contract_test.dart
+// (rides the normal `flutter test` CI job; reads the contract with plain File
+// IO relative to the package root, which is where `flutter test` runs).
+//
+// WHAT IS ASSERTED (v1 semantics):
+//   * address -- exact match.
+//   * length  -- exact match.
+//   * scale   -- app writeScale == contract mult AND app readScale == 1/mult.
+//               Non-scaled registers carry the default 1.0/1.0 and contract
+//               mult 1, so the same rule covers every kind.
+//   * range   -- app SUBSET of contract: a min/max bound the app declares must
+//               sit inside the contract's bound. The app declaring NO bound is
+//               legal (contract bounds are documentation -- the firmware never
+//               range-checks Bengle macro-path writes; the app is the guard),
+//               and the app being strictly narrower is legal (e.g. CalFlowEst
+//               app raw min 130 vs contract 125).
+//   * perms are NOT asserted in v1: the app enums carry no perms field (a
+//     `perms` getter on MmrAddress is proposed via the Phase-0 issue).
+//   * Direction: every app-declared register must exist in the contract and
+//     match; contract rows with no app entry are legal -- the app grows into
+//     the contract branch by branch (unconsumed rows are printed
+//     informationally below).
+//
+// EXTENSION PROTOCOL (how capability branches extend this test):
+//   The single registration table is `entriesUnderTest` below, grouped into
+//   clearly-marked sections, one per capability branch. On the foundation
+//   branch only the MMRItem section (and its import) is active; each later
+//   capability branch that introduces an MMR enum:
+//     1. uncomments (or appends) its section's `ContractEntry` lines -- one
+//        line per register, mapping the enum entry to its contract row by the
+//        FIRMWARE register name;
+//     2. uncomments the import its section needs (marked alongside);
+//     3. never edits the assertions -- if the checker fails, the enum or the
+//        contract (with a contract_version bump) is wrong, not the test.
+//   An app desc string that deliberately differs from the firmware name is
+//   recorded in the contract as `app_alias` (today: TargetMilkTemp vs the
+//   app's 'StopAtTemperatureTarget').
+//
+// CONTRACT CHANGE PROTOCOL: firmware changes a register -> regenerate
+// bengle_hw_v1.yml from the new the firmware register table (never from a stale working tree) ->
+// bump contract_version -> update the app enums -> update
+// `_expectedContractVersion` here. Firmware and app PRs both cite the version.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart'
+    show MMRItem;
+import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart'
+    show MmrAddress;
+// Thermal branch (spec 08) uncomments this import with its section below:
+// import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart'
+//     show BengleMmr, BengleSteamMmr;
+// The first of the SAW/tare (spec 05) / cal (spec 06) / LED (spec 07)
+// branches to land uncomments this import (the enums are parts of the
+// unified_de1 library) and extends the `show` list as the others follow:
+// import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart'
+//     show BengleCalMmr, BengleLedMmr, BengleScaleMmr;
+
+const String _contractPath = 'assets/api/bengle_hw_v1.yml';
+
+/// The contract_version this registration table was written against.
+/// Bump deliberately, together with the enum updates the new contract needs.
+const int _expectedContractVersion = 1;
+
+/// One app-declared register under test: the app enum entry and the FIRMWARE
+/// register name of its row in bengle_hw_v1.yml.
+class ContractEntry {
+  const ContractEntry(this.register, this.contractName);
+
+  final MmrAddress register;
+
+  /// Firmware register name (the `name:` field of the contract row).
+  final String contractName;
+
+  String get label => '${register.runtimeType}.${register.name}';
+}
+
+// =============================================================================
+// REGISTRATION TABLE -- one line per app-declared MMR register.
+// Capability branches extend this list (see EXTENSION PROTOCOL above).
+// =============================================================================
+const List<ContractEntry> entriesUnderTest = <ContractEntry>[
+  // ---------------------------------------------------------------------------
+  // Foundation branch (spec 01): shared-DE1 `MMRItem` baseline.
+  // ---------------------------------------------------------------------------
+  ContractEntry(MMRItem.externalFlash, 'ExternalFlash'),
+  ContractEntry(MMRItem.hwConfig, 'HWConfig'),
+  ContractEntry(MMRItem.model, 'Model'),
+  ContractEntry(MMRItem.cpuBoardModel, 'CPUBoardModel'),
+  ContractEntry(MMRItem.v13Model, 'v13Model'),
+  ContractEntry(MMRItem.cpuFirmwareBuild, 'CPUFirmwareBuild'),
+  ContractEntry(MMRItem.debugLen, 'DebugLen'),
+  ContractEntry(MMRItem.debugBuffer, 'DebugBuffer'),
+  ContractEntry(MMRItem.debugConfig, 'DebugConfig'),
+  ContractEntry(MMRItem.fanThreshold, 'FanThreshold'),
+  ContractEntry(MMRItem.tankTemp, 'TankTemp'),
+  ContractEntry(MMRItem.heaterUp1Flow, 'HeaterUp1Flow'),
+  ContractEntry(MMRItem.heaterUp2Flow, 'HeaterUp2Flow'),
+  ContractEntry(MMRItem.waterHeaterIdleTemp, 'WaterHeaterIdleTemp'),
+  ContractEntry(MMRItem.ghcInfo, 'GHCInfo'),
+  ContractEntry(MMRItem.targetSteamFlow, 'TargetSteamFlow'),
+  // The expected SteamStartSecs scales are readScale 0.01 / writeScale 100.0
+  // (== fw mult 100). The entry historically carried the latent default-1.0
+  // scales (known drift, the contract change protocol) and MUST fail here if that ever
+  // regresses.
+  ContractEntry(MMRItem.steamStartSecs, 'SteamStartSecs'),
+  ContractEntry(MMRItem.serialN, 'SerialN'),
+  ContractEntry(MMRItem.heaterV, 'HeaterV'),
+  ContractEntry(MMRItem.heaterUp2Timeout, 'HeaterUp2Timeout'),
+  ContractEntry(MMRItem.calFlowEst, 'CalFlowEst'),
+  ContractEntry(MMRItem.flushFlowRate, 'FlushFlowRate'),
+  ContractEntry(MMRItem.flushTemp, 'FlushTemp'),
+  ContractEntry(MMRItem.flushTimeout, 'FlushTimeout'),
+  ContractEntry(MMRItem.hotWaterFlowRate, 'HotWaterFlowRate'),
+  ContractEntry(MMRItem.steamPurgeMode, 'SteamPurgeMode'),
+  ContractEntry(MMRItem.allowUSBCharging, 'AllowUSBCharging'),
+  ContractEntry(MMRItem.appFeatureFlags, 'AppFeatureFlags'),
+  ContractEntry(MMRItem.refillKitPresent, 'RefillKitPresent'),
+  ContractEntry(MMRItem.userPresent, 'UserPresent'),
+
+  // ---------------------------------------------------------------------------
+  // SAW/tare branch (spec 05): `BengleScaleMmr`
+  // (in integrated_scale_capability.dart, part of unified_de1).
+  // UNCOMMENT these lines (and the unified_de1 import) when the branch lands:
+  // ---------------------------------------------------------------------------
+  // ContractEntry(BengleScaleMmr.stopAtWeightTarget, 'EndOfShotWeight'),
+  // ContractEntry(BengleScaleMmr.scaleTare, 'ScaleTare'),
+
+  // ---------------------------------------------------------------------------
+  // Calibration-wizard branch (spec 06): `BengleCalMmr`
+  // (in scale_calibration_capability.dart, part of unified_de1).
+  // UNCOMMENT these lines (and the unified_de1 import) when the branch lands:
+  // ---------------------------------------------------------------------------
+  // ContractEntry(BengleCalMmr.cmd, 'ScaleCalCmd'),
+  // ContractEntry(BengleCalMmr.state, 'ScaleCalState'),
+  // ContractEntry(BengleCalMmr.weight, 'ScaleCalWeight'),
+
+  // ---------------------------------------------------------------------------
+  // LED-strip branch (spec 07): `BengleLedMmr`
+  // (in led_strip_capability.dart, part of unified_de1).
+  // UNCOMMENT these lines (and the unified_de1 import) when the branch lands:
+  // ---------------------------------------------------------------------------
+  // ContractEntry(BengleLedMmr.frontLive, 'FrontLEDColor'),
+  // ContractEntry(BengleLedMmr.rearLive, 'RearLEDColor'),
+  // ContractEntry(BengleLedMmr.frontAwake, 'FrontLEDAwake'),
+  // ContractEntry(BengleLedMmr.rearAwake, 'RearLEDAwake'),
+  // ContractEntry(BengleLedMmr.frontSleep, 'FrontLEDSleep'),
+  // ContractEntry(BengleLedMmr.rearSleep, 'RearLEDSleep'),
+
+  // ---------------------------------------------------------------------------
+  // Thermal branch (spec 08: cup-warmer mode + milk temp + mat-temp read):
+  // `BengleMmr` + `BengleSteamMmr` (bengle_mmr.dart). The app desc string
+  // 'StopAtTemperatureTarget' is the contract row's `app_alias`.
+  // UNCOMMENT these lines (and the bengle_mmr import) when the branch lands:
+  // ---------------------------------------------------------------------------
+  // ContractEntry(BengleMmr.matSetPoint, 'MatSetPoint'),
+  // ContractEntry(BengleMmr.cupWarmerMode, 'CupWarmerMode'),
+  // ContractEntry(BengleSteamMmr.stopAtTemperatureTarget, 'TargetMilkTemp'),
+];
+
+// =============================================================================
+// Minimal contract parser.
+//
+// Deliberately hand-rolled: `package:yaml` is only a TRANSITIVE dependency of
+// this package, and depending on it directly would need a pubspec change.
+// The parser supports exactly the subset bengle_hw_v1.yml is written in --
+// top-level scalar keys, the two-space-indented `firmware:` block map, and
+// the `registers:` list of `- key: value` block maps with `#` comments
+// (whole-line or trailing, quote-aware). The packet_0xA013 / serial_verbs
+// sections are documentation for humans and are intentionally skipped.
+// =============================================================================
+
+class ContractRegister {
+  const ContractRegister({
+    required this.name,
+    required this.fwRow,
+    required this.address,
+    required this.length,
+    required this.perms,
+    required this.mult,
+    required this.valueKind,
+    required this.min,
+    required this.max,
+    required this.appAlias,
+  });
+
+  final String name;
+  final int? fwRow;
+  final int address;
+  final int length;
+  final String perms;
+  final int mult;
+  final String valueKind;
+  final int? min;
+  final int? max;
+  final String? appAlias;
+}
+
+class HwContract {
+  const HwContract({
+    required this.contractVersion,
+    required this.firmwareCommit,
+    required this.registers,
+  });
+
+  final int contractVersion;
+  final String firmwareCommit;
+
+  /// Keyed by firmware register name.
+  final Map<String, ContractRegister> registers;
+}
+
+/// Drops a `#` comment (whole-line or trailing) unless the `#` sits inside a
+/// double-quoted scalar. Trailing comments in the contract are always
+/// whitespace-separated from the value.
+String _stripComment(String line) {
+  var inQuotes = false;
+  for (var i = 0; i < line.length; i++) {
+    final ch = line[i];
+    if (ch == '"') inQuotes = !inQuotes;
+    if (ch == '#' &&
+        !inQuotes &&
+        (i == 0 || line[i - 1] == ' ' || line[i - 1] == '\t')) {
+      return line.substring(0, i);
+    }
+  }
+  return line;
+}
+
+String _unquote(String value) {
+  final t = value.trim();
+  if (t.length >= 2 && t.startsWith('"') && t.endsWith('"')) {
+    return t.substring(1, t.length - 1);
+  }
+  return t;
+}
+
+/// Parses `null`, decimal, or 0x-prefixed hex scalars (optionally quoted).
+int? _intOrNull(String? value) {
+  if (value == null) return null;
+  final t = _unquote(value);
+  if (t.isEmpty || t == 'null' || t == '~') return null;
+  if (t.startsWith('0x') || t.startsWith('0X')) {
+    return int.parse(t.substring(2), radix: 16);
+  }
+  return int.parse(t);
+}
+
+HwContract parseBengleHwContract(String text) {
+  int? version;
+  String? commit;
+  final registers = <String, ContractRegister>{};
+
+  var topKey = '';
+  Map<String, String>? current;
+
+  void flushCurrent() {
+    final fields = current;
+    current = null;
+    if (fields == null) return;
+    final name = _unquote(
+      fields['name'] ?? (throw FormatException('register row without a name')),
+    );
+    registers[name] = ContractRegister(
+      name: name,
+      fwRow: _intOrNull(fields['fw_row']),
+      address:
+          _intOrNull(fields['address']) ??
+          (throw FormatException('register $name has no address')),
+      length:
+          _intOrNull(fields['length']) ??
+          (throw FormatException('register $name has no length')),
+      perms: _unquote(fields['perms'] ?? ''),
+      mult:
+          _intOrNull(fields['mult']) ??
+          (throw FormatException('register $name has no mult')),
+      valueKind: _unquote(fields['value_kind'] ?? ''),
+      min: _intOrNull(fields['min']),
+      max: _intOrNull(fields['max']),
+      appAlias: fields['app_alias'] == null
+          ? null
+          : _unquote(fields['app_alias']!),
+    );
+  }
+
+  for (final raw in text.split('\n')) {
+    final line = _stripComment(raw).trimRight();
+    if (line.trim().isEmpty) continue;
+
+    if (!line.startsWith(' ')) {
+      // New top-level key ends any open register row.
+      flushCurrent();
+      final sep = line.indexOf(':');
+      if (sep < 0) continue;
+      topKey = line.substring(0, sep).trim();
+      final value = line.substring(sep + 1).trim();
+      if (topKey == 'contract_version' && value.isNotEmpty) {
+        version = int.parse(value);
+      }
+      continue;
+    }
+
+    if (topKey == 'firmware') {
+      final sep = line.indexOf(':');
+      if (sep > 0 && line.substring(0, sep).trim() == 'commit') {
+        commit = _unquote(line.substring(sep + 1));
+      }
+      continue;
+    }
+
+    if (topKey != 'registers') continue;
+
+    var body = line.trimLeft();
+    if (body.startsWith('- ')) {
+      flushCurrent();
+      current = <String, String>{};
+      body = body.substring(2);
+    }
+    final fields = current;
+    if (fields == null) continue;
+    final sep = body.indexOf(':');
+    if (sep <= 0) continue;
+    fields[body.substring(0, sep).trim()] = body.substring(sep + 1).trim();
+  }
+  flushCurrent();
+
+  if (version == null) {
+    throw const FormatException('contract_version missing from contract');
+  }
+  if (commit == null) {
+    throw const FormatException('firmware.commit missing from contract');
+  }
+  if (registers.isEmpty) {
+    throw const FormatException('no registers parsed from contract');
+  }
+  return HwContract(
+    contractVersion: version,
+    firmwareCommit: commit,
+    registers: registers,
+  );
+}
+
+// =============================================================================
+// Checker
+// =============================================================================
+
+HwContract? _cached;
+HwContract _contract() =>
+    _cached ??= parseBengleHwContract(File(_contractPath).readAsStringSync());
+
+String _hex(int value) =>
+    '0x${value.toRadixString(16).toUpperCase().padLeft(8, '0')}';
+
+void main() {
+  group('bengle_hw_v1.yml', () {
+    test('parses, pins a firmware commit, and matches the checker version', () {
+      final c = _contract();
+      expect(
+        c.contractVersion,
+        _expectedContractVersion,
+        reason:
+            'contract_version drift: the contract file is '
+            'v${c.contractVersion} but this registration table was written '
+            'against v$_expectedContractVersion. Update the enums against the '
+            'new contract, then bump _expectedContractVersion deliberately.',
+      );
+      expect(
+        c.firmwareCommit,
+        hasLength(40),
+        reason: 'firmware.commit must pin a full 40-char firmware SHA',
+      );
+      stdout.writeln(
+        '  contract v${c.contractVersion}, firmware pin ${c.firmwareCommit}, '
+        '${c.registers.length} contract rows, '
+        '${entriesUnderTest.length} app registers under test',
+      );
+    });
+
+    test('every app register maps to a distinct contract row', () {
+      final names = entriesUnderTest.map((e) => e.contractName).toList();
+      expect(
+        names.toSet().length,
+        names.length,
+        reason: 'two registration entries claim the same contract row',
+      );
+      final registers = entriesUnderTest.map((e) => e.register).toList();
+      expect(
+        registers.toSet().length,
+        registers.length,
+        reason: 'an app register is registered twice',
+      );
+    });
+  });
+
+  group('app register matches contract (address/length/scale/range)', () {
+    for (final entry in entriesUnderTest) {
+      test('${entry.label} <-> ${entry.contractName}', () {
+        final row = _contract().registers[entry.contractName];
+        expect(
+          row,
+          isNotNull,
+          reason:
+              'app register ${entry.label} is missing from the contract: '
+              'no row named "${entry.contractName}" in $_contractPath. Every '
+              'app-declared register must exist in the contract.',
+        );
+        final contract = row!;
+        final app = entry.register;
+
+        expect(
+          _hex(app.address),
+          _hex(contract.address),
+          reason:
+              'ADDRESS drift on ${entry.label}: app ${_hex(app.address)} '
+              'vs contract ${_hex(contract.address)}',
+        );
+        expect(
+          app.length,
+          contract.length,
+          reason:
+              'LENGTH drift on ${entry.label}: app ${app.length} vs '
+              'contract ${contract.length}',
+        );
+
+        // Scale: writeScale must equal the firmware mult; readScale must be
+        // its inverse. Non-scaled registers have mult 1 and default 1.0
+        // scales, so the same rule covers every value kind.
+        expect(
+          app.writeScale,
+          contract.mult.toDouble(),
+          reason:
+              'SCALE drift on ${entry.label}: app writeScale '
+              '${app.writeScale} vs contract mult ${contract.mult} '
+              '(wire value = engineering value x mult)',
+        );
+        expect(
+          app.readScale,
+          closeTo(1.0 / contract.mult, 1e-9),
+          reason:
+              'SCALE drift on ${entry.label}: app readScale '
+              '${app.readScale} vs contract 1/mult '
+              '(${1.0 / contract.mult})',
+        );
+
+        // Range: app bounds (raw wire units) must be a SUBSET of the contract
+        // bounds. Declaring no bound is legal; narrower is legal.
+        final appMin = app.min;
+        final appMax = app.max;
+        if (appMin != null && contract.min != null) {
+          expect(
+            appMin >= contract.min!,
+            isTrue,
+            reason:
+                'RANGE drift on ${entry.label}: app min $appMin lies '
+                'below contract min ${contract.min} (app range must be a '
+                'subset of the contract range)',
+          );
+        }
+        if (appMax != null && contract.max != null) {
+          expect(
+            appMax <= contract.max!,
+            isTrue,
+            reason:
+                'RANGE drift on ${entry.label}: app max $appMax lies '
+                'above contract max ${contract.max} (app range must be a '
+                'subset of the contract range)',
+          );
+        }
+      });
+    }
+  });
+
+  group('contract coverage (informational, never fails)', () {
+    test('contract rows not yet consumed by the app', () {
+      final covered = entriesUnderTest.map((e) => e.contractName).toSet();
+      final unconsumed =
+          _contract().registers.values
+              .where((r) => !covered.contains(r.name))
+              .toList()
+            ..sort((a, b) => (a.fwRow ?? -1).compareTo(b.fwRow ?? -1));
+      stdout.writeln(
+        '  ${unconsumed.length} contract rows have no app entry '
+        '(legal -- the app grows into the contract):',
+      );
+      for (final r in unconsumed) {
+        stdout.writeln(
+          '    row ${r.fwRow} ${r.name} @ ${_hex(r.address)} '
+          '(${r.perms}, mult ${r.mult})',
+        );
+      }
+    });
+
+    test('contract rows carrying an app_alias (desc differs from FW name)', () {
+      for (final r in _contract().registers.values) {
+        if (r.appAlias != null) {
+          stdout.writeln(
+            '    ${r.name}: app declares desc "${r.appAlias}" (documented '
+            'alias, not drift)',
+          );
+        }
+      }
+    });
+
+    test('app ranges strictly narrower than the contract (legal)', () {
+      for (final entry in entriesUnderTest) {
+        final row = _contract().registers[entry.contractName];
+        if (row == null) continue;
+        final app = entry.register;
+        final narrowerMin =
+            app.min != null && row.min != null && app.min! > row.min!;
+        final narrowerMax =
+            app.max != null && row.max != null && app.max! < row.max!;
+        if (narrowerMin || narrowerMax) {
+          stdout.writeln(
+            '    ${entry.label}: app [${app.min}..${app.max}] inside '
+            'contract [${row.min}..${row.max}]',
+          );
+        }
+      }
+    });
+  });
+}

--- a/test/unit/models/device/impl/de1/unified_de1/bengle_detection_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/bengle_detection_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+
+import '../../../../../../helpers/fake_ble_transport.dart';
+
+/// The authoritative Bengle gate is `v13Model >= 128` read on connect, NOT
+/// the BLE advertised name. `DeviceMatcher` stays name-based (that selection
+/// is covered by `device_matcher_test.dart`); this proves the runtime
+/// capability flag `UnifiedDe1.isBengle` tracks the model the firmware
+/// reports over the wire, independent of which class the name happened to
+/// pick.
+void main() {
+  group('UnifiedDe1 Bengle detection', () {
+    late FakeBleTransport transport;
+
+    setUp(() {
+      transport = FakeBleTransport();
+      // `queueOnConnectResponses` doesn't cover `calFlowEst` (the flow-cal
+      // warm-up read at the tail of onConnect); queue it so onConnect
+      // returns immediately instead of eating the MMR read-retry timeout.
+      transport.queueMmrResponseInt(MMRItem.calFlowEst, 100);
+    });
+
+    tearDown(() => transport.dispose());
+
+    test('isBengle is false before onConnect has read the model', () {
+      final de1 = UnifiedDe1(transport: transport);
+      expect(de1.isBengle, isFalse);
+    });
+
+    test('v13Model >= 128 gates Bengle on a plain UnifiedDe1', () async {
+      final de1 = UnifiedDe1(transport: transport);
+      transport.queueOnConnectResponses(v13Model: 128);
+      await de1.onConnect();
+      expect(de1.isBengle, isTrue);
+    });
+
+    test('the boundary value 128 gates Bengle', () async {
+      final de1 = UnifiedDe1(transport: transport);
+      transport.queueOnConnectResponses(v13Model: 128);
+      await de1.onConnect();
+      expect(de1.isBengle, isTrue);
+    });
+
+    test('v13Model == 1 leaves a plain UnifiedDe1 as DE1', () async {
+      final de1 = UnifiedDe1(transport: transport);
+      transport.queueOnConnectResponses(v13Model: 1);
+      await de1.onConnect();
+      expect(de1.isBengle, isFalse);
+    });
+
+    test(
+      'a name-picked Bengle reading model 128 is authoritatively Bengle',
+      () async {
+        final bengle = Bengle(transport: transport);
+        transport.queueOnConnectResponses(v13Model: 128);
+        await bengle.onConnect();
+        expect(bengle.isBengle, isTrue);
+      },
+    );
+
+    test(
+      'self-verify: a name-picked Bengle reading a DE1 model is NOT Bengle',
+      () async {
+        // The incremental self-verify seam: the flag follows the wire, so a
+        // mis-named device that reports a DE1-family model (1..7) is flagged
+        // DE1 even though its advertised name matched "Bengle".
+        final bengle = Bengle(transport: transport);
+        transport.queueOnConnectResponses(v13Model: 1);
+        await bengle.onConnect();
+        expect(bengle.isBengle, isFalse);
+      },
+    );
+  });
+}

--- a/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
@@ -228,6 +228,50 @@ void main() {
       expect(payload.getInt32(0, Endian.little), 500);
     });
 
+    test('writeMmrScaled rounds, not truncates, the scaled value (Bengle path)',
+        () async {
+      // 2.3 * 100 == 229.999… in IEEE-754: the old toInt() truncated to
+      // 229; round() gives the correct 230. Every Bengle scaled write
+      // rides this non-MMRItem branch, so this guards the load-bearing
+      // helper for the whole Bengle feature set.
+      const addr = _CapabilityAddr(
+        address: 0x00805000,
+        length: 4,
+        name: 'roundProbe',
+        kind: MmrValueKind.scaledFloat,
+        writeScale: 100.0,
+      );
+      transport.writes.clear();
+      await de1.capWriteScaled(addr, 2.3);
+      final frame = transport.writes.firstWhere(
+        (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
+      );
+      final payload = ByteData.sublistView(frame.data, 4, 8);
+      expect(payload.getInt32(0, Endian.little), 230);
+    });
+
+    test('_writeMMRScaled truncates like de1plus (base-DE1 setter path)',
+        () async {
+      // The base-DE1 scaled setters (flush/hot-water/steam/heater/cal flow)
+      // must stay byte-identical to a plain DE1 and to de1plus, which
+      // truncates via int(...). targetSteamFlow uses writeScale 100 with no
+      // clamp, so setSteamFlow(2.3) lands 229 (2.3*100 == 229.999… truncated),
+      // NOT the rounded 230 — rounding is correct only for the Bengle ×100
+      // weight write on the separate public writeMmrScaled helper.
+      transport.writes.clear();
+      await de1.setSteamFlow(2.3);
+      final frame = transport.writes.firstWhere(
+        (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
+      );
+      final addrBytes = ByteData(4)
+        ..setInt32(0, MMRItem.targetSteamFlow.address, Endian.big);
+      expect(frame.data[1], addrBytes.getUint8(1));
+      expect(frame.data[2], addrBytes.getUint8(2));
+      expect(frame.data[3], addrBytes.getUint8(3));
+      final payload = ByteData.sublistView(frame.data, 4, 8);
+      expect(payload.getInt32(0, Endian.little), 229);
+    });
+
     test('notificationsFor(shotSample) routes to transport shotSample',
         () async {
       // The transport's BLE subscriber for the shotSample characteristic

--- a/test/unit/models/device/impl/de1/unified_de1/serial_parity_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/serial_parity_test.dart
@@ -1,0 +1,418 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart';
+
+import '../../../../../../helpers/fake_serial_transport.dart';
+
+String _hex(List<int> bytes) =>
+    bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+
+/// A [FakeSerialTransport] whose [writeCommand] throws for one specific
+/// command — used to prove a failing `<+X>` request can't leak an
+/// unhandled async timeout out of the armed one-shot read future.
+class _FailingWriteSerialTransport extends FakeSerialTransport {
+  final String failOn;
+  _FailingWriteSerialTransport({required this.failOn});
+
+  @override
+  Future<void> writeCommand(String command) async {
+    if (command == failOn) {
+      throw StateError('injected write failure: $command');
+    }
+    return super.writeCommand(command);
+  }
+}
+
+void main() {
+  group('length-exact <F> (writeToMMR) frames on serial', () {
+    late FakeSerialTransport serial;
+    late UnifiedDe1Transport transport;
+
+    setUp(() {
+      serial = FakeSerialTransport();
+      transport = UnifiedDe1Transport(transport: serial);
+    });
+
+    tearDown(() => transport.dispose());
+
+    test('a short final DFU chunk is zero-padded to 20 bytes', () async {
+      await transport.connect();
+      serial.writes.clear();
+
+      // 6-byte final image chunk: Len=6, addr 0x000120, 6 data bytes —
+      // exactly what uploadFW emits for a trailing partial chunk.
+      final chunk = Uint8List.fromList([
+        6,
+        0x00,
+        0x01,
+        0x20,
+        0xDE,
+        0xAD,
+        0xBE,
+        0xEF,
+        0x01,
+        0x02,
+      ]);
+      await transport.writeWithResponse(Endpoint.writeToMMR, chunk);
+
+      final expected = '<F>${_hex(chunk).padRight(2 * 20, '0')}'; // 40 hex
+      expect(
+        serial.writes.single,
+        expected,
+        reason:
+            'firmware parser reads exactly sizeof(the MMR write frame)=20 '
+            'bytes per <F> frame; a short frame desyncs it',
+      );
+    });
+
+    test('a full 20-byte frame is passed through unmodified', () async {
+      await transport.connect();
+      serial.writes.clear();
+
+      final chunk = Uint8List.fromList(List<int>.generate(20, (i) => i + 1));
+      await transport.writeWithResponse(Endpoint.writeToMMR, chunk);
+
+      expect(serial.writes.single, '<F>${_hex(chunk)}');
+    });
+
+    test('other endpoints are not padded', () async {
+      await transport.connect();
+      serial.writes.clear();
+
+      final settings = Uint8List.fromList(List<int>.filled(9, 0x42));
+      await transport.writeWithResponse(Endpoint.shotSettings, settings);
+
+      expect(serial.writes.single, '<K>${_hex(settings)}');
+    });
+  });
+
+  group('serial reads', () {
+    late FakeSerialTransport serial;
+    late UnifiedDe1Transport transport;
+
+    setUp(() {
+      serial = FakeSerialTransport();
+      transport = UnifiedDe1Transport(transport: serial);
+    });
+
+    tearDown(() => transport.dispose());
+
+    test('read(calibration) is a <+R> single-notify round trip', () async {
+      await transport.connect();
+      serial.writes.clear();
+
+      final pending = transport.read(Endpoint.calibration);
+      await pumpEventQueue();
+      expect(
+        serial.writes,
+        contains('<+R>'),
+        reason:
+            'the serial view has no read verb; a read is an '
+            'add-notify that provokes one [R] frame',
+      );
+
+      final payload = List<int>.generate(14, (i) => 0xA0 + i);
+      serial.injectSerial('[R]${_hex(payload)}\n');
+
+      final result = await pending;
+      expect(result.buffer.asUint8List(), payload);
+      expect(
+        serial.writes.last,
+        '<-R>',
+        reason: 'the one-shot read must not leave a subscription behind',
+      );
+    });
+
+    test('read(versions) round-trips via <+A>', () async {
+      await transport.connect();
+      serial.writes.clear();
+
+      final pending = transport.read(Endpoint.versions);
+      await pumpEventQueue();
+      expect(serial.writes, contains('<+A>'));
+
+      final payload = List<int>.generate(18, (i) => i);
+      serial.injectSerial('[A]${_hex(payload)}\n');
+
+      final result = await pending;
+      expect(result.buffer.asUint8List(), payload);
+      expect(serial.writes.last, '<-A>');
+    });
+
+    test('read(temperatures) round-trips via <+J>', () async {
+      await transport.connect();
+      serial.writes.clear();
+
+      final pending = transport.read(Endpoint.temperatures);
+      await pumpEventQueue();
+      expect(serial.writes, contains('<+J>'));
+
+      final payload = List<int>.generate(20, (i) => 0x10 + i);
+      serial.injectSerial('[J]${_hex(payload)}\n');
+
+      final result = await pending;
+      expect(result.buffer.asUint8List(), payload);
+      expect(serial.writes.last, '<-J>');
+    });
+
+    test(
+      'a single-notify read times out cleanly when firmware never answers',
+      () async {
+        // Real (shortened) time: fakeAsync stalls on the root-zone
+        // `_nullFuture` returned by broadcast-subscription cancels inside
+        // `Stream.first`, so the timeout is injected small instead.
+        final serial2 = FakeSerialTransport();
+        final transport2 = UnifiedDe1Transport(
+          transport: serial2,
+          serialSingleReadTimeout: const Duration(milliseconds: 50),
+        );
+        addTearDown(transport2.dispose);
+        await transport2.connect();
+
+        await expectLater(
+          transport2.read(Endpoint.versions),
+          throwsA(isA<TimeoutException>()),
+          reason: 'firmware that never emits [A] must not hang the caller',
+        );
+        expect(
+          serial2.writes,
+          contains('<-A>'),
+          reason: 'the failed read still cleans up its notify',
+        );
+      },
+    );
+
+    test(
+      'a failing <+X> request write does not leak an unhandled timeout',
+      () async {
+        // Locks the `response.ignore()` line in _serialSingleNotifyRead:
+        // when the `<+A>` write throws, nothing ever awaits the armed
+        // `frames.first.timeout(...)` future — without ignore() its
+        // eventual TimeoutException surfaces as an unhandled async error
+        // and fails this test when it fires below.
+        final serial2 = _FailingWriteSerialTransport(failOn: '<+A>');
+        final transport2 = UnifiedDe1Transport(
+          transport: serial2,
+          serialSingleReadTimeout: const Duration(milliseconds: 40),
+        );
+        addTearDown(transport2.dispose);
+        await transport2.connect();
+
+        await expectLater(
+          transport2.read(Endpoint.versions),
+          throwsA(isA<StateError>()),
+          reason: 'the write failure itself must surface to the caller',
+        );
+        expect(
+          serial2.writes,
+          contains('<-A>'),
+          reason: 'the failed read still cleans up its notify (finally)',
+        );
+
+        // Let the armed timeout fire inside the test body; an unhandled
+        // async TimeoutException here fails the test.
+        await Future<void>.delayed(const Duration(milliseconds: 120));
+      },
+    );
+
+    test(
+      'endpoints with no serial read path throw UnsupportedError',
+      () async {
+        await transport.connect();
+
+        for (final e in [
+          Endpoint.setTime,
+          Endpoint.shotDirectory,
+          Endpoint.writeToMMR,
+          Endpoint.shotMapRequest,
+          Endpoint.deleteShotRange,
+          Endpoint.deprecatedShotDesc,
+          Endpoint.headerWrite,
+          Endpoint.frameWrite,
+        ]) {
+          await expectLater(
+            transport.read(e),
+            throwsA(isA<UnsupportedError>()),
+            reason: '${e.name} is write-only / never emitted by the firmware',
+          );
+        }
+      },
+    );
+
+    test(
+      'read(requestedState) serves the stateInfo subject ([N] carries state)',
+      () async {
+        // There is no [B] notify on the wire; requestedState deliberately
+        // aliases the stateInfo subject over serial. Pinned here so a
+        // future refactor can't silently break the raw-API read.
+        await transport.connect();
+        serial.injectSerial('[N]0402\n');
+        await pumpEventQueue();
+
+        final viaRequestedState = await transport.read(
+          Endpoint.requestedState,
+        );
+        final viaStateInfo = await transport.read(Endpoint.stateInfo);
+        expect(
+          viaRequestedState.buffer.asUint8List(),
+          viaStateInfo.buffer.asUint8List(),
+        );
+        expect(viaRequestedState.buffer.asUint8List(), [0x04, 0x02]);
+      },
+    );
+  });
+
+  group('serial RX framing — parser edge cases', () {
+    late FakeSerialTransport serial;
+    late UnifiedDe1Transport transport;
+
+    setUp(() {
+      serial = FakeSerialTransport();
+      transport = UnifiedDe1Transport(transport: serial);
+    });
+
+    tearDown(() => transport.dispose());
+
+    test('a frame split across chunks reassembles', () async {
+      await transport.connect();
+
+      // [E] reply split mid-payload: first chunk has no terminator so it
+      // must stay buffered, not be dropped.
+      serial.injectSerial('[E]0480');
+      await pumpEventQueue();
+      serial.injectSerial('000c80000000\n');
+      await pumpEventQueue();
+
+      final mmr = await transport.read(Endpoint.readFromMMR);
+      expect(mmr.buffer.asUint8List(), [
+        0x04,
+        0x80,
+        0x00,
+        0x0C,
+        0x80,
+        0x00,
+        0x00,
+        0x00,
+      ]);
+    });
+
+    test('leading junk before the first [ is discarded', () async {
+      await transport.connect();
+
+      serial.injectSerial('OK\r\nboot junk[N]0403\n');
+      await pumpEventQueue();
+
+      final state = await transport.read(Endpoint.stateInfo);
+      expect(state.buffer.asUint8List(), [0x04, 0x03]);
+    });
+
+    test(
+      'a >4096-char unterminated buffer is dumped and parsing resyncs',
+      () async {
+        await transport.connect();
+
+        // A '[M]' start with no terminator ever: grows past the 4096 guard
+        // and must be discarded (no checksum/retransmit on this framing —
+        // the keepalive's forced [N] resyncs the stream afterwards).
+        serial.injectSerial('[M]${'00' * 2500}');
+        await pumpEventQueue();
+
+        // The stream recovers: the next complete frame parses normally.
+        serial.injectSerial('[N]0405\n');
+        await pumpEventQueue();
+
+        final state = await transport.read(Endpoint.stateInfo);
+        expect(state.buffer.asUint8List(), [0x04, 0x05]);
+
+        // The dumped garbage never surfaced as a shotSample frame.
+        final shot = await transport.read(Endpoint.shotSample);
+        expect(
+          shot.buffer.asUint8List(),
+          List<int>.filled(19, 0),
+          reason: 'the overflowed [M] bufferful must be dropped, not parsed',
+        );
+      },
+    );
+  });
+
+  group('serial keepalive (actively drive the shared link)', () {
+    // Real (shortened) time via the injectable interval: fakeAsync stalls
+    // on the root-zone `_nullFuture` that broadcast-subscription cancels
+    // return inside disconnect()/dispose().
+    const interval = Duration(milliseconds: 40);
+    const threePeriods = Duration(milliseconds: 140);
+
+    test('re-asserts the link with <+N> every keepalive period', () async {
+      final serial = FakeSerialTransport();
+      final transport = UnifiedDe1Transport(
+        transport: serial,
+        serialKeepaliveInterval: interval,
+      );
+      addTearDown(transport.dispose);
+      await transport.connect();
+      serial.writes.clear();
+
+      await Future<void>.delayed(threePeriods);
+      expect(
+        serial.writes.where((w) => w == '<+N>').length,
+        greaterThanOrEqualTo(2),
+        reason:
+            'a passively-listening USB client silently loses the '
+            'notify stream to the BLE source arbitration — the keepalive '
+            'must re-assert periodically, not once',
+      );
+    });
+
+    test('disconnect() stops the keepalive', () async {
+      final serial = FakeSerialTransport();
+      final transport = UnifiedDe1Transport(
+        transport: serial,
+        serialKeepaliveInterval: interval,
+      );
+      addTearDown(transport.dispose);
+      await transport.connect();
+
+      await transport.disconnect();
+      serial.writes.clear();
+
+      await Future<void>.delayed(threePeriods);
+      expect(serial.writes.where((w) => w == '<+N>'), isEmpty);
+    });
+
+    test('dispose() stops the keepalive', () async {
+      final serial = FakeSerialTransport();
+      final transport = UnifiedDe1Transport(
+        transport: serial,
+        serialKeepaliveInterval: interval,
+      );
+      await transport.connect();
+
+      await transport.dispose();
+      serial.writes.clear();
+
+      await Future<void>.delayed(threePeriods);
+      expect(serial.writes.where((w) => w == '<+N>'), isEmpty);
+    });
+
+    test('detach() stops the keepalive (re-resolution seam)', () async {
+      // A demoted/promoted machine hands its live transport to the
+      // replacement wrapper; the discarded wrapper's keepalive must not
+      // keep writing on the shared port.
+      final serial = FakeSerialTransport();
+      final transport = UnifiedDe1Transport(
+        transport: serial,
+        serialKeepaliveInterval: interval,
+      );
+      await transport.connect();
+
+      await transport.detach();
+      serial.writes.clear();
+
+      await Future<void>.delayed(threePeriods);
+      expect(serial.writes.where((w) => w == '<+N>'), isEmpty);
+    });
+  });
+}

--- a/test/unit/services/serial/serial_probe_name_gate_test.dart
+++ b/test/unit/services/serial/serial_probe_name_gate_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/serial/serial_service_android.dart';
+import 'package:reaprime/src/services/serial/usb_ids.dart';
+import 'package:reaprime/src/services/serial/utils.dart';
+
+// usb_serial is pulled in transitively via flutter_libserialport's git source.
+// ignore: depend_on_referenced_packages
+import 'package:usb_serial/usb_serial.dart';
+
+UsbDevice _usbDevice({String? productName, int? vid, int? pid}) => UsbDevice(
+  '/dev/bus/usb/001/002',
+  vid,
+  pid,
+  productName,
+  null, // manufacturerName
+  42, // deviceId
+  null, // serial
+  1, // interfaceCount
+);
+
+void main() {
+  group('serialProbeAllowsProductName', () {
+    test('allows "Bengle"', () {
+      expect(
+        serialProbeAllowsProductName('Bengle'),
+        isTrue,
+        reason:
+            'the pre-filter used to drop a Bengle board before the '
+            'v13Model probe ever ran',
+      );
+    });
+
+    test('allows "DE1"', () {
+      expect(serialProbeAllowsProductName('DE1'), isTrue);
+    });
+
+    test('allows "Half Decent Scale"', () {
+      expect(serialProbeAllowsProductName('Half Decent Scale'), isTrue);
+    });
+
+    test('allows generic serial adapters (name contains "Serial")', () {
+      expect(serialProbeAllowsProductName('USB Serial Port'), isTrue);
+      expect(serialProbeAllowsProductName('CP2102 USB to Serial'), isTrue);
+    });
+
+    test('allows unknown (null) product names — probe decides', () {
+      expect(serialProbeAllowsProductName(null), isTrue);
+    });
+
+    test('rejects unrelated devices', () {
+      expect(serialProbeAllowsProductName('Gaming Mouse'), isFalse);
+      expect(
+        serialProbeAllowsProductName('bengle'),
+        isFalse,
+        reason: 'exact match only — the USB descriptor string is fixed',
+      );
+    });
+  });
+
+  group('isBengleProbeCandidate', () {
+    test('admits the captured Bengle VID:PID (TinyUSB defaults)', () {
+      expect(
+        isBengleProbeCandidate(vid: 0x2E8A, pid: 0x000A),
+        isTrue,
+        reason:
+            'firmware enumerates as "TinyUSB Device", so the name '
+            'gate alone would drop a real Bengle',
+      );
+    });
+
+    test('rejects other ids and null', () {
+      expect(
+        isBengleProbeCandidate(vid: 0x2E8A, pid: 0x000C),
+        isFalse,
+        reason: 'Pi debug probe shares the vendor id',
+      );
+      expect(isBengleProbeCandidate(vid: null, pid: 0x000A), isFalse);
+    });
+  });
+
+  group('SerialServiceAndroid.shouldProbeUsbDevice — the OR call-site '
+      '', () {
+    // This is the gate `_detectDevice` actually evaluates: name gate OR
+    // probe candidate. The predicate tests above don't lock the
+    // combination, and the combination IS the fix — the old inline check
+    // dropped a TinyUSB-default Bengle before any shortcut/probe ran.
+    test(
+      'TinyUSB-default Bengle passes on VID:PID despite the useless name',
+      () {
+        expect(
+          SerialServiceAndroid.shouldProbeUsbDevice(
+            _usbDevice(
+              productName: 'TinyUSB Device',
+              vid: 0x2E8A,
+              pid: 0x000A,
+            ),
+          ),
+          isTrue,
+          reason:
+              '"TinyUSB Device" fails the name gate; the probe-candidate '
+              'VID:PID must still admit it',
+        );
+      },
+    );
+
+    test('a named Bengle passes even with unknown ids', () {
+      expect(
+        SerialServiceAndroid.shouldProbeUsbDevice(
+          _usbDevice(productName: 'Bengle', vid: 0x1234, pid: 0x5678),
+        ),
+        isTrue,
+      );
+    });
+
+    test('null name with null ids still reaches the probe', () {
+      expect(
+        SerialServiceAndroid.shouldProbeUsbDevice(_usbDevice()),
+        isTrue,
+        reason: 'Android often reports null before permission is granted',
+      );
+    });
+
+    test('unrelated name + unrelated ids is skipped', () {
+      expect(
+        SerialServiceAndroid.shouldProbeUsbDevice(
+          _usbDevice(productName: 'Gaming Mouse', vid: 0x046D, pid: 0xC08B),
+        ),
+        isFalse,
+      );
+    });
+
+    test('the Pi debug probe (shared vendor id) is skipped', () {
+      expect(
+        SerialServiceAndroid.shouldProbeUsbDevice(
+          _usbDevice(
+            productName: 'Debug Probe (CMSIS-DAP)',
+            vid: 0x2E8A,
+            pid: 0x000C,
+          ),
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
> **Stacked PR — B-2 of 10.** Builds on #459 (`feat/bengle-foundation`). Until that merges this PR's diff includes its commits; please review/merge in order **B-1 → B-10**.


## The story

Plug a machine in over USB, turn Bluetooth off, and the app shows you a full-screen "Connection
error: Bluetooth is turned off." and nothing else. USB discovery is running perfectly well behind
that screen and has almost certainly already found your machine, but you cannot see it and you
cannot get to the picker, so a wired-only setup simply cannot be used. That was reproduced on the
bench, and it is two separate gates, not one: fixing either alone leaves the picker hidden behind the
other. On top of that, USB-serial is not at parity with BLE in the shared transport. A firmware
upload desyncs the framing on its last chunk, several reads are outright `UnimplementedError`, and a
USB client that just sits and listens gets its notification stream silently stolen by the BLE module,
because both share one serial view in the firmware arbitrated by a last-writer-wins flag. This PR
closes all of that.

## Summary

- **Problem:** (a) Two independent gates in the scan flow (the guardian's adapter-error view, and
  the connection manager's sticky `adapterOff` error) hid a working USB discovery behind a Bluetooth
  error screen. (b) The Android USB pre-filter dropped any port whose product name was not `DE1`,
  `Half Decent Scale`, or something containing `Serial`, before the class shortcut or the `v13Model`
  probe ever ran, which made a real Bengle undetectable over USB on Android. (c) Three serial-only
  correctness gaps in the shared transport: short `<F>` frames desync the firmware parser, several
  reads throw `UnimplementedError`, and a passive USB listener loses its notify stream to the BLE
  module.
- **Why it matters:** (a) is a dead end for a wired-only user. (b) means the wire works and the app
  never looks: current Bengle firmware enumerates with the pico-sdk **default** TinyUSB descriptors,
  VID:PID `0x2E8A:0x000A` and product string "TinyUSB Device" (captured from hardware 2026-07-10), so
  it passes neither the name check nor the (empty) direct-ID table. (c) turns a firmware upload into
  a desync and a raw-API read into a crash, and the stolen-stream case is the nasty one: the client
  is not disconnected, it just stops being told anything.
- **What changed:** Both scan gates are demoted by a single `busyWithoutBle` predicate; the Android
  probe gate is now an OR of a name predicate and a VID:PID probe-candidate predicate; short
  `writeToMMR` frames are zero-padded to the firmware's exact 20-byte frame size; serial reads gain
  a real three-shape implementation (subscribed / single-notify round trip / honestly unsupported);
  and a 5-second `<+N>` keepalive re-asserts the USB source on the shared link.
- **What did NOT change (scope boundary):** Every path added or altered here is gated on
  `transportType == TransportType.serial`. The BLE path is byte-for-byte unchanged. Every product
  name the Android probe admitted before still passes. Only the `adapterOff` error kind is demoted in
  the scan flow: a genuine `machineConnectFailed` with machines on screen still shows the error view.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms (the USB/serial half of it)
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [x] UI / Flutter widgets (`scan_flow_view.dart`)
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes # `N/A - no tracking issue`
- Related # `N/A`

## Root Cause (if bug fix)

- **Root cause (scan flow):** the adapter-error view was written when Bluetooth was the only
  transport, so "the adapter is off" and "we cannot find anything" were the same statement. Serial
  discovery made them different statements, and the view was never revisited. The device scan already
  runs every discovery service in parallel and records per-service failures; only the presentation
  was wrong.
- **Root cause (Android probe):** the name check was an inline three-way condition written against
  the descriptors the DE1 ships. The Bengle shortcut immediately below it (`productName == "Bengle"`)
  was therefore dead code, because the gate above rejected the port first. The firmware never got
  around to setting a product string.
- **Root cause (serial parity):** the serial view was implemented for the parts that a DE1 exercises
  and stubbed for the rest. The `UnimplementedError` reads and the unpadded `<F>` frame are that
  stub showing.
- **Missing detection or guardrail:** `bengleUsbIds` being empty was documented but not tested, so
  somebody "completing" the table later would have changed detection semantics with every existing
  test still green. That is now pinned.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- **Target test or file:** `test/unit/models/device/impl/de1/unified_de1/serial_parity_test.dart`
  (new, 418 lines), `test/device_discovery_feature/scan_flow_ble_off_test.dart` (new),
  `test/controllers/connection_manager_wired_preferred_test.dart` (new),
  `test/unit/services/serial/serial_probe_name_gate_test.dart` (new, 13 tests),
  `test/services/serial/usb_ids_test.dart`, plus a new inbound-capable `FakeSerialTransport` helper.
- **Scenario the test should lock in:** With the adapter reporting off, a machine arriving over
  serial must reach the picker (both the guardian view and the sticky-error view are asserted, since
  demoting only one leaves the bug). The probe gate is tested as the **OR combination** at the call
  site, not just as two predicates, because the OR is the actual fix. On the transport: a short
  `<F>` frame is padded to 20 bytes and the true length still rides the `Len` byte; a single-notify
  read completes its `<+X>` / `[X]` / `<-X>` round trip and times out cleanly rather than hanging
  when the firmware never emits the char; the keepalive fires; and the parser survives chunk-split
  reassembly, leading junk, and a 4096-byte overflow followed by a resync.

## Documentation Obligations (required)

- [ ] API spec updated
- [ ] API docs updated: `doc/Api.md`
- [ ] Plugin docs updated
- [ ] Skin docs updated
- [ ] Profile docs updated
- [x] Device docs updated: `doc/DeviceManagement.md` - a new "USB/serial transport behaviour (DE1
      family)" block covering reads, length-exact frames, throughput and link arbitration; a
      "Bluetooth-off operation" paragraph; and the Android name-gate and VID:PID probe-candidate
      wording in the serial detection list.
- [ ] N/A

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `Yes`, and this is the section to read. The Android USB probe now also
  admits ports whose VID:PID is `0x2E8A:0x000A`, and ports whose product name is null (Android often
  reports null before USB permission is granted). That pair is the pico-sdk default, so it matches
  any default Raspberry Pi Pico CDC device, not only a Bengle. Two things bound the risk. First, the
  pair only qualifies a port for the **identification probe**; `bengleUsbIds`, the direct
  instantiation table, is deliberately **empty** and now test-pinned empty, so a random hobby board
  can never be instantiated as an espresso machine. Second, the probe is the existing 3-second
  DE1-protocol handshake, and a device that does not answer it is dropped. The name predicates stay
  exact and case-sensitive on purpose; the descriptor strings are fixed, and loosening them widens
  the probe's reach onto unrelated hardware. `0x2E8A:0x000C` (the Pi debug probe) is explicitly not
  matched. Auto-permission for the VID:PID was already upstream in `device_filter.xml`; I verified
  that and did not re-add it.
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`

## User-Visible Changes

A machine connected over USB is reachable with Bluetooth turned off, and the adapter-error screen now
tells the user that USB keeps working. A Bengle is detected over USB on Android. The preferred
machine continues to be stored per **transport id** (a serial id is the `usb-<vid>-<pid>-<serial>`
stable id, not a BLE MAC), deliberately un-aliased across transports: the first wired session ends at
the picker, and picking the USB machine once makes later launches auto-connect over the wire.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` - clean (`No issues found!`)
- [x] `flutter test` - **2080 tests pass** at this branch head (B-1 was 2041; `+39` from this
      branch's own tests)
- [x] `(cd packages/dye2-plugin && npm run build)` - plugin builds

### Manual verification (if applicable)

- OS / platform tested: Linux (analyzer, full test suite).
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `Yes`, for the facts the fixes are built on, though not as a
  re-run of this exact branch. The TinyUSB default descriptors (`0x2E8A:0x000A`, "TinyUSB Device")
  were captured from a Bengle on 2026-07-10. The Bluetooth-off dead end was reproduced on the bench,
  which is how it became clear that fixing one gate is not enough.
- What you personally verified and how: the local gate set above, and the transport behaviour against
  the new `FakeSerialTransport` at the byte level.
- Edge cases checked: a request write that throws while a read is armed (the armed future is
  `.ignore()`d so its later timeout cannot surface as an unhandled async error); a failed read
  (the `<-X>` unsubscribe is sent in a `finally`, so a failure never leaves a subscription eating
  downlink budget); keepalive cancellation on `disconnect()`, `dispose()` and `detach()`.
- What you did **not** verify: I did not re-run this branch on the machine. Specifically unverified
  by me: an actual DFU firmware upload over USB end to end (the `<F>` padding is asserted at the byte
  level in tests, and the DFU uploader's final image chunk is the only short-frame producer in the
  codebase, but I did not push an image through it); and iOS/macOS serial, which this repo does not
  support anyway.

### Evidence

- [x] Test output (2080 pass)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`

A DE1 over BLE is byte-for-byte unaffected. A DE1 over serial gains the reads that used to throw and
the keepalive, and loses nothing. The keepalive costs roughly one 8-character command up and one
`[N]` frame down every 5 seconds.

## Deliberate choices worth your review

1. **The keepalive exists because the firmware link is shared.** BLE and USB share one serial view in
   the firmware, arbitrated by a last-writer-wins `Source` flag, so any stray byte from the BLE module
   silently steals the notify stream from a passively listening USB client. A periodic `<+N>`
   re-asserts `Source = USB`, and because the firmware treats an add-notify as a force-update, it
   doubles as a resync for a framing that has no checksum and no retransmit. 5 seconds bounds the
   worst-case stolen-stream window. This is a workaround for a firmware arbitration design, and if
   you would rather the firmware fixed it, say so; the app-side cost is small but it is not nothing.
2. **Reads that have no serial path now throw `UnsupportedError`, not `UnimplementedError`.** The DE1
   serial view genuinely never emits those characteristics; `setTime`, `writeToMMR`, `headerWrite`
   and `frameWrite` are write-only commands. A descriptive `UnsupportedError` means the raw WebSocket
   API surfaces a clean error to the client instead of crashing the read. That is a behaviour change
   for anyone who was catching `UnimplementedError`, which I doubt is anyone, but it is a change.
3. **`serialKeepaliveInterval` and `serialSingleReadTimeout` are constructor test seams.** They exist
   because `fakeAsync` stalls on the root-zone `_nullFuture` that broadcast-subscription cancels
   return, so the timer tests have to run on real, shortened time. Production never sets them. If you
   dislike constructor seams I can hide them behind `@visibleForTesting` statics instead.
4. **`shouldProbeUsbDevice` is a `@visibleForTesting` static.** It was extracted precisely so the OR
   combination is unit-tested rather than only the two predicates. The predicates passing
   individually is what the old code already "had".

## Risks & Mitigations

- **Risk:** the probe now reaches out to any default pico-sdk CDC device plugged into an Android
  tablet.
  - **Mitigation:** the probe is the DE1-protocol handshake and it is bounded at 3 seconds; a device
    that does not answer is dropped, and `bengleUsbIds` stays empty so nothing can be instantiated
    from the ID alone. The worst case is a 3-second delay on scan for a user with a Pico plugged in.
- **Risk:** demoting the adapter-error view could hide a real Bluetooth problem.
  - **Mitigation:** only the `adapterOff` kind is demoted, and only while something that works
    without Bluetooth is in flight (an active connect, a pending picker, found machines, or machines
    streaming in over `DeviceController.deviceStream`). I included `_discoveredMachines`, not just
    `foundMachines`, on purpose: the latter fills later, and using only it re-opens a window where
    the error flashes over live discovery.
- **Risk:** zero-padding a `<F>` frame changes what goes on the wire for a DE1.
  - **Mitigation:** it is serial-only, it applies only to `writeToMMR`, and the `Len` byte carries
    the true payload length so the padding is inert to the firmware. Every other endpoint already
    emits struct-sized frames by construction.
