### PR TITLE
feat(bengle): sync the wake schedule and sleep timeout to the machine

### DIFF
--- a/.agents/skills/decent-app/scenarios/bengle-cup-warmer.md
+++ b/.agents/skills/decent-app/scenarios/bengle-cup-warmer.md
@@ -1,12 +1,14 @@
 # Scenario: Bengle cup-warmer + capability discovery
 
-Verifies the first Bengle peripheral surface end-to-end: `GET /api/v1/machine/capabilities` lists `cupWarmer` when a Bengle is connected, `GET /api/v1/machine/cupWarmer` returns the current setpoint, `POST /api/v1/machine/cupWarmer` writes a new setpoint, and out-of-range writes are rejected at 400 before reaching the device.
+Verifies the first Bengle peripheral surface end-to-end: `GET /api/v1/machine/capabilities` lists `cupWarmer` when a Bengle is connected, `GET /api/v1/machine/cupWarmer` returns the current setpoint plus the live mat temperature (`currentTemperature`, `null` when the firmware has no valid reading), `PUT /api/v1/machine/cupWarmer` writes a new setpoint, and out-of-range writes are rejected at 400 before reaching the device.
 
 ## Preconditions
 
 ```bash
-scripts/sb-dev.sh start --connect-machine MockBengle --connect-scale MockScale
+scripts/sb-dev.sh start --connect-machine MockBengle
 ```
+
+(No `--connect-scale`: on Bengle the integrated scale always wins and `preferredScaleId` is ignored.)
 
 ## Steps
 
@@ -18,24 +20,24 @@ curl -sf http://localhost:8080/api/v1/machine/capabilities | jq -e '.capabilitie
 
 Exit 0 → `cupWarmer` present in the capability list.
 
-### 2. Read initial setpoint (off)
+### 2. Read initial setpoint (off) + live mat temperature placeholder
 
 ```bash
-curl -sf http://localhost:8080/api/v1/machine/cupWarmer | jq -e '.temperature == 0'
+curl -sf http://localhost:8080/api/v1/machine/cupWarmer | jq -e '.temperature == 0 and .currentTemperature == null'
 ```
 
-MockBengle boots with `_cupWarmerTemp = 0.0`. Exit 0 → off.
+MockBengle boots with `_cupWarmerTemp = 0.0` and no simulated mat reading — `currentTemperature` is `null` (the "no valid reading" placeholder case; field firmware without the MatCurrentTemp register behaves the same). Exit 0 → off + placeholder.
 
 ### 3. Set a valid setpoint
 
 ```bash
-curl -sf -X POST http://localhost:8080/api/v1/machine/cupWarmer \
+curl -sf -X PUT http://localhost:8080/api/v1/machine/cupWarmer \
   -H 'Content-Type: application/json' \
   -d '{"temperature": 60}' \
   -o /dev/null -w '%{http_code}\n'
 ```
 
-Expected: `202`.
+Expected: `200`. (Also enables the warmer — a target `> 0` = on; the FW enable register is app-managed.)
 
 ### 4. Confirm the new setpoint
 
@@ -48,7 +50,7 @@ Exit 0 → MockBengle stored the value.
 ### 5. Reject out-of-range
 
 ```bash
-curl -s -X POST http://localhost:8080/api/v1/machine/cupWarmer \
+curl -s -X PUT http://localhost:8080/api/v1/machine/cupWarmer \
   -H 'Content-Type: application/json' \
   -d '{"temperature": 100}' \
   -o /dev/null -w '%{http_code}\n'

--- a/.agents/skills/decent-app/scenarios/bengle-integrated-scale.md
+++ b/.agents/skills/decent-app/scenarios/bengle-integrated-scale.md
@@ -50,6 +50,8 @@ curl -s -X PUT http://localhost:8080/api/v1/scale/tare
 
 Expected: `200 OK`, empty body.
 
+On real hardware this generic endpoint reaches the machine's `ScaleTare` MMR write-trigger (`0x0080388C`) through `BengleVirtualScale.tare()` → `tareIntegratedScale()`; the firmware performs an immediate tare and subsequent `0xA013` weight arrives already net of the new zero. Confirm a tare by watching the weight drop toward 0 — never the `0xA013` Flags bit.
+
 Re-sample the snapshot and confirm weight is ~0 (MockBengle resets `_tareOffset` to the current accumulated weight, so the next emission reads near zero):
 
 ```bash

--- a/.agents/skills/decent-app/scenarios/bengle-integrated-scale.md
+++ b/.agents/skills/decent-app/scenarios/bengle-integrated-scale.md
@@ -21,7 +21,7 @@ curl -sf http://localhost:8080/api/v1/machine/capabilities | jq .
 Expected:
 
 ```json
-{ "capabilities": ["cupWarmer", "integratedScale", "ledStrip", "stopAtWeight"] }
+{ "capabilities": ["cupWarmer", "integratedScale", "ledStrip", "stopAtWeight", "scaleCalibration"] }
 ```
 
 Quick assertions:

--- a/.agents/skills/decent-app/scenarios/bengle-integrated-scale.md
+++ b/.agents/skills/decent-app/scenarios/bengle-integrated-scale.md
@@ -1,6 +1,6 @@
 # Scenario: Bengle integrated scale end-to-end
 
-Verifies that when a Bengle is the connected machine, the integrated scale is auto-attached as a virtual scale (no external scale connection needed), capability discovery advertises `integratedScale`, the `/api/v1/scale/*` REST surface and `/ws/v1/scale/snapshot` stream both flow through the integrated scale, and software stop-at-weight (SAW) ends an espresso shot when the integrated scale weight crosses the profile target.
+Verifies that when a Bengle is the connected machine, the integrated scale is auto-attached as a virtual scale (no external scale connection needed), capability discovery advertises `integratedScale` and `stopAtWeight`, the `/api/v1/scale/*` REST surface and `/ws/v1/scale/snapshot` stream both flow through the integrated scale, and **autonomous** stop-at-weight (SAW) ends an espresso shot: the app reflects the workflow's `targetYield` into the machine's SAW target and defers the final yield stop to the machine (`machineHasAutonomousSAW`), which `MockBengle` simulates firmware-side.
 
 ## Preconditions
 
@@ -12,7 +12,7 @@ No `--connect-scale` flag. On Bengle the integrated scale always wins — extern
 
 ## Steps
 
-### 1. Capability discovery lists both Bengle surfaces
+### 1. Capability discovery lists the Bengle surfaces
 
 ```bash
 curl -sf http://localhost:8080/api/v1/machine/capabilities | jq .
@@ -21,17 +21,17 @@ curl -sf http://localhost:8080/api/v1/machine/capabilities | jq .
 Expected:
 
 ```json
-{ "capabilities": ["cupWarmer", "integratedScale"] }
+{ "capabilities": ["cupWarmer", "integratedScale", "ledStrip", "stopAtWeight"] }
 ```
 
 Quick assertions:
 
 ```bash
 curl -sf http://localhost:8080/api/v1/machine/capabilities \
-  | jq -e '.capabilities | index("integratedScale") != null and index("cupWarmer") != null'
+  | jq -e '.capabilities | index("integratedScale") != null and index("stopAtWeight") != null'
 ```
 
-Exit 0 → both identifiers present.
+Exit 0 → both identifiers present. `stopAtWeight` advertises that the machine firmware runs its own stop-at-weight from the integrated scale — there is no dedicated SAW endpoint; the target rides `PUT /api/v1/workflow` (`context.targetYield`).
 
 ### 2. Scale snapshot stream is alive without an external scale
 
@@ -59,14 +59,14 @@ websocat --no-async-stdio -n -U -t --max-messages-rev 1 \
 
 Expected: a value within ~±0.1 g of zero.
 
-### 4. Run a shot — software SAW stops at the profile target weight
+### 4. Run a shot — the machine's autonomous SAW stops at the workflow target yield
 
-Upload the bundled flow profile (target weight = 42 g):
+Set the workflow target yield (the single source of truth for SAW — `BengleSawBridge` reflects it into the machine's `EndOfShotWeight` target after a short debounce):
 
 ```bash
-curl -sf -X POST http://localhost:8080/api/v1/machine/profile \
+curl -sf -X PUT http://localhost:8080/api/v1/workflow \
   -H 'Content-Type: application/json' \
-  --data @assets/defaultProfiles/Flow_profile_for_straight_espresso.json
+  -d '{"context": {"targetYield": 42.0}}' | jq .
 ```
 
 Tare, then start the espresso shot:
@@ -76,20 +76,24 @@ curl -s -X PUT http://localhost:8080/api/v1/scale/tare
 curl -sX PUT http://localhost:8080/api/v1/machine/state/espresso
 ```
 
-Watch the machine snapshot stream — `MockDe1` simulates flow, `MockBengle` integrates flow into weight, `ShotController` projects `weight + flow * multiplier` against `targetYield` (42 g for this profile) and drives the machine to `idle` once the projection crosses the target:
+Watch the machine snapshot stream — `MockDe1` simulates flow, `MockBengle` integrates flow into weight and (simulating the Bengle firmware's autonomous SAW) requests `idle` itself once the integrated-scale weight crosses the 42 g target. The app's `ShotSequencer` deliberately does **not** issue its own final-yield stop on a Bengle (`machineHasAutonomousSAW` — no double stop); it observes the machine-side stop and reports it as `machineEnded`:
 
 ```bash
 websocat --no-async-stdio -n -U -t --max-messages-rev 200 \
   ws://localhost:8080/ws/v1/machine/snapshot | jq -c '{state, substate}'
 ```
 
-Expected sequence ends with `state == "idle"` once the integrated scale crosses ~42 g (projection causes the cutoff slightly before the literal reading). Logs show:
+Expected sequence ends with `state == "idle"` once the integrated scale crosses ~42 g.
+
+Confirm the app deferred to the machine — the shotState feed advertises the autonomous SAW (the idle re-seed frame carries the flag between shots too), and the persisted shot records the machine-side stop:
 
 ```bash
-sb-dev logs -n 60 --filter "ShotController\|target weight"
+websocat --no-async-stdio -n -U -t --max-messages-rev 1 \
+  ws://localhost:8080/ws/v1/machine/shotState | jq -e '.machineHasAutonomousSAW == true'
+curl -sf http://localhost:8080/api/v1/shots/latest | jq -e '.stopReason == "machineEnded"'
 ```
 
-Expected log line: `Target weight 42.0g reached (projected: ...). Stopping shot.`
+Both exit 0.
 
 ### 5. No external scale connection ever happened
 
@@ -108,5 +112,5 @@ scripts/sb-dev.sh stop
 ## Notes
 
 - **Why no `--connect-scale`?** On Bengle, `ConnectionManager` skips the external-scale phase entirely (see `doc/DeviceManagement.md`). Passing `--connect-scale MockScale` will be ignored / overridden by the integrated-scale auto-attach.
-- **Target weight is profile-driven**, not a global default. The bundled `Flow_profile_for_straight_espresso.json` ships with `target_weight: 42.0`. Workflow target weight (when set via `/api/v1/workflow`) overrides per-run; this scenario relies on the profile value alone for simplicity.
-- **Stop is software SAW**, identical to the external-scale path — `ShotController` makes the stop decision; the integrated scale just sources weight via `BengleVirtualScale` instead of a BLE scale.
+- **Target yield is workflow-driven.** `WorkflowContext.targetYield` is the single source of truth for the SAW target; there is deliberately no `POST /machine/saw`-style endpoint. The default workflow ships with `targetYield: 36.0`, so the bridge arms 36 g on connect even before step 4 sets 42 g.
+- **The stop is autonomous (firmware-side on real hardware).** The app's `ShotSequencer` bypasses only the FINAL target-yield stop on `BengleInterface` machines; per-step weight exits still run app-side. On real hardware the target lands in the `EndOfShotWeight` MMR (`0x00803864`, ×100) and the Bengle firmware ends the shot itself; `MockBengle` simulates that firmware behavior in-process.

--- a/.agents/skills/decent-app/scenarios/bengle-led-strip.md
+++ b/.agents/skills/decent-app/scenarios/bengle-led-strip.md
@@ -1,91 +1,127 @@
-# Bengle LED strip v2
+# Scenario: Bengle LED strip + live preview
 
-Exercises the full LED strip v2 API on a `MockBengle`: PUT configuration, verify response, commit, reset.
+Verifies the LED strip surface end-to-end: `GET /api/v1/machine/capabilities` lists `ledStrip` when a Bengle is connected, `GET`/`PUT /api/v1/machine/ledStrip` round-trip the 3-zone × 2-mode configuration, `POST .../commit` re-asserts it (202), `POST .../reset` re-hydrates the cache and returns the refreshed state, and the live-preview pair `POST .../preview` / `POST .../preview/clear` is accepted (202) without touching the stored configuration.
 
 ## Preconditions
 
-- A running Decent instance with `simulate=1,scale` (MockBengle auto-discovered)
-- `curl` and `jq` available
-
-## Procedure
-
-### 1. Verify capability
-
 ```bash
-curl -s http://localhost:8080/api/v1/machine/capabilities | jq
+scripts/sb-dev.sh start --connect-machine MockBengle
 ```
 
-Expect `ledStrip` in the `capabilities` array.
+`MockBengle` has no physical strips: `preview`/`preview/clear` are accepted but visually no-ops, and its `commit`/`reset` model an NVM snapshot (commit stores, reset restores). On real hardware every palette `PUT` already persists (the firmware registers are disk-backed) and `reset` re-reads whatever was last written — see the notes.
 
-### 2. Read initial (all-off)
+## Steps
+
+### 1. Capability discovery lists `ledStrip`
 
 ```bash
-curl -s http://localhost:8080/api/v1/machine/ledStrip | jq
+curl -sf http://localhost:8080/api/v1/machine/capabilities \
+  | jq -e '.capabilities | index("ledStrip") != null'
 ```
 
-Expect all zones sleeping/awake → `"000000000000"`.
+Exit 0 → the LED endpoints are available on this machine.
 
-### 3. Write a config
+### 2. Read initial configuration (all-off)
 
 ```bash
-curl -s -X PUT http://localhost:8080/api/v1/machine/ledStrip \
+curl -sf http://localhost:8080/api/v1/machine/ledStrip \
+  | jq -e '.frontStrip.awake == "000000000000" and .backStrip.awake == "000000000000"'
+```
+
+On real hardware the cache is hydrated from the machine's four stored palette registers on connect, so this GET returns whatever the machine has stored (all-off only as a fallback when that read fails, until the first `PUT` or `/reset`). `MockBengle` has no firmware to read — its cache starts all-off, which is what this step asserts.
+
+### 3. Write a configuration
+
+```bash
+curl -sf -X PUT http://localhost:8080/api/v1/machine/ledStrip \
   -H 'Content-Type: application/json' \
   -d '{
     "frontStrip": {"sleeping": "0000FFFF0000", "awake": "FFFF80000000"},
     "backStrip":  {"sleeping": "000000000000", "awake": "FFFFFFFFFFFF"},
     "frontSwitch":{"sleeping": "FFFF00000000", "awake": "000000000000"}
-  }' | jq
+  }' | jq -e '.status == "accepted"'
 ```
 
-Expect `{"status": "accepted"}` (status 200).
+Status 200. (`frontSwitch` is accepted for API symmetry but has no register — the physical switch light mirrors the front strip in firmware.)
 
 ### 4. Read back
 
 ```bash
-curl -s http://localhost:8080/api/v1/machine/ledStrip | jq
+curl -sf http://localhost:8080/api/v1/machine/ledStrip \
+  | jq -e '.frontStrip.awake == "FFFF80000000" and .backStrip.awake == "FFFFFFFFFFFF"'
 ```
-
-Expect the same values just written.
 
 ### 5. Commit
 
 ```bash
-curl -s -X POST http://localhost:8080/api/v1/machine/ledStrip/commit \
-  -H 'Content-Type: application/json' \
-  -d '{}'
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -X POST http://localhost:8080/api/v1/machine/ledStrip/commit
 ```
 
-Expect 202.
+Expected: `202`. On real hardware this re-asserts the cached palette (palette writes already persist); on `MockBengle` it snapshots the cache for `reset`.
 
-### 6. Overwrite cache without committing
+### 6. Overwrite, then reset restores the committed config
 
 ```bash
-curl -s -X PUT http://localhost:8080/api/v1/machine/ledStrip \
+curl -sf -X PUT http://localhost:8080/api/v1/machine/ledStrip \
   -H 'Content-Type: application/json' \
   -d '{"frontStrip":{"sleeping":"000000000000","awake":"000000000000"},
        "backStrip":{"sleeping":"000000000000","awake":"000000000000"},
-       "frontSwitch":{"sleeping":"000000000000","awake":"000000000000"}}'
+       "frontSwitch":{"sleeping":"000000000000","awake":"000000000000"}}' > /dev/null
+
+curl -sf -X POST http://localhost:8080/api/v1/machine/ledStrip/reset \
+  | jq -e '.frontStrip.sleeping == "0000FFFF0000"'
 ```
 
-### 7. Reset — should restore committed values
+Status 200 with the step-3 configuration — the mock restores its committed snapshot. (Real hardware: reset re-reads the firmware palette, which holds whatever was last written.)
+
+### 7. Live preview (does not touch the stored config)
 
 ```bash
-curl -s -X POST http://localhost:8080/api/v1/machine/ledStrip/reset \
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -X POST http://localhost:8080/api/v1/machine/ledStrip/preview \
   -H 'Content-Type: application/json' \
-  -d '{}' | jq
+  -d '{"front": "FFFF00000000", "back": "00000000FFFF"}'
+
+curl -sf http://localhost:8080/api/v1/machine/ledStrip \
+  | jq -e '.frontStrip.sleeping == "0000FFFF0000"'
 ```
 
-Expect the config from step 3 (`frontStrip.sleeping: 0000FFFF0000`, etc.), not the all-off from step 6.
+Expected: `202`, and the stored configuration is unchanged (preview writes only the live colour registers). On real hardware the strips show red/blue immediately, regardless of awake/sleep state; `MockBengle` has no strips so only the status code is observable.
 
-### 8. Plain DE1 returns 404
-
-If you connect a plain DE1 or MockDe1 (no `simulate=1`), all four endpoints return 404:
+### 8. Clear the preview
 
 ```bash
-curl -s http://localhost:8080/api/v1/machine/ledStrip | jq
-curl -s -X PUT http://localhost:8080/api/v1/machine/ledStrip -H 'Content-Type: application/json' -d '{}' | jq
-curl -s -X POST http://localhost:8080/api/v1/machine/ledStrip/commit -H 'Content-Type: application/json' -d '{}' | jq
-curl -s -X POST http://localhost:8080/api/v1/machine/ledStrip/reset -H 'Content-Type: application/json' -d '{}' | jq
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -X POST http://localhost:8080/api/v1/machine/ledStrip/preview/clear
 ```
 
-All four return `{"error": "ledStrip not supported"}` with status 404.
+Expected: `202`. Real hardware: the strips return to the cached awake palette.
+
+### 9. Preview validation
+
+```bash
+# Empty object: missing keys preview as black (Color16 defensive default):
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -X POST http://localhost:8080/api/v1/machine/ledStrip/preview \
+  -H 'Content-Type: application/json' -d '{}'
+# Non-object body is rejected:
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -X POST http://localhost:8080/api/v1/machine/ledStrip/preview \
+  -H 'Content-Type: application/json' -d '[1,2,3]'
+```
+
+Expected: `202` then `400`.
+
+## Postconditions
+
+```bash
+scripts/sb-dev.sh stop
+```
+
+## Notes
+
+- **`404` on a plain DE1.** Restart with `--connect-machine MockDe1` and all six endpoints (`GET`/`PUT /ledStrip`, `commit`, `reset`, `preview`, `preview/clear`) return `404 {"error": "ledStrip not supported"}` — the capability probe in step 1 is how skins should decide whether to show the Lighting page.
+- **A preview never survives a sleep/wake edge.** The firmware copies the active stored palette into the live registers on every state transition, clobbering any preview.
+- **Clearing a preview restores the cached awake palette.** `preview/clear` restores from the app-side cache, which on real hardware is hydrated from the machine's stored palette on connect — the strips return to the machine's real awake colours. Only when that connect-time hydration failed (and before any `PUT`/`reset`) is the cache still all-off, in which case clearing a preview writes black.
+- **Colours are 16-bit per channel in JSON, 8-bit on the wire.** The firmware takes each channel's high byte (`0x00RRGGBB`) and read-back byte-replicates (`0xAB → 0xABAB`), so 8-bit sources round-trip losslessly.

--- a/.agents/skills/decent-app/scenarios/bengle-scale-calibration.md
+++ b/.agents/skills/decent-app/scenarios/bengle-scale-calibration.md
@@ -1,0 +1,94 @@
+# Scenario: Bengle load-cell calibration end-to-end
+
+Verifies the two-point load-cell calibration wizard over REST: `GET /api/v1/machine/capabilities` lists `scaleCalibration` when a Bengle is connected, `POST /api/v1/machine/scale/calibrate` runs the `zero` → `left` → `right` procedure (each call is non-blocking on the device side and returns the terminal calibration result), `abort` is accepted with `202`, and malformed requests are rejected at `400` before reaching the device.
+
+## Preconditions
+
+```bash
+scripts/sb-dev.sh start --connect-machine MockBengle
+```
+
+`MockBengle`'s calibration always succeeds instantly (no real load cells to settle). On real hardware each `zero`/`left`/`right` call blocks the HTTP request for the firmware run (~15 s settle+average, bounded by a 30 s deadline) — the wizard is still non-blocking on the machine: the app polls the packed `ScaleCalState` word and the shot surfaces stay live.
+
+## Steps
+
+### 1. Capability discovery lists `scaleCalibration`
+
+```bash
+curl -sf http://localhost:8080/api/v1/machine/capabilities \
+  | jq -e '.capabilities | index("scaleCalibration") != null'
+```
+
+Exit 0 → the wizard endpoint is available on this machine.
+
+### 2. Zero the empty platform
+
+```bash
+curl -sf -X POST http://localhost:8080/api/v1/machine/scale/calibrate \
+  -H 'Content-Type: application/json' -d '{"command":"zero"}' | jq .
+```
+
+Expected:
+
+```json
+{ "success": true, "finalStep": "complete", "pointStatus": "none" }
+```
+
+On real hardware run this with NOTHING on the platform — the firmware rejects a later latch with `noZero` if the cells were never zeroed.
+
+### 3. Latch point 1 — reference mass on the LEFT half
+
+```bash
+curl -sf -X POST http://localhost:8080/api/v1/machine/scale/calibrate \
+  -H 'Content-Type: application/json' -d '{"command":"left","grams":500}' \
+  | jq -e '.success == true and .pointStatus == "incomplete"'
+```
+
+Exit 0. `pointStatus: incomplete` means the point latched and the firmware is waiting for the sibling point — nothing is persisted yet. Use a whole-gram mass (the firmware reads the reference back at whole-gram resolution).
+
+### 4. Latch point 2 — the SAME mass on the RIGHT half solves + persists
+
+```bash
+curl -sf -X POST http://localhost:8080/api/v1/machine/scale/calibrate \
+  -H 'Content-Type: application/json' -d '{"command":"right","grams":500}' \
+  | jq -e '.success == true and .pointStatus == "ok"'
+```
+
+Exit 0. `pointStatus: ok` = both points solved; the firmware persisted and applied the new per-cell calibration.
+
+### 5. Abort is accepted with 202
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -X POST http://localhost:8080/api/v1/machine/scale/calibrate \
+  -H 'Content-Type: application/json' -d '{"command":"abort"}'
+```
+
+Expected: `202`.
+
+### 6. Validation rejects bad requests at 400
+
+```bash
+# left without the required grams:
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -X POST http://localhost:8080/api/v1/machine/scale/calibrate \
+  -H 'Content-Type: application/json' -d '{"command":"left"}'
+# unknown command:
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -X POST http://localhost:8080/api/v1/machine/scale/calibrate \
+  -H 'Content-Type: application/json' -d '{"command":"wiggle"}'
+```
+
+Expected: `400` twice.
+
+## Postconditions
+
+```bash
+scripts/sb-dev.sh stop
+```
+
+## Notes
+
+- **A calibration failure is still HTTP 200.** The HTTP layer reports transport success; the calibration outcome is data — clients branch on the body's `success`/`pointStatus`/`message` (a busy wizard returns `200 {"success": false, "message": "calibration already in progress"}`, not `409`).
+- **`404` on a plain DE1.** Restart with `--connect-machine MockDe1` and any calibrate POST returns `404 {"error": "scale calibration not supported"}` — the capability probe in step 1 is how skins should decide whether to show the wizard.
+- **Field firmware caveat.** Older single-point field firmware only latches `zero` (its step numbering differs; the app keys completion off the SubState so `zero` still terminates correctly); `left`/`right` need the two-point firmware.

--- a/assets/api/bengle_hw_v1.yml
+++ b/assets/api/bengle_hw_v1.yml
@@ -714,7 +714,7 @@ packet_0xA013:
     - { offset: 4,  size: 2, name: SetGroupPressure, type: u16, scale: 0.01, unit: bar,  semantics: "Set pressure; 0 if no target." }
     - { offset: 6,  size: 2, name: GroupFlow,        type: u16, scale: 0.01, unit: ml/s, semantics: "Estimated flow at group." }
     - { offset: 8,  size: 2, name: SetGroupFlow,     type: u16, scale: 0.01, unit: ml/s, semantics: "Set flow; 0 if no target." }
-    - { offset: 10, size: 2, name: GFlow,            type: u16, scale: 0.01, unit: g/s,  semantics: "Gravimetric flow from the integrated scale -> MachineSnapshot.weightFlow." }
+    - { offset: 10, size: 2, name: GFlow,            type: u16, scale: 0.01, unit: g/s,  semantics: "Gravimetric flow, computed on-device from the load cell -> MachineSnapshot.weightFlow AND the scale surface's weightFlow (passed through verbatim; the app does not re-estimate flow for a device that computes its own)." }
     - { offset: 12, size: 2, name: MixTemp,          type: u16, scale: 0.01, unit: degC, semantics: "Water temperature entering the group." }
     - { offset: 14, size: 2, name: HeadTemp,         type: u16, scale: 0.01, unit: degC, semantics: "Showerhead water temperature (u16/100 here; 0xA00D used 3-byte U24P16 -- layout differs)." }
     - { offset: 16, size: 2, name: SetMixTemp,       type: u16, scale: 0.01, unit: degC, semantics: "Mix temperature target; 0 if no target." }

--- a/assets/api/bengle_hw_v1.yml
+++ b/assets/api/bengle_hw_v1.yml
@@ -1,0 +1,757 @@
+# =============================================================================
+# Bengle firmware <-> app hardware contract (bengle_hw_v1.yml)
+# =============================================================================
+# contract_version: 1
+#
+# Generated from firmware the firmware register table at:
+#
+#
+# Change protocol: firmware changes a register -> regenerate this file from the
+# new the firmware register table -> bump contract_version -> update the app enums (BengleMmr /
+# BengleSteamMmr / BengleScaleMmr / BengleCalMmr / BengleLedMmr / MMRItem) ->
+# the mmr_contract_test checker enforces agreement; firmware and app PRs both
+# cite the contract_version.
+#
+# Normalization rules applied (binding):
+#   * mult / min / max are only meaningful on firmware register-table rows with auto > 0 (the
+#     macro read/write path). auto = 0 rows are served by hand-written firmware
+#     cases; for those, `mult` below records the VERIFIED behaviour of the
+#     hand-written path (which matches the the firmware register table column everywhere except
+#     v13Model, whose mult=1000 column is inert -- recorded as mult: 1).
+#   * min / max below are RAW WIRE UNITS (the little-endian int32 actually on
+#     the wire). Where the firmware register table used post-divide engineering units, the original
+#     engineering values are kept in a trailing comment.
+#   * min/max encoding: where the firmware register table declares the full-u32 column
+#     0..0xFFFFFFFF it is retained verbatim (for a u32 wire value that is
+#     identical to "no constraint"); ScaleTare alone is normalized to
+#     null/null because its written value is ignored entirely (pure trigger).
+#     Deliberate, not drift -- a subset checker passes either encoding.
+#   * Read-back resolution on FLOAT-backed rows (EndOfShotWeight, LastTARE,
+#     ScaleCalWeight, TargetMilkTemp, V24CurrentBudget, MatCurrentTemp): the
+#     firmware macro read path truncates BEFORE scaling
+#     (the firmware the firmware read path),
+#     so wire READS return floor(engineering) x mult -- whole engineering
+#     units -- while writes keep full x-mult resolution. The same U32(float)
+#     cast saturates a negative stored value to 0 on Cortex-M, so these rows
+#     can never read back negative. Affected rows carry a "Read-back" note.
+#     (MatSetPoint is float-backed too but exact: mult 1, whole-degC writes.)
+#   * The firmware does NOT enforce min/max on Bengle macro-path writes
+#     the firmware write path never range-checks): bounds here are documentation and the app
+#     is the sole guard. Checker semantics: app range must be a SUBSET of the
+#     contract range (not equal) -- e.g. calFlowEst app min raw 130 vs FW 125.
+#   * perms are canonicalized from the the firmware register table ENTRY column:
+#     PERM_READ -> R, PERM_RT -> RT, PERM_RW -> RW, PERM_RWD -> RWD (persisted
+#     to disk), PERM_RWT -> RWT (write triggers an action). The ENTRY column is
+#     AUTHORITATIVE: the firmware register table's own header comment block disagrees with it on
+#     row 33 (comment "RW" vs ENTRY PERM_READ) and rows 34/35/37 (comment "W"
+#     vs ENTRY PERM_RWT); the firmware write macro verifiably enforces the
+#     ENTRY perms. App enums carry no perms today, so the checker must NOT
+#     assert perms in v1.
+#   * `app_alias` is present only where the app's declared description string
+#     differs from the firmware register name (TargetMilkTemp is the only
+#     case). Rows are keyed by FIRMWARE name, so the alias records the
+#     app-side name.
+#   * Rows 12 (PrefGHCMCI) and 13 (MaxShotPres) are omitted: PERM_NONE TODO
+#     stubs in firmware, unreachable and irrelevant to the app.
+#   * All len=4 registers are little-endian int32 on the MMR wire. Addresses in
+#     frames are 24-bit big-endian (the 0x00 top byte of 0x008038xx-style
+#     addresses is discarded).
+# =============================================================================
+
+contract_version: 1
+firmware:
+  commit: 0381e7ab58eb5b5ee36c14b0bef123ea3cfe4f2e
+  build: 90
+  source: the firmware register table
+generated: 2026-07-11
+
+# -----------------------------------------------------------------------------
+# MMR register table
+# name = firmware register name; fw_row = the firmware register table RangeNum; address as it
+# appears in a read/write frame (before the 24-bit truncation); length in
+# bytes; mult = raw wire value / engineering value.
+# -----------------------------------------------------------------------------
+registers:
+  # --- Shared DE1-family rows the app's MMRItem enum declares -----------------
+  - name: ExternalFlash
+    fw_row: 0
+    address: "0x00000000"
+    length: 1048575 # 0xFFFFF -- first 1 MB mapped to external flash
+    perms: RW
+    mult: 1
+    value_kind: bytes
+    min: null
+    max: null
+    unit: null
+    semantics: "External-flash window (disk operations, firmware images); not a scalar register."
+
+  - name: HWConfig
+    fw_row: 1
+    address: "0x00800000"
+    length: 4
+    perms: R
+    mult: 1
+    value_kind: int32
+    min: null
+    max: null
+    unit: bitmask
+    semantics: "Hardware configuration word."
+
+  - name: Model
+    fw_row: 2
+    address: "0x00800004"
+    length: 4
+    perms: R
+    mult: 1
+    value_kind: int32
+    min: null
+    max: null
+    unit: null
+    semantics: "Legacy machine model."
+
+  - name: CPUBoardModel
+    fw_row: 19
+    address: "0x00800008"
+    length: 4
+    perms: R
+    mult: 1
+    value_kind: int32
+    min: null
+    max: null
+    unit: "model x 1000"
+    semantics: "CPU board model x 1000 by convention (e.g. 1100 = 1.1); served raw, no mult column."
+
+  - name: v13Model
+    fw_row: 20
+    address: "0x0080000C"
+    length: 4
+    perms: R
+    # the firmware register table's mult column says 1000 but the row is auto=0 and served UNSCALED
+    # by a hand-written case (a hand-written firmware case) -- the column is inert. A
+    # generator that trusted it would declare v13Model x1000 and break Bengle
+    # detection. HW-verified: a live Bengle answers 128 raw.
+    mult: 1
+    value_kind: int32
+    min: null
+    max: null
+    unit: null
+    semantics: "v1.3+ firmware model: Unset=0, DE1=1, DE1Plus=2, DE1Pro=3, DE1XL=4, DE1Cafe=5, DE1XXL=6, DE1XXXL=7, Bengle=128. Bengle identity gate is value >= 128."
+
+  - name: CPUFirmwareBuild
+    fw_row: 21
+    address: "0x00800010"
+    length: 4
+    perms: R
+    mult: 1
+    value_kind: int32
+    min: null
+    max: null
+    unit: build
+    semantics: "CPU board firmware build number (starts at 1000 for v1.3, +1 per build). This contract pins the validated firmware build on a firmware development branch
+
+  - name: DebugLen
+    fw_row: 3
+    address: "0x00802800"
+    length: 4
+    perms: RT
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 4096
+    unit: chars
+    semantics: "Valid characters in the debug buffer; accessing pauses BLE debug logging."
+
+  - name: DebugBuffer
+    fw_row: 4
+    address: "0x00802804"
+    length: 4096 # 0x1000
+    perms: RT
+    mult: 1
+    value_kind: bytes
+    min: null
+    max: null
+    unit: null
+    semantics: "Last 4 K of debug output; zero-terminated if not full. Pauses BLE debug logging."
+
+  - name: DebugConfig
+    fw_row: 5
+    address: "0x00803804"
+    length: 4
+    perms: RT
+    mult: 1
+    value_kind: int32
+    min: null
+    max: null
+    unit: bitmask
+    semantics: "BLE debug config; reading restarts logging into the BLE log."
+
+  - name: FanThreshold
+    fw_row: 6
+    address: "0x00803808"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 50
+    unit: degC
+    semantics: "Fan threshold temperature."
+
+  - name: TankTemp
+    fw_row: 7
+    address: "0x0080380C"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 60
+    unit: degC
+    semantics: "Tank water temperature threshold."
+
+  - name: HeaterUp1Flow
+    fw_row: 8
+    address: "0x00803810"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 5 # the firmware register table 0.5 ml/s (post-divide)
+    max: 80 # the firmware register table 8.0 ml/s
+    unit: "ml/s x 10"
+    semantics: "HeaterUp phase-1 flow rate."
+
+  - name: HeaterUp2Flow
+    fw_row: 9
+    address: "0x00803814"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 5 # the firmware register table 0.5 ml/s
+    max: 80 # the firmware register table 8.0 ml/s
+    unit: "ml/s x 10"
+    semantics: "HeaterUp phase-2 flow rate."
+
+  - name: WaterHeaterIdleTemp
+    fw_row: 10
+    address: "0x00803818"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 5 # the firmware register table 0.5 degC
+    max: 1000 # the firmware register table 100.0 degC
+    unit: "degC x 10"
+    semantics: "Water heater idle temperature."
+
+  - name: GHCInfo
+    fw_row: 11
+    address: "0x0080381C"
+    length: 4
+    perms: R
+    mult: 1
+    value_kind: int32
+    min: null
+    max: 4294967295 # 0xFFFFFFFF
+    unit: bitmask
+    semantics: "GHC info bitmask: 0x1 LED controller, 0x2 touch controller, 0x4 GHC active, 0x80000000 factory mode."
+
+  - name: TargetSteamFlow
+    fw_row: 14
+    address: "0x00803828"
+    length: 4
+    perms: RW
+    mult: 100
+    value_kind: scaledFloat
+    min: 40 # the firmware register table 0.4 ml/s
+    max: 400 # the firmware register table 4.0 ml/s
+    unit: "ml/s x 100"
+    semantics: "Target steam flow rate."
+
+  - name: SteamStartSecs
+    fw_row: 15
+    address: "0x0080382C"
+    length: 4
+    perms: RW
+    # KNOWN DECLARATION MISMATCH (D5): this scaledFloat was previously declared
+    # with scales 1.0 while the firmware mult is 100. Latent (nothing reads/writes
+    # it today); the declaration is corrected to readScale 0.01 / writeScale 100.0.
+    mult: 100
+    value_kind: scaledFloat
+    min: 10 # the firmware register table 0.1 s
+    max: 400 # the firmware register table 4.0 s
+    unit: "seconds x 100"
+    semantics: "Seconds of high steam flow; 0 may overheat the heater."
+
+  - name: SerialN
+    fw_row: 16
+    address: "0x00803830"
+    length: 4
+    perms: R
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 4294967295 # 0xFFFFFFFF
+    unit: null
+    semantics: "Current machine serial number."
+
+  - name: HeaterV
+    fw_row: 17
+    address: "0x00803834"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 1230
+    unit: volts
+    semantics: "Nominal heater voltage (0, 120 or 230); +1000 when it is a set value."
+
+  - name: HeaterUp2Timeout
+    fw_row: 18
+    address: "0x00803838"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 5 # the firmware register table 0.5 s
+    max: 300 # the firmware register table 30.0 s
+    unit: "seconds x 10"
+    semantics: "HeaterUp phase-2 timeout."
+
+  - name: CalFlowEst
+    fw_row: 22
+    address: "0x0080383C"
+    length: 4
+    perms: RW
+    mult: 1000
+    value_kind: scaledFloat
+    min: 125 # the firmware register table 0.125 (post-divide). App declares min raw 130 -- narrower is legal (app range must be a subset of this range).
+    max: 2000 # the firmware register table 2.0
+    unit: "ratio x 1000"
+    semantics: "Flow-estimation calibration multiplier."
+
+  - name: FlushFlowRate
+    fw_row: 23
+    address: "0x00803840"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 10 # the firmware register table 1 ml/s
+    max: 80 # the firmware register table 8.0 ml/s
+    unit: "ml/s x 10"
+    semantics: "Flush flow rate."
+
+  - name: FlushTemp
+    fw_row: 24
+    address: "0x00803844"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 10 # the firmware register table 1 degC
+    max: 990 # the firmware register table 99.0 degC
+    unit: "degC x 10"
+    semantics: "Flush temperature."
+
+  - name: FlushTimeout
+    fw_row: 25
+    address: "0x00803848"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 10 # the firmware register table 1 s
+    max: 2500 # the firmware register table 250.0 s
+    unit: "seconds x 10"
+    semantics: "Flush timeout."
+
+  - name: HotWaterFlowRate
+    fw_row: 26
+    address: "0x0080384C"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 0
+    max: 80 # the firmware register table 8.0 ml/s
+    unit: "ml/s x 10"
+    semantics: "Hot water flow rate."
+
+  - name: SteamPurgeMode
+    fw_row: 27
+    address: "0x00803850"
+    length: 4
+    perms: RWD
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 1
+    unit: enum
+    semantics: "Steam purge mode."
+
+  - name: AllowUSBCharging
+    fw_row: 28
+    address: "0x00803854"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: boolean
+    min: 0
+    max: 1
+    unit: bool
+    semantics: "Allow USB charging."
+
+  - name: AppFeatureFlags
+    fw_row: 29
+    address: "0x00803858"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 2147483647 # 0x7FFFFFFF -- top bit unavailable (parts of FW treat it as signed)
+    unit: bitmask
+    semantics: "App-reported feature flags; bit0 = app supports the UserNotPresent substate (app writes 1 on connect)."
+
+  - name: RefillKitPresent
+    fw_row: 30
+    address: "0x0080385C"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 2147483647 # 0x7FFFFFFF
+    unit: enum
+    semantics: "Refill kit presence -- TRI-STATE 0/1/2, not a boolean."
+
+  - name: UserPresent
+    fw_row: 31
+    address: "0x00803860"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: boolean
+    min: 0
+    max: 1
+    unit: bool
+    semantics: "Is the user present."
+
+  # --- Bengle scale / stop-at-weight (app: BengleScaleMmr) --------------------
+  - name: EndOfShotWeight
+    fw_row: 32
+    address: "0x00803864"
+    length: 4
+    perms: RWD
+    mult: 100
+    value_kind: scaledFloat
+    min: 0
+    max: 1000000 # the firmware register table 10000.0 g (post-divide) -- the 10000 g WIRE clamp the app enforces (grams clamped 0..10000 before x100).
+    # Footnote: the firmware's internal model table
+    # gives EOSW a model range of 0..3000 g -- targets above 3000 g are
+    # wire-legal but outside the firmware's model range.
+    unit: "g x 100"
+    semantics: "Stop-at-weight target: firmware ends the shot autonomously at this weight; 0 = disabled. App writes round(grams x 100) -- rounding, not truncation. Read-back is whole grams only (firmware truncates before scaling: floor(g) x 100)."
+
+  - name: MatSetPoint
+    fw_row: 36
+    address: "0x00803874"
+    length: 4
+    perms: RWD
+    mult: 1 # WHOLE degrees C -- not deci-degC, not float32 
+    value_kind: scaledFloat
+    min: 0
+    max: 4294967295 # the firmware register table column is unbounded (0..0xFFFFFFFF); firmware never clamps -- the app is the sole guard, clamping 0..80 degC.
+    unit: degC
+    semantics: "Cup-warmer target in whole degC; 0 = off. Inert unless CupWarmerMode=1; app re-sends both on every connect."
+
+  - name: ScaleCalCmd
+    fw_row: 39
+    address: "0x00803880"
+    length: 4
+    perms: RWT
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 5
+    unit: enum
+    semantics: "Start a non-blocking cal step: 0=abort 1=zero 3=tare 4=latch point 1 (LEFT half) 5=latch point 2 (RIGHT half); 2 = retired auto-detect (errors, never send). Non-zero cmd while busy OR during Espresso is ignored (a cal step would move the mass reference the running shot's stop-at-weight gate depends on; the step stays Idle)."
+
+  - name: ScaleCalState
+    fw_row: 40
+    address: "0x00803884"
+    length: 4
+    perms: R
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 4294967295 # 0xFFFFFFFF
+    unit: packed
+    semantics: "Packed cal state: Step[31:24] SubState[23:16] Remaining[15:8] CalStatus[7:0]. SubState: 0=settling 1=averaging 2=done 3=error. Step at THIS pin (two-point cal): Idle=0 Zeroing=1 CalPoint1=2 CalPoint2=3 Taring=4 Complete=5 Error=6; the FIELD single-point variant numbers Complete=4 / Error=5 (colliding with two-point Taring/Complete). Terminal detection MUST therefore key off SubState (done=2 / error=3), never Step."
+
+  - name: ScaleCalWeight
+    fw_row: 41
+    address: "0x00803888"
+    length: 4
+    perms: RW
+    mult: 10
+    value_kind: scaledFloat
+    min: 0
+    max: 100000 # the firmware register table 10000 g (post-divide)
+    unit: "g x 10"
+    semantics: "Known reference calibration mass; write and read-back-confirm (within 0.1 g) before ScaleCalCmd 4/5. Read-back is whole grams only (firmware truncates before scaling: floor(g) x 10), so the 0.1 g confirm round-trips ONLY integer-gram references -- use whole-gram masses."
+
+  - name: ScaleTare
+    fw_row: 42
+    address: "0x0080388C"
+    length: 4
+    perms: RWT
+    mult: 1
+    value_kind: int32
+    min: null # trigger -- value ignored, never clamped
+    max: null
+    unit: trigger
+    semantics: "Quick tare: writing any value performs an immediate tare; app writes 1 (de1plus parity). Confirm by watching Weight drop, not by the 0xA013 Flags bit."
+
+  # --- LED strip (app: BengleLedMmr); all packed 0x00RRGGBB -------------------
+  # 16-bit app channels map DOWN by taking each channel's high byte and UP by
+  # byte-replication (0xAB -> 0xABAB). There is NO switch-LED register: the
+  # firmware mirrors the front strip to the switch.
+  - name: FrontLEDColor
+    fw_row: 43
+    address: "0x00803890"
+    length: 4
+    perms: RWD
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 16777215 # 0x00FFFFFF
+    unit: rgb24
+    semantics: "Live/preview front strip colour 0x00RRGGBB: shows immediately regardless of awake/sleep without touching the stored palette; FW refreshes it when a stored palette is applied."
+
+  - name: RearLEDColor
+    fw_row: 44
+    address: "0x00803894"
+    length: 4
+    perms: RWD
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 16777215 # 0x00FFFFFF
+    unit: rgb24
+    semantics: "Live/preview rear strip colour 0x00RRGGBB (as FrontLEDColor)."
+
+  - name: FrontLEDAwake
+    fw_row: 45
+    address: "0x00803898"
+    length: 4
+    perms: RWD
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 16777215 # 0x00FFFFFF
+    unit: rgb24
+    semantics: "Stored front awake palette 0x00RRGGBB; FW applies on wake and immediately when written while awake."
+
+  - name: RearLEDAwake
+    fw_row: 46
+    address: "0x0080389C"
+    length: 4
+    perms: RWD
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 16777215 # 0x00FFFFFF
+    unit: rgb24
+    semantics: "Stored rear awake palette 0x00RRGGBB."
+
+  - name: FrontLEDSleep
+    fw_row: 47
+    address: "0x008038A0"
+    length: 4
+    perms: RWD
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 16777215 # 0x00FFFFFF
+    unit: rgb24
+    semantics: "Stored front sleep palette 0x00RRGGBB; FW applies on sleep."
+
+  - name: RearLEDSleep
+    fw_row: 48
+    address: "0x008038A4"
+    length: 4
+    perms: RWD
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 16777215 # 0x00FFFFFF
+    unit: rgb24
+    semantics: "Stored rear sleep palette 0x00RRGGBB."
+
+  # --- Milk auto-stop (app: BengleSteamMmr) -----------------------------------
+  - name: TargetMilkTemp
+    fw_row: 49
+    address: "0x008038A8"
+    length: 4
+    perms: RWD
+    mult: 10
+    value_kind: scaledFloat
+    min: 0
+    max: 850 # ALREADY RAW (= 85.0 degC): the firmware register table lists 850 in violation of its own post-divide convention (desc says "Range 0-85").
+    unit: "degC x 10"
+    semantics: "Milk-probe steam auto-stop target; 0 = disabled. App clamps 0..85 degC before scaling; live probe reading rides 0xA013 MilkTemp, not an MMR. Read-back resolution is whole degC (floor(degC) x 10) -- writes keep deci-degC."
+    app_alias: StopAtTemperatureTarget # app desc string differs from the FW name (BengleSteamMmr.stopAtTemperatureTarget)
+
+  # --- Cup warmer mode + status (app: BengleMmr.cupWarmerMode + thermal reads) -
+  - name: CupWarmerMode
+    fw_row: 50
+    address: "0x008038AC"
+    length: 4
+    perms: RW # deliberately NOT RWD: resets to 0 every boot so the heater cannot auto-activate after a power cut -- app must re-send on every connect
+    mult: 1
+    value_kind: boolean
+    min: 0
+    max: 1
+    unit: bool
+    semantics: "Cup-warmer enable 0=Off 1=On; RAM-only by design. App writes 1 iff target > 0 and re-asserts (with MatSetPoint) on reconnect."
+
+  - name: InactivitySleepTimeout
+    fw_row: 54
+    address: "0x008038BC"
+    length: 4
+    perms: RWD
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 240
+    unit: minutes
+    semantics: "Minutes of inactivity before autonomous sleep when no tablet is connected; 0 = disabled, default 60. While a tablet is connected the tablet owns sleep."
+
+  - name: SetLocalTimeOfWeek
+    fw_row: 55
+    address: "0x008038C0"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 604800
+    unit: seconds
+    semantics: "Local time as seconds since Sunday 00:00:00; sets the firmware wall-clock. RAM-only, re-push on connect."
+
+  - name: ScheduleEntry
+    fw_row: 56
+    address: "0x008038C4"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 2147483647 # 0x7FFFFFFF
+    unit: packed
+    semantics: "One wake window, packed (dow<<22)|(startMin<<11)|endMin; appended to the schedule table."
+
+  - name: ScheduleControl
+    fw_row: 57
+    address: "0x008038C8"
+    length: 4
+    perms: RW
+    mult: 1
+    value_kind: int32
+    min: 0
+    max: 255
+    unit: enum
+    semantics: "Schedule control: 0 = clear table + disable, 1 = enable. Write 0, then entries, then 1."
+
+  - name: MatCurrentTemp
+    fw_row: 58
+    address: "0x008038CC"
+    length: 4
+    perms: R
+    mult: 10
+    value_kind: scaledFloat
+    min: 0
+    max: 1600 # ALREADY RAW (= 160.0 degC): second the firmware register table post-divide convention violation, like TargetMilkTemp.
+    unit: "degC x 10"
+    semantics: "Cup-warmer current mat temperature; 0 = no valid reading (NTC open/short) -- app maps 0 to null ('no reading'), never fake data. Read resolution is whole degC despite the x10 unit (firmware truncates before scaling) -- wire values are always multiples of 10."
+
+# -----------------------------------------------------------------------------
+# 0xA013 BengleShotSample -- the sole shot/telemetry source on a Bengle
+# -----------------------------------------------------------------------------
+# BLE: additive characteristic 0xA013 on service 0xA000 (never present on a
+# plain DE1; requires large ATT MTU -- app requests 517). Serial: CID letter S
+# ("<+S>" / "<-S>" / "[S]hex"). 28 bytes, size-locked in firmware
+# (static_assert on T_BengleShotSample), streamed at 15 Hz.
+#
+# ALL multi-byte fields are BIG-endian -- the opposite of the little-endian MMR
+# payloads. It is a reorganised superset of 0xA00D, not 0xA00D + a tail: field
+# order, widths and scaling all differ; never reuse the 0xA00D parser.
+#
+# DROP RULE: frames shorter than 28 bytes are dropped (decoder returns null,
+# transport drops + warns) -- never a RangeError, never a snapshot. Bytes
+# beyond 28 are ignored.
+#
+# Golden frame (hand-computed, cross-checked vs firmware + de1plus):
+#   03E8 0384 0258 00FA 00C8 00B4 2422 2260 2454 2328 0490 07 34BC 0000 00
+#   -> time 1000, pressure 9.00, setPressure 6.00, flow 2.50, setFlow 2.00,
+#      gFlow 1.80, mix 92.50, head 88.00, setMix 93.00, setHead 90.00,
+#      weight 1168/32 = 36.5 g, frame 7, steam 135.00, milk 0.00, flags 0
+packet_0xA013:
+  size_bytes: 28
+  endianness: big
+  ble_characteristic: "A013"
+  ble_service: "A000"
+  serial_cid: S
+  rate_hz: 15
+  drop_rule: "Frames < 28 bytes are dropped at both the transport and the decoder (null, no RangeError); trailing bytes beyond 28 are ignored."
+  fields:
+    - { offset: 0,  size: 2, name: SampleTime,       type: u16, scale: 1,    unit: halfcycles, semantics: "Half-cycles since shot start (same basis as 0xA00D SampleTime)." }
+    - { offset: 2,  size: 2, name: GroupPressure,    type: u16, scale: 0.01, unit: bar,  semantics: "Pressure at group (u16 / 100)." }
+    - { offset: 4,  size: 2, name: SetGroupPressure, type: u16, scale: 0.01, unit: bar,  semantics: "Set pressure; 0 if no target." }
+    - { offset: 6,  size: 2, name: GroupFlow,        type: u16, scale: 0.01, unit: ml/s, semantics: "Estimated flow at group." }
+    - { offset: 8,  size: 2, name: SetGroupFlow,     type: u16, scale: 0.01, unit: ml/s, semantics: "Set flow; 0 if no target." }
+    - { offset: 10, size: 2, name: GFlow,            type: u16, scale: 0.01, unit: g/s,  semantics: "Gravimetric flow from the integrated scale -> MachineSnapshot.weightFlow." }
+    - { offset: 12, size: 2, name: MixTemp,          type: u16, scale: 0.01, unit: degC, semantics: "Water temperature entering the group." }
+    - { offset: 14, size: 2, name: HeadTemp,         type: u16, scale: 0.01, unit: degC, semantics: "Showerhead water temperature (u16/100 here; 0xA00D used 3-byte U24P16 -- layout differs)." }
+    - { offset: 16, size: 2, name: SetMixTemp,       type: u16, scale: 0.01, unit: degC, semantics: "Mix temperature target; 0 if no target." }
+    - { offset: 18, size: 2, name: SetHeadTemp,      type: u16, scale: 0.01, unit: degC, semantics: "Showerhead temperature target; 0 if no target." }
+    - { offset: 20, size: 2, name: Weight,           type: u16, scale: 0.03125, unit: g, semantics: "Integrated-scale weight, U16P5 (u16 / 32 -- NOT / 100): max 2048 g, step 0.03125 g. ALREADY net of tare (firmware serializes CurrW - LastTARE, the exact stop-at-weight control expression). A negative net weight (platform unloaded after a tare) clamps to 0 on the wire -- U16P5 has no sign bit." }
+    - { offset: 22, size: 1, name: FrameNumber,      type: u8,  scale: 1,    unit: index, semantics: "Profile frame currently executing." }
+    - { offset: 23, size: 2, name: SteamTemp,        type: u16, scale: 0.01, unit: degC, semantics: "Steam metal temperature (unaligned offset -- the struct is packed)." }
+    - { offset: 25, size: 2, name: MilkTemp,         type: u16, scale: 0.01, unit: degC, semantics: "Milk-probe temperature (u16 / 100). 0 = no probe / no fresh reading: at this firmware pin the value is a refreshed only while the probe reports live data." }
+    - { offset: 27, size: 1, name: Flags,            type: u8,  scale: 1,    unit: bitmask, semantics: "Newer FW (this pin): bit0 = LastTARE != 0.0f; app must never gate on it. (Older firmware wrote 0 unconditionally; it is a value proxy, not a tare event.)" }
+
+# -----------------------------------------------------------------------------
+# Serial (USB) ASCII view -- shared with the firmware BLE module
+# -----------------------------------------------------------------------------
+serial_verbs:
+  framing:
+    write: '"<X>" + lowercase hex (2 chars/byte) + newline -- write payload to endpoint letter X'
+    subscribe: '"<+X>" + newline -- add-notify for endpoint letter X; firmware add-notify ALWAYS provokes one immediate [X] frame even if the value is unchanged'
+    unsubscribe: '"<-X>" + newline -- remove-notify'
+    reply: '"[X]" + HEX -- one inbound frame; a message is complete when followed by the next "[" or a newline'
+    notes: "No checksum, no retransmit; leading junk before the first '[' is discarded; a receive buffer past 4096 chars with no complete message is dumped with a warning. Resync relies on the keepalive and on MMR-read retries."
+  mmr_read: # <E> = readFromMMR (BLE 0xA005). Reads go over E, never F.
+    request: '"<E>" + 40 hex chars: 20-byte T_ReadFromMMR -- byte[0] Len (firmware reads (Len+1)*4 bytes; app sends 0 => 4 bytes), byte[1..3] 24-bit address BIG-endian, byte[4..19] zeros'
+    response: '"[E]" + hex: byte[0] length, byte[1..3] address BIG-endian (match the request triplet), byte[4..7] value LITTLE-endian int32, echo padded to the 20-byte frame'
+    round_trip: "Arm the [E] listener BEFORE writing the request (address-triplet match closes the race); bounded 4 s timeout, 2 retries with 300 ms settle; readFromMMR is continuously subscribed on serial (<+E> at connect). Addresses must be 4-aligned or the firmware silently drops the frame."
+    probe_example: 'v13Model probe: "<E>0080000c" + 32 zero chars -> "[E]0480000C80000000..." (len 4, LE value 0x00000080 = 128 = Bengle)'
+  mmr_write: # <F> = writeToMMR (BLE 0xA006). Write-only: no [F] frame ever exists.
+    frame: '"<F>" + EXACTLY 40 hex chars: 20-byte the MMR write frame -- byte[0] Len = TRUE payload byte count (firmware requires 1..16), byte[1..3] 24-bit address BIG-endian, byte[4..19] data (int values LE int32 at offset 4, unused tail zeros)'
+    zero_pad_rule: "The firmware serial parser consumes exactly sizeof(the MMR write frame) = 20 bytes (40 hex chars) per <F> frame before accepting the newline; a short frame desyncs it. The app zero-pads ONLY writeToMMR frames shorter than 20 bytes (the DFU uploader's final chunk is the sole short-frame producer). The Len byte carries the true length so padding is inert; the BLE path is unchanged and other endpoints are never padded."
+  one_shot_read: 'Endpoints without a continuous subscription (versions "A", temperatures "J", calibration "R") read as a round trip: "<+X>" -> await the fresh "[X]" (listener armed before the write) -> "<-X>" sent even on failure; bounded timeout (default 2 s). Continuously-subscribed endpoints serve their latest-received frame; endpoints the firmware cannot emit throw a descriptive UnsupportedError.'
+  keepalive: 'A 5 s periodic "<+N>" actively drives the shared BLE/USB serial view: the firmware source arbitration is last-writer-wins (any byte on the BLE-module UART silently steals the notify stream from a passive USB listener), so the client must keep writing; because add-notify forces an immediate [N], it doubles as a resync for the checksum-less ASCII framing.'
+  throughput: "Downlink ceiling ~1920 B/s: the firmware main loop drains at most 16 bytes per ~120 Hz tick and polls for input only on ticks where it sent nothing (half-duplex, downlink-prioritised). Dual 15 Hz [M]+[S] streams (~42 + ~60 chars/frame) overrun the budget -- hardware-confirmed truncated frames and weight flicker -- so on a confirmed Bengle the app unsubscribes 0xA00D over serial with <-M> (BLE has headroom and keeps 0xA00D subscribed, parse-and-dropped)."
+  bengle_specifics:
+    - '"<+S>" is sent unconditionally at serial connect (a plain DE1 simply never emits [S]); "[S]" + 56 hex chars = one 0xA013 frame; the <28-byte drop rule applies on serial too.'
+    - '"<-M>" is sent after Bengle identity is confirmed (v13Model >= 128) -- see throughput.'
+    - '"<-S>" mirrors at disconnect.'
+  usb_identity: # the USB half of brief-Section-5 invariant 11
+    enumeration: 'The Bengle enumerates with the pico-sdk DEFAULT VID:PID 0x2E8A:0x000A and product string "TinyUSB Device" (the device ships TinyUSB default descriptors). Captured from hardware.'
+    app_dispatch: 'The defaults are too generic for the direct-instantiation shortcut: bengleUsbIds stays deliberately EMPTY and 0x2E8A:0x000A rides bengleProbeCandidateIds into the identification PROBE path instead -- the serial v13Model read (>= 128) remains the sole authority on Bengle identity.'
+    android_name_gate: 'serialProbeAllowsProductName() admits a port to the probe when the USB product name is null/unknown, contains "Serial", or is exactly one of "DE1" / "Bengle" / "Half Decent Scale"; every other name is skipped without probing. Desktop has NO name gate.'
+    android_auto_permission: 'android/app/src/main/res/xml/device_filter.xml grants USB permission without a user prompt for vendor-id 11914 (0x2E8A) / product-id 10 (0x000A).'

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -355,10 +355,15 @@ paths:
       description: |
         Returns the optional capability surfaces the currently connected
         machine exposes. Plain DE1s return an empty list; Bengle returns
-        `["cupWarmer", "integratedScale"]` plus any future capabilities
-        as they ship. Skins should query this
-        endpoint once after connect to decide which UI to render and
-        which `/api/v1/machine/...` capability endpoints to call.
+        `["cupWarmer", "integratedScale", "ledStrip", "stopAtWeight"]`
+        plus any future capabilities as they ship. `stopAtWeight` means
+        the machine firmware runs its own autonomous stop-at-weight from
+        the integrated scale: the app reflects `WorkflowContext.targetYield`
+        into the SAW MMR, so clients keep setting the target yield through
+        `PUT /api/v1/workflow` — there is no dedicated SAW endpoint.
+        Skins should query this endpoint once after connect to decide
+        which UI to render and which `/api/v1/machine/...` capability
+        endpoints to call.
       tags: [Machine]
       responses:
         "200":

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -4914,7 +4914,7 @@ components:
           type: array
           items:
             type: string
-            enum: [machine, scale, sensor]
+            enum: [machine, scale, sensor, bengle]
           nullable: true
         themeMode:
           description: App theme mode
@@ -5004,7 +5004,7 @@ components:
           type: array
           items:
             type: string
-            enum: [machine, scale, sensor]
+            enum: [machine, scale, sensor, bengle]
         themeMode:
           description: App theme mode
           type: string

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -355,12 +355,15 @@ paths:
       description: |
         Returns the optional capability surfaces the currently connected
         machine exposes. Plain DE1s return an empty list; Bengle returns
-        `["cupWarmer", "integratedScale", "ledStrip", "stopAtWeight"]`
-        plus any future capabilities as they ship. `stopAtWeight` means
-        the machine firmware runs its own autonomous stop-at-weight from
-        the integrated scale: the app reflects `WorkflowContext.targetYield`
-        into the SAW MMR, so clients keep setting the target yield through
-        `PUT /api/v1/workflow` — there is no dedicated SAW endpoint.
+        `["cupWarmer", "integratedScale", "ledStrip", "stopAtWeight",
+        "scaleCalibration"]` plus any future capabilities as they ship.
+        `stopAtWeight` means the machine firmware runs its own autonomous
+        stop-at-weight from the integrated scale: the app reflects
+        `WorkflowContext.targetYield` into the SAW MMR, so clients keep
+        setting the target yield through `PUT /api/v1/workflow` — there is
+        no dedicated SAW endpoint. `scaleCalibration` is the non-blocking
+        load-cell zero/weight wizard over MMR — see
+        `POST /api/v1/machine/scale/calibrate`.
         Skins should query this endpoint once after connect to decide
         which UI to render and which `/api/v1/machine/...` capability
         endpoints to call.
@@ -372,6 +375,41 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/MachineCapabilities"
+  /api/v1/machine/scale/calibrate:
+    post:
+      summary: Calibrate integrated scale (Bengle)
+      description: |
+        Run one step of the Bengle's **two-point** load-cell calibration.
+        Procedure: `zero` → `left` → `right`. `command`:
+          * `zero` — precision-zero the cells with NOTHING on the platform;
+          * `left` — latch point 1: known reference mass (`grams`, required) on
+            the LEFT half;
+          * `right` — latch point 2: the same mass on the RIGHT half; solving
+            this point persists + applies the cal;
+          * `abort` — cancel an in-flight run.
+        `zero`/`left`/`right` trigger the firmware and poll it to a terminal
+        step or a bounded deadline, returning the outcome. Returns 404 on a
+        plain DE1 (no integrated scale).
+      tags: [Machine]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ScaleCalibrationRequest"
+      responses:
+        "200":
+          description: Calibration finished (see `success`)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ScaleCalibrationResult"
+        "202":
+          description: Abort accepted
+        "400":
+          description: Unknown command, or `left`/`right` without `grams`
+        "404":
+          description: Machine connected but has no integrated scale
   /api/v1/machine/cupWarmer:
     get:
       summary: Get cup-warmer setpoint
@@ -4318,17 +4356,72 @@ components:
           description: |
             Capability identifiers supported by the currently connected
             machine. Plain DE1 returns an empty array. Bengle returns
-            `cupWarmer`, `integratedScale`, `ledStrip`, and
+            `cupWarmer`, `integratedScale`, `ledStrip`,
             `stopAtWeight` (autonomous in-FW stop-at-weight driven by
             the integrated scale; the app reflects
-            `WorkflowContext.targetYield` into the SAW MMR). Future
-            Bengle peripherals will append their identifiers as they
-            ship. Note: the milk-probe scaffolding lives in `/sensors`,
-            not here.
+            `WorkflowContext.targetYield` into the SAW MMR), and
+            `scaleCalibration` (non-blocking load-cell zero/weight
+            wizard over MMR — see `POST /api/v1/machine/scale/calibrate`).
+            Future Bengle peripherals will append their identifiers as
+            they ship. Note: the milk-probe scaffolding lives in
+            `/sensors`, not here.
           items:
             type: string
-            enum: [cupWarmer, integratedScale, ledStrip, stopAtWeight]
-          example: [cupWarmer, integratedScale, ledStrip, stopAtWeight]
+            enum: [cupWarmer, integratedScale, ledStrip, stopAtWeight, scaleCalibration]
+          example: [cupWarmer, integratedScale, ledStrip, stopAtWeight, scaleCalibration]
+
+    ScaleCalibrationRequest:
+      type: object
+      required: [command]
+      properties:
+        command:
+          type: string
+          enum: [zero, left, right, abort]
+          description: |
+            `zero` precision-zeros the empty cells; `left`/`right` latch the
+            two-point weight cal (LEFT then RIGHT half) against a known mass;
+            `abort` cancels an in-flight run.
+        grams:
+          type: number
+          format: float
+          minimum: 0.0
+          maximum: 10000.0
+          description: |
+            Known reference mass in grams. Required for `command: left` and
+            `command: right` (use the same mass for both); ignored otherwise.
+            Out-of-range values are clamped. Use a whole-gram mass — the
+            firmware reads the reference back at whole-gram resolution and the
+            app refuses to latch when the read-back does not confirm the write.
+          example: 500.0
+
+    ScaleCalibrationResult:
+      type: object
+      required: [success, finalStep, pointStatus]
+      properties:
+        success:
+          type: boolean
+          description: |
+            Whether the step succeeded — for `zero` a Complete step; for `left`
+            a latched point (pointStatus `incomplete`); for `right` a solved cal
+            (pointStatus `ok`).
+        finalStep:
+          type: string
+          enum: [idle, zeroing, calPoint1, calPoint2, taring, complete, error, unknown]
+          description: Terminal firmware Step reached.
+          example: complete
+        pointStatus:
+          type: string
+          enum: [ok, incomplete, noZero, notSettled, badWeight, badDelta, illConditioned, outOfRange, none, unknown]
+          description: |
+            Firmware CalStatus of the last weight-cal latch. `incomplete` = the
+            point latched, awaiting the other half; `ok` = both points solved
+            and the cal was persisted. `none` for zero. The rest are rejections.
+          example: ok
+        message:
+          type: string
+          description: >-
+            Reason on failure (`timed out`, `firmware reported error`,
+            `calibration not accepted (status: …)`, …); absent on success.
 
     CupWarmerState:
       type: object

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -453,7 +453,13 @@ paths:
       summary: Get LED strip configuration
       description: |
         Read the current LED strip configuration (all 3 zones × 2 modes)
-        from the in-memory cache. Returns 404 when the connected
+        from the in-memory cache. The cache is hydrated from the
+        machine's four stored palette registers on connect (read-only —
+        the live/preview registers are never touched), so after an app
+        restart this returns the colours stored on the machine without
+        needing a `PUT` or `POST /reset` first. If the connect-time
+        hydration read fails, the cache falls back to all-off until the
+        first `PUT` or `POST /reset`. Returns 404 when the connected
         machine is not a Bengle.
       tags: [Machine]
       responses:
@@ -468,10 +474,16 @@ paths:
     put:
       summary: Set LED strip configuration
       description: |
-        Write a full LED strip configuration (all 3 zones × 2 modes).
-        Updates cache and pushes to FW live registers. Does NOT persist
-        to NVM — call `/commit` separately. Returns 404 when the
-        connected machine is not a Bengle.
+        Write a full LED strip configuration (all 3 zones × 2 modes) to
+        the cache and the firmware palette registers. The firmware
+        persists each palette write immediately (registers are
+        disk-backed) and also applies it to the strip right away when
+        the machine is already in that colour's awake/sleep state —
+        there is no separate live/persist split. The `frontSwitch` zone
+        has no register: the physical switch light mirrors the front
+        strip in firmware (the zone is accepted for API symmetry and
+        ignored on write). Returns 404 when the connected machine is
+        not a Bengle.
       tags: [Machine]
       requestBody:
         required: true
@@ -489,14 +501,16 @@ paths:
 
   /api/v1/machine/ledStrip/commit:
     post:
-      summary: Commit LED strip config to NVM
+      summary: Re-assert LED strip config to the firmware
       description: |
-        Persist the current in-memory LED strip configuration to FW
-        non-volatile memory. The machine retains settings across power
-        cycles. Returns 404 when the connected machine is not a Bengle.
+        Re-write the cached LED strip configuration to the firmware
+        palette registers. Palette writes already persist (`PUT` is
+        sufficient); this endpoint is kept for API symmetry / as an
+        explicit re-assert. Body is ignored. Returns 404 when the
+        connected machine is not a Bengle.
       tags: [Machine]
       requestBody:
-        required: true
+        required: false
         content:
           application/json:
             schema:
@@ -510,15 +524,17 @@ paths:
 
   /api/v1/machine/ledStrip/reset:
     post:
-      summary: Reset LED strip cache from NVM
+      summary: Reset LED strip cache from the firmware
       description: |
-        Reload the LED strip cache from FW non-volatile memory,
-        dropping any uncommitted changes. Returns the refreshed
-        configuration. Returns 404 when the connected machine is not
-        a Bengle.
+        Re-read the four firmware palette registers into the cache,
+        dropping local edits, and return the refreshed configuration.
+        Because the firmware persists on every palette write, this
+        returns whatever was last written — it is a cache re-hydrate,
+        not a rollback. Body is ignored. Returns 404 when the connected
+        machine is not a Bengle.
       tags: [Machine]
       requestBody:
-        required: true
+        required: false
         content:
           application/json:
             schema:
@@ -531,6 +547,67 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/LedStripState"
+        "404":
+          description: Machine connected but does not support LED strip
+
+  /api/v1/machine/ledStrip/preview:
+    post:
+      summary: Preview LED strip colours live
+      description: |
+        Show the given front/back colours on the strips immediately,
+        regardless of awake/sleep state, WITHOUT changing the stored
+        palette or the cached configuration. Cleared by
+        `/ledStrip/preview/clear`; the firmware also overwrites the
+        live colour from the stored palette on the next sleep/wake
+        transition, so a preview never survives a state change.
+        Missing or malformed `front`/`back` values are treated as
+        black (`000000000000`), matching `Color16` semantics — an
+        empty object previews both strips black. Returns 404 when the
+        connected machine is not a Bengle.
+      tags: [Machine]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [front, back]
+              properties:
+                front:
+                  $ref: "#/components/schemas/Color16"
+                back:
+                  $ref: "#/components/schemas/Color16"
+      responses:
+        "202":
+          description: Preview accepted
+        "400":
+          description: Invalid JSON body (not an object)
+        "404":
+          description: Machine connected but does not support LED strip
+
+  /api/v1/machine/ledStrip/preview/clear:
+    post:
+      summary: Clear LED preview
+      description: |
+        Restore the strips to the cached awake palette after a
+        `/ledStrip/preview`. The restore source is the app-side cache,
+        which is hydrated from the machine's stored palette on connect
+        (see `GET`) — so this normally restores the machine's real
+        awake colours. Only when that connect-time hydration failed
+        (and before any `PUT`/`reset`) does clearing a preview write
+        black. Body is ignored. Returns 404 when the connected machine
+        is not a Bengle.
+      tags: [Machine]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              example: {}
+      responses:
+        "202":
+          description: Preview cleared
         "404":
           description: Machine connected but does not support LED strip
   /api/v1/machine/settings:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -5386,12 +5386,15 @@ components:
           format: double
           description: >
             Stop steaming when the milk-probe reading reaches this
-            temperature (°C). `0` disables the stop. Range 0..80.
-            Scaffolding only today — no machine in production has an
-            integrated probe wired, so the field round-trips but does
-            not affect machine behaviour. On Bengle with a future probe
-            firmware the stop is FW-autonomous; on other machines or
-            third-party probes the app stops via `requestState(idle)`.
+            temperature (°C). `0` disables the stop. Range 0..85 on
+            Bengle (the firmware TargetMilkTemp register caps at
+            85.0 °C; the app clamps before writing). On Bengle the
+            target is written to the machine and the stop is
+            FW-autonomous the moment a milk probe is physically
+            attached; on other machines or third-party probes the app
+            stops via `requestState(idle)` when a registered sensor
+            crosses the target (with no probe attached and no sensor
+            registered the field round-trips but nothing stops).
           example: 65.0
           default: 0.0
 

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -412,14 +412,20 @@ paths:
           description: Machine connected but has no integrated scale
   /api/v1/machine/cupWarmer:
     get:
-      summary: Get cup-warmer setpoint
+      summary: Get cup-warmer setpoint + live mat temperature
       description: |
-        Read the current cup-warmer mat target temperature in °C.
+        Read the current cup-warmer mat target temperature in °C
+        (`temperature`) and the live measured mat temperature
+        (`currentTemperature`). `currentTemperature` is `null` when the
+        firmware has no valid reading (sensor fault, or older firmware
+        without the register) — clients must render a placeholder for
+        `null` and must also tolerate the key being absent entirely
+        (responses from older app versions). Never fabricate a value.
         Returns 404 when the connected machine is not a Bengle.
       tags: [Machine]
       responses:
         "200":
-          description: Current cup-warmer setpoint
+          description: Current cup-warmer setpoint + live mat temperature
           content:
             application/json:
               schema:
@@ -4522,6 +4528,20 @@ components:
             is cleared by the machine on every reboot and re-asserted by
             the app on reconnect.
           example: 60.0
+        currentTemperature:
+          type: number
+          format: float
+          nullable: true
+          readOnly: true
+          description: |
+            Live measured mat temperature in °C (one decimal, from the
+            read-only MatCurrentTemp register, wire ×10). `null` when the
+            firmware reports no valid reading (raw 0 — sensor open/short)
+            or does not expose the register (older firmware). Response
+            only — ignored on PUT. Clients render a placeholder for
+            `null` and must tolerate the key being absent (older app
+            versions); never substitute fake data.
+          example: 42.5
 
     LedStripState:
       type: object

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -4418,6 +4418,21 @@ components:
           type: integer
         steamTemperature:
           type: number
+        weight:
+          type: number
+          description: >
+            Integrated-scale weight in grams (Bengle 0xA013, already net of
+            tare). 0 on machines without an integrated scale.
+        weightFlow:
+          type: number
+          description: >
+            Gravimetric flow in g/s from the integrated scale (Bengle 0xA013
+            GFlow). 0 on machines without an integrated scale.
+        milkTemperature:
+          type: number
+          description: >
+            Milk-probe temperature in °C (Bengle 0xA013). 0 when the firmware
+            does not provide it.
     MachineState:
       type: string
       enum:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -430,9 +430,15 @@ paths:
       summary: Set cup-warmer setpoint
       description: |
         Set the cup-warmer mat target temperature in °C. Range
-        `0.0`–`80.0`; `0.0` turns the mat off (there is no separate
-        enable flag). Out-of-range values return 400; the app does not
-        rely on FW-side clamping so callers see immediate feedback.
+        `0.0`–`80.0`. A target `> 0` also enables the warmer and `0.0`
+        disables it — the separate firmware enable register is an
+        implementation detail the API hides. The enable does not survive
+        a machine reboot (the firmware deliberately clears it so the mat
+        can never heat unattended after a power cut), but the app
+        re-asserts the last requested state on every reconnect, so
+        clients only ever set the temperature. Out-of-range values
+        return 400; the app does not rely on FW-side clamping so callers
+        see immediate feedback.
         Returns 404 when the connected machine is not a Bengle.
       tags: [Machine]
       requestBody:
@@ -4511,7 +4517,10 @@ components:
           maximum: 80.0
           description: |
             Cup-warmer mat target temperature in °C. `0.0` turns the
-            mat off — there is no separate enable flag.
+            mat off; `> 0` turns it on. The firmware's separate enable
+            register is managed by the app and hidden from the API — it
+            is cleared by the machine on every reboot and re-asserted by
+            the app on reconnect.
           example: 60.0
 
     LedStripState:

--- a/assets/api/websocket_v1.yml
+++ b/assets/api/websocket_v1.yml
@@ -419,7 +419,13 @@ components:
           description: Current weight reading in grams.
         weightFlow:
           type: number
-          description: Smoothed weight-derived flow in g/s (moving average over the smoothing window).
+          description: >
+            Flow in g/s. A scale that reports weight only (every BLE scale) has
+            no flow of its own, so the app derives one from the weight series and
+            smooths it. A scale that computes flow on-hardware — the Bengle's
+            integrated scale, via the 0xA013 GFlow field — reports its own value,
+            and it is passed through verbatim with no app-side re-estimation, so
+            this field agrees with the machine snapshot's weightFlow.
         battery:
           type: integer
           nullable: true

--- a/assets/api/websocket_v1.yml
+++ b/assets/api/websocket_v1.yml
@@ -560,6 +560,21 @@ components:
           type: integer
         steamTemperature:
           type: number
+        weight:
+          type: number
+          description: >
+            Integrated-scale weight in grams (Bengle 0xA013, already net of
+            tare). 0 on machines without an integrated scale.
+        weightFlow:
+          type: number
+          description: >
+            Gravimetric flow in g/s from the integrated scale (Bengle 0xA013
+            GFlow). 0 on machines without an integrated scale.
+        milkTemperature:
+          type: number
+          description: >
+            Milk-probe temperature in °C (Bengle 0xA013). 0 when the firmware
+            does not provide it.
     MachineState:
       type: string
       enum:

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -56,7 +56,7 @@ For browser clients on a different origin, `ETag` is exposed via `Access-Control
 | GET | `/api/v1/machine/capabilities` | List capability identifiers (`cupWarmer`, `integratedScale`, `ledStrip`, `stopAtWeight`, `scaleCalibration`) supported by the connected machine | |
 | POST | `/api/v1/machine/scale/calibrate` | Two-point integrated-scale cal: `{"command":"zero"}` (empty), then `{"command":"left","grams":500}` and `{"command":"right","grams":500}` (same mass, LEFT then RIGHT half), or `{"command":"abort"}`. Non-blocking; returns the calibration result — Bengle only, 404 elsewhere | |
 | GET | `/api/v1/machine/cupWarmer` | Read cup-warmer setpoint °C — Bengle only, 404 elsewhere | |
-| PUT | `/api/v1/machine/cupWarmer` | Set cup-warmer setpoint °C (range 0.0–80.0, `0.0` = off) — Bengle only | |
+| PUT | `/api/v1/machine/cupWarmer` | Set cup-warmer setpoint °C (range 0.0–80.0; `> 0` = on, `0.0` = off; the FW enable register is app-managed — cleared on machine reboot, re-asserted on reconnect) — Bengle only | |
 | GET | `/api/v1/machine/ledStrip` | Read full LED strip config (3 zones × 2 modes, 16-bit RGB) from the app cache, hydrated from the machine's stored palette on connect (all-off fallback until a PUT or `/reset` only if that read fails) — Bengle only | |
 | PUT | `/api/v1/machine/ledStrip` | Write full LED strip config to the FW palette registers (persisted + live-applied by FW on write; `frontSwitch` has no register — FW mirrors the front strip) — Bengle only | |
 | POST | `/api/v1/machine/ledStrip/commit` | Re-assert the cached LED config to the FW (palette writes already persist; kept for API symmetry) — Bengle only | |

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -57,10 +57,12 @@ For browser clients on a different origin, `ETag` is exposed via `Access-Control
 | POST | `/api/v1/machine/scale/calibrate` | Two-point integrated-scale cal: `{"command":"zero"}` (empty), then `{"command":"left","grams":500}` and `{"command":"right","grams":500}` (same mass, LEFT then RIGHT half), or `{"command":"abort"}`. Non-blocking; returns the calibration result — Bengle only, 404 elsewhere | |
 | GET | `/api/v1/machine/cupWarmer` | Read cup-warmer setpoint °C — Bengle only, 404 elsewhere | |
 | PUT | `/api/v1/machine/cupWarmer` | Set cup-warmer setpoint °C (range 0.0–80.0, `0.0` = off) — Bengle only | |
-| GET | `/api/v1/machine/ledStrip` | Read full LED strip config (3 zones × 2 modes, 16-bit RGB) — Bengle only | |
-| PUT | `/api/v1/machine/ledStrip` | Write full LED strip config (cache + FW live registers) — Bengle only | |
-| POST | `/api/v1/machine/ledStrip/commit` | Persist LED config to FW NVM — Bengle only | |
-| POST | `/api/v1/machine/ledStrip/reset` | Reload LED config from FW NVM, return refreshed state — Bengle only | |
+| GET | `/api/v1/machine/ledStrip` | Read full LED strip config (3 zones × 2 modes, 16-bit RGB) from the app cache, hydrated from the machine's stored palette on connect (all-off fallback until a PUT or `/reset` only if that read fails) — Bengle only | |
+| PUT | `/api/v1/machine/ledStrip` | Write full LED strip config to the FW palette registers (persisted + live-applied by FW on write; `frontSwitch` has no register — FW mirrors the front strip) — Bengle only | |
+| POST | `/api/v1/machine/ledStrip/commit` | Re-assert the cached LED config to the FW (palette writes already persist; kept for API symmetry) — Bengle only | |
+| POST | `/api/v1/machine/ledStrip/reset` | Re-read the FW palette registers into the cache, return refreshed state — Bengle only | |
+| POST | `/api/v1/machine/ledStrip/preview` | Show `{"front","back"}` (12-char hex) on the strips now, without changing the stored palette — Bengle only | |
+| POST | `/api/v1/machine/ledStrip/preview/clear` | Restore the strips to the cached awake palette after a preview — Bengle only | |
 
 ### Scale
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -315,7 +315,7 @@ All WebSocket endpoints are on port 8080 at `/ws/v1/...`. See [`assets/api/webso
 
 | Path | Description | Data |
 |------|-------------|------|
-| `/ws/v1/machine/snapshot` | Machine state stream (~10Hz) | Temps, pressures, flow, state |
+| `/ws/v1/machine/snapshot` | Machine state stream (~10Hz) | Temps, pressures, flow, state; `weight` / `weightFlow` (gravimetric) / `milkTemperature` from the integrated scale on a Bengle, 0 otherwise |
 | `/ws/v1/scale/snapshot` | Scale weight/flow stream. Stays open across scale disconnects; emits `{"status":"connected"\|"disconnected"}` frames on state change. | Weight, flow, battery |
 | `/ws/v1/machine/shotSettings` | Shot settings changes | Target temp, volume, weight |
 | `/ws/v1/machine/waterLevels` | Water level changes | Current/limit levels |

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -55,7 +55,7 @@ For browser clients on a different origin, `ETag` is exposed via `Access-Control
 | POST | `/api/v1/machine/waterLevels` | Update water level threshold | |
 | GET | `/api/v1/machine/capabilities` | List capability identifiers (`cupWarmer`, `integratedScale`, `ledStrip`, `stopAtWeight`, `scaleCalibration`) supported by the connected machine | |
 | POST | `/api/v1/machine/scale/calibrate` | Two-point integrated-scale cal: `{"command":"zero"}` (empty), then `{"command":"left","grams":500}` and `{"command":"right","grams":500}` (same mass, LEFT then RIGHT half), or `{"command":"abort"}`. Non-blocking; returns the calibration result — Bengle only, 404 elsewhere | |
-| GET | `/api/v1/machine/cupWarmer` | Read cup-warmer setpoint °C — Bengle only, 404 elsewhere | |
+| GET | `/api/v1/machine/cupWarmer` | Read cup-warmer setpoint °C + live mat temperature (`currentTemperature`, `null` = no valid reading / older FW — render a placeholder, never fake data) — Bengle only, 404 elsewhere | |
 | PUT | `/api/v1/machine/cupWarmer` | Set cup-warmer setpoint °C (range 0.0–80.0; `> 0` = on, `0.0` = off; the FW enable register is app-managed — cleared on machine reboot, re-asserted on reconnect) — Bengle only | |
 | GET | `/api/v1/machine/ledStrip` | Read full LED strip config (3 zones × 2 modes, 16-bit RGB) from the app cache, hydrated from the machine's stored palette on connect (all-off fallback until a PUT or `/reset` only if that read fails) — Bengle only | |
 | PUT | `/api/v1/machine/ledStrip` | Write full LED strip config to the FW palette registers (persisted + live-applied by FW on write; `frontSwitch` has no register — FW mirrors the front strip) — Bengle only | |

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -53,7 +53,8 @@ For browser clients on a different origin, `ETag` is exposed via `Access-Control
 | POST | `/api/v1/machine/firmware` | Upload firmware image to machine (raw binary body) | |
 | — | USB charger | Controlled via `POST /api/v1/machine/settings` with `{"usb": "enable"}` or `{"usb": "disable"}` | |
 | POST | `/api/v1/machine/waterLevels` | Update water level threshold | |
-| GET | `/api/v1/machine/capabilities` | List capability identifiers (`cupWarmer`, `integratedScale`, `ledStrip`, `stopAtWeight`) supported by the connected machine | |
+| GET | `/api/v1/machine/capabilities` | List capability identifiers (`cupWarmer`, `integratedScale`, `ledStrip`, `stopAtWeight`, `scaleCalibration`) supported by the connected machine | |
+| POST | `/api/v1/machine/scale/calibrate` | Two-point integrated-scale cal: `{"command":"zero"}` (empty), then `{"command":"left","grams":500}` and `{"command":"right","grams":500}` (same mass, LEFT then RIGHT half), or `{"command":"abort"}`. Non-blocking; returns the calibration result — Bengle only, 404 elsewhere | |
 | GET | `/api/v1/machine/cupWarmer` | Read cup-warmer setpoint °C — Bengle only, 404 elsewhere | |
 | PUT | `/api/v1/machine/cupWarmer` | Set cup-warmer setpoint °C (range 0.0–80.0, `0.0` = off) — Bengle only | |
 | GET | `/api/v1/machine/ledStrip` | Read full LED strip config (3 zones × 2 modes, 16-bit RGB) — Bengle only | |

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -116,12 +116,14 @@ reaches `connected`.
 ### Steams
 
 Recorded milk-steaming sessions. Each record is opened when the machine
-enters `steam` and finalized when it leaves. Today no probe is wired in
-production, so `SteamSnapshot.milkTemperature` is `null` on every frame —
-the API surface is scaffolding for skin developers and for future
-probe / FW support. `SteamSettings.stopAtTemperature` (in
-`/api/v1/workflow`) is the target the future FW-autonomous stop or
-in-app stop will trigger on.
+enters `steam` and finalized when it leaves. `SteamSnapshot.milkTemperature`
+is populated from the first registered milk sensor; no probe ships in
+production today, so the field is `null` on every frame until one is
+attached. `SteamSettings.stopAtTemperature` (in `/api/v1/workflow`, range
+0–85 °C on Bengle) is written to the Bengle's `TargetMilkTemp` register:
+the machine stops steam autonomously once a milk probe is physically
+attached and the reading crosses the target; on other machines or
+third-party probes the app requests `idle` instead.
 
 | Method | Path | Description | Handler |
 |--------|------|-------------|---------|

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -109,6 +109,39 @@ Discovery services are responsible for scanning and creating device instances. E
   (`0x2E8A:0x000A`) comes from
   `android/app/src/main/res/xml/device_filter.xml`.
 
+  **USB/serial transport behaviour (DE1 family).** The wire protocol is the
+  DE1 ASCII serial view (uplink `<X>hex` / `<+X>` / `<-X>`, downlink
+  `[X]hex`), shared with the firmware's BLE module. Constraints the client
+  designs around (`UnifiedDe1Transport`):
+
+  - **Reads.** The serial view has no read verb. Continuously-subscribed
+    frames (state, shot sample, water levels, MMR, FW map) are served from
+    the latest received frame; `versions`, `temperatures` and `calibration`
+    are one-shot `<+X>` → `[X]` → `<-X>` round trips with a 2 s timeout
+    (firmware that never emits the char fails fast instead of hanging).
+    Endpoints the firmware cannot emit (`setTime`, `shotDirectory`,
+    `headerWrite`, `frameWrite`, …) throw `UnsupportedError`. Shot settings
+    (`[K]`) are accepted as writes by the the Bengle firmware but not yet
+    emitted — a serial read returns the seeded zero frame until the
+    firmware gains `[K]` support.
+  - **Length-exact frames.** The firmware parser consumes exactly
+    `sizeof(struct)` hex bytes per `<X>` frame; a short frame is dropped and
+    desyncs the parser to the next `<`. The only short-frame producer — the
+    DFU uploader's final image chunk — is zero-padded to the 20-byte
+    the MMR write frame size on serial (the `Len` byte keeps the true length).
+  - **Throughput.** The firmware serial downlink is capped at ~1920 B/s
+    (16 bytes per 120 Hz tick), half-duplex and downlink-prioritised.
+    Subscriptions are budgeted accordingly, and truncated frames from a
+    momentary overrun are dropped with a warning rather than crashing the
+    parser.
+  - **Link arbitration.** BLE and USB are mutually exclusive in the
+    firmware (last-writer-wins source flag): a passively-listening USB
+    client can silently lose its notify stream to a stray BLE-module byte.
+    The transport actively drives the link with a 5 s `<+N>` keepalive,
+    which re-asserts the USB source and re-syncs subscribed frames (the
+    ASCII framing has no checksum/retransmit; MMR reads additionally carry
+    their own timeout+retry).
+
 #### 3. SimulatedDeviceService
 - **Platform:** All
 - **File:** `lib/src/services/simulated_device_service.dart`

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -142,6 +142,18 @@ Discovery services are responsible for scanning and creating device instances. E
     ASCII framing has no checksum/retransmit; MMR reads additionally carry
     their own timeout+retry).
 
+  **Bluetooth-off operation.** USB/serial discovery keeps running with the
+  Bluetooth adapter off (the scan runs every discovery service in parallel
+  and records per-service failures instead of failing the whole scan). The
+  scan-flow UI demotes only the `adapterOff` error while non-Bluetooth
+  results are in flight — found machines, an active connect, a pending
+  picker — so a wired-only setup still reaches its picker; genuine connect
+  failures still surface, and the adapter-off view tells the user USB keeps
+  working. The preferred machine is stored per transport id (a serial
+  device's `usb-…` stable id vs a BLE MAC), so the first wired session ends
+  at the picker; picking the wired machine once makes later launches
+  auto-connect over USB.
+
 #### 3. SimulatedDeviceService
 - **Platform:** All
 - **File:** `lib/src/services/simulated_device_service.dart`

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -115,9 +115,10 @@ Discovery services are responsible for scanning and creating device instances. E
   designs around (`UnifiedDe1Transport`):
 
   - **Reads.** The serial view has no read verb. Continuously-subscribed
-    frames (state, shot sample, water levels, MMR, FW map) are served from
-    the latest received frame; `versions`, `temperatures` and `calibration`
-    are one-shot `<+X>` → `[X]` → `<-X>` round trips with a 2 s timeout
+    frames (state, shot sample, water levels, MMR, FW map, the Bengle 0xA013
+    shot sample) are served from the latest received frame; `versions`,
+    `temperatures` and `calibration` are one-shot
+    `<+X>` → `[X]` → `<-X>` round trips with a 2 s timeout
     (firmware that never emits the char fails fast instead of hanging).
     Endpoints the firmware cannot emit (`setTime`, `shotDirectory`,
     `headerWrite`, `frameWrite`, …) throw `UnsupportedError`. Shot settings
@@ -133,7 +134,11 @@ Discovery services are responsible for scanning and creating device instances. E
     (16 bytes per 120 Hz tick), half-duplex and downlink-prioritised.
     Subscriptions are budgeted accordingly, and truncated frames from a
     momentary overrun are dropped with a warning rather than crashing the
-    parser.
+    parser. On a confirmed Bengle the redundant `[M]` (0xA00D) stream is
+    unsubscribed (`<-M>`) as soon as the identity is known — 0xA013 is the
+    sole snapshot source there, and the dual 15 Hz stream overruns the
+    ceiling (hw-confirmed: truncated frames, weight flicker). BLE has the
+    headroom and keeps 0xA00D subscribed (parse-and-dropped).
   - **Link arbitration.** BLE and USB are mutually exclusive in the
     firmware (last-writer-wins source flag): a passively-listening USB
     client can silently lose its notify stream to a stray BLE-module byte.

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -89,11 +89,25 @@ Discovery services are responsible for scanning and creating device instances. E
   1. `productName == "DE1"` → `UnifiedDe1`. `productName == "Bengle"` →
      `Bengle`. Cheapest path.
   2. VID:PID match against `lib/src/services/serial/usb_ids.dart`.
-     Tables empty until concrete pairs are captured from hardware.
+     Direct-instantiation tables stay empty: the Bengle's captured pair
+     (`0x2E8A:0x000A`, product string "TinyUSB Device") is the pico-sdk
+     default that any hobby CDC board also uses, so it only *qualifies
+     the port for the probe* (`bengleProbeCandidateIds`) — the `v13Model`
+     read decides what the device actually is.
   3. Fallback: open the port, send `<+M>` and the v13Model MMR-read
      request, wait for `[M]` (DE1-protocol baseline) plus an `[E]…`
      reply at addr `0x0080000C`. v13Model `>= 128` → `Bengle`, else
      `UnifiedDe1`. Encoded via `lib/src/services/serial/mmr_codec.dart`.
+
+  On Android the enumeration is pre-filtered by USB `productName`
+  (`serialProbeAllowsProductName` in `lib/src/services/serial/utils.dart`):
+  `DE1`, `Bengle`, `Half Decent Scale`, anything containing `Serial`, and
+  unknown (null) names are probed; everything else is skipped so the
+  3-second probe never opens unrelated USB devices. A port whose VID:PID is
+  in `bengleProbeCandidateIds` passes the gate regardless of its name.
+  Desktop has no name gate. Auto-permission for the Bengle VID:PID
+  (`0x2E8A:0x000A`) comes from
+  `android/app/src/main/res/xml/device_filter.xml`.
 
 #### 3. SimulatedDeviceService
 - **Platform:** All

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -131,6 +131,31 @@ Discovery services use name-based matching via `DeviceMatcher` to create appropr
 - Service verification happens during `onConnect()` using `BleServiceIdentifier`
 - DiFluid R2 reflectometers are matched separately from DiFluid scales by advertised name and the R2 BLE service UUID, then exposed as `Sensor` devices with a `measure` command
 
+#### Bengle: name is a hint, `v13Model` is authoritative
+
+The BLE advertised name only *selects the class at scan time* — it must not
+decide the DE1-vs-Bengle protocol, because the authoritative identity is the
+`v13Model` MMR register (`0x0080000C`), which is readable only **after**
+connecting: `model >= 128` ⇒ Bengle (the DE1 family is `1..7`; served
+unscaled). `UnifiedDe1.onConnect` reads it and sets the `isBengle` flag.
+
+So `DeviceMatcher` stays name-based, and `De1Controller.connectToDe1`
+re-resolves the machine class from the connected model
+(`resolveMachineForModel`, `lib/src/models/device/impl/de1/de1_resolver.dart`):
+
+- if the name-picked class already agrees with the model (the common case —
+  real Bengle hardware advertises `"Bengle"`), the same instance is used, with
+  no reconnect;
+- otherwise a fresh instance of the correct class (`Bengle` / `UnifiedDe1`) is
+  built over the **same live transport**, carrying the connect-time identity
+  across, and re-connected (which only re-subscribes + runs capability init —
+  no MMR re-read).
+
+This mirrors the serial path (`serial_service_*`), which already instantiates
+`Bengle` vs `UnifiedDe1` from `v13Model >= 128` at detection time. Net effect:
+a Bengle presenting any advertised name still gets Bengle features, and a DE1
+mis-advertising `"Bengle"` is driven as a plain DE1.
+
 ### Service Lifecycle
 
 1. **Initialization:** `service.initialize()`

--- a/doc/Profiles.md
+++ b/doc/Profiles.md
@@ -548,6 +548,36 @@ Example error response:
 
 Mock machines execute profiles in a simulated shot loop that follows profile step targets (flow, pressure, temperature) with simplified machine-response dynamics. Design decisions are recorded in archived plans — see `doc/plans/mock-shot-fidelity.md` for the substate model, flow→pressure coupling, weight accumulation, transition shaping, and skipStep semantics.
 
+### Device upload wire format (DE1 v1 / Bengle v2)
+
+When a profile is sent to a physical machine it is serialised to the DE1 binary
+shot descriptor (a header frame plus one frame per step, optional per-step
+extension frames, and a tail) over the `headerWrite` / `frameWrite`
+characteristics. reaprime negotiates one of **two wire versions**, selected by
+the connected machine (`UnifiedDe1.isBengle`, established from `v13Model >= 128`
+on connect — see `doc/DeviceManagement.md`). Encoding is in
+`unified_de1.profile.dart`.
+
+| Aspect | DE1 (v1) | Bengle (v2) |
+|--------|----------|-------------|
+| Header version byte | `1` | `2` (firmware rejects and wipes any header where `HeaderV != 2`) |
+| Flow / pressure fields¹ | **U8P4** — `round(v × 16)`, range 0–15.9375 ml/s / bar | **U8D1** — `round(v × 10)`, range 0–25.5 ml/s / bar |
+| Max flow ceiling | 8 ml/s | 20 ml/s (flow-priority targets clamped to it before encoding) |
+
+¹ SetVal (per-step target), TriggerVal (exit-comparison threshold), the header
+MinimumPressure / MaximumFlow, and the extension-frame MaxFlowOrPressure /
+MaxFoPRange. Temperature (U8P1), frame length (F8_1.7) and volume (U10P0)
+encodings are identical across both versions.
+
+The distinction is load-bearing: a Bengle silently discards a v1 header (so **no
+shot runs**), and a v1-scaled flow/pressure over-commands the machine by 60% and
+wraps above 15.9. The DE1 path is unchanged — a DE1 must behave exactly as
+before. Only the Bengle U8D1 encoder clamps (to 0..25.5); the DE1 U8P4 encoder
+is unchanged and wraps mod-256 above 15.9375, which is harmless in practice
+since DE1 flow/pressure values stay well within range. This mirrors de1plus's
+`use_ble_v2` path (`binary.tcl`); the byte layout is verified in
+`test/models/device/unified_de1_bengle_profile_v2_test.dart`.
+
 ### Future Enhancements
 
 - **Cloud Sync**: Hash-based IDs make conflict-free cloud sync straightforward

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/controllers/battery_controller.dart';
 import 'package:reaprime/src/controllers/bengle_probe_bridge.dart';
 import 'package:reaprime/src/controllers/bengle_saw_bridge.dart';
+import 'package:reaprime/src/controllers/bengle_schedule_sync.dart';
 import 'package:reaprime/src/controllers/bengle_steam_stop_bridge.dart';
 import 'package:reaprime/src/controllers/hot_water_sequencer.dart';
 import 'package:reaprime/src/controllers/steam_sequencer.dart';
@@ -358,6 +359,18 @@ void main(List<String> args) async {
     settingsController: settingsController,
   );
   presenceController.initialize();
+
+  // Pushes the sleep timeout + the wake schedule into the Bengle's own
+  // registers, so the machine runs its scheduler with NO tablet connected
+  // (all three registers read zero on a fresh machine: no clock, no entries,
+  // schedule disabled). Bengle-gated: a plain DE1 gets nothing on the wire,
+  // and PresenceController's app-side wake/sleep keeps working for it.
+  // ignore: unused_local_variable
+  final bengleScheduleSync = BengleScheduleSync(
+    de1Controller: de1Controller,
+    settingsController: settingsController,
+  );
+  bengleScheduleSync.initialize();
 
   workflowController.addListener(() {
     persistenceController.saveWorkflow(workflowController.currentWorkflow);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -383,10 +383,9 @@ void main(List<String> args) async {
     de1Controller: de1Controller,
   );
 
-  // Reflects SteamSettings.stopAtTemperature into Bengle's stop-at-
-  // temperature MMR (currently stubbed FW slot — bridge keeps the
-  // cache consistent so the day FW publishes, writes hit the wire
-  // automatically). See [[bengle_steam_stop_bridge]].
+  // Reflects SteamSettings.stopAtTemperature into Bengle's
+  // TargetMilkTemp MMR (real register).
+  // See [[bengle_steam_stop_bridge]].
   // ignore: unused_local_variable
   final bengleSteamStopBridge = BengleSteamStopBridge(
     workflowController: workflowController,

--- a/lib/src/controllers/bengle_schedule_sync.dart
+++ b/lib/src/controllers/bengle_schedule_sync.dart
@@ -1,0 +1,376 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/models/device/bengle_interface.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/wake_schedule_windows.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/settings/sleep_timeout_safety.dart';
+
+/// Pushes the app's sleep timeout and wake schedule into the Bengle's own
+/// registers, so **the machine runs its scheduler autonomously — with the
+/// tablet disconnected**.
+///
+/// Before this existed, the wake schedule was a purely app-side feature: a
+/// 30-second `PresenceController` timer that woke the machine off Android's
+/// clock. With the tablet away (or the app killed) nothing woke the machine,
+/// and the three firmware registers read zero on older firmware — no clock, no
+/// entries, schedule disabled.
+///
+/// What is written, and when:
+///
+/// * **Clock** (`SetLocalTimeOfWeek`) — idempotent, no side effects. Written
+///   on connect and re-written every [clockResyncInterval] (RAM-only in
+///   firmware: lost on every machine reboot, and a DST jump makes it an hour
+///   wrong until the next tick).
+/// * **Sleep timeout** (`InactivitySleepTimeout`) — persisted in firmware;
+///   written whenever the user's setting differs from what we last pushed, and
+///   always at least once per connect. **It is never written as `0`**: it is the
+///   machine's thermal safety net for when this tablet is gone, and the app must
+///   leave every machine it touches at least as safe as it found it. See
+///   `sleep_timeout_safety.dart`.
+/// * **Table** (`ScheduleControl` 0 → `ScheduleEntry`… → `ScheduleControl` 1)
+///   — written ONLY when the desired table actually changed, or when the
+///   machine has demonstrably lost it. A re-push clears the table, which drops
+///   the firmware's `WasInAwakeWindow` edge — so a gratuitous re-push mid-window
+///   would re-wake a machine the user had just manually put to sleep. Hence the
+///   diff, and hence the periodic tick never touches the table.
+///
+/// **Bengle-gated.** A non-Bengle DE1 connecting is a complete no-op: not one
+/// byte goes to the wire (these registers do not exist on a stock DE1).
+///
+/// Resilient by construction: every write path is wrapped, a failure logs and
+/// retries with capped backoff, and desired state is only stamped as pushed
+/// after the write lands — so a failure during the connect flow can never
+/// crash it, and self-heals on the next trigger at the latest.
+class BengleScheduleSync {
+  BengleScheduleSync({
+    required De1Controller de1Controller,
+    required SettingsController settingsController,
+    DateTime Function()? clock,
+    this.clockResyncInterval = const Duration(minutes: 15),
+    this.retryDelays = const [
+      Duration(seconds: 3),
+      Duration(seconds: 10),
+      Duration(seconds: 30),
+    ],
+  })  : _de1 = de1Controller,
+        _settings = settingsController,
+        _clock = clock ?? DateTime.now;
+
+  final De1Controller _de1;
+  final SettingsController _settings;
+  final DateTime Function() _clock;
+  final Logger _log = Logger('BengleScheduleSync');
+
+  /// How often the firmware clock is re-written while a Bengle is connected.
+  /// A 4-byte MMR write is negligible; 15 minutes bounds DST error, crystal
+  /// drift and post-reboot clock loss, and sits well inside the smallest
+  /// useful wake window. The same tick carries the reboot verify-poll.
+  final Duration clockResyncInterval;
+
+  /// Backoff for a failed push; the last entry repeats as the cap.
+  final List<Duration> retryDelays;
+
+  /// The connected Bengle, or null (no machine, or a non-Bengle DE1).
+  BengleInterface? _machine;
+
+  StreamSubscription<De1Interface?>? _de1Sub;
+  Timer? _clockTimer;
+  Timer? _retryTimer;
+  int _attempt = 0;
+
+  /// Bumped on every connection edge and on dispose. In-flight awaits capture
+  /// it and bail when it changes, so a write that was in flight across a
+  /// disconnect can never stamp state for a machine that is gone.
+  int _generation = 0;
+
+  /// What the CONNECTED machine is known to hold. All three are cleared on
+  /// every connection edge — the firmware keeps the clock and the table in RAM
+  /// only, so a machine that went away must never be assumed to have kept
+  /// anything (the same rule `WorkflowDeviceSync` follows).
+  bool _clockSynced = false;
+  int? _lastPushedTimeout;
+  List<int>? _lastPushedTable;
+
+  /// Single-flight guard: the drain loop and the periodic tick both talk to
+  /// the machine, and interleaving them could tear the clear → entries →
+  /// enable sequence apart.
+  bool _busy = false;
+
+  /// Set when a settings change lands mid-drain, so the loop re-evaluates
+  /// desired state instead of finishing against a stale snapshot.
+  bool _dirty = false;
+
+  bool _disposed = false;
+
+  /// Subscribe to the machine stream and the settings, and push to whatever
+  /// Bengle is already connected.
+  void initialize() {
+    _de1Sub = _de1.de1.listen(_onDe1Changed);
+    _settings.addListener(_onSettingsChanged);
+  }
+
+  /// Cancel every subscription and timer. Safe to call twice.
+  void dispose() {
+    _disposed = true;
+    _generation++;
+    _settings.removeListener(_onSettingsChanged);
+    _de1Sub?.cancel();
+    _de1Sub = null;
+    _clockTimer?.cancel();
+    _clockTimer = null;
+    _retryTimer?.cancel();
+    _retryTimer = null;
+    _machine = null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Desired state
+  // ---------------------------------------------------------------------------
+
+  /// The `InactivitySleepTimeout` the machine should hold, in minutes.
+  ///
+  /// **NEVER 0.** `0` disables the machine's autonomous sleep *permanently and
+  /// in flash* — the thermal safety net that turns the heaters off when this
+  /// tablet is gone (dead battery, crashed app, blackout). A previous version
+  /// of this getter pushed `0` whenever the user turned "Auto sleep & wake"
+  /// off, or picked "Disabled" in the dropdown, which left the machine LESS
+  /// safe than one that had never met the app (the firmware's own default is
+  /// 60 min). Those settings govern whether the TABLET sleeps the machine; they
+  /// are not licence to disarm the MACHINE. See `sleep_timeout_safety.dart` for
+  /// the full reasoning — please read it before changing this.
+  int get _desiredTimeout => machineSleepTimeoutMinutes(
+        userPresenceEnabled: _settings.userPresenceEnabled,
+        userTimeoutMinutes: _settings.sleepTimeoutMinutes,
+      );
+
+  /// The wake table the machine should hold, packed for `ScheduleEntry`.
+  ///
+  /// Gated on the master toggle — **and on nothing else**. When it is ON the
+  /// table stays armed in the firmware precisely SO THAT the machine keeps
+  /// waking itself with no tablet present: the FW wakes it at the window start,
+  /// holds it awake for the window, and the (always non-zero, see
+  /// [_desiredTimeout]) inactivity timeout sleeps it once the window closes.
+  /// That autonomy is the whole point of this class. Never gate it on tablet
+  /// connectivity.
+  ///
+  /// When the toggle is OFF the user has explicitly asked for no scheduled
+  /// waking — and the UI hides the schedule section, so they believe wake is
+  /// off. It must actually BE off: an empty table makes `pushWakeSchedule`
+  /// write `ScheduleControl = 0` (clear + disable). That is respecting a
+  /// deliberate setting, not second-guessing the tablet's presence.
+  List<int> get _desiredTable => _settings.userPresenceEnabled
+      ? windowsFromSettingsJson(_settings.wakeSchedules)
+          .map((w) => w.packed)
+          .toList(growable: false)
+      : const <int>[];
+
+  // ---------------------------------------------------------------------------
+  // Triggers
+  // ---------------------------------------------------------------------------
+
+  void _onDe1Changed(De1Interface? device) {
+    // Every connection edge invalidates everything we believe about the
+    // machine's registers (the clock and the table are RAM-only in firmware).
+    _generation++;
+    _retryTimer?.cancel();
+    _retryTimer = null;
+    _clockTimer?.cancel();
+    _clockTimer = null;
+    _attempt = 0;
+    _clockSynced = false;
+    _lastPushedTimeout = null;
+    _lastPushedTable = null;
+    _dirty = false;
+
+    if (device is! BengleInterface) {
+      // Bengle-only feature. A plain DE1 (or no machine) gets NOTHING —
+      // these registers do not exist there.
+      _machine = null;
+      return;
+    }
+
+    _machine = device;
+    _log.info('Bengle connected — syncing clock, sleep timeout and schedule');
+    _clockTimer = Timer.periodic(clockResyncInterval, (_) => _onTick());
+    unawaited(_drain());
+  }
+
+  void _onSettingsChanged() {
+    // `SettingsController.addListener` fires on ANY settings write (theme,
+    // units, …) — it is not a per-key stream. The drain loop diffs desired
+    // state against what was actually pushed, so an unrelated change writes
+    // nothing and, crucially, never re-pushes (and re-arms) the wake table.
+    if (_machine == null) return;
+    _dirty = true;
+    unawaited(_drain());
+  }
+
+  // ---------------------------------------------------------------------------
+  // The push
+  // ---------------------------------------------------------------------------
+
+  /// Brings the connected machine in line with desired state, one write at a
+  /// time. Concurrent calls collapse into the running loop.
+  Future<void> _drain() async {
+    if (_busy) {
+      _dirty = true;
+      return;
+    }
+    _busy = true;
+    try {
+      while (true) {
+        final generation = _generation;
+        final machine = _machine;
+        if (machine == null || _disposed) return;
+        _dirty = false;
+
+        final desiredTimeout = _desiredTimeout;
+        final desiredTable = _desiredTable;
+
+        try {
+          // Clock FIRST: the firmware ignores an enabled table while its
+          // clock is invalid (the firmware schedule check short-circuits on
+          // !ClockValid), and the enable is what arms the rising-edge wake.
+          if (!_clockSynced) {
+            await machine.setLocalTimeOfWeek(localSecondsOfWeek(_clock()));
+            if (generation != _generation) return;
+            _clockSynced = true;
+          }
+
+          if (_lastPushedTimeout != desiredTimeout) {
+            await machine.setInactivitySleepTimeout(desiredTimeout);
+            if (generation != _generation) return;
+            _lastPushedTimeout = desiredTimeout;
+            _log.info('InactivitySleepTimeout = $desiredTimeout min');
+          }
+
+          // `null` (nothing pushed on this connection yet) never equals the
+          // desired table, not even an empty one: a fresh machine must always
+          // be told, if only to clear a table left by a previous session.
+          if (!_sameTable(_lastPushedTable, desiredTable)) {
+            await machine.pushWakeSchedule(desiredTable);
+            if (generation != _generation) return;
+            _lastPushedTable = desiredTable;
+            _log.info('Wake schedule pushed: ${desiredTable.length} window(s)');
+          }
+
+          _attempt = 0;
+        } catch (e, st) {
+          if (generation != _generation) return;
+          // Nothing is stamped, so the retry re-attempts from the top — and a
+          // half-written table (control=0 landed, entries did not) is repaired
+          // by the next full sequence, which starts with control=0 again.
+          _scheduleRetry(generation, e, st);
+          return;
+        }
+
+        // A settings change that landed mid-write: re-evaluate rather than
+        // exit against a stale snapshot.
+        if (!_dirty) return;
+      }
+    } finally {
+      _busy = false;
+      // A trigger that arrived mid-write collapsed into `_dirty` (the single-
+      // flight guard above). If we then abandoned the loop for a stale
+      // generation — a machine that swapped while a write was in flight — the
+      // clean-exit re-check at the bottom of the loop was never reached, and
+      // nobody would ever pick that work up: the NEW machine would sit
+      // unconfigured (no protective sleep timeout) until the 15-minute tick.
+      // Hand off to a fresh drain, which re-reads `_machine` from scratch.
+      if (_dirty && !_disposed && _machine != null) {
+        unawaited(_drain());
+      }
+    }
+  }
+
+  /// The 15-minute tick: re-sync the clock, and detect a machine that rebooted
+  /// while we stayed connected (possible over USB serial).
+  ///
+  /// **Never touches the table on a healthy machine** — re-pushing it would
+  /// re-arm the firmware's rising-edge wake (§1.7 of the spec).
+  Future<void> _onTick() async {
+    if (_busy || _disposed) return; // a drain/retry is already talking
+    final machine = _machine;
+    if (machine == null) return;
+    _busy = true;
+    final generation = _generation;
+    try {
+      // The read is a WRITE ECHO, not the live firmware clock — comparing it
+      // to "now" would be meaningless. Its one meaning: 0 ⇒ the machine
+      // rebooted (RAM-only slot, initval 0) and the app never writes 0.
+      final echo = await machine.readLocalTimeOfWeekEcho();
+      if (generation != _generation) return;
+      if (echo == 0) {
+        _log.warning('Machine clock reads 0 — it rebooted; re-pushing '
+            'clock, sleep timeout and schedule');
+        _forgetDeviceState();
+        return; // the drain in `finally` re-pushes everything
+      }
+
+      // Same trick for the table: we cannot read it back, but a
+      // ScheduleControl echo of 0 while we expect 1 means it is gone.
+      if (_lastPushedTable != null && _lastPushedTable!.isNotEmpty) {
+        final control = await machine.readScheduleControl();
+        if (generation != _generation) return;
+        if (control == 0) {
+          _log.warning('ScheduleControl reads 0 but a schedule is expected — '
+              're-pushing the table');
+          _forgetDeviceState();
+          return;
+        }
+      }
+
+      await machine.setLocalTimeOfWeek(localSecondsOfWeek(_clock()));
+    } catch (e, st) {
+      if (generation != _generation) return;
+      // A failed tick is not worth a retry storm: the next tick re-runs the
+      // whole check. Keep the desired state stamped — nothing here proves the
+      // machine lost anything.
+      _log.warning('Clock re-sync/verify tick failed', e, st);
+    } finally {
+      _busy = false;
+      // Runs after the guard is released so the drain can take it. If nothing
+      // was forgotten, the diff makes this a no-op.
+      if (!_disposed && generation == _generation && _machine != null) {
+        unawaited(_drain());
+      }
+    }
+  }
+
+  /// Forget everything we believe the machine holds, so the next drain pushes
+  /// the lot. Used when the machine has demonstrably lost its RAM state.
+  void _forgetDeviceState() {
+    _clockSynced = false;
+    _lastPushedTimeout = null;
+    _lastPushedTable = null;
+  }
+
+  void _scheduleRetry(int generation, Object error, StackTrace st) {
+    final delay = retryDelays[min(_attempt, retryDelays.length - 1)];
+    _attempt++;
+    _log.warning(
+      'Schedule sync write failed (attempt $_attempt); retrying in '
+      '${delay.inSeconds}s',
+      error,
+      st,
+    );
+    _retryTimer?.cancel();
+    _retryTimer = Timer(delay, () {
+      if (generation != _generation || _disposed) return;
+      unawaited(_drain());
+    });
+  }
+
+  static bool _sameTable(List<int>? a, List<int> b) {
+    if (a == null) return false;
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+}

--- a/lib/src/controllers/bengle_steam_stop_bridge.dart
+++ b/lib/src/controllers/bengle_steam_stop_bridge.dart
@@ -8,16 +8,13 @@ import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/errors.dart';
 
 /// Reflects `SteamSettings.stopAtTemperature` into the connected
-/// Bengle's `setStopAtTemperatureTarget` MMR endpoint. Mirrors
-/// [BengleSawBridge] — same debounce + generation-token + re-assert on
-/// reconnect shape.
+/// Bengle's `setStopAtTemperatureTarget` MMR endpoint (`TargetMilkTemp`,
+/// real register). Mirrors [BengleSawBridge] — same
+/// debounce + generation-token + re-assert on reconnect shape.
 ///
-/// **Scaffolding.** While the FW MMR slot is stubbed
-/// (`BengleSteamMmr.stopAtTemperatureTarget.address == 0x00000000`),
-/// `Bengle.setStopAtTemperatureTarget` caches the value locally and
-/// log-onces; this bridge keeps the cache consistent with the workflow
-/// so the day FW lands, the write hits the wire automatically with no
-/// app-side changes.
+/// The write is deliberately NOT gated on probe presence: firmware
+/// stops autonomously the moment a probe is physically attached, so the
+/// target must always be current on the machine.
 class BengleSteamStopBridge {
   BengleSteamStopBridge({
     required WorkflowController workflowController,

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -563,7 +563,17 @@ class ConnectionManager {
     switch (machineAction) {
       case ConnectMachineAction(machine: final m):
         await _connectMachineTracked(m, scanReport);
-        await _runScalePhase(m, scales, preferredScaleId, scanReport);
+        // connectToDe1 may re-resolve the machine to a new class instance
+        // over the same transport (v13Model-authoritative). Run the
+        // scale phase against the *connected* machine (latestMachine), not
+        // the stale name-picked `m`, so a promoted Bengle's integrated scale
+        // attaches. Matches the sibling _runScalePhase calls above.
+        await _runScalePhase(
+          _disconnectSupervisor.latestMachine,
+          scales,
+          preferredScaleId,
+          scanReport,
+        );
         _maybeArmDeferredScaleScan();
         _maybeSchedulePreferredScaleReconnect();
       case MachinePickerAction():

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -10,6 +10,9 @@ import 'package:reaprime/src/models/data/shot_state_event.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1_resolver.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/errors.dart';
 import 'package:rxdart/subjects.dart';
 
@@ -141,14 +144,57 @@ class De1Controller {
   }
 
   Future<void> connectToDe1(De1Interface de1Interface) async {
-    if (de1Interface == _de1) {
-        _log.fine("trying to connect to existing de1, exit early");
-        return;
-      }
+    // Guard on deviceId, not object identity: after a model-based class swap
+    // (resolveMachineForModel below) `_de1` is a rebuilt instance, so a
+    // caller re-passing the name-picked interim (same physical machine)
+    // would otherwise fall through and needlessly tear down + rebuild the
+    // live connection.
+    if (_de1 != null &&
+        (identical(de1Interface, _de1) ||
+            de1Interface.deviceId == _de1!.deviceId)) {
+      _log.fine("trying to connect to existing de1, exit early");
+      return;
+    }
     _onDisconnect(); // just in case
     _log.fine("found de1, connecting");
+    var machine = de1Interface;
     try {
-      await de1Interface.onConnect();
+      await machine.onConnect();
+      // BLE discovery picks the class by advertised name, but the v13Model
+      // read in onConnect is authoritative. If they disagree, re-resolve to
+      // the correct class over the same live transport and finish connecting
+      // it (the re-connect only (re)subscribes + runs capability init —
+      // identity was carried over, so no MMR re-read).
+      final resolved = resolveMachineForModel(machine);
+      if (!identical(resolved, machine)) {
+        _log.info(
+          'v13Model disagrees with name-picked class: re-resolved '
+          '${machine.name} -> ${resolved.name} over the same transport',
+        );
+        await resolved.onConnect();
+        // The name-picked interim is discarded but shares the live transport
+        // with `resolved`; detach its wrapper (stop listening + close its
+        // subjects) WITHOUT disposing the shared transport, which `resolved`
+        // now owns. Prevents a lingering serial readStream listener and
+        // leaked subjects.
+        //
+        // A *demoted* Bengle interim (name-picked "Bengle" that reads
+        // v13Model < 128) ran its capability init in onConnect, attaching
+        // capability subjects to itself that only Bengle.onDisconnect would
+        // release — and the discarded interim never sees a disconnect.
+        // Dispose EVERY capability Bengle.onConnect initialises; when a new
+        // capability mixin is added to Bengle, extend this teardown or the
+        // demotion path leaks its subjects
+        // (test/controllers/de1_controller_resolve_test.dart locks this).
+        if (machine is Bengle) {
+          await machine.disposeIntegratedScale();
+          await machine.disposeLedStrip();
+        }
+        if (machine is UnifiedDe1) {
+          await machine.detachTransport();
+        }
+        machine = resolved;
+      }
     } catch (e, st) {
       _log.warning(
         'Failed to connect to ${de1Interface.name} '
@@ -159,7 +205,7 @@ class De1Controller {
       _onDisconnect();
       rethrow;
     }
-    _de1 = de1Interface;
+    _de1 = machine;
     _de1Controller.add(_de1);
 
     _subscriptions.add(

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -188,6 +188,7 @@ class De1Controller {
         // (test/controllers/de1_controller_resolve_test.dart locks this).
         if (machine is Bengle) {
           await machine.disposeIntegratedScale();
+          await machine.disposeScaleCalibration();
           await machine.disposeLedStrip();
         }
         if (machine is UnifiedDe1) {

--- a/lib/src/controllers/scale_controller.dart
+++ b/lib/src/controllers/scale_controller.dart
@@ -111,6 +111,7 @@ class ScaleController {
     _kalmanEstimator = null;
     _lastSnapshotTime = null;
     _flowSettleUntil = null;
+    _deviceProvidesFlow = false;
   }
 
   Scale connectedScale() {
@@ -174,7 +175,13 @@ class ScaleController {
   Future<void> tare() async {
     final scale = connectedScale();
     await scale.tare();
-    if (_kalmanFlowEnabled) {
+    if (_deviceProvidesFlow) {
+      // The device tares the load cell it computes flow from, so there is no
+      // app-side estimator state to drop. Still arm the settle window: the
+      // no-flow-spike-after-tare guarantee is specced, and honouring it here
+      // costs one comparison per sample.
+      _flowSettleUntil = _lastSnapshotTime?.add(smoothingWindowDuration);
+    } else if (_kalmanFlowEnabled) {
       _kalmanEstimator?.reset(0.0);
     } else {
       _flowCalculator =
@@ -184,8 +191,38 @@ class ScaleController {
     }
   }
 
+  /// Set once a scale reports a device-computed [ScaleSnapshot.flow], so
+  /// [tare] knows there is no estimator state to rebuild. Cleared on disconnect.
+  bool _deviceProvidesFlow = false;
+
   void _processSnapshot(ScaleSnapshot snapshot) {
     _lastSnapshotTime = snapshot.timestamp;
+
+    final deviceFlow = snapshot.flow;
+    if (deviceFlow != null) {
+      // The device computed this flow on-hardware, from the load cell it owns
+      // (the Bengle's integrated scale: `GFlow` in the 15 Hz `0xA013` frame).
+      // Pass it through and bypass BOTH estimators. Re-deriving flow from the
+      // weight the device derived it FROM is strictly worse: the estimators
+      // read ~0 g/s at shot onset and take ~1 s to converge on a value the
+      // device already has correct at the first sample. This also pins the
+      // scale surface to the same number the machine snapshot carries, so the
+      // two cannot disagree, and it holds no matter which estimator upstream
+      // makes the default.
+      _deviceProvidesFlow = true;
+      final settling = _flowSettleUntil != null &&
+          snapshot.timestamp.isBefore(_flowSettleUntil!);
+      _weightSnapshotController.add(
+        WeightSnapshot(
+          timestamp: snapshot.timestamp,
+          weight: snapshot.weight,
+          weightFlow: settling ? 0.0 : deviceFlow,
+          battery: snapshot.batteryLevel,
+          timerValue: snapshot.timerValue,
+        ),
+      );
+      return;
+    }
 
     final double filteredWeight;
     final double flow;

--- a/lib/src/controllers/steam_sequencer.dart
+++ b/lib/src/controllers/steam_sequencer.dart
@@ -10,28 +10,25 @@ import 'package:reaprime/src/models/data/steam_snapshot.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
-import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/device/sensor.dart';
 import 'package:uuid/uuid.dart';
 
-/// Long-lived service that records steaming sessions and orchestrates
-/// the stop-at-temperature scaffolding. Mirrors `ShotSequencer` shape
+/// Long-lived service that records steaming sessions and arbitrates
+/// the stop-at-temperature source. Mirrors `ShotSequencer` shape
 /// but lives across the app lifetime (not per-shot) because steaming
 /// has no separate "begin shot" command — the user just enters the
 /// steam state on the machine.
 ///
-/// **Today (FW not ready):**
 /// - Records persist via `PersistenceController.persistSteam`.
 /// - `SteamSnapshot.milkTemperature` is populated from the first
 ///   sensor registered in `SensorController`. No probe is registered
 ///   in production today, so the field is `null` in real recordings.
-/// - The stop-at-temperature path: the FW-autonomous branch is
-///   gated on `BengleSteamMmr.stopAtTemperatureTarget.address != 0`,
-///   which is `false` today — so the app-side branch is taken. With
-///   no sensor registered, the app-side branch is also inert. The
-///   test suite exercises both branches via `MockBengle` +
-///   `TestSensor`.
+/// - The stop-at-temperature path: the FW-autonomous branch fires when a
+///   Bengle probe is attached and a positive target is set (`TargetMilkTemp`
+/// is wired); otherwise the app-side branch is taken. With no
+///   sensor registered in production, the app-side branch is also inert. The
+///   test suite exercises both branches via `MockBengle` + `TestSensor`.
 class SteamSequencer {
   SteamSequencer({
     required De1Controller de1Controller,
@@ -69,9 +66,10 @@ class SteamSequencer {
 
   /// Stop-source predicate (see plan §Approach). Public for tests.
   ///
-  /// `true` means the FW will autonomously stop the steam at the
-  /// target temperature — the sequencer must NOT request `idle`. Today
-  /// this is always `false` because the MMR address is stubbed.
+  /// `true` means the FW will autonomously stop the steam at the target
+  /// temperature — the sequencer must NOT request `idle`. Requires a Bengle,
+  /// a probe attached, and a positive target (the `TargetMilkTemp` MMR is
+  /// wired).
   bool useFwAutonomousStop({
     required De1Interface? machine,
     required bool probeAttached,
@@ -80,9 +78,6 @@ class SteamSequencer {
     if (machine is! BengleInterface) return false;
     if (stopAtTemperature <= 0) return false;
     if (!probeAttached) return false;
-    if (BengleSteamMmr.stopAtTemperatureTarget.address == 0x00000000) {
-      return false;
-    }
     return true;
   }
 

--- a/lib/src/device_discovery_feature/scan_flow_view.dart
+++ b/lib/src/device_discovery_feature/scan_flow_view.dart
@@ -5,6 +5,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:reaprime/src/controllers/connection_error.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/scan_state_guardian.dart';
@@ -252,12 +253,29 @@ class ScanFlowViewState extends State<ScanFlowView> {
   Widget build(BuildContext context) {
     final Widget content;
 
-    // Adapter error takes precedence
-    if (_adapterError != null) {
+    // Adapter error takes precedence -- but only while nothing that works
+    // WITHOUT Bluetooth is in flight. USB/serial discovery keeps running
+    // with the adapter off, so found machines, an active
+    // connect, or a pending picker keep the normal flow visible and a
+    // wired-only setup can reach the skin. `ready` navigates away above
+    // regardless.
+    final busyWithoutBle =
+        _status.phase == ConnectionPhase.connectingMachine ||
+        _status.phase == ConnectionPhase.connectingScale ||
+        _status.pendingAmbiguity != null ||
+        _status.foundMachines.isNotEmpty ||
+        _discoveredMachines.isNotEmpty;
+    if (_adapterError != null && !busyWithoutBle) {
       content = _adapterErrorView(context);
     }
-    // Error state from connection manager
-    else if (_status.error != null && _status.phase == ConnectionPhase.idle) {
+    // Error state from connection manager. The sticky adapter-off error
+    // gets the same treatment as the guardian view above: it must not
+    // hide machines that were found WITHOUT Bluetooth (USB/serial), or
+    // a wired-only setup can never reach its picker.
+    else if (_status.error != null &&
+        _status.phase == ConnectionPhase.idle &&
+        !(busyWithoutBle &&
+            _status.error!.kind == ConnectionErrorKind.adapterOff)) {
       content = _errorView(context);
     }
     // Scanning
@@ -610,6 +628,12 @@ class ScanFlowViewState extends State<ScanFlowView> {
           Text('Bluetooth Unavailable', style: theme.textTheme.h4),
           Text(
             _adapterError!,
+            style: theme.textTheme.muted,
+            textAlign: TextAlign.center,
+          ),
+          Text(
+            'USB connections keep working: plug the machine in over USB '
+            'and it will be found without Bluetooth.',
             style: theme.textTheme.muted,
             textAlign: TextAlign.center,
           ),

--- a/lib/src/models/data/workflow.dart
+++ b/lib/src/models/data/workflow.dart
@@ -165,8 +165,9 @@ class SteamSettings {
   int targetTemperature;
   int duration;
   double flow;
-  // 0.0 = off. Set/get target only; FW autonomous stop gated on a
-  // future MMR address (see [[bengle_steam_mmr]]).
+  // 0.0 = off. On Bengle the target is reflected into the real
+  // TargetMilkTemp MMR (see [[bengle_steam_mmr]]); FW stops autonomously
+  // when a milk probe is attached, otherwise the app-side stop applies.
   double stopAtTemperature;
 
   SteamSettings({

--- a/lib/src/models/device/bengle_interface.dart
+++ b/lib/src/models/device/bengle_interface.dart
@@ -146,6 +146,50 @@ abstract class BengleInterface extends De1Interface {
   /// `MockBengle` defaults to `true` for tests.
   Stream<bool> get probeAttached;
 
+  // --- Autonomous sleep + wake schedule ---------------------------------------
+  //
+  // These five exist so the machine can run its own scheduler with NO tablet
+  // connected. `writeMmrInt` is `@protected` on `UnifiedDe1`, so the sync
+  // service (`BengleScheduleSync`) cannot touch MMRs directly — every write
+  // goes through this interface. See [[bengle_mmr]] `BengleScheduleMmr` for
+  // the register semantics and `wake_schedule_windows.dart` for the packing.
+
+  /// Set the firmware's autonomous inactivity-sleep timeout in [minutes]
+  /// (`InactivitySleepTimeout`, persisted). `0` disables it; the firmware
+  /// clamps/accepts 0..240. The firmware only acts on this when it believes
+  /// no tablet is connected — which, over USB serial, is always.
+  Future<void> setInactivitySleepTimeout(int minutes);
+
+  /// Set the firmware's wall-clock to [secondsOfWeek] = LOCAL seconds since
+  /// Sunday 00:00:00 (`SetLocalTimeOfWeek`). The clock is RAM-only and is
+  /// lost on every machine reboot, so this must be re-sent on (re)connect and
+  /// periodically. Implementations clamp to the firmware's writable range
+  /// (1..604799 — never 0, which is the "never synced" sentinel).
+  Future<void> setLocalTimeOfWeek(int secondsOfWeek);
+
+  /// Replace the firmware's weekly wake table with [packedWindows], each
+  /// packed by `packWakeWindow` (`(dow << 22) | (startMin << 11) | endMin`).
+  ///
+  /// Performs the whole firmware protocol: `ScheduleControl = 0` (clear the
+  /// table + disable), then one `ScheduleEntry` write per window, then
+  /// `ScheduleControl = 1` (enable). An empty list writes ONLY the `0` —
+  /// clearing and disabling the schedule, with no enable.
+  ///
+  /// NB this re-arms the firmware's rising-edge wake, so callers must only
+  /// push when the desired table actually changed (a mid-window re-push would
+  /// re-wake a machine the user had just manually slept).
+  Future<void> pushWakeSchedule(List<int> packedWindows);
+
+  /// Read back `SetLocalTimeOfWeek`. **This is the last value WRITTEN, not
+  /// the running firmware clock** — it is useless for measuring drift. Its
+  /// one meaning: `0` ⇒ the machine rebooted and lost the clock (and the
+  /// schedule table with it), because the app never writes 0.
+  Future<int> readLocalTimeOfWeekEcho();
+
+  /// Read back `ScheduleControl` (also a write echo). `0` while the app
+  /// expects `1` ⇒ the machine rebooted, or another client cleared the table.
+  Future<int> readScheduleControl();
+
   /// Live milk-probe temperature stream (°C). `PublishSubject<double>` —
   /// no replay, latest-only consumers should track themselves. Real
   /// `Bengle` never emits today; `MockBengle` synthesises during steam.

--- a/lib/src/models/device/bengle_interface.dart
+++ b/lib/src/models/device/bengle_interface.dart
@@ -1,6 +1,7 @@
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/led_strip.dart';
 import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/device/scale_calibration.dart';
 
 /// Marker interface for Bengle-specific machine API.
 ///
@@ -47,6 +48,34 @@ abstract class BengleInterface extends De1Interface {
   /// Latest SAW target stream (`0.0` = SAW off). Late subscribers see
   /// the cached current value immediately.
   Stream<double> get stopAtWeightTarget;
+
+  // --- Load-cell calibration (two-point) -----------------------------
+  //
+  // Procedure: [calibrateScaleZero] (empty platform) → [calibrateScaleWeightLeft]
+  // (known mass on the LEFT half) → [calibrateScaleWeightRight] (same mass on
+  // the RIGHT half). The firmware solves a 2x2 system on the second point and
+  // persists + applies the cal. Each call is non-blocking (polls to a terminal
+  // firmware step or a bounded deadline) and out-of-range masses are clamped.
+
+  /// Precision-zero the load cells with NOTHING on the platform. Must run
+  /// before the weight-cal points.
+  Future<ScaleCalResult> calibrateScaleZero();
+
+  /// Latch weight-cal point 1: the known reference [grams] mass placed anywhere
+  /// on the **LEFT** half. Success means the point latched (awaiting the RIGHT
+  /// point).
+  Future<ScaleCalResult> calibrateScaleWeightLeft(double grams);
+
+  /// Latch weight-cal point 2: the same reference [grams] mass placed anywhere
+  /// on the **RIGHT** half. Success means both points solved and the cal was
+  /// persisted + applied.
+  Future<ScaleCalResult> calibrateScaleWeightRight(double grams);
+
+  /// Abort an in-flight calibration.
+  Future<void> abortScaleCalibration();
+
+  /// Live calibration status while a run is in progress (each polled state).
+  Stream<ScaleCalStatus> get scaleCalibrationProgress;
 
   /// Current LED strip state stream.
   Stream<LedStripState> get ledStripState;

--- a/lib/src/models/device/bengle_interface.dart
+++ b/lib/src/models/device/bengle_interface.dart
@@ -106,21 +106,26 @@ abstract class BengleInterface extends De1Interface {
   /// Restore the strip to the cached awake palette after a [previewLedColor].
   Future<void> clearLedPreview();
 
-  // --- Milk-probe steam stop (scaffolding) -----------------------------------
+  // --- Milk-probe steam stop -----------------------------------------
   //
-  // FW is not yet ready. The methods + streams below are the API surface
-  // skin developers can target now. On real `Bengle` the streams are inert
-  // (target replays cached value, probeAttached stays `false`,
-  // probeTemperature never emits) until FW publishes the wire spec. See
-  // [[bengle_steam_mmr]] for the MMR slot and [[bengle_milk_probe]] for
-  // the planned probe device wrapper.
+  // The auto-stop TARGET is a real MMR write (`TargetMilkTemp`, ×10
+  // decicelsius on the wire — see [[bengle_steam_mmr]]). The live probe
+  // READING is separate: it rides the `0xA013` shot-sample stream into
+  // `MachineSnapshot.milkTemperature` (÷100), and current firmware
+  // serialises 0 there until a probe pipeline ships — so on real `Bengle`
+  // `probeAttached` stays `false` and `probeTemperature` never emits
+  // (graceful degradation, no fake data). The target write is NOT gated on
+  // probe presence: firmware stops autonomously the moment a probe is
+  // physically attached. See [[bengle_milk_probe]] for the sensor wrapper.
 
   /// Set the autonomous stop-at-temperature target in °C. `0.0` disables
-  /// the stop. Range `0..80`. Today: caches locally + log-once; no MMR
-  /// write until FW publishes the slot.
+  /// the stop. Range `0..85` (FW max 850 deci-°C). Implementations clamp
+  /// out-of-range values before writing.
   Future<void> setStopAtTemperatureTarget(double celsius);
 
-  /// Read the current stop-at-temperature target in °C.
+  /// Read the current stop-at-temperature target in °C. On real `Bengle`
+  /// this reads the register and echoes the value onto
+  /// [stopAtTemperatureTarget] so replay subscribers see post-read truth.
   Future<double> getStopAtTemperatureTarget();
 
   /// Latest stop-at-temperature target stream (`0.0` = stop off).
@@ -129,8 +134,8 @@ abstract class BengleInterface extends De1Interface {
 
   /// Whether the milk probe is physically attached to the machine.
   /// `BehaviorSubject<bool>` seeded `false`. Real `Bengle` stays `false`
-  /// until FW publishes a presence signal; `MockBengle` defaults to
-  /// `true` for tests.
+  /// until FW publishes a presence signal (the live reading rides `0xA013`);
+  /// `MockBengle` defaults to `true` for tests.
   Stream<bool> get probeAttached;
 
   /// Live milk-probe temperature stream (°C). `PublishSubject<double>` —

--- a/lib/src/models/device/bengle_interface.dart
+++ b/lib/src/models/device/bengle_interface.dart
@@ -21,6 +21,14 @@ abstract class BengleInterface extends De1Interface {
   /// Read the current cup-warmer mat setpoint in °C.
   Future<double> getCupWarmerTemperature();
 
+  /// Read the LIVE cup-warmer mat temperature in °C, or `null` when there
+  /// is no valid reading. Distinct from [getCupWarmerTemperature] (the
+  /// setpoint): this is the measured mat temperature. `null` covers both
+  /// firmware reporting raw `0` (NTC open/short — no valid reading) and
+  /// older firmware without the register at all (the read is defensive).
+  /// Implementations must never substitute fake data for `null`.
+  Future<double?> getCupWarmerCurrentTemperature();
+
   /// Live snapshot stream from the integrated scale.
   ///
   /// Real `Bengle` wires this to `IntegratedScaleCapability.weightSnapshot`

--- a/lib/src/models/device/bengle_interface.dart
+++ b/lib/src/models/device/bengle_interface.dart
@@ -83,16 +83,28 @@ abstract class BengleInterface extends De1Interface {
   /// One-shot read of the current LED strip state.
   Future<LedStripState> getLedStripState();
 
-  /// Write a full LED strip configuration (all zones, both modes).
-  /// Updates cache and pushes to FW live registers. Does NOT persist
-  /// to NVM — call [commitLedStrip] separately.
+  /// Write a full LED strip configuration (all zones, both modes) to the
+  /// cache and the FW palette registers. The palette registers persist on
+  /// write (`PERM_RWD`) — [commitLedStrip] is a re-assert kept for API
+  /// symmetry, not a separate persist step.
   Future<void> setLedStrip(LedStripState state);
 
-  /// Persist the current LED strip configuration to FW NVM.
+  /// Re-assert the cached LED strip configuration to the FW. The palette
+  /// registers already persist on every write; there is no separate commit
+  /// register — kept for API symmetry.
   Future<void> commitLedStrip();
 
-  /// Reload the LED strip configuration from FW NVM, dropping uncommitted changes.
+  /// Reload the LED strip configuration from the FW palette registers,
+  /// dropping local edits.
   Future<void> resetLedStrip();
+
+  /// Preview a colour live on the strip (front + rear) immediately, regardless
+  /// of awake/sleep state, without changing the stored palette — used to show
+  /// e.g. the sleep colour while the machine is awake. [clearLedPreview] restores.
+  Future<void> previewLedColor(Color16 front, Color16 back);
+
+  /// Restore the strip to the cached awake palette after a [previewLedColor].
+  Future<void> clearLedPreview();
 
   // --- Milk-probe steam stop (scaffolding) -----------------------------------
   //

--- a/lib/src/models/device/bengle_interface.dart
+++ b/lib/src/models/device/bengle_interface.dart
@@ -32,7 +32,7 @@ abstract class BengleInterface extends De1Interface {
   Future<void> tareIntegratedScale();
 
   /// Set the autonomous stop-at-weight target in grams. `0.0` disables
-  /// SAW (mirrors cup-warmer `0.0 = off`). Range `0.0..500.0`.
+  /// SAW (mirrors cup-warmer `0.0 = off`). Range `0.0..10000.0`.
   /// Implementations clamp out-of-range values.
   ///
   /// When set to a positive value the Bengle FW stops the shot when

--- a/lib/src/models/device/impl/bengle/bengle.dart
+++ b/lib/src/models/device/impl/bengle/bengle.dart
@@ -6,7 +6,10 @@ import 'package:reaprime/src/models/device/machine.dart';
 import 'package:rxdart/rxdart.dart';
 
 class Bengle extends UnifiedDe1
-    with IntegratedScaleCapability, LedStripCapability
+    with
+        IntegratedScaleCapability,
+        LedStripCapability,
+        ScaleCalibrationCapability
     implements BengleInterface {
   Bengle({required super.transport});
 
@@ -104,12 +107,14 @@ class Bengle extends UnifiedDe1
   Future<void> onConnect() async {
     await super.onConnect();
     await initIntegratedScale();
+    await initScaleCalibration();
     await initLedStrip();
   }
 
   @override
   Future<void> onDisconnect() async {
     await disposeLedStrip();
+    await disposeScaleCalibration();
     await disposeIntegratedScale();
     if (!_stopAtTempTarget.isClosed) {
       await _stopAtTempTarget.close();

--- a/lib/src/models/device/impl/bengle/bengle.dart
+++ b/lib/src/models/device/impl/bengle/bengle.dart
@@ -52,19 +52,17 @@ class Bengle extends UnifiedDe1
   @protected
   Duration get firmwareUploadBatchPause => Duration.zero;
 
-  // --- Milk-probe steam stop (FW-stubbed scaffolding) -----------------------
+  // --- Milk-probe steam stop ------------------------------------------------
   //
-  // Mirrors `IntegratedScaleCapability`'s SAW stub: cache locally,
-  // log-once, no MMR write until FW publishes the slot. `probeAttached`
-  // stays `false` and `probeTemperature` never emits — probe discovery
-  // and data transport are TBD (may be a new BLE characteristic, not
-  // another MMR slot).
+  // The auto-stop TARGET is a real MMR write ([BengleSteamMmr.stopAtTemperatureTarget]
+  // = TargetMilkTemp). The live probe READING is separate — it rides the
+  // `0xA013` shot-sample stream, not an MMR — so `probeAttached`/`probeTemperature`
+  // are surfaced by that pipeline, not here. (FW currently serialises MilkTemp as 0.)
   final BehaviorSubject<double> _stopAtTempTarget =
       BehaviorSubject<double>.seeded(0.0);
   final BehaviorSubject<bool> _probeAttached =
       BehaviorSubject<bool>.seeded(false);
   final PublishSubject<double> _probeTemperature = PublishSubject<double>();
-  int _stopAtTempStubWarningsEmitted = 0;
 
   @override
   Stream<double> get stopAtTemperatureTarget => _stopAtTempTarget.stream;
@@ -77,37 +75,20 @@ class Bengle extends UnifiedDe1
 
   @override
   Future<void> setStopAtTemperatureTarget(double celsius) async {
-    final clamped = celsius.clamp(0.0, 80.0).toDouble();
+    final clamped = celsius.clamp(0.0, 85.0).toDouble();
     if (!_stopAtTempTarget.isClosed) {
       _stopAtTempTarget.add(clamped);
     }
-    final addr = BengleSteamMmr.stopAtTemperatureTarget;
-    if (addr.address == 0x00000000) {
-      _logStopAtTempStubOnce(
-          'setStopAtTemperatureTarget($clamped) ignored. Awaiting FW.');
-      return;
-    }
-    await writeMmrScaled(addr, clamped);
+    await writeMmrScaled(BengleSteamMmr.stopAtTemperatureTarget, clamped);
   }
 
   @override
   Future<double> getStopAtTemperatureTarget() async {
-    final addr = BengleSteamMmr.stopAtTemperatureTarget;
-    if (addr.address == 0x00000000) {
-      return _stopAtTempTarget.value;
-    }
-    final value = await readMmrScaled(addr);
+    final value = await readMmrScaled(BengleSteamMmr.stopAtTemperatureTarget);
     if (!_stopAtTempTarget.isClosed) {
       _stopAtTempTarget.add(value);
     }
     return value;
-  }
-
-  void _logStopAtTempStubOnce(String msg) {
-    if (_stopAtTempStubWarningsEmitted < 1) {
-      log.info('Bengle: stop-at-temperature endpoint unwired; $msg');
-      _stopAtTempStubWarningsEmitted++;
-    }
   }
 
   // --- integrated scale lifecycle ---

--- a/lib/src/models/device/impl/bengle/bengle.dart
+++ b/lib/src/models/device/impl/bengle/bengle.dart
@@ -16,9 +16,18 @@ class Bengle extends UnifiedDe1
   @override
   String get name => "Bengle";
 
+  /// Last requested cup-warmer target °C (`0` = off). Remembered so the
+  /// RAM-only [BengleMmr.cupWarmerMode] can be re-asserted on reconnect.
+  double _cupWarmerTarget = 0.0;
+
   @override
-  Future<void> setCupWarmerTemperature(double celsius) =>
-      writeMmrScaled(BengleMmr.matSetPoint, celsius);
+  Future<void> setCupWarmerTemperature(double celsius) async {
+    _cupWarmerTarget = celsius.clamp(0.0, 80.0).toDouble();
+    await writeMmrScaled(BengleMmr.matSetPoint, _cupWarmerTarget);
+    // CupWarmerMode is the real enable — a temperature alone does nothing.
+    // `> 0 °C` ⇒ On. It is RAM-only, so it is also re-pushed on every connect.
+    await writeMmrInt(BengleMmr.cupWarmerMode, _cupWarmerTarget > 0 ? 1 : 0);
+  }
 
   @override
   Future<double> getCupWarmerTemperature() =>
@@ -109,6 +118,15 @@ class Bengle extends UnifiedDe1
     await initIntegratedScale();
     await initScaleCalibration();
     await initLedStrip();
+    // CupWarmerMode is RAM-only (FW resets it to 0 on boot) — re-assert the
+    // desired state on every (re)connect so an enabled warmer survives.
+    // Conditional on purpose: an app instance that never enabled the warmer
+    // must write NOTHING here, or it would stomp state set by another client
+    // sharing the machine.
+    if (_cupWarmerTarget > 0) {
+      await writeMmrScaled(BengleMmr.matSetPoint, _cupWarmerTarget);
+      await writeMmrInt(BengleMmr.cupWarmerMode, 1);
+    }
   }
 
   @override

--- a/lib/src/models/device/impl/bengle/bengle.dart
+++ b/lib/src/models/device/impl/bengle/bengle.dart
@@ -3,6 +3,8 @@ import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/wake_schedule_windows.dart'
+    show kMaxWakeWindows, kSecondsPerWeek;
 import 'package:rxdart/rxdart.dart';
 
 class Bengle extends UnifiedDe1
@@ -105,6 +107,53 @@ class Bengle extends UnifiedDe1
     }
     return value;
   }
+
+  // --- Autonomous sleep + wake schedule --------------------------------------
+  //
+  // Thin register plumbing only. WHAT to write and WHEN lives in
+  // `BengleScheduleSync`; HOW a window is packed lives in
+  // `wake_schedule_windows.dart`. See [BengleScheduleMmr] for why reads here
+  // are write-echoes rather than device state.
+
+  @override
+  Future<void> setInactivitySleepTimeout(int minutes) =>
+      // writeMmrInt clamps to the enum's declared 0..240.
+      writeMmrInt(BengleScheduleMmr.inactivitySleepTimeout, minutes);
+
+  @override
+  Future<void> setLocalTimeOfWeek(int secondsOfWeek) => writeMmrInt(
+        BengleScheduleMmr.setLocalTimeOfWeek,
+        // Never 0 (the FW's "never synced" sentinel) and never >= 604800
+        // (the FW setter rejects it outright, leaving the clock invalid).
+        secondsOfWeek.clamp(1, kSecondsPerWeek - 1),
+      );
+
+  @override
+  Future<void> pushWakeSchedule(List<int> packedWindows) async {
+    // The firmware protocol, in order: 0 clears the table AND disables the
+    // schedule; entries append; 1 enables. Sequential awaits on purpose —
+    // the entries must land between the clear and the enable.
+    await writeMmrInt(BengleScheduleMmr.scheduleControl, 0);
+    if (packedWindows.isEmpty) {
+      // No enabled schedules: cleared + disabled is the whole desired state.
+      // Writing 1 here would enable an empty table (harmless but a lie).
+      return;
+    }
+    // The FW silently drops the 33rd entry; expandWindows already caps at 32,
+    // so this take() is belt-and-braces for a caller that packs its own list.
+    for (final packed in packedWindows.take(kMaxWakeWindows)) {
+      await writeMmrInt(BengleScheduleMmr.scheduleEntry, packed);
+    }
+    await writeMmrInt(BengleScheduleMmr.scheduleControl, 1);
+  }
+
+  @override
+  Future<int> readLocalTimeOfWeekEcho() =>
+      readMmrInt(BengleScheduleMmr.setLocalTimeOfWeek);
+
+  @override
+  Future<int> readScheduleControl() =>
+      readMmrInt(BengleScheduleMmr.scheduleControl);
 
   // --- integrated scale lifecycle ---
 

--- a/lib/src/models/device/impl/bengle/bengle.dart
+++ b/lib/src/models/device/impl/bengle/bengle.dart
@@ -33,6 +33,21 @@ class Bengle extends UnifiedDe1
   Future<double> getCupWarmerTemperature() =>
       readMmrScaled(BengleMmr.matSetPoint);
 
+  @override
+  Future<double?> getCupWarmerCurrentTemperature() async {
+    // Defensive read: MatCurrentTemp exists only on newer
+    // firmware (firmware register-table row 58). A raw 0 means "no valid reading" (NTC
+    // open/short) and older FW may not answer at all — both map to null,
+    // never fake data.
+    try {
+      final celsius = await readMmrScaled(BengleMmr.matCurrentTemp);
+      return celsius > 0 ? celsius : null;
+    } on Exception catch (e) {
+      log.fine('MatCurrentTemp read failed (older firmware?): $e');
+      return null;
+    }
+  }
+
   /// Bengle FW requires entering state 0x22 (`MachineState.fwUpgrade`) between
   /// the `requestState(sleeping)` step and the start of `.dat` upload.
   /// DE1 doesn't need this — see [UnifiedDe1.beforeFirmwareUpload]

--- a/lib/src/models/device/impl/bengle/bengle_mmr.dart
+++ b/lib/src/models/device/impl/bengle/bengle_mmr.dart
@@ -41,6 +41,25 @@ enum BengleMmr implements MmrAddress {
     'CupWarmerMode',
     min: 0,
     max: 1,
+  ),
+
+  /// Live cup-warmer mat temperature. Firmware `MatCurrentTemp`
+  /// (`0x008038CC`, firmware register-table row 58), **read-only**, ×10 deci-°C on the
+  /// wire, max 1600 (= 160.0 °C). Raw `0` = no valid reading (NTC
+  /// open/short) — callers map it to `null` and NEVER fake data. Older
+  /// firmware lacks the register entirely, so reads are defensive
+  /// (failure → `null`); see [Bengle.getCupWarmerCurrentTemperature].
+  /// `writeScale` mirrors the contract `mult` for the drift checker —
+  /// the app never writes this register.
+  matCurrentTemp(
+    0x008038CC,
+    4,
+    MmrValueKind.scaledFloat,
+    'MatCurrentTemp',
+    min: 0,
+    max: 1600,
+    readScale: 0.1,
+    writeScale: 10.0,
   );
   // Integrated-scale tare (`ScaleTare`) lives with the scale capability
   // that owns it: [BengleScaleMmr.scaleTare]. Milk-probe stop

--- a/lib/src/models/device/impl/bengle/bengle_mmr.dart
+++ b/lib/src/models/device/impl/bengle/bengle_mmr.dart
@@ -83,25 +83,26 @@ enum BengleMmr implements MmrAddress {
 
 /// MMR addresses for the milk-probe steam stop. Currently the
 /// stop-at-temperature target only — probe discovery / temperature
-/// transport is unknown and may end up as a separate characteristic
-/// rather than another MMR slot.
+/// transport is separate (the live reading rides the `0xA013`
+/// shot-sample stream, not an MMR).
 ///
 /// `stopAtTemperatureTarget` is a **set/get target** endpoint, not a
-/// presence/detection mechanism. Address is stubbed `0x00000000`; the
-/// `setStopAtTemperatureTarget` implementation no-ops on the wire and
-/// caches locally until FW publishes the slot. Pin tests assert the
-/// stub address so the day FW lands, the test flips and forces review.
+/// presence/detection mechanism. Backed by firmware `TargetMilkTemp`
+/// (`0x008038A8`, firmware register-table row 49), decicelsius on the wire
+/// (`mult = 10`), `0` = disabled. NB the asymmetric milk scaling
+///: this target is ×10 while the live `0xA013` `MilkTemp`
+/// reading is ÷100 — confusing them puts the auto-stop 10× off.
 enum BengleSteamMmr implements MmrAddress {
   /// Stop-at-temperature target in °C. `0.0` disables autonomous stop.
   /// Encoded as `scaledFloat` with scale factor 10 — decicelsius on
-  /// the wire, unsigned. Range `0..80 °C`.
+  /// the wire, unsigned. Range `0..85 °C` (FW max 850).
   stopAtTemperatureTarget(
-    0x00000000, // TBD with FW
+    0x008038A8, // TargetMilkTemp
     4,
     MmrValueKind.scaledFloat,
     'StopAtTemperatureTarget',
     min: 0,
-    max: 800, // 80.0 °C
+    max: 850, // 85.0 °C
     readScale: 0.1,
     writeScale: 10.0,
   );

--- a/lib/src/models/device/impl/bengle/bengle_mmr.dart
+++ b/lib/src/models/device/impl/bengle/bengle_mmr.dart
@@ -9,7 +9,8 @@ enum BengleMmr implements MmrAddress {
   /// Cup-warmer mat target temperature in whole °C. Firmware `MatSetPoint`
   /// uses `mult = 1`, packed as a little-endian int32 (NOT an IEEE-754
   /// float, NOT deci-°C). Matches de1plus `set_cupwarmer_temperature`
-  /// (unscaled). Range `0..80 °C`; `0` = off. Permission RWD.
+  /// (unscaled). Range `0..80 °C`; `0` = off. Permission RWD. Enabling the
+  /// warmer is a separate register — [cupWarmerMode] (0x008038AC, 0/1);
   ///
   /// history: the register has been mis-encoded twice — first as
   /// float32 (early FW notes), then as ×10 deci-°C (every set landed 10×
@@ -26,18 +27,24 @@ enum BengleMmr implements MmrAddress {
     writeScale: 1.0,
   ),
 
-  /// Integrated-scale tare trigger. Address and value semantics are
-  /// stubbed — FW slot TBD. Once published, fill in the real address
-  /// and tighten [kind] / bounds. Capability code (`IntegratedScale-
-  /// Capability.tareIntegratedScale`) currently routes through the
-  /// control endpoint, not MMR — this entry exists so the FW slot has
-  /// a home when the wire spec arrives.
-  scaleTare(
-    0x00000000, // TBD with FW
+  /// Cup-warmer enable: `0` = Off, `1` = On. Firmware `CupWarmerMode`
+  /// (`0x008038AC`, firmware register-table row 50), plain int32 0/1, **not persisted** —
+  /// deliberately `PERM_RW` (not RWD) so the machine can never boot with
+  /// the mat silently heating; the firmware resets it to 0 every boot and
+  /// the app must re-send it on every connect. Enabling the warmer needs
+  /// this in addition to [matSetPoint] (setting the temperature alone does
+  /// nothing)
+  cupWarmerMode(
+    0x008038AC,
     4,
-    MmrValueKind.int32, // TBD with FW
-    'ScaleTare',
+    MmrValueKind.boolean,
+    'CupWarmerMode',
+    min: 0,
+    max: 1,
   );
+  // Integrated-scale tare (`ScaleTare`) lives with the scale capability
+  // that owns it: [BengleScaleMmr.scaleTare]. Milk-probe stop
+  // lives in [BengleSteamMmr].
 
   const BengleMmr(
     this.address,

--- a/lib/src/models/device/impl/bengle/bengle_mmr.dart
+++ b/lib/src/models/device/impl/bengle/bengle_mmr.dart
@@ -100,6 +100,138 @@ enum BengleMmr implements MmrAddress {
   String get name => (this as Enum).name;
 }
 
+/// Tablet-synced clock + weekly wake schedule (firmware firmware register-table rows
+/// 54–57, logic in the firmware, consumers in
+/// the firmware). Kept out of [BengleMmr] (the cup-warmer /
+/// thermal group) for the same reason as [BengleSteamMmr]: addresses live
+/// with the capability that owns them.
+///
+/// **All four are WRITE-DRIVEN. A read echoes the last value WRITTEN, not
+/// live device state** (the firmware — the `F_` hooks only act on
+/// `Write` and pass the value through on `Read`). There is no way to read
+/// the schedule table back, and no register exposes the running firmware
+/// clock, so drift cannot be measured. The only meaningful read is `== 0`
+/// on [setLocalTimeOfWeek] / [scheduleControl]: the machine rebooted (both
+/// slots are RAM-only with initval 0). [inactivitySleepTimeout] is the one
+/// exception — it is `PERM_RWD`, persisted, and genuinely readable.
+///
+/// Write protocol for the table: [scheduleControl] `0` (clear + disable) →
+/// one [scheduleEntry] per window → [scheduleControl] `1` (enable). The
+/// clock must be valid first: a table enabled with an invalid clock does
+/// nothing (the firmware schedule check returns false).
+enum BengleScheduleMmr implements MmrAddress {
+  /// `InactivitySleepTimeout` (0x008038BC, firmware register-table row 54, PERM_RWD —
+  /// **persisted**). Minutes of inactivity before the firmware sleeps
+  /// ITSELF; `0` = disabled, firmware default 60, max 240.
+  ///
+  /// NB the firmware skips this timer only while `TabletConnected`, which
+  /// is latched exclusively from the BLE GAP connect event
+  ///. **Over USB serial the firmware
+  /// believes no tablet is present and the timer ACTS** — so this value
+  /// governs a serial-connected tablet too. Inside an active schedule
+  /// window the firmware calls its user-present hook every tick, which
+  /// defers (never forces) this sleep.
+  inactivitySleepTimeout(
+    0x008038BC,
+    4,
+    MmrValueKind.int32,
+    'InactivitySleepTimeout',
+    min: 0,
+    max: 240,
+  ),
+
+  /// `SetLocalTimeOfWeek` (0x008038C0, firmware register-table row 55, PERM_RW — RAM-only,
+  /// **lost on every reboot**; there is no battery-backed RTC). LOCAL
+  /// seconds since Sunday 00:00:00. Once set, the firmware ticks it from
+  /// its own 1 Hz counter and wraps the week itself — no tablet needed.
+  ///
+  /// `max` is 604799, deliberately NARROWER than the contract's 604800:
+  /// the setter rejects `secOfWeek >= SECONDS_PER_WEEK`,
+  /// so writing exactly 604800 would silently leave the clock invalid. The
+  /// app also never writes `0` — a read-back of `0` is the "rebooted, never
+  /// synced" sentinel (see `localSecondsOfWeek`, which clamps to `>= 1`).
+  setLocalTimeOfWeek(
+    0x008038C0,
+    4,
+    MmrValueKind.int32,
+    'SetLocalTimeOfWeek',
+    min: 0,
+    max: 604799,
+  ),
+
+  /// `ScheduleEntry` (0x008038C4, firmware register-table row 56). ONE wake window,
+  /// APPENDED to the firmware table: `(dow << 22) | (startMin << 11) |
+  /// endMin`.
+  ///
+  /// **`dow` is a day INDEX, 0 = Sunday … 6 = Saturday — NOT a bitmask.**
+  /// The firmware masks it to 3 bits and compares it for EQUALITY
+  ///, so a Mon–Fri schedule is FIVE entries.
+  /// `startMin` is inclusive, `endMin` exclusive and `<= 1440`;
+  /// `startMin >= endMin` is silently dropped, so midnight-crossing windows
+  /// must be split by the app. The table holds 32 entries and the 33rd is
+  /// silently dropped — the packing/merging/cap lives in
+  /// `wake_schedule_windows.dart`.
+  scheduleEntry(
+    0x008038C4,
+    4,
+    MmrValueKind.int32,
+    'ScheduleEntry',
+    min: 0,
+    max: 0x7FFFFFFF,
+  ),
+
+  /// `ScheduleControl` (0x008038C8, firmware register-table row 57). `0` = clear the table
+  /// **and** disable; `1` = enable. Protocol: write `0`, then the entries,
+  /// then `1`.
+  ///
+  /// `max` is 1, narrower than the contract's 255, on purpose: the firmware
+  /// reads only bit 0 on a non-zero write, so a stray `2` would disable the
+  /// schedule WITHOUT clearing it. Declaring max 1 makes that structurally
+  /// impossible — `writeMmrInt` clamps to the declared range.
+  scheduleControl(
+    0x008038C8,
+    4,
+    MmrValueKind.int32,
+    'ScheduleControl',
+    min: 0,
+    max: 1,
+  );
+
+  const BengleScheduleMmr(
+    this.address,
+    this.length,
+    this.kind,
+    this.description, {
+    this.min,
+    this.max,
+  });
+
+  @override
+  final int address;
+  @override
+  final int length;
+  @override
+  final MmrValueKind kind;
+  final String description;
+  @override
+  final int? min;
+  @override
+  final int? max;
+
+  /// All four rows are `mult 1` in the contract — raw ints, no scaling. Fixed
+  /// getters rather than constructor params so no caller can introduce a scale
+  /// the firmware does not apply (the contract checker asserts
+  /// `writeScale == mult` and `readScale == 1/mult`).
+  @override
+  double get readScale => 1.0;
+
+  @override
+  double get writeScale => 1.0;
+
+  @override
+  String get name => (this as Enum).name;
+}
+
 /// MMR addresses for the milk-probe steam stop. Currently the
 /// stop-at-temperature target only — probe discovery / temperature
 /// transport is separate (the live reading rides the `0xA013`

--- a/lib/src/models/device/impl/bengle/bengle_mmr.dart
+++ b/lib/src/models/device/impl/bengle/bengle_mmr.dart
@@ -6,18 +6,24 @@ import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
 /// shared DE1 MMRs stay in `de1.models.dart#MMRItem`. The milk-probe
 /// stop-at-temperature target lives in [BengleSteamMmr].
 enum BengleMmr implements MmrAddress {
-  /// Cup-warmer mat target temperature in °C, stored as raw IEEE-754
-  /// float32 (little-endian). Range `0.0..80.0`; `0.0` = off.
-  /// FW name: `MatSetPoint`. Permission RWD.
+  /// Cup-warmer mat target temperature in whole °C. Firmware `MatSetPoint`
+  /// uses `mult = 1`, packed as a little-endian int32 (NOT an IEEE-754
+  /// float, NOT deci-°C). Matches de1plus `set_cupwarmer_temperature`
+  /// (unscaled). Range `0..80 °C`; `0` = off. Permission RWD.
+  ///
+  /// history: the register has been mis-encoded twice — first as
+  /// float32 (early FW notes), then as ×10 deci-°C (every set landed 10×
+  /// too hot, every read 10× too cold). FW firmware register-table row 36 is `mult 1`
+  /// and the FW write path consumes the raw value as °C; hardware won.
   matSetPoint(
     0x00803874,
     4,
     MmrValueKind.scaledFloat,
     'MatSetPoint',
     min: 0,
-    max: 800,
-    readScale: 0.1,
-    writeScale: 10.0,
+    max: 80,
+    readScale: 1.0,
+    writeScale: 1.0,
   ),
 
   /// Integrated-scale tare trigger. Address and value semantics are

--- a/lib/src/models/device/impl/bengle/mock_bengle.dart
+++ b/lib/src/models/device/impl/bengle/mock_bengle.dart
@@ -192,6 +192,65 @@ class MockBengle extends MockDe1 implements BengleInterface, SimulatedDevice {
     }
   }
 
+  // --- autonomous sleep + wake schedule ---
+  //
+  // Models the firmware's registers closely enough to be honest: the clock and
+  // the table are RAM-only (a [simulateReboot] wipes them, exactly as a real
+  // power-cycle does), the sleep timeout persists, and the reads are WRITE
+  // ECHOES, not live state.
+
+  int _inactivitySleepTimeout = 60; // FW default
+  int _localTimeOfWeekEcho = 0; // 0 = never synced since boot
+  int _scheduleControl = 0;
+  List<int> _wakeScheduleTable = const [];
+
+  /// Last `InactivitySleepTimeout` written (minutes; persisted in FW).
+  int get inactivitySleepTimeout => _inactivitySleepTimeout;
+
+  /// Last `SetLocalTimeOfWeek` written. `0` = never synced since boot.
+  int get localTimeOfWeekEcho => _localTimeOfWeekEcho;
+
+  /// The simulated firmware wake table (packed windows).
+  List<int> get wakeScheduleTable => List.unmodifiable(_wakeScheduleTable);
+
+  /// Whether the simulated firmware schedule is enabled.
+  bool get scheduleEnabled => _scheduleControl == 1;
+
+  @override
+  Future<void> setInactivitySleepTimeout(int minutes) async {
+    _inactivitySleepTimeout = minutes.clamp(0, 240);
+  }
+
+  @override
+  Future<void> setLocalTimeOfWeek(int secondsOfWeek) async {
+    _localTimeOfWeekEcho = secondsOfWeek.clamp(1, 604799);
+  }
+
+  @override
+  Future<void> pushWakeSchedule(List<int> packedWindows) async {
+    // ScheduleControl = 0 clears the table AND disables.
+    _wakeScheduleTable = const [];
+    _scheduleControl = 0;
+    if (packedWindows.isEmpty) return;
+    _wakeScheduleTable = List.of(packedWindows.take(32));
+    _scheduleControl = 1;
+  }
+
+  @override
+  Future<int> readLocalTimeOfWeekEcho() async => _localTimeOfWeekEcho;
+
+  @override
+  Future<int> readScheduleControl() async => _scheduleControl;
+
+  /// Test hook: simulate a machine power-cycle. The clock and the schedule
+  /// table are RAM-only in firmware and do not survive; the sleep timeout is
+  /// persisted and does.
+  void simulateReboot() {
+    _localTimeOfWeekEcho = 0;
+    _scheduleControl = 0;
+    _wakeScheduleTable = const [];
+  }
+
   @override
   Future<void> tareIntegratedScale() async {
     _weightModel.tare();

--- a/lib/src/models/device/impl/bengle/mock_bengle.dart
+++ b/lib/src/models/device/impl/bengle/mock_bengle.dart
@@ -160,7 +160,9 @@ class MockBengle extends MockDe1 implements BengleInterface, SimulatedDevice {
 
   @override
   Future<void> setStopAtTemperatureTarget(double celsius) async {
-    _stopAtTempTarget = celsius.clamp(0.0, 80.0).toDouble();
+    // 0..85 matches the real Bengle (TargetMilkTemp FW max 850 deci-°C) —
+    // NB wider than the cup-warmer's 0..80.
+    _stopAtTempTarget = celsius.clamp(0.0, 85.0).toDouble();
     if (!_stopAtTempTargetSubject.isClosed) {
       _stopAtTempTargetSubject.add(_stopAtTempTarget);
     }
@@ -273,8 +275,8 @@ class MockBengle extends MockDe1 implements BengleInterface, SimulatedDevice {
   /// Synthesises milk-probe temperature during `MachineState.steam`.
   /// Rises linearly from [_probeStartTemp]; resets when steam exits.
   /// If [_stopAtTempTarget] is set and reached, requests `idle` — the
-  /// FW-autonomous stop behaviour the real Bengle will perform once
-  /// the MMR slot is published.
+  /// FW-autonomous stop behaviour the real Bengle performs when a probe
+  /// is attached (`TargetMilkTemp`).
   void _tickProbeTemperature(MachineSnapshot s, DateTime now) {
     if (!(_probeAttachedSubject.hasValue && _probeAttachedSubject.value)) {
       _lastProbeTickAt = null;

--- a/lib/src/models/device/impl/bengle/mock_bengle.dart
+++ b/lib/src/models/device/impl/bengle/mock_bengle.dart
@@ -106,6 +106,21 @@ class MockBengle extends MockDe1 implements BengleInterface, SimulatedDevice {
   @override
   Stream<ScaleSnapshot> get weightSnapshot => _weight.stream;
 
+  /// The simulated machine snapshot, enriched with the integrated scale's
+  /// synthesised weight and gravimetric flow. A real Bengle's firmware puts
+  /// its own gFlow into the shot sample, so `ws/v1/machine/snapshot` carries
+  /// `weightFlow`; the plain [MockDe1] leaves both at 0. Overlaying the weight
+  /// model here makes the mock behave like the device it mocks, so the machine
+  /// surface and the scale surface report the SAME single-source flow instead
+  /// of disagreeing by the whole estimator.
+  @override
+  Stream<MachineSnapshot> get currentSnapshot => super.currentSnapshot.map(
+        (s) => s.copyWith(
+          weight: _weightModel.weight,
+          weightFlow: _weightModel.flow,
+        ),
+      );
+
   @override
   Stream<double> get stopAtWeightTarget => _sawTargetSubject.stream;
 
@@ -161,6 +176,10 @@ class MockBengle extends MockDe1 implements BengleInterface, SimulatedDevice {
     _weight.add(ScaleSnapshot(
       timestamp: DateTime.now(),
       weight: _weightModel.weight,
+      // Report the synthesised gravimetric flow so ScaleController takes the
+      // device-flow path (no estimator), exactly as a real Bengle's firmware
+      // gFlow does — the opt-out this branch introduces.
+      flow: _weightModel.flow,
       batteryLevel: 100,
     ));
   }

--- a/lib/src/models/device/impl/bengle/mock_bengle.dart
+++ b/lib/src/models/device/impl/bengle/mock_bengle.dart
@@ -6,6 +6,7 @@ import 'package:reaprime/src/models/device/impl/simulated_shot_weight_model.dart
 import 'package:reaprime/src/models/device/led_strip.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/device/scale_calibration.dart';
 import 'package:reaprime/src/models/device/simulated_device.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -171,6 +172,61 @@ class MockBengle extends MockDe1 implements BengleInterface, SimulatedDevice {
     _emit();
   }
 
+  // --- load-cell calibration (two-point) ---
+  // Behavioural mock: each step "succeeds" immediately (no real load cells to
+  // settle). Emits a terminal status so progress subscribers see a completion,
+  // then returns a successful result. Left latch => Incomplete (awaiting
+  // right); right latch / zero => Ok / none. NB: the seeded idle/done status
+  // is mock-only convenience — the real mixin starts an EMPTY BehaviorSubject
+  // (no synthetic initial status); do not copy the seed there.
+  final BehaviorSubject<ScaleCalStatus> _calProgress =
+      BehaviorSubject<ScaleCalStatus>.seeded(
+        const ScaleCalStatus(
+          step: ScaleCalStep.idle,
+          subState: ScaleCalSubState.done,
+          remainingSeconds: 0,
+          pointStatus: ScaleCalPointStatus.none,
+          raw: 0,
+        ),
+      );
+
+  @override
+  Stream<ScaleCalStatus> get scaleCalibrationProgress => _calProgress.stream;
+
+  @override
+  Future<ScaleCalResult> calibrateScaleZero() async =>
+      _mockCalComplete(ScaleCalPointStatus.none);
+
+  @override
+  Future<ScaleCalResult> calibrateScaleWeightLeft(double grams) async =>
+      _mockCalComplete(ScaleCalPointStatus.incomplete);
+
+  @override
+  Future<ScaleCalResult> calibrateScaleWeightRight(double grams) async =>
+      _mockCalComplete(ScaleCalPointStatus.ok);
+
+  @override
+  Future<void> abortScaleCalibration() async {}
+
+  ScaleCalResult _mockCalComplete(ScaleCalPointStatus pointStatus) {
+    if (!_calProgress.isClosed) {
+      _calProgress.add(
+        ScaleCalStatus(
+          step: ScaleCalStep.complete,
+          subState: ScaleCalSubState.done,
+          remainingSeconds: 0,
+          pointStatus: pointStatus,
+          raw: 0,
+        ),
+      );
+    }
+    return ScaleCalResult(
+      success: true,
+      finalStep: ScaleCalStep.complete,
+      pointStatus: pointStatus,
+    );
+  }
+
   void _emit() {
     if (_weight.isClosed) return;
     _weight.add(ScaleSnapshot(
@@ -273,6 +329,9 @@ class MockBengle extends MockDe1 implements BengleInterface, SimulatedDevice {
     }
     if (!_probeTemperatureSubject.isClosed) {
       await _probeTemperatureSubject.close();
+    }
+    if (!_calProgress.isClosed) {
+      await _calProgress.close();
     }
     await super.onDisconnect();
   }

--- a/lib/src/models/device/impl/bengle/mock_bengle.dart
+++ b/lib/src/models/device/impl/bengle/mock_bengle.dart
@@ -33,6 +33,11 @@ class MockBengle extends MockDe1 implements BengleInterface, SimulatedDevice {
   // --- cup warmer ---
   double _cupWarmerTemp = 0.0;
 
+  /// Simulated live mat temperature. Defaults to `null` ("no valid
+  /// reading") — matching field firmware without the MatCurrentTemp
+  /// register — so consumers exercise the placeholder path by default.
+  double? _matCurrentTemp;
+
   @override
   Future<void> setCupWarmerTemperature(double celsius) async {
     _cupWarmerTemp = celsius.clamp(0.0, 80.0).toDouble();
@@ -40,6 +45,15 @@ class MockBengle extends MockDe1 implements BengleInterface, SimulatedDevice {
 
   @override
   Future<double> getCupWarmerTemperature() async => _cupWarmerTemp;
+
+  @override
+  Future<double?> getCupWarmerCurrentTemperature() async => _matCurrentTemp;
+
+  /// Test hook: set the simulated live mat temperature reading.
+  /// `null` = no valid reading (the default).
+  void setMatCurrentTemperature(double? celsius) {
+    _matCurrentTemp = celsius;
+  }
 
   // --- LED strip ---
   /// Cache of the last-set config (not necessarily committed to NVM).

--- a/lib/src/models/device/impl/bengle/mock_bengle.dart
+++ b/lib/src/models/device/impl/bengle/mock_bengle.dart
@@ -71,6 +71,16 @@ class MockBengle extends MockDe1 implements BengleInterface, SimulatedDevice {
     _ledState.add(_committedLedState);
   }
 
+  @override
+  Future<void> previewLedColor(Color16 front, Color16 back) async {
+    // Mock: no live strip to preview.
+  }
+
+  @override
+  Future<void> clearLedPreview() async {
+    // Mock: nothing to restore.
+  }
+
   // --- integrated scale ---
   // Weight synthesis lives in the shared SimulatedShotWeightModel (also used
   // by the standalone MockScale): preinfusion absorbed, first-drops holdback,

--- a/lib/src/models/device/impl/bengle/mock_bengle.dart
+++ b/lib/src/models/device/impl/bengle/mock_bengle.dart
@@ -126,7 +126,7 @@ class MockBengle extends MockDe1 implements BengleInterface, SimulatedDevice {
 
   @override
   Future<void> setStopAtWeightTarget(double grams) async {
-    _sawTarget = grams.clamp(0.0, 500.0).toDouble();
+    _sawTarget = grams.clamp(0.0, 10000.0).toDouble();
     if (!_sawTargetSubject.isClosed) {
       _sawTargetSubject.add(_sawTarget);
     }

--- a/lib/src/models/device/impl/de1/de1.models.dart
+++ b/lib/src/models/device/impl/de1/de1.models.dart
@@ -24,7 +24,11 @@ enum Endpoint implements LogicalEndpoint {
   headerWrite('A00F', 'O'),
   frameWrite('A010', 'P'),
   waterLevels('A011', 'Q'),
-  calibration('A012', 'R');
+  calibration('A012', 'R'),
+  // Bengle-only high-res shot sample (integrated-scale weight + gravimetric
+  // flow + milk). Additive characteristic on service 0xA000; serial char 'S'.
+  // Wire layout: assets/api/bengle_hw_v1.yml `packet_0xA013`.
+  bengleShotSample('A013', 'S');
 
   @override
   final String uuid;

--- a/lib/src/models/device/impl/de1/de1.models.dart
+++ b/lib/src/models/device/impl/de1/de1.models.dart
@@ -291,11 +291,17 @@ enum MMRItem implements MmrAddress {
     readScale: 0.01,
     writeScale: 100.0,
   ),
+  // Scales fixed against firmware the firmware register table (mult = 100, seconds ×100 on the
+  // wire): this entry used to carry the default 1.0 scales, which was latent
+  // (nothing reads/writes it yet) but the first wired setter would have
+  // written 100× low. Pinned by the bengle_hw_v1.yml contract checker.
   steamStartSecs(
     0x0080382C,
     4,
     MmrValueKind.scaledFloat,
     "Seconds of high steam flow * 100. Valid range 0.0 - 4.0. 0 may result in an overheated heater. Be careful.",
+    readScale: 0.01,
+    writeScale: 100.0,
   ),
   serialN(0x00803830, 4, MmrValueKind.int32, "Current serial number"),
   heaterV(

--- a/lib/src/models/device/impl/de1/de1.models.dart
+++ b/lib/src/models/device/impl/de1/de1.models.dart
@@ -415,10 +415,13 @@ enum DecentMachineModel {
         return DecentMachineModel.DE1XXL;
       case 6:
         return DecentMachineModel.DE1XXXL;
-      case 128:
-        return DecentMachineModel.Bengle;
       default:
-        return DecentMachineModel.Unknown;
+        // v13Model >= 128 => Bengle; the DE1 family is 1..7. Matches the
+        // detection gate (unified_de1 / serial_service both use `>= 128`),
+        // so a future Bengle model number resolves to Bengle, not Unknown.
+        return model >= 128
+            ? DecentMachineModel.Bengle
+            : DecentMachineModel.Unknown;
     }
   }
 }

--- a/lib/src/models/device/impl/de1/de1_resolver.dart
+++ b/lib/src/models/device/impl/de1/de1_resolver.dart
@@ -1,0 +1,42 @@
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+
+/// Model-authoritative machine class selection.
+///
+/// BLE discovery instantiates the machine class from the advertised name
+/// (`DeviceMatcher`), before a connection exists. But the authoritative
+/// identity is `v13Model` (`>= 128` ⇒ Bengle), which is only readable after
+/// connecting. So the name-picked class can be wrong: a Bengle advertising a
+/// DE1-style name lands as a plain [UnifiedDe1] (Bengle features dark), and a
+/// DE1 mis-advertising "Bengle" lands as a [Bengle].
+///
+/// Call this **after** [UnifiedDe1.onConnect] (which sets [UnifiedDe1.isBengle]
+/// from the read model). It returns:
+///  - the same instance when the name-picked class already matches the model
+///    (the common case — real Bengle hardware advertises "Bengle"), or
+///  - a fresh instance of the correct class built over the **same live
+///    transport**, with the connect-time identity carried over
+///    ([UnifiedDe1.adoptIdentityFrom]). The caller runs `onConnect` on the
+///    returned instance; because its identity is pre-populated, that call
+///    skips the MMR re-reads and only (re)subscribes + runs capability init.
+///
+/// This mirrors the serial path, which already picks `Bengle` vs `UnifiedDe1`
+/// from `v13Model >= 128` at detection time (`serial_service_*`). The BLE
+/// transport's per-characteristic subscriptions are replaced (not stacked) on
+/// the re-`connect`, so rebuilding over the shared transport is safe.
+De1Interface resolveMachineForModel(De1Interface machine) {
+  // Only DE1-family machines carry the v13Model gate; anything else is
+  // returned untouched.
+  if (machine is! UnifiedDe1) return machine;
+
+  final wantsBengle = machine.isBengle;
+  if (wantsBengle && machine is! Bengle) {
+    return Bengle(transport: machine.dataTransport)..adoptIdentityFrom(machine);
+  }
+  if (!wantsBengle && machine is Bengle) {
+    return UnifiedDe1(transport: machine.dataTransport)
+      ..adoptIdentityFrom(machine);
+  }
+  return machine;
+}

--- a/lib/src/models/device/impl/de1/unified_de1/bengle_shot_sample.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/bengle_shot_sample.dart
@@ -1,0 +1,118 @@
+import 'dart:typed_data';
+
+/// Wire length of the Bengle `0xA013` BengleShotSample characteristic, in
+/// bytes. Firmware struct `T_BengleShotSample` is size-locked with
+/// `static_assert(sizeof(T_BengleShotSample) == 28)`; the authoritative field
+/// table lives in `assets/api/bengle_hw_v1.yml` (`packet_0xA013`).
+const int bengleShotSampleBytes = 28;
+
+/// Decoded Bengle `0xA013` BengleShotSample frame.
+///
+/// This is a *reorganised superset* of the DE1 `0xA00D` ShotSample — the field
+/// order, widths and scaling differ, so it needs its own decoder (do NOT reuse
+/// the `0xA00D` fixed-point parser). Unlike the little-endian MMR registers,
+/// the shot-sample payload is **big-endian**.
+///
+/// Two firmware caveats (see the contract file's `packet_0xA013` rows):
+///  * [milkTemp] — `0` means no probe / no fresh reading; older firmware
+/// hardcoded the field to `0` outright. Parse it, expose it,
+///    never fake a reading.
+///  * [flags] — on newer firmware bit0 is `LastTARE != 0` (a value proxy, not
+///    a tare event); older firmware wrote `0` unconditionally. Never gate any
+///    behaviour on it — the real tare signal is that [weight] already arrives
+///    net of `LastTARE` (firmware subtracts it before serialising).
+class BengleShotSample {
+  /// Half-cycles since shot start (offset 0, `u16`).
+  final int sampleTime;
+
+  /// Group pressure, bar (offset 2, `u16 / 100`).
+  final double groupPressure;
+
+  /// Target group pressure, bar (offset 4, `u16 / 100`).
+  final double setGroupPressure;
+
+  /// Group flow, ml/s (offset 6, `u16 / 100`).
+  final double groupFlow;
+
+  /// Target group flow, ml/s (offset 8, `u16 / 100`).
+  final double setGroupFlow;
+
+  /// Gravimetric flow from the integrated scale, g/s (offset 10, `u16 / 100`).
+  final double gFlow;
+
+  /// Mix temperature, °C (offset 12, `u16 / 100`).
+  final double mixTemp;
+
+  /// Head (group) temperature, °C (offset 14, `u16 / 100`).
+  final double headTemp;
+
+  /// Target mix temperature, °C (offset 16, `u16 / 100`).
+  final double setMixTemp;
+
+  /// Target head temperature, °C (offset 18, `u16 / 100`).
+  final double setHeadTemp;
+
+  /// Integrated-scale weight, g (offset 20, `u16 / 32`, U16P5 — max 2048 g,
+  /// step 0.03125 g). **Already net of tare** — firmware subtracts `LastTARE`
+  /// before serialising, so trust it directly. A negative net weight clamps
+  /// to 0 on the wire (U16P5 has no sign bit).
+  final double weight;
+
+  /// Profile frame number (offset 22, `u8`).
+  final int frameNumber;
+
+  /// Steam temperature, °C (offset 23, `u16 / 100` — unaligned offset, the
+  /// firmware struct is packed).
+  final double steamTemp;
+
+  /// Milk-probe temperature, °C (offset 25, `u16 / 100`). `0` = no probe /
+  /// no fresh reading (older firmware hardcodes `0`).
+  final double milkTemp;
+
+  /// Status flags (offset 27, `u8`). Never gate on this — see the class doc.
+  final int flags;
+
+  const BengleShotSample({
+    required this.sampleTime,
+    required this.groupPressure,
+    required this.setGroupPressure,
+    required this.groupFlow,
+    required this.setGroupFlow,
+    required this.gFlow,
+    required this.mixTemp,
+    required this.headTemp,
+    required this.setMixTemp,
+    required this.setHeadTemp,
+    required this.weight,
+    required this.frameNumber,
+    required this.steamTemp,
+    required this.milkTemp,
+    required this.flags,
+  });
+}
+
+/// Decode a big-endian `0xA013` BengleShotSample frame.
+///
+/// Returns `null` when the frame is shorter than [bengleShotSampleBytes] — a
+/// truncated notification (e.g. a stale/undersized ATT MTU) is dropped rather
+/// than throwing a `RangeError`. Extra trailing bytes are ignored.
+BengleShotSample? parseBengleShotSample(ByteData d) {
+  if (d.lengthInBytes < bengleShotSampleBytes) return null;
+  return BengleShotSample(
+    sampleTime: d.getUint16(0, Endian.big),
+    groupPressure: d.getUint16(2, Endian.big) / 100.0,
+    setGroupPressure: d.getUint16(4, Endian.big) / 100.0,
+    groupFlow: d.getUint16(6, Endian.big) / 100.0,
+    setGroupFlow: d.getUint16(8, Endian.big) / 100.0,
+    gFlow: d.getUint16(10, Endian.big) / 100.0,
+    mixTemp: d.getUint16(12, Endian.big) / 100.0,
+    headTemp: d.getUint16(14, Endian.big) / 100.0,
+    setMixTemp: d.getUint16(16, Endian.big) / 100.0,
+    setHeadTemp: d.getUint16(18, Endian.big) / 100.0,
+    weight: d.getUint16(20, Endian.big) / 32.0,
+    frameNumber: d.getUint8(22),
+    steamTemp: d.getUint16(23, Endian.big) / 100.0,
+    milkTemp: d.getUint16(25, Endian.big) / 100.0,
+    flags: d.getUint8(27),
+  );
+}

--- a/lib/src/models/device/impl/de1/unified_de1/integrated_scale_capability.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/integrated_scale_capability.dart
@@ -30,6 +30,19 @@ enum BengleScaleMmr implements MmrAddress {
     max: 1000000, // 10000.0 g × 100
     readScale: 0.01,
     writeScale: 100.0,
+  ),
+
+  /// Instant tare trigger. Firmware `ScaleTare` (`0x0080388C`, RWT):
+  /// writing any value performs an immediate tare (de1plus writes
+  /// `1`). Not a stored value — `int32` write-trigger; reading it
+  /// returns 0. Confirm the tare by watching `Weight` drop toward 0,
+  /// never the `0xA013` Flags bit (a `LastTARE` value proxy at best;
+  /// older firmware hardcodes it to 0).
+  scaleTare(
+    0x0080388C,
+    4,
+    MmrValueKind.int32,
+    'ScaleTare',
   );
 
   const BengleScaleMmr(
@@ -123,15 +136,12 @@ mixin IntegratedScaleCapability on UnifiedDe1 {
     }
   }
 
-  /// Tare the integrated scale. Logged no-op until the `ScaleTare` MMR
-  /// write-trigger lands (stop-at-weight/tare branch). Note the
-  /// `0xA013` Weight already arrives net of the firmware's own tare state,
-  /// so bridged weights stay correct meanwhile.
+  /// Tare the integrated scale. Write-trigger to the firmware
+  /// `ScaleTare` register — the value is ignored, so we send `1` (matching
+  /// de1plus). The firmware performs an immediate tare; subsequent `0xA013`
+  /// Weight arrives already net of the new zero.
   Future<void> tareIntegratedScale() async {
-    this.log.info(
-      'IntegratedScaleCapability: tare is not yet wired — the ScaleTare '
-      'MMR trigger lands.',
-    );
+    await writeMmrInt(BengleScaleMmr.scaleTare, 1);
   }
 
   /// Write the autonomous SAW target (grams) to the firmware

--- a/lib/src/models/device/impl/de1/unified_de1/integrated_scale_capability.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/integrated_scale_capability.dart
@@ -1,28 +1,9 @@
 part of 'unified_de1.dart';
 
-/// Wire endpoints for Bengle's integrated scale.
-///
-/// Both [uuid] and [representation] return `null` for now — the firmware
-/// slots have not yet been published. The [IntegratedScaleCapability]
-/// mixin treats null wires as "capability not yet wired" and silently
-/// no-ops. Once FW publishes the wire spec, fill these in and the rest
-/// of the capability light up unchanged.
-enum BengleScaleEndpoint implements LogicalEndpoint {
-  /// Notify characteristic carrying weight frames.
-  weight,
-
-  /// Write characteristic for tare and other scale commands.
-  control;
-
-  @override
-  String? get uuid => null; // TBD with FW
-
-  @override
-  String? get representation => null; // TBD with FW
-
-  @override
-  String get name => (this as Enum).name;
-}
+// NOTE: the integrated scale is NOT a separate BLE characteristic —
+// weight rides on the 0xA013 BengleShotSample stream, already net of tare in
+// firmware. The early `BengleScaleEndpoint` null-UUID scaffolding that assumed
+// dedicated weight/control endpoints was the wrong model and has been dropped.
 
 /// MMR addresses for the integrated scale.
 ///
@@ -79,17 +60,15 @@ enum BengleScaleMmr implements MmrAddress {
 
 /// Stateful capability for Bengle's integrated scale.
 ///
-/// Owns the weight stream and tare endpoint. Lifecycle is managed by the
+/// Bridges the `0xA013` BengleShotSample frame's integrated-scale Weight
+/// into the standard scale pipeline. Lifecycle is managed by the
 /// concrete `Bengle` device — call [initIntegratedScale] from
 /// `onConnect`, [disposeIntegratedScale] from `onDisconnect`.
 /// `UnifiedDe1.disconnect()` invokes `onDisconnect()` for the device, so
 /// `disposeIntegratedScale()` runs on every real disconnect. The
 /// capability is also re-init-safe: `initIntegratedScale()` recreates
 /// `_bengleWeight` if a previous dispose closed it, so a reconnect on
-/// the same instance restores a live stream. The capability is
-/// intentionally a no-op until firmware publishes the wire identifiers
-/// (see [BengleScaleEndpoint]); when that happens, fill in the enum and
-/// replace the placeholder parser/encoder bodies.
+/// the same instance restores a live stream.
 mixin IntegratedScaleCapability on UnifiedDe1 {
   BehaviorSubject<ScaleSnapshot> _bengleWeight =
       BehaviorSubject<ScaleSnapshot>();
@@ -103,20 +82,21 @@ mixin IntegratedScaleCapability on UnifiedDe1 {
   /// spam — same pattern as `LedStripCapability._stubWarningsEmitted`).
   int _sawStubWarningsEmitted = 0;
 
-  /// Live weight stream from the integrated scale. Emits nothing while
-  /// the wire identifiers in [BengleScaleEndpoint] are null (FW TBD).
+  /// Live weight stream from the integrated scale (one [ScaleSnapshot] per
+  /// valid `0xA013` frame).
   Stream<ScaleSnapshot> get weightSnapshot => _bengleWeight.stream;
 
   /// Current stop-at-weight target in grams (`0.0` = SAW off).
   Stream<double> get stopAtWeightTarget => _sawTarget.stream;
 
-  /// Subscribe to the integrated-scale weight notify endpoint. No-op
-  /// (with a single info log) while the endpoint wires are null.
+  /// Start bridging `0xA013` Weight into the scale pipeline.
   ///
-  /// Re-init-safe: if a previous [disposeIntegratedScale] closed the
-  /// subject, a fresh one is created here so that listeners attaching
-  /// after a reconnect see a live stream rather than an immediately-
-  /// done one.
+  /// The 0xA013 subscription itself is enabled by `UnifiedDe1.onConnect`
+  ///; here we just listen to the transport's already-guarded frame
+  /// stream. Re-init-safe: cancels any prior subscription first (a reconnect
+  /// calls this again), and if a previous [disposeIntegratedScale] closed the
+  /// subjects, fresh ones are created so that listeners attaching after a
+  /// reconnect see a live stream rather than an immediately-done one.
   Future<void> initIntegratedScale() async {
     if (_bengleWeight.isClosed) {
       _bengleWeight = BehaviorSubject<ScaleSnapshot>();
@@ -124,15 +104,10 @@ mixin IntegratedScaleCapability on UnifiedDe1 {
     if (_sawTarget.isClosed) {
       _sawTarget = BehaviorSubject<double>.seeded(0.0);
     }
-    final endpoint = BengleScaleEndpoint.weight;
-    if (endpoint.uuid == null && endpoint.representation == null) {
-      this.log.info('IntegratedScaleCapability: weight endpoint unwired; '
-          'no notify subscription. Awaiting FW.');
-      return;
-    }
-    // When wires are real:
-    // _bengleWeightSub =
-    //     notificationsFor(endpoint).listen(_handleWeightFrame);
+    await _bengleWeightSub?.cancel();
+    _bengleWeightSub = _transport.bengleShotSample.listen(
+      _handleBengleShotSample,
+    );
   }
 
   /// Cancel the weight subscription and close the snapshot subject.
@@ -147,18 +122,15 @@ mixin IntegratedScaleCapability on UnifiedDe1 {
     }
   }
 
-  /// Tare the integrated scale. No-op (with a single info log) while
-  /// the control endpoint wires are null.
+  /// Tare the integrated scale. Logged no-op until the `ScaleTare` MMR
+  /// write-trigger lands (stop-at-weight/tare branch). Note the
+  /// `0xA013` Weight already arrives net of the firmware's own tare state,
+  /// so bridged weights stay correct meanwhile.
   Future<void> tareIntegratedScale() async {
-    final ctl = BengleScaleEndpoint.control;
-    if (ctl.uuid == null && ctl.representation == null) {
-      this.log.info('IntegratedScaleCapability: tare ignored — control '
-          'endpoint unwired. Awaiting FW.');
-      return;
-    }
-    // When wired:
-    // await writeEndpoint(ctl, Uint8List.fromList(_encodeTareCommand()),
-    //     withResponse: false);
+    this.log.info(
+      'IntegratedScaleCapability: tare is not yet wired — the ScaleTare '
+      'MMR trigger lands.',
+    );
   }
 
   /// Write the autonomous SAW target (grams) to FW. `0.0` disables
@@ -204,14 +176,24 @@ mixin IntegratedScaleCapability on UnifiedDe1 {
     }
   }
 
-  // Frame parser placeholder — replaced once FW spec lands.
-  // ignore: unused_element
-  void _handleWeightFrame(ByteData frame) {
-    this.log.warning('IntegratedScaleCapability: weight frame received but '
-        'parser not yet implemented (FW spec TBD)');
+  /// Bridge a 0xA013 frame's integrated-scale weight into the scale pipeline
+  ///. Weight (offset 20, U16P5 ÷32) arrives already tare-netted, so
+  /// we trust it directly. GFlow (gravimetric flow) and milk temp travel on
+  /// the [MachineSnapshot] (see `_parseStateAndBengleShotSample`); the Scale
+  /// surface carries weight only ([ScaleSnapshot] has no flow field).
+  ///
+  /// The **Flags** byte is deliberately ignored — bit0 is a `LastTARE` value
+  /// proxy at best (older firmware hardcodes 0), so a tare must be confirmed
+  /// by watching the weight, not the flag.
+  void _handleBengleShotSample(ByteData frame) {
+    final sample = parseBengleShotSample(frame);
+    if (sample == null || _bengleWeight.isClosed) return;
+    _bengleWeight.add(
+      ScaleSnapshot(
+        timestamp: DateTime.now(),
+        weight: sample.weight,
+        batteryLevel: 100, // integrated scale is mains-powered; report full
+      ),
+    );
   }
-
-  // Tare command encoder placeholder — replaced once FW spec lands.
-  // ignore: unused_element
-  List<int> _encodeTareCommand() => const [];
 }

--- a/lib/src/models/device/impl/de1/unified_de1/integrated_scale_capability.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/integrated_scale_capability.dart
@@ -176,11 +176,16 @@ mixin IntegratedScaleCapability on UnifiedDe1 {
     }
   }
 
-  /// Bridge a 0xA013 frame's integrated-scale weight into the scale pipeline
-  ///. Weight (offset 20, U16P5 ÷32) arrives already tare-netted, so
-  /// we trust it directly. GFlow (gravimetric flow) and milk temp travel on
-  /// the [MachineSnapshot] (see `_parseStateAndBengleShotSample`); the Scale
-  /// surface carries weight only ([ScaleSnapshot] has no flow field).
+  /// Bridge a 0xA013 frame's integrated-scale weight **and firmware-computed
+  /// gravimetric flow** into the scale pipeline. Weight (offset 20,
+  /// U16P5 ÷32) arrives already tare-netted, so we trust it directly.
+  ///
+  /// GFlow rides [ScaleSnapshot.flow] so the Scale surface carries the value
+  /// the firmware computed on its own load cell, rather than having
+  /// [ScaleController] re-estimate flow from the weight the firmware derived it
+  /// from. The same GFlow also travels on the [MachineSnapshot] (see
+  /// `_parseStateAndBengleShotSample`) — sourcing both surfaces from the frame
+  /// is what keeps them from disagreeing.
   ///
   /// The **Flags** byte is deliberately ignored — bit0 is a `LastTARE` value
   /// proxy at best (older firmware hardcodes 0), so a tare must be confirmed
@@ -193,6 +198,7 @@ mixin IntegratedScaleCapability on UnifiedDe1 {
         timestamp: DateTime.now(),
         weight: sample.weight,
         batteryLevel: 100, // integrated scale is mains-powered; report full
+        flow: sample.gFlow,
       ),
     );
   }

--- a/lib/src/models/device/impl/de1/unified_de1/integrated_scale_capability.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/integrated_scale_capability.dart
@@ -9,22 +9,27 @@ part of 'unified_de1.dart';
 ///
 /// Co-located with [IntegratedScaleCapability] so the mixin owns its
 /// wire identifiers (mirrors how `LedStripCapability` owns
-/// [BengleLedEndpoint]). Address is stubbed `0x00000000` — FW slot
-/// TBD. While stubbed the capability is a logged no-op; once FW
-/// publishes the address, fill it in and the rest lights up.
+/// [BengleLedEndpoint]) — the pattern rule: the capability owns the
+/// registers it writes.
 enum BengleScaleMmr implements MmrAddress {
-  /// Stop-at-weight target in grams. `0.0` disables autonomous SAW
+  /// Autonomous stop-at-weight target in grams. Firmware
+  /// `EndOfShotWeight` (`0x00803864`, RWD): the Bengle stops the shot
+  /// when its integrated scale reaches this weight. `0.0` disables SAW
   /// (mirrors cup-warmer `0.0 = off`). Encoded as `scaledFloat` with
-  /// scale factor 10 — decigrams on the wire.
+  /// scale factor 100 — centigrams on the wire (`round(g × 100)`, matching
+  /// de1plus `int(round(weight × 100))`, `de1_comms.tcl:1164`). Max
+  /// 10000 g (the firmware register table); the firmware never clamps Bengle registers
+  ///, so reaprime is
+  /// the sole guard.
   stopAtWeightTarget(
-    0x00000000, // TBD with FW
+    0x00803864,
     4,
     MmrValueKind.scaledFloat,
-    'StopAtWeightTarget',
+    'EndOfShotWeight',
     min: 0,
-    max: 5000, // 500.0 g
-    readScale: 0.1,
-    writeScale: 10.0,
+    max: 1000000, // 10000.0 g × 100
+    readScale: 0.01,
+    writeScale: 100.0,
   );
 
   const BengleScaleMmr(
@@ -78,10 +83,6 @@ mixin IntegratedScaleCapability on UnifiedDe1 {
   /// Seeded so late subscribers see the current value immediately.
   BehaviorSubject<double> _sawTarget = BehaviorSubject<double>.seeded(0.0);
 
-  /// Count of stub-related info logs emitted this session (avoids
-  /// spam — same pattern as `LedStripCapability._stubWarningsEmitted`).
-  int _sawStubWarningsEmitted = 0;
-
   /// Live weight stream from the integrated scale (one [ScaleSnapshot] per
   /// valid `0xA013` frame).
   Stream<ScaleSnapshot> get weightSnapshot => _bengleWeight.stream;
@@ -133,47 +134,28 @@ mixin IntegratedScaleCapability on UnifiedDe1 {
     );
   }
 
-  /// Write the autonomous SAW target (grams) to FW. `0.0` disables
-  /// SAW. Range `0.0..500.0`; out-of-range values are clamped.
-  ///
-  /// While [BengleScaleMmr.stopAtWeightTarget] is stubbed
-  /// (`address == 0x00000000`) this is a logged no-op on the wire —
-  /// the value is still cached so [stopAtWeightTarget] subscribers
-  /// see the intent. Mirrors `LedStripCapability.setLedStrip`'s
-  /// stub-friendly behaviour.
+  /// Write the autonomous SAW target (grams) to the firmware
+  /// `EndOfShotWeight` register. `0.0` disables SAW. Range
+  /// `0.0..10000.0`; out-of-range values are clamped client-side (the
+  /// firmware does not clamp its Bengle registers). The scaled write
+  /// rounds (`writeMmrScaled`), matching de1plus.
   Future<void> setStopAtWeightTarget(double grams) async {
-    final clamped = grams.clamp(0.0, 500.0).toDouble();
+    final clamped = grams.clamp(0.0, 10000.0).toDouble();
     if (!_sawTarget.isClosed) {
       _sawTarget.add(clamped);
     }
-    final addr = BengleScaleMmr.stopAtWeightTarget;
-    if (addr.address == 0x00000000) {
-      _logSawStubOnce('setStopAtWeightTarget($clamped) ignored. Awaiting FW.');
-      return;
-    }
-    await writeMmrScaled(addr, clamped);
+    await writeMmrScaled(BengleScaleMmr.stopAtWeightTarget, clamped);
   }
 
-  /// Read the SAW target from cache. While the MMR slot is stubbed
-  /// the cache is authoritative; once FW publishes the address this
-  /// hydrates from the wire on first call.
+  /// Read the SAW target back from the firmware `EndOfShotWeight`
+  /// register (grams) and hydrate the cache so [stopAtWeightTarget]
+  /// subscribers see the wire truth.
   Future<double> getStopAtWeightTarget() async {
-    final addr = BengleScaleMmr.stopAtWeightTarget;
-    if (addr.address == 0x00000000) {
-      return _sawTarget.value;
-    }
-    final value = await readMmrScaled(addr);
+    final value = await readMmrScaled(BengleScaleMmr.stopAtWeightTarget);
     if (!_sawTarget.isClosed) {
       _sawTarget.add(value);
     }
     return value;
-  }
-
-  void _logSawStubOnce(String msg) {
-    if (_sawStubWarningsEmitted < 1) {
-      this.log.info('IntegratedScaleCapability: SAW endpoint unwired; $msg');
-      _sawStubWarningsEmitted++;
-    }
   }
 
   /// Bridge a 0xA013 frame's integrated-scale weight **and firmware-computed

--- a/lib/src/models/device/impl/de1/unified_de1/led_strip_capability.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/led_strip_capability.dart
@@ -1,112 +1,166 @@
 part of 'unified_de1.dart';
 
-/// Wire endpoints for Bengle's LED zones.
-///
-/// Six zone-mode colour writes (frontStrip/backStrip/frontSwitch ×
-/// sleeping/awake) plus two control endpoints for NVM commit/reset.
-///
-/// All [uuid] and [representation] return `null` for now — the firmware
-/// slots have not yet been published. The [LedStripCapability] mixin
-/// treats null wires as "capability not yet wired" and silently no-ops
-/// (with an info log per session). Once FW publishes the wire spec,
-/// fill these in and the rest lights up unchanged.
-enum BengleLedEndpoint implements LogicalEndpoint {
-  frontStripSleeping,
-  frontStripAwake,
-  backStripSleeping,
-  backStripAwake,
-  frontSwitchSleeping,
-  frontSwitchAwake,
-  commitConfig,
-  resetConfig;
+/// Bengle LED palette MMR registers.
+/// Each holds a raw `0x00RRGGBB` int32 (little-endian on the wire, no scaling).
+/// The FW auto-applies the awake/sleep palette on state transitions — and
+/// immediately if the machine is already in that state — so a palette write
+/// both previews live and stores it (`PERM_RWD`). There is NO switch-LED
+/// register: the physical switch light mirrors the front strip in firmware, so
+/// [LedStripState]'s `frontSwitch` zone has no wire and is ignored on write.
+enum BengleLedMmr implements MmrAddress {
+  frontAwake(0x00803898, 'FrontLEDAwake'),
+  frontSleep(0x008038A0, 'FrontLEDSleep'),
+  rearAwake(0x0080389C, 'RearLEDAwake'),
+  rearSleep(0x008038A4, 'RearLEDSleep'),
+
+  /// Live/preview colour registers (`F_LEDStripColor`): writing pushes to the
+  /// strip immediately regardless of awake/sleep state, without touching the
+  /// stored palette. Used to preview a colour (e.g. the sleep colour) while the
+  /// machine is awake.
+  frontLive(0x00803890, 'FrontLEDColor'),
+  rearLive(0x00803894, 'RearLEDColor');
+
+  const BengleLedMmr(this.address, this.description);
 
   @override
-  String? get uuid => null; // TBD with FW
-
+  final int address;
+  final String description;
   @override
-  String? get representation => null; // TBD with FW
-
+  int get length => 4;
+  @override
+  MmrValueKind get kind => MmrValueKind.int32;
+  @override
+  double get readScale => 1.0;
+  @override
+  double get writeScale => 1.0;
+  @override
+  int? get min => null;
+  @override
+  int? get max => null;
   @override
   String get name => (this as Enum).name;
 }
 
-/// Stateful capability for Bengle's 3-zone LED strip (front strip,
-/// back strip, front switch) with sleeping/awake mode colours.
+/// Stateful capability for Bengle's LED strip — front and rear strips, each
+/// with a sleeping/awake palette colour. ([LedStripState] also carries a
+/// `frontSwitch` zone for API symmetry, but the switch LED is not independently
+/// controllable — it mirrors the front strip.)
 ///
 /// Owns the current [LedStripState] and exposes getter/setter plus
-/// [commitLedStrip] (persist to FW NVM) and [resetLedStrip] (reload
-/// from FW NVM). Lifecycle is managed by the concrete `Bengle` device
-/// — call [initLedStrip] from `onConnect`, [disposeLedStrip] from
-/// `onDisconnect`.
-///
-/// The capability is a no-op until firmware publishes the wire identifiers
-/// (see [BengleLedEndpoint]); when that happens, [setLedStrip] writes
-/// all six zone-mode endpoints, [commitLedStrip] writes the commit
-/// endpoint, and [resetLedStrip] writes the reset endpoint then
-/// re-reads the cache.
+/// [commitLedStrip] and [resetLedStrip]. Lifecycle is managed by the concrete
+/// `Bengle` device — call [initLedStrip] from `onConnect`, [disposeLedStrip]
+/// from `onDisconnect`.
 mixin LedStripCapability on UnifiedDe1 {
   BehaviorSubject<LedStripState> _ledStripState =
       BehaviorSubject<LedStripState>.seeded(const LedStripState());
 
-  /// Count of info-log messages emitted this session to avoid log spam.
-  int _stubWarningsEmitted = 0;
-
-  /// Current LED strip state (cached in SB, not necessarily committed to FW).
+  /// Current LED strip state (cached in SB; reflects the connect-time
+  /// hydration and the last write / reset).
   Stream<LedStripState> get ledStripState => _ledStripState.stream;
 
   /// One-shot read of the current cached LED strip state.
   Future<LedStripState> getLedStripState() => _ledStripState.first;
 
-  /// Write a full configuration to cache and to FW live registers.
-  ///
-  /// Updates all six zone-mode colours. The FW auto-selects between
-  /// sleeping and awake based on its internal machine state. Does NOT
-  /// persist to NVM — call [commitLedStrip] separately.
+  /// Write the full palette to the FW and cache. Front strip →
+  /// Front{Awake,Sleep}, rear strip → Rear{Awake,Sleep}; the front-switch zone
+  /// has no register and is ignored. Because the palette registers are
+  /// `PERM_RWD` the write also persists — there is no separate live/commit
+  /// split on the wire.
   Future<void> setLedStrip(LedStripState state) async {
-    _logStubOnce('setLedStrip($state) ignored. Awaiting FW.');
-    // When wires are real, iterate zone-mode endpoints:
-    // await _writeColor(BengleLedEndpoint.frontStripSleeping, state.frontStrip.sleeping);
-    // await _writeColor(BengleLedEndpoint.frontStripAwake, state.frontStrip.awake);
-    // await _writeColor(BengleLedEndpoint.backStripSleeping, state.backStrip.sleeping);
-    // await _writeColor(BengleLedEndpoint.backStripAwake, state.backStrip.awake);
-    // await _writeColor(BengleLedEndpoint.frontSwitchSleeping, state.frontSwitch.sleeping);
-    // await _writeColor(BengleLedEndpoint.frontSwitchAwake, state.frontSwitch.awake);
+    await _writeLedColor(BengleLedMmr.frontAwake, state.frontStrip.awake);
+    await _writeLedColor(BengleLedMmr.frontSleep, state.frontStrip.sleeping);
+    await _writeLedColor(BengleLedMmr.rearAwake, state.backStrip.awake);
+    await _writeLedColor(BengleLedMmr.rearSleep, state.backStrip.sleeping);
     _ledStripState.add(state);
   }
 
-  /// Persist the current cache to FW NVM. The machine retains the last
-  /// committed state across power cycles.
-  Future<void> commitLedStrip() async {
-    _logStubOnce('commitLedStrip() ignored. Awaiting FW.');
-    // When wires are real:
-    // await writeEndpoint(BengleLedEndpoint.commitConfig, Uint8List(0));
+  /// The palette registers persist on write and the FW exposes no separate
+  /// commit register, so a write is already the commit. Kept for API symmetry —
+  /// re-asserts the current cache to the FW.
+  Future<void> commitLedStrip() => setLedStrip(_ledStripState.value);
+
+  /// Push a live colour to the strip immediately (`FrontLEDColor`/`RearLEDColor`),
+  /// regardless of awake/sleep state and WITHOUT changing the stored palette or
+  /// the cache — used to preview a colour (e.g. the sleep colour) while the
+  /// machine is awake. Call [clearLedPreview] to restore the awake palette.
+  Future<void> previewLedColor(Color16 front, Color16 back) async {
+    await _writeLedColor(BengleLedMmr.frontLive, front);
+    await _writeLedColor(BengleLedMmr.rearLive, back);
   }
 
-  /// Reload cache from FW NVM. Drops any uncommitted changes.
+  /// Restore the strip to the cached awake palette after a [previewLedColor].
+  Future<void> clearLedPreview() async {
+    final s = _ledStripState.value;
+    await _writeLedColor(BengleLedMmr.frontLive, s.frontStrip.awake);
+    await _writeLedColor(BengleLedMmr.rearLive, s.backStrip.awake);
+  }
+
+  /// Reload the cache from the FW palette registers, dropping local edits.
   Future<void> resetLedStrip() async {
-    _logStubOnce('resetLedStrip() ignored. Awaiting FW.');
-    // When wires are real:
-    // await writeEndpoint(BengleLedEndpoint.resetConfig, Uint8List(0));
-    // Then re-read from endpoints to hydrate cache.
+    _ledStripState.add(await _readLedStrip());
   }
 
-  /// Emit an info-level log once per session for stub-related messages.
-  void _logStubOnce(String msg) {
-    if (_stubWarningsEmitted < 1) {
-      this.log.info('LedStripCapability: endpoints unwired; $msg');
-      _stubWarningsEmitted++;
-    }
+  /// Read the four palette registers into a [LedStripState]; the front-switch
+  /// zone mirrors the front strip.
+  Future<LedStripState> _readLedStrip() async {
+    final front = ZoneLedState(
+      awake: await _readLedColor(BengleLedMmr.frontAwake),
+      sleeping: await _readLedColor(BengleLedMmr.frontSleep),
+    );
+    return LedStripState(
+      frontStrip: front,
+      backStrip: ZoneLedState(
+        awake: await _readLedColor(BengleLedMmr.rearAwake),
+        sleeping: await _readLedColor(BengleLedMmr.rearSleep),
+      ),
+      frontSwitch: front,
+    );
   }
 
-  /// Re-init-safe: if a previous [disposeLedStrip] closed the subject,
-  /// a fresh one is created here.
+  Future<void> _writeLedColor(BengleLedMmr reg, Color16 color) => _mmrWriteRaw(
+    reg.address,
+    _packMMRInt(_color16ToPacked(color)),
+    label: reg.description,
+  );
+
+  Future<Color16> _readLedColor(BengleLedMmr reg) async => _packedToColor16(
+    _unpackMMRInt(await _mmrReadRaw(reg.address, label: reg.description)),
+  );
+
+  /// 16-bit-per-channel [Color16] → FW `0x00RRGGBB` (high byte of each channel).
+  int _color16ToPacked(Color16 c) =>
+      (((c.red >> 8) & 0xFF) << 16) |
+      (((c.green >> 8) & 0xFF) << 8) |
+      ((c.blue >> 8) & 0xFF);
+
+  /// FW `0x00RRGGBB` → [Color16], byte-replicating each 8-bit channel to 16-bit
+  /// (`0xAB → 0xABAB`) so a round-trip is lossless for 8-bit sources.
+  Color16 _packedToColor16(int v) {
+    int up(int x) => (x << 8) | x;
+    return Color16(up((v >> 16) & 0xFF), up((v >> 8) & 0xFF), up(v & 0xFF));
+  }
+
+  /// Re-init-safe: if a previous [disposeLedStrip] closed the subject, a fresh
+  /// one is created here — then the cache is hydrated from the machine's four
+  /// stored palette registers so a GET right after connect serves the real
+  /// stored colours instead of all-off (and [clearLedPreview] restores the
+  /// machine's true awake palette, not black). Hydration is read-only: it
+  /// never touches the live/preview registers. Failure-tolerant: a failed
+  /// read leaves the cache seeded all-off (the pre-hydration behavior) and
+  /// never fails the connect.
   Future<void> initLedStrip() async {
     if (_ledStripState.isClosed) {
-      _ledStripState =
-          BehaviorSubject<LedStripState>.seeded(const LedStripState());
+      _ledStripState = BehaviorSubject<LedStripState>.seeded(
+        const LedStripState(),
+      );
     }
-    _stubWarningsEmitted = 0;
-    _logStubOnce('no write surface registered. Awaiting FW.');
+    try {
+      _ledStripState.add(await _readLedStrip());
+    } catch (e) {
+      // `this.` disambiguates the protected Logger getter from dart:math's
+      // top-level `log`, which shadows it in this library's lexical scope.
+      this.log.warning('Could not hydrate LED palette on connect: $e');
+    }
   }
 
   /// Cancel any subscriptions and close the subject.
@@ -116,4 +170,3 @@ mixin LedStripCapability on UnifiedDe1 {
     }
   }
 }
-

--- a/lib/src/models/device/impl/de1/unified_de1/scale_calibration_capability.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/scale_calibration_capability.dart
@@ -1,0 +1,329 @@
+part of 'unified_de1.dart';
+
+// FIX-07 — Load-cell calibration wizard (non-blocking, ISOLATED-CELL
+// AUTO-DETECT).
+//
+// Drives the firmware's non-blocking load-cell calibration (firmware
+// its calibration engine) over MMR: write ScaleCalCmd (a trigger), poll
+// ScaleCalState (a packed status word), set ScaleCalWeight (the known
+// reference mass) before each latch.
+//
+// The procedure: platform OFF (cells mechanically isolated), precision-zero,
+// then latch the SAME known mass directly on either cell — the firmware
+// AUTO-DETECTS the loaded cell — move it to the other cell and latch again.
+// The 2x2 solve recovers both per-cell sensitivities, so summed mass is
+// position-independent. The old explicit left/right latches (ScaleCalCmd
+// 4/5) are retired and return an error.
+//
+// Bounded polling (deadline + fast interval — better than de1plus's untimed
+// 1 Hz loop), progress derived from the firmware `Remaining` field on a status
+// stream, and the reference-weight write is read-back-confirmed before the
+// latch is triggered.
+
+/// Calibration MMR slots. Co-located with [ScaleCalibrationCapability] so the
+/// mixin owns its wire identifiers (same pattern as [BengleScaleMmr] /
+/// [BengleLedMmr]).
+enum BengleCalMmr implements MmrAddress {
+  /// Cal command trigger (`0x00803880`, RWT). Firmware values:
+  /// `0=abort 1=zero 2=latch gain cal (platform OFF, auto-detect cell; run
+  /// once per cell) 3=tare`. (`4`/`5` — the retired explicit left/right
+  /// latches — return an error.) A non-zero command while the firmware is
+  /// busy is ignored.
+  cmd(0x00803880, 4, MmrValueKind.int32, 'ScaleCalCmd'),
+
+  /// Packed cal status word (`0x00803884`, R):
+  /// `Step[31:24] | SubState[23:16] | Remaining[15:8] | CalStatus[7:0]`,
+  /// where the SubState byte carries the phase in its low nibble and the
+  /// auto-detected cell in its high nibble (0 none, 1 cell A, 2 cell B).
+  state(0x00803884, 4, MmrValueKind.int32, 'ScaleCalState'),
+
+  /// Known reference weight in grams (`0x00803888`, RW, scale ×10). Written
+  /// before [ScaleCalCommand.latch]. Firmware never clamps its Bengle
+  /// registers, so reaprime clamps (0..10000 g).
+  weight(
+    0x00803888,
+    4,
+    MmrValueKind.scaledFloat,
+    'ScaleCalWeight',
+    min: 0,
+    max: 100000, // 10000.0 g × 10
+    readScale: 0.1,
+    writeScale: 10.0,
+  );
+
+  const BengleCalMmr(
+    this.address,
+    this.length,
+    this.kind,
+    this.description, {
+    this.readScale = 1.0,
+    this.writeScale = 1.0,
+    this.min,
+    this.max,
+  });
+
+  @override
+  final int address;
+  @override
+  final int length;
+  @override
+  final MmrValueKind kind;
+  final String description;
+  @override
+  final double readScale;
+  @override
+  final double writeScale;
+  @override
+  final int? min;
+  @override
+  final int? max;
+
+  @override
+  String get name => (this as Enum).name;
+}
+
+/// A `ScaleCalCmd` value (`BengleCalMmr.cmd`). Tare (cmd 3) exists in firmware
+/// too, but reaprime tares through the dedicated `ScaleTare` register (FIX-06),
+/// so it is not part of the cal command set here.
+enum ScaleCalCommand {
+  abort(0),
+  zero(1),
+  latch(2); // latch the loaded cell (auto-detected; platform OFF)
+
+  const ScaleCalCommand(this.wire);
+  final int wire;
+}
+
+// Public status/result types (ScaleCalStep/SubState/PointStatus/Status/Result)
+// live in `lib/src/models/device/scale_calibration.dart` so the interface +
+// handler can import them without depending on this impl library.
+
+/// Non-blocking two-point load-cell calibration for Bengle's integrated scale
+/// (FIX-07).
+///
+/// Lifecycle mirrors [IntegratedScaleCapability]: [initScaleCalibration] from
+/// `onConnect`, [disposeScaleCalibration] from `onDisconnect`; re-init-safe.
+///
+/// Procedure (platform OFF): [calibrateScaleZero] → [calibrateScaleWeightLeft]
+/// (known mass directly on either cell; auto-detected) →
+/// [calibrateScaleWeightRight] (same mass on the OTHER cell). The second
+/// latch solving both cells persists + applies the cal. Both weight methods
+/// trigger the same auto-detect latch — the left/right names survive for the
+/// wizard's step ordering only.
+mixin ScaleCalibrationCapability on UnifiedDe1 {
+  /// Poll cadence while a calibration phase runs.
+  Duration _calPollInterval = const Duration(milliseconds: 500);
+
+  /// Hard ceiling on a single command. The firmware settle+average is ~15 s;
+  /// 30 s leaves headroom. de1plus has no timeout at all.
+  Duration _calPollDeadline = const Duration(seconds: 30);
+
+  /// Test seam: shorten polling so a timeout path is exercisable without a
+  /// 30 s wall-clock wait.
+  @visibleForTesting
+  void configureScaleCalibrationTiming({
+    Duration? pollInterval,
+    Duration? deadline,
+  }) {
+    if (pollInterval != null) _calPollInterval = pollInterval;
+    if (deadline != null) _calPollDeadline = deadline;
+  }
+
+  BehaviorSubject<ScaleCalStatus> _calProgress =
+      BehaviorSubject<ScaleCalStatus>();
+  bool _calInProgress = false;
+
+  /// Monotonic run token. [_runCalStep] captures it at start and bails as soon
+  /// as it changes; [abortScaleCalibration] / [disposeScaleCalibration] bump it
+  /// to unwind an in-flight poll. A counter (not a bool) so a stale poll
+  /// surviving a disconnect→reconnect still sees the change — a reset-on-init
+  /// flag could be cleared before the stale poll observed it. Firmware abort →
+  /// Step Idle is non-terminal, so without this the poll would spin to the
+  /// deadline; and a dispose must tear down in-flight work (mirrors
+  /// `disposeIntegratedScale` cancelling its subscription).
+  int _calGeneration = 0;
+
+  /// Live calibration status stream. Emits each polled [ScaleCalStatus].
+  Stream<ScaleCalStatus> get scaleCalibrationProgress => _calProgress.stream;
+
+  /// Whether a calibration run is currently in flight (single-flight guard).
+  bool get scaleCalibrationInProgress => _calInProgress;
+
+  Future<void> initScaleCalibration() async {
+    // Deliberately does NOT touch _calGeneration — it only ever increases, so
+    // a stale poll from a prior connection still detects the dispose bump.
+    if (_calProgress.isClosed) {
+      _calProgress = BehaviorSubject<ScaleCalStatus>();
+    }
+  }
+
+  Future<void> disposeScaleCalibration() async {
+    // Bump the run token first so a poll running across a disconnect unwinds
+    // instead of injecting stale status into a post-reconnect subject or
+    // firing _safeAbort on a fresh calibration.
+    _calGeneration++;
+    _calInProgress = false;
+    if (!_calProgress.isClosed) {
+      await _calProgress.close();
+    }
+  }
+
+  /// Precision-zero the load cells. Place NOTHING on the platform. Must run
+  /// before the weight-cal points (the firmware rejects a latch with `NoZero`
+  /// otherwise).
+  Future<ScaleCalResult> calibrateScaleZero() async {
+    if (_calInProgress) return _busyResult();
+    _calInProgress = true;
+    try {
+      return await _runCalStep(ScaleCalCommand.zero, (s) => s.isComplete);
+    } finally {
+      _calInProgress = false;
+    }
+  }
+
+  /// First latch: place the known [grams] reference mass directly on EITHER
+  /// bare cell (platform off); the firmware auto-detects which. Success means
+  /// the cell latched — the firmware reports
+  /// [ScaleCalPointStatus.incomplete] (awaiting the other cell). Run
+  /// [calibrateScaleZero] first.
+  Future<ScaleCalResult> calibrateScaleWeightLeft(double grams) =>
+      _weightCalPoint(
+        ScaleCalCommand.latch,
+        grams,
+        (s) =>
+            s.isComplete &&
+            (s.pointStatus == ScaleCalPointStatus.incomplete ||
+                s.pointStatus == ScaleCalPointStatus.ok),
+      );
+
+  /// Second latch: the same known [grams] reference mass moved to the OTHER
+  /// cell. Success means both cells solved ([ScaleCalPointStatus.ok]) — the
+  /// firmware persisted + applied the cal. Re-latching the same cell reports
+  /// incomplete (a refresh), which this step surfaces as "not accepted".
+  Future<ScaleCalResult> calibrateScaleWeightRight(double grams) =>
+      _weightCalPoint(
+        ScaleCalCommand.latch,
+        grams,
+        (s) => s.isComplete && s.pointStatus == ScaleCalPointStatus.ok,
+      );
+
+  Future<ScaleCalResult> _weightCalPoint(
+    ScaleCalCommand cmd,
+    double grams,
+    bool Function(ScaleCalStatus) isSuccess,
+  ) async {
+    if (_calInProgress) return _busyResult();
+    _calInProgress = true;
+    try {
+      final clamped = grams.clamp(0.0, 10000.0).toDouble();
+      // Set the reference mass and confirm it landed before triggering the
+      // latch — a dropped write would calibrate to the wrong mass.
+      await writeMmrScaled(BengleCalMmr.weight, clamped);
+      final readBack = await readMmrScaled(BengleCalMmr.weight);
+      if ((readBack - clamped).abs() > 0.1) {
+        return ScaleCalResult(
+          success: false,
+          finalStep: ScaleCalStep.idle,
+          pointStatus: ScaleCalPointStatus.none,
+          message: 'reference weight write not confirmed '
+              '(wrote $clamped g, read $readBack g)',
+        );
+      }
+      return await _runCalStep(cmd, isSuccess);
+    } finally {
+      _calInProgress = false;
+    }
+  }
+
+  /// Abort an in-flight calibration: unwind the poll loop (by bumping
+  /// [_calGeneration]) AND tell the firmware to abort (ScaleCalCmd = 0). Both
+  /// are needed — the firmware returns to Step Idle (non-terminal), which the
+  /// poll would otherwise keep polling until the deadline.
+  Future<void> abortScaleCalibration() async {
+    _calGeneration++;
+    await writeMmrInt(BengleCalMmr.cmd, ScaleCalCommand.abort.wire);
+  }
+
+  /// Trigger [cmd], then poll [BengleCalMmr.state] to a terminal Step
+  /// (Complete/Error), a cancel (run-token bump), or the deadline. [isSuccess]
+  /// decides whether a *Complete* step counts as success for this command
+  /// (e.g. a point-1 latch is Complete with `pointStatus == incomplete`). The
+  /// caller owns [_calInProgress].
+  Future<ScaleCalResult> _runCalStep(
+    ScaleCalCommand cmd,
+    bool Function(ScaleCalStatus) isSuccess,
+  ) async {
+    final gen = _calGeneration;
+    // Bind this run's progress subject so a dispose+reconnect that swaps
+    // `_calProgress` can't route a late status into the new session's stream.
+    final progress = _calProgress;
+    await writeMmrInt(BengleCalMmr.cmd, cmd.wire);
+    final deadline = DateTime.now().add(_calPollDeadline);
+    var last = ScaleCalStatus.fromRaw(0); // Idle until the first read
+    while (true) {
+      if (gen != _calGeneration) return _abortedResult(last);
+      last = ScaleCalStatus.fromRaw(await readMmrInt(BengleCalMmr.state));
+      if (!progress.isClosed) progress.add(last);
+
+      if (last.isTerminal) {
+        final ok = isSuccess(last);
+        return ScaleCalResult(
+          success: ok,
+          finalStep: last.step,
+          pointStatus: last.pointStatus,
+          message: ok ? null : _terminalFailMessage(last),
+        );
+      }
+      if (gen != _calGeneration) return _abortedResult(last);
+      if (DateTime.now().isAfter(deadline)) {
+        await _safeAbort();
+        return ScaleCalResult(
+          success: false,
+          finalStep: last.step,
+          pointStatus: last.pointStatus,
+          message: 'timed out after ${_calPollDeadline.inSeconds}s',
+        );
+      }
+      await Future<void>.delayed(_calPollInterval);
+    }
+  }
+
+  String _terminalFailMessage(ScaleCalStatus s) {
+    final st = s.pointStatus;
+    final hasReason = st != ScaleCalPointStatus.none &&
+        st != ScaleCalPointStatus.unknown &&
+        st != ScaleCalPointStatus.ok;
+    if (s.isError) {
+      // Upfront rejects (BadWeight / NoZero) surface as an Error step; carry
+      // the CalStatus reason when the firmware set one.
+      return hasReason
+          ? 'firmware error (status: ${st.name})'
+          : 'firmware reported error';
+    }
+    // Completed step but the point status is a rejection (NotSettled,
+    // BadDelta, IllConditioned, OutOfRange) or unexpected.
+    return 'calibration not accepted (status: ${st.name})';
+  }
+
+  ScaleCalResult _abortedResult(ScaleCalStatus last) => ScaleCalResult(
+        success: false,
+        finalStep: last.step,
+        pointStatus: last.pointStatus,
+        message: 'aborted',
+      );
+
+  Future<void> _safeAbort() async {
+    try {
+      await writeMmrInt(BengleCalMmr.cmd, ScaleCalCommand.abort.wire);
+    } catch (_) {
+      // Best-effort — the caller already has a timeout result.
+    }
+  }
+
+  ScaleCalResult _busyResult() => const ScaleCalResult(
+        success: false,
+        finalStep: ScaleCalStep.unknown,
+        pointStatus: ScaleCalPointStatus.unknown,
+        message: 'calibration already in progress',
+      );
+}

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -13,6 +13,7 @@ import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.utils.dart';
 import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/bengle_shot_sample.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/device/led_strip.dart';
@@ -46,26 +47,56 @@ class UnifiedDe1 implements De1Interface {
   @override
   Stream<ConnectionState> get connectionState => _transport.connectionState;
 
-  late final Stream<MachineSnapshot> _currentSnapshot = _transport.shotSample
-      .map((d) {
-        notifyFrom(Endpoint.shotSample, d.buffer.asUint8List());
-        return d;
-      })
-      .withLatestFrom(
-        _transport.state.map((d) {
-          notifyFrom(Endpoint.stateInfo, d.buffer.asUint8List());
-          return d;
-        }),
-        (snp, st) {
-          final snapshot = _parseStateAndShotSample(st, snp);
-          _log.finest("new state: ${snapshot.toJson()}");
-          return snapshot;
-        },
-      )
-      .shareReplay(maxSize: 1);
+  // DE1 snapshots come from the 0xA00D shot sample (fixed-point layout). This
+  // is the only source on a plain DE1.
+  late final Stream<MachineSnapshot> _de1Snapshot = _buildSnapshotStream(
+    _transport.shotSample,
+    Endpoint.shotSample,
+    _parseStateAndShotSample,
+  );
 
+  // on a Bengle the 0xA013 BengleShotSample is the SOLE snapshot
+  // source (weight + gravimetric flow + milk). 0xA00D stays subscribed at the
+  // transport but is never turned into snapshots ("parse-and-drop") because
+  // nothing listens to [_de1Snapshot] on a Bengle. Firmware streams both at
+  // 15 Hz; charting both would double-sample. Lazily built (late final), so on
+  // a plain DE1 this never subscribes to the 0xA013 stream.
+  late final Stream<MachineSnapshot> _bengleSnapshot = _buildSnapshotStream(
+    _transport.bengleShotSample,
+    Endpoint.bengleShotSample,
+    _parseStateAndBengleShotSample,
+  );
+
+  Stream<MachineSnapshot> _buildSnapshotStream(
+    Stream<ByteData> source,
+    Endpoint sourceEndpoint,
+    MachineSnapshot Function(ByteData state, ByteData shot) parse,
+  ) {
+    return source
+        .map((d) {
+          notifyFrom(sourceEndpoint, d.buffer.asUint8List());
+          return d;
+        })
+        .withLatestFrom(
+          _transport.state.map((d) {
+            notifyFrom(Endpoint.stateInfo, d.buffer.asUint8List());
+            return d;
+          }),
+          (snp, st) {
+            final snapshot = parse(st, snp);
+            _log.finest("new state: ${snapshot.toJson()}");
+            return snapshot;
+          },
+        )
+        .shareReplay(maxSize: 1);
+  }
+
+  // Picked at access time (post-onConnect, once [_isBengle] is known) rather
+  // than captured in a field initialiser, so the DE1/Bengle choice is always
+  // correct. _isBengle only ever transitions false->true (during onConnect).
   @override
-  Stream<MachineSnapshot> get currentSnapshot => _currentSnapshot;
+  Stream<MachineSnapshot> get currentSnapshot =>
+      _isBengle ? _bengleSnapshot : _de1Snapshot;
 
   @override
   String get deviceId => _transport.id;
@@ -235,10 +266,35 @@ class UnifiedDe1 implements De1Interface {
   /// class swap. See `resolveMachineForModel`.
   Future<void> detachTransport() => _transport.detach();
 
+  /// Enable the Bengle 0xA013 BengleShotSample stream. Gated on the
+  /// confirmed Bengle identity by the caller. Non-fatal: a failed subscribe
+  /// must not abort connect — the serial `<+S>` is already enabled in
+  /// `_serialConnect`, and on BLE a stalled subscribe would only lose
+  /// telemetry, not the connection.
+  Future<void> _enableBengleShotSample() async {
+    try {
+      await _transport.subscribeBengleShotSample();
+    } catch (e) {
+      _log.warning('Could not subscribe to 0xA013 BengleShotSample: $e');
+    }
+  }
+
   @override
   Future<void> onConnect() async {
     initRawStream();
     await _transport.connect();
+
+    // (re)enable the 0xA013 stream on every connect. On the FIRST
+    // connect _isBengle is still false here (set below from v13Model), so this
+    // no-ops and the enable happens in the post-detection block. On a RECONNECT
+    // the flag is already known and `_transport.connect()` just re-subscribed
+    // the base characteristics, so re-subscribe 0xA013 alongside them (the
+    // reconnect short-circuits below before reaching the detection block). On
+    // serial this also re-sends the `<-M>` after `_serialConnect`
+    // re-subscribed `<+M>` — without it a reconnected link saturates again.
+    if (_isBengle) {
+      await _enableBengleShotSample();
+    }
 
     if (_info != null) {
       return;
@@ -257,6 +313,10 @@ class UnifiedDe1 implements De1Interface {
         'v13Model=$model (>=128): Bengle hardware detected. Advertised '
         'name is a hint only.',
       );
+      // first-connect enable of the 0xA013 stream, now that the Bengle
+      // identity is confirmed. Feeds both the snapshot pipeline and the
+      // integrated scale.
+      await _enableBengleShotSample();
     }
     final ghcInfo = _unpackMMRInt(await _mmrRead(MMRItem.ghcInfo));
     final serial = _unpackMMRInt(await _mmrRead(MMRItem.serialN));
@@ -750,6 +810,8 @@ class UnifiedDe1 implements De1Interface {
           return _mmr;
         case Endpoint.fwMapRequest:
           return _transport.fwMapRequest;
+        case Endpoint.bengleShotSample:
+          return _transport.bengleShotSample;
         default:
           throw UnimplementedError(
             'UnifiedDe1.notificationsFor: Endpoint.${endpoint.name} is '

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -807,7 +807,11 @@ class UnifiedDe1 implements De1Interface {
   @protected
   Future<void> writeMmrScaled(MmrAddress addr, double value) async {
     _assertKind(addr, const {MmrValueKind.scaledFloat}, 'writeMmrScaled');
-    final scaled = (value * addr.writeScale).toInt();
+    // round(), not toInt(): floating error (e.g. 2.3 * 100 == 229.999…)
+    // truncates a whole unit low. Matches de1plus, which rounds this write
+    // class. (Bengle path — every Bengle capability scaled write routes
+    // through here.)
+    final scaled = (value * addr.writeScale).round();
     if (addr is MMRItem) return _writeMMRInt(addr, scaled);
     final clamped = (addr.min != null && addr.max != null)
         ? scaled.clamp(addr.min!, addr.max!)

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -18,6 +18,7 @@ import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1_tran
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/device/led_strip.dart';
 import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/device/scale_calibration.dart';
 import 'package:reaprime/src/models/device/ble_service_identifier.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/transport/logical_endpoint.dart';
@@ -31,6 +32,7 @@ part 'unified_de1.firmware.dart';
 part 'unified_de1.raw.dart';
 part 'integrated_scale_capability.dart';
 part 'led_strip_capability.dart';
+part 'scale_calibration_capability.dart';
 
 class UnifiedDe1 implements De1Interface {
   static final BleServiceIdentifier advertisingIdentifier =

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -193,6 +193,48 @@ class UnifiedDe1 implements De1Interface {
   int _refillKit = -1;
   double? _cachedFlowEstimation;
 
+  bool _isBengle = false;
+
+  /// Authoritative Bengle identity, established on [onConnect] from the
+  /// `v13Model` MMR (`0x0080000C`): `model >= 128` ⇒ Bengle (the DE1 family
+  /// is 1..7; the register is served unscaled).
+  ///
+  /// The BLE advertised name is only a scan hint — `DeviceMatcher` picks the
+  /// class by name before a connection exists — so this runtime flag, read
+  /// from the wire, is authoritative. `resolveMachineForModel` uses it at
+  /// connect time to re-resolve the machine to the correct class over the
+  /// same transport, so a Bengle advertising a DE1-style name still presents
+  /// Bengle features. `false` until `onConnect` has read the model; the
+  /// serial path gates the same way (`serial_service_*`).
+  bool get isBengle => _isBengle;
+
+  /// The underlying [DataTransport], exposed for connect-time model-based
+  /// class resolution (`resolveMachineForModel`): when `v13Model` disagrees
+  /// with the name-picked class, a fresh instance is built over this same
+  /// live transport. Not intended for direct I/O.
+  DataTransport get dataTransport => _transport.dataTransport;
+
+  /// Copies the connect-time identity that [onConnect] reads (machine info,
+  /// heater voltage, refill-kit state, flow-cal cache, Bengle flag) from
+  /// [other] onto this instance. Used by `resolveMachineForModel` so a
+  /// re-resolved machine's [onConnect] short-circuits the MMR re-reads (its
+  /// `_info` is already populated) and only (re)subscribes + runs capability
+  /// init over the shared transport.
+  void adoptIdentityFrom(UnifiedDe1 other) {
+    _info = other._info;
+    _voltage = other._voltage;
+    _refillKit = other._refillKit;
+    _cachedFlowEstimation = other._cachedFlowEstimation;
+    _isBengle = other._isBengle;
+  }
+
+  /// Releases this instance's transport wrapper (its subjects + serial read
+  /// subscription) WITHOUT disposing the underlying transport, which a
+  /// re-resolved replacement now owns. Used by `De1Controller.connectToDe1`
+  /// to tear down the discarded name-picked interim after a model-based
+  /// class swap. See `resolveMachineForModel`.
+  Future<void> detachTransport() => _transport.detach();
+
   @override
   Future<void> onConnect() async {
     initRawStream();
@@ -203,10 +245,17 @@ class UnifiedDe1 implements De1Interface {
     }
 
     final model = _unpackMMRInt(await _mmrRead(MMRItem.v13Model));
-    if (model >= 128) {
-      _log.warning(
-        'Device model $model indicates non-DE1 hardware '
-        '(Bengle or similar). Advertised name may be misleading.',
+    // v13Model (0x0080000C) is the authoritative Bengle identity —
+    // model >= 128 ⇒ Bengle (DE1 family is 1..7), served unscaled. The BLE
+    // advertised name is only a scan hint (DeviceMatcher picks the class by
+    // name); De1Controller.connectToDe1 re-resolves the class from this flag
+    // afterwards (resolveMachineForModel), so a mis-named Bengle still gets
+    // Bengle features.
+    _isBengle = model >= 128;
+    if (_isBengle) {
+      _log.info(
+        'v13Model=$model (>=128): Bengle hardware detected. Advertised '
+        'name is a hint only.',
       );
     }
     final ghcInfo = _unpackMMRInt(await _mmrRead(MMRItem.ghcInfo));
@@ -448,7 +497,7 @@ class UnifiedDe1 implements De1Interface {
     await _sendProfile(profile);
     _currentProfile = profile;
     // Guard against firmware ProfileDownloadInProgress race: the DE1 writes
-    // the shot descriptor to internal flash inside APIView::write for the
+    // the shot descriptor to internal flash inside the firmware for the
     // final frame and tail, and only clears ProfileDownloadInProgress when
     // that flash write returns. If a state=espresso request hits the
     // firmware task loop before the flag clears, doEspresso() aborts to

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.mmr.dart
@@ -151,6 +151,13 @@ extension UnifiedDe1MMR on UnifiedDe1 {
   }
 
   Future<void> _writeMMRScaled(MMRItem item, double value) async {
+    // toInt() (truncate), NOT round(): these base-DE1 setters
+    // (flush/hot-water/steam/heater/cal flow) must stay byte-identical to a
+    // plain DE1 as shipped, and de1plus truncates them via int(...) —
+    // e.g. set_flush_flow_rate `int(10*rate)`, set_steam_flow (de1_comms.tcl).
+    // The Bengle-only ×100 weight case that genuinely needs rounding (floating
+    // error: 2.3*100 == 229.999… truncates low) rides the SEPARATE public
+    // writeMmrScaled() helper, which de1plus also rounds — not this one.
     final scaledValue = (value * item.writeScale).toInt();
     await _writeMMRInt(item, scaledValue);
   }

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.parsing.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.parsing.dart
@@ -43,6 +43,66 @@ extension MessageParsing on UnifiedDe1 {
     );
   }
 
+  /// Build a [MachineSnapshot] from a Bengle `0xA013` BengleShotSample frame
+  /// (the sole snapshot source on a Bengle) plus the latest DE1 state
+  /// frame (state layout is unchanged, so it is read exactly like the `0xA00D`
+  /// path). Adds integrated-scale weight, gravimetric flow and milk temp
+  ///.
+  MachineSnapshot _parseStateAndBengleShotSample(
+    ByteData stateSample,
+    ByteData shotSample,
+  ) {
+    final state = De1StateEnum.fromHexValue(stateSample.getUint8(0));
+    final subState =
+        De1SubState.fromHexValue(stateSample.getUint8(1)) ??
+        De1SubState.noState;
+    final machineState = MachineStateSnapshot(
+      state: mapDe1ToMachineState(state),
+      substate: mapDe1SubToMachineSubstate(subState),
+    );
+
+    final s = parseBengleShotSample(shotSample);
+    if (s == null) {
+      // Truncated frame — the transport already drops these, so this
+      // is defensive: emit a state-only snapshot rather than throw.
+      return MachineSnapshot(
+        timestamp: DateTime.now(),
+        state: machineState,
+        pressure: 0,
+        flow: 0,
+        mixTemperature: 0,
+        groupTemperature: 0,
+        targetMixTemperature: 0,
+        targetGroupTemperature: 0,
+        targetPressure: 0,
+        targetFlow: 0,
+        profileFrame: 0,
+        steamTemperature: 0,
+      );
+    }
+
+    return MachineSnapshot(
+      timestamp: DateTime.now(),
+      state: machineState,
+      pressure: s.groupPressure,
+      flow: s.groupFlow,
+      mixTemperature: s.mixTemp,
+      groupTemperature: s.headTemp,
+      targetMixTemperature: s.setMixTemp,
+      targetGroupTemperature: s.setHeadTemp,
+      targetPressure: s.setGroupPressure,
+      targetFlow: s.setGroupFlow,
+      profileFrame: s.frameNumber,
+      // MachineSnapshot.steamTemperature is an int; the 0xA013 value is
+      // fractional (÷100). Rounding matches the whole-degree 0xA00D field and
+      // keeps the shared type unchanged.
+      steamTemperature: s.steamTemp.round(),
+      weight: s.weight,
+      weightFlow: s.gFlow,
+      milkTemperature: s.milkTemp,
+    );
+  }
+
   De1WaterLevels _parseWaterLevels(ByteData data) {
     try {
       var waterlevel = data.getUint16(0, Endian.big);

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.profile.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.profile.dart
@@ -1,5 +1,12 @@
 part of 'unified_de1.dart';
 
+/// Bengle firmware (BLE protocol v2) supports flow rates up to 20 ml/s,
+/// versus the DE1's 8 ml/s. de1plus raises `max_flowrate` to 20 when
+/// `use_ble_v2` is negotiated (`de1_de1.tcl:778-782`). reaprime is headless
+/// — there is no UI slider to bound a flow input — so the profile encoder
+/// is the enforcement point for this ceiling.
+const double _bengleMaxFlowMlPerSec = 20.0;
+
 extension UnifiedDe1Profile on UnifiedDe1 {
   Future<void> _sendProfile(Profile profile) async {
     await _writeHeader(profile);
@@ -17,22 +24,42 @@ extension UnifiedDe1Profile on UnifiedDe1 {
     await _writeMMRInt(MMRItem.tankTemp, profile.tankTemperature.round());
   }
 
+  /// Encode a flow (ml/s) or pressure (bar) profile field to its wire byte,
+  /// honouring the negotiated protocol version.
+  ///
+  /// A Bengle decodes these as **U8D1** (`byte × 0.1`, range 0..25.5); a DE1
+  /// uses **U8P4** (`byte / 16`, range 0..15.9375). Encoding a v2 value with
+  /// the v1 scale silently mis-commands the machine (`6 ml/s` written as the
+  /// v1 `96` reads back as `9.6` on a Bengle). Only the Bengle U8D1 path clamps
+  /// (to 0..25.5); the DE1 U8P4 path is unchanged from stock reaprime and wraps
+  /// mod-256 above 15.9375 — harmless in practice, as DE1 flow/pressure stays
+  /// well within range. Mirrors de1plus `convert_float_to_flow_pressure_byte`
+  /// (`binary.tcl`).
+  int _encodeFlowPressure(double value) => isBengle
+      ? Helper.convert_float_to_U8D1(value)
+      : (0.5 + value * 16.0).toInt();
+
   Future<void> _writeHeader(Profile profile) async {
     Uint8List data = Uint8List(5);
 
     int index = 0;
-    data[index] = 1; // Header version
+    // a Bengle rejects any header whose version != 2 — the firmware
+    // memsets the header and returns, silently dropping the whole profile
+    //. The DE1 stays on v1.
+    data[index] = isBengle ? 2 : 1; // Header version
     index++;
     data[index] = profile.steps.length;
     index++;
     data[index] = profile.targetVolumeCountStart;
     index++;
-    // min pressure
+    // min pressure (U8D1 on Bengle / U8P4 on DE1 — encodes to 0 either way)
     data[index] = 0;
     index++;
-    // TODO: make this configurable
-    // max flow
-    data[index] = (0.5 + 12.0 * 16.0).toInt();
+    // Global max flow. On a Bengle this advertises the raised 20 ml/s ceiling
+    // (v1 machines cap at 8); every frame sets IgnoreLimit so it is a soft
+    // bound, but it must still be encoded for the negotiated wire version —
+    // the old hard-coded `12 * 16` was a raw v1 (U8P4) byte.
+    data[index] = _encodeFlowPressure(isBengle ? _bengleMaxFlowMlPerSec : 12.0);
 
     await _transport.writeWithResponse(Endpoint.headerWrite, data);
   }
@@ -51,13 +78,24 @@ extension UnifiedDe1Profile on UnifiedDe1 {
       index++;
       data[index] = Helper.convertProfileFlags(step);
       index++;
-      data[index] = (0.5 + step.getTarget() * 16.0).toInt();
-      index++; // note to add 0.5, as "round" is used, not truncate
+      // SetVal: the target flow (ml/s) or pressure (bar). U8D1 on a
+      // Bengle, U8P4 on a DE1. A flow-priority target is clamped to the Bengle
+      // 20 ml/s ceiling first (pressure targets ride the U8D1 0..25.5 clamp).
+      double setVal = step.getTarget();
+      if (isBengle &&
+          step is ProfileStepFlow &&
+          setVal > _bengleMaxFlowMlPerSec) {
+        setVal = _bengleMaxFlowMlPerSec;
+      }
+      data[index] = _encodeFlowPressure(setVal);
+      index++;
       data[index] = (0.5 + step.temperature * 2.0).toInt();
       index++;
       data[index] = Helper.convert_float_to_F8_1_7(step.seconds);
       index++;
-      data[index] = (0.5 + (step.exit?.value ?? 0) * 16.0).toInt();
+      // TriggerVal: the exit-comparison threshold (flow or pressure) — same
+      // U8D1/U8P4 split as SetVal.
+      data[index] = _encodeFlowPressure(step.exit?.value ?? 0.0);
       index++;
       Helper.convert_float_to_U10P0(step.volume, data, index);
 
@@ -79,8 +117,10 @@ extension UnifiedDe1Profile on UnifiedDe1 {
       double limiterValue = step.limiter!.value;
       double limiterRange = step.limiter!.range;
 
-      data[1] = (0.5 + limiterValue * 16.0).toInt();
-      data[2] = (0.5 + limiterRange * 16.0).toInt();
+      // Extension-frame max flow-or-pressure limiter + its range — U8D1 on a
+      // Bengle, U8P4 on a DE1.
+      data[1] = _encodeFlowPressure(limiterValue);
+      data[2] = _encodeFlowPressure(limiterRange);
 
       data[3] = 0;
       data[4] = 0;
@@ -117,6 +157,17 @@ class Helper {
     } else {
       return (x & 127).toDouble();
     }
+  }
+
+  /// U8D1: unsigned byte, scale ×0.1 (range 0..25.5, step 0.1) — the Bengle
+  /// (BLE protocol v2) flow/pressure encoding. Clamps to the byte range so
+  /// out-of-range values saturate instead of wrapping. Uses round-half-up (to
+  /// match the `+ 0.5` truncation the v1 path uses). Mirrors de1plus
+  /// `convert_float_to_U8D1` (`binary.tcl`).
+  // ignore: non_constant_identifier_names
+  static int convert_float_to_U8D1(double x) {
+    final clamped = x < 0.0 ? 0.0 : (x > 25.5 ? 25.5 : x);
+    return (clamped * 10).round();
   }
 
   // ignore: non_constant_identifier_names

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -5,6 +5,8 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart' as device;
 import 'package:reaprime/src/models/device/ble_service_identifier.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/bengle_shot_sample.dart'
+    show bengleShotSampleBytes;
 import 'package:reaprime/src/models/device/transport/ble_timeout_exception.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
@@ -104,6 +106,12 @@ class UnifiedDe1Transport {
   final BehaviorSubject<ByteData> _fwMapRequestSubject = BehaviorSubject.seeded(
     ByteData(7),
   );
+  // Bengle 0xA013 BengleShotSample (28 bytes). Only fed on a Bengle — the
+  // subscription is gated (BLE via [subscribeBengleShotSample], serial via the
+  // `<+S>` in `_serialConnect`). Seeded 28 zero bytes so late subscribers get a
+  // valid-length frame.
+  final BehaviorSubject<ByteData> _bengleShotSampleSubject =
+      BehaviorSubject.seeded(ByteData(bengleShotSampleBytes));
 
   // single-notify serial read channels ([A] Versions,
   // [J] Temperatures, [R] Calibration). Plain broadcast controllers, NOT
@@ -122,6 +130,8 @@ class UnifiedDe1Transport {
   Stream<ByteData> get waterLevels => _waterLevelsSubject.asBroadcastStream();
   Stream<ByteData> get mmr => _mmrSubject.asBroadcastStream();
   Stream<ByteData> get fwMapRequest => _fwMapRequestSubject.asBroadcastStream();
+  Stream<ByteData> get bengleShotSample =>
+      _bengleShotSampleSubject.asBroadcastStream();
 
   // Serial only
   String _currentBuffer = "";
@@ -230,6 +240,39 @@ class UnifiedDe1Transport {
     });
   }
 
+  /// Subscribe to the Bengle 0xA013 BengleShotSample characteristic over BLE.
+  ///
+  /// Called by `UnifiedDe1.onConnect` **after** the Bengle identity is
+  /// confirmed (`v13Model >= 128`), never blind-enabled: enabling a
+  /// characteristic a plain DE1 lacks throws and permanently stalls the BLE
+  /// command queue (de1plus `de1_comms.tcl:777-785`). Idempotent: [subscribe]
+  /// replaces (not stacks) a prior listener for the same characteristic.
+  ///
+  /// On serial the `<+S>` enable already happened in `_serialConnect`;
+  /// instead this post-detection hook drops the now-redundant base stream
+  ///: on a Bengle, 0xA013 is the sole snapshot source, so `[M]`
+  /// (0xA00D) is pure wasted bandwidth — and the dual 15 Hz stream overruns
+  /// the firmware's ~1920 B/s serial downlink ceiling (hw-confirmed
+  /// 2026-07-09: truncated/odd-length frames, weight flicker).
+  /// `_serialConnect` must keep subscribing `<+M>` unconditionally because
+  /// it runs before the identity is known and `[M]` is how the serial probe
+  /// recognises a DE1-family device at all. BLE has the headroom and keeps
+  /// 0xA00D subscribed (parse-and-drop).
+  Future<void> subscribeBengleShotSample() async {
+    final t = _transport;
+    if (transportType == TransportType.serial && t is SerialTransport) {
+      await t.writeCommand("<-${Endpoint.shotSample.representation}>");
+      return;
+    }
+    if (transportType != TransportType.ble) return;
+    if (_transport is! BLETransport) return;
+    await _transport.subscribe(de1ServiceUUID, Endpoint.bengleShotSample.uuid, (
+      d,
+    ) {
+      _bengleShotSampleNotification(ByteData.sublistView(Uint8List.fromList(d)));
+    });
+  }
+
   Future<void> _serialConnect() async {
     if (_transport is! SerialTransport) {
       throw "Wrong transport type";
@@ -249,6 +292,12 @@ class UnifiedDe1Transport {
     await _transport.writeCommand("<+${Endpoint.shotSettings.representation}>");
     await _transport.writeCommand("<+${Endpoint.readFromMMR.representation}>");
     await _transport.writeCommand("<+${Endpoint.fwMapRequest.representation}>");
+    // Bengle 0xA013. Unconditional on serial (unlike the gated BLE subscribe):
+    // the serial parser has no CCCD-on-missing-characteristic stall hazard,
+    // and a plain DE1 simply never emits `[S]` frames.
+    await _transport.writeCommand(
+      "<+${Endpoint.bengleShotSample.representation}>",
+    );
 
     // needed to know which state we're at - request idle state
     await _transport.writeCommand("<B>02");
@@ -285,6 +334,7 @@ class UnifiedDe1Transport {
     if (!_waterLevelsSubject.isClosed) _waterLevelsSubject.close();
     if (!_mmrSubject.isClosed) _mmrSubject.close();
     if (!_fwMapRequestSubject.isClosed) _fwMapRequestSubject.close();
+    if (!_bengleShotSampleSubject.isClosed) _bengleShotSampleSubject.close();
     if (!_versionsController.isClosed) _versionsController.close();
     if (!_temperaturesController.isClosed) _temperaturesController.close();
     if (!_calibrationController.isClosed) _calibrationController.close();
@@ -311,6 +361,7 @@ class UnifiedDe1Transport {
     if (!_waterLevelsSubject.isClosed) _waterLevelsSubject.close();
     if (!_mmrSubject.isClosed) _mmrSubject.close();
     if (!_fwMapRequestSubject.isClosed) _fwMapRequestSubject.close();
+    if (!_bengleShotSampleSubject.isClosed) _bengleShotSampleSubject.close();
     if (!_versionsController.isClosed) _versionsController.close();
     if (!_temperaturesController.isClosed) _temperaturesController.close();
     if (!_calibrationController.isClosed) _calibrationController.close();
@@ -349,6 +400,9 @@ class UnifiedDe1Transport {
         );
         await _transport.writeCommand(
           "<-${Endpoint.fwMapRequest.representation}>",
+        );
+        await _transport.writeCommand(
+          "<-${Endpoint.bengleShotSample.representation}>",
         );
         break;
       case TransportType.ble:
@@ -453,6 +507,8 @@ class UnifiedDe1Transport {
           _mmrNotification(data);
         case "[I]":
           _fwMapNotification(data);
+        case "[S]":
+          _bengleShotSampleNotification(data);
         // single-notify read replies. Only ever solicited by
         // _serialSingleNotifyRead's own `<+X>`, so no length guard here —
         // the awaiting reader owns interpretation.
@@ -500,6 +556,21 @@ class UnifiedDe1Transport {
       return;
     }
     _shotSampleSubject.add(d);
+  }
+
+  // a truncated 0xA013 frame (e.g. a stale/undersized ATT MTU) is
+  // dropped rather than forwarded, so the downstream decoder never hits a
+  // RangeError. Applies to both transports — serial `[S]` frames route here
+  // too.
+  void _bengleShotSampleNotification(ByteData d) {
+    if (d.lengthInBytes < bengleShotSampleBytes) {
+      _log.warning(
+        'Dropping short bengleShotSample frame '
+        '(${d.lengthInBytes} < $bengleShotSampleBytes bytes)',
+      );
+      return;
+    }
+    _bengleShotSampleSubject.add(d);
   }
 
   void _stateNotification(ByteData d) {
@@ -594,7 +665,7 @@ class UnifiedDe1Transport {
   ///    frame immediately, so a read is `<+X>` → await fresh frame →
   ///    `<-X>` ([_serialSingleNotifyRead]).
   /// 3. **No read path** — the firmware never emits the char (its
-  ///    the firmware notify loop serves only N/M/Q/I/E/R — plus J/K with the
+  ///    the firmware notify loop serves only N/M/S/Q/I/E/R — plus J/K with the
   ///    serial-parity firmware; the firmware has no version-frame support,
   ///    so a `versions` read times out cleanly on every firmware today —
   ///    and F/G/H are write-only commands). A descriptive
@@ -623,6 +694,8 @@ class UnifiedDe1Transport {
         return _shotSampleSubject.first;
       case Endpoint.waterLevels:
         return _waterLevelsSubject.first;
+      case Endpoint.bengleShotSample:
+        return _bengleShotSampleSubject.first;
 
       // -- single-notify round trips.
       case Endpoint.versions:

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -26,6 +26,43 @@ class UnifiedDe1Transport {
   // serial branch never runs.
   StreamSubscription<String>? _transportSubscription;
 
+  /// period of the serial keepalive that actively drives the
+  /// shared firmware link. BLE and USB share one serial view in the
+  /// firmware, arbitrated by a last-writer-wins `Source` flag — any stray
+  /// byte from the BLE module silently steals the notify stream from a
+  /// passively-listening USB client (the firmware its BLE input path vs
+  /// the BLE-UART RX path). A periodic `<+N>` re-add re-asserts
+  /// Source=USB, and — because the firmware treats an add-notify as a
+  /// force-update — also re-syncs any subscribed frame a silently-dropped
+  /// byte corrupted (the ASCII framing has no checksum/retransmit). 5 s
+  /// bounds the worst-case stolen-stream window at negligible cost (one
+  /// ~8-char command up, one [N] frame + changed frames down).
+  static const defaultSerialKeepaliveInterval = Duration(seconds: 5);
+
+  /// Test seam: keepalive cadence, injectable so the timer tests can run
+  /// on real (shortened) time — fakeAsync stalls on the root-zone
+  /// `_nullFuture` that broadcast-subscription cancels return.
+  final Duration serialKeepaliveInterval;
+  Timer? _serialKeepalive;
+
+  /// bounded wait for a single-notify serial read. The firmware
+  /// answers a `<+X>` with one `[X]` frame within a notify tick, so 2 s is
+  /// generous; firmware that never emits the char (e.g. a pre-parity
+  /// the firmware asked for `[A]`) fails fast with a [TimeoutException] instead
+  /// of hanging the raw-API caller.
+  static const defaultSerialSingleReadTimeout = Duration(seconds: 2);
+
+  /// Test seam: see [serialKeepaliveInterval].
+  final Duration serialSingleReadTimeout;
+
+  /// the firmware serial parser consumes exactly
+  /// the frame length is 20 bytes per `<F>`
+  /// frame (the firmware serial view counts hex pairs before accepting
+  /// the newline). BLE tolerates a short final DFU chunk; serial drops the
+  /// whole frame and resyncs on the next `<`. The `Len` byte (`data[0]`)
+  /// carries the true payload length, so trailing zeros are inert.
+  static const _writeToMmrFrameBytes = 20;
+
   // True while `_handleBleTimeout` is doing a deliberate disconnect→reconnect
   // to recover from a BLE timeout. The disconnect it issues must stay
   // invisible to upstream (De1Controller would otherwise null the machine on
@@ -68,6 +105,17 @@ class UnifiedDe1Transport {
     ByteData(7),
   );
 
+  // single-notify serial read channels ([A] Versions,
+  // [J] Temperatures, [R] Calibration). Plain broadcast controllers, NOT
+  // BehaviorSubjects: a read must resolve with the fresh frame provoked by
+  // its own `<+X>`, never a cached one.
+  final StreamController<ByteData> _versionsController =
+      StreamController.broadcast();
+  final StreamController<ByteData> _temperaturesController =
+      StreamController.broadcast();
+  final StreamController<ByteData> _calibrationController =
+      StreamController.broadcast();
+
   Stream<ByteData> get state => _stateSubject.asBroadcastStream();
   Stream<ByteData> get shotSample => _shotSampleSubject.asBroadcastStream();
   Stream<ByteData> get shotSettings => shotSettingsSubject.asBroadcastStream();
@@ -78,7 +126,11 @@ class UnifiedDe1Transport {
   // Serial only
   String _currentBuffer = "";
 
-  UnifiedDe1Transport({required DataTransport transport})
+  UnifiedDe1Transport({
+    required DataTransport transport,
+    this.serialKeepaliveInterval = defaultSerialKeepaliveInterval,
+    this.serialSingleReadTimeout = defaultSerialSingleReadTimeout,
+  })
     : _transport = transport,
       transportType =
           transport is BLETransport
@@ -200,6 +252,20 @@ class UnifiedDe1Transport {
 
     // needed to know which state we're at - request idle state
     await _transport.writeCommand("<B>02");
+
+    // actively drive the shared BLE/USB link — see
+    // [serialKeepaliveInterval] for why a passive USB client loses its
+    // notify stream. Fire-and-forget: a failed keepalive write means the
+    // port is dying, which the read-side onError/onDone paths already
+    // handle; it must not become an unhandled async error.
+    _serialKeepalive?.cancel();
+    _serialKeepalive = Timer.periodic(serialKeepaliveInterval, (_) {
+      _transport
+          .writeCommand("<+${Endpoint.stateInfo.representation}>")
+          .catchError(
+            (Object e) => _log.fine('serial keepalive write failed', e),
+          );
+    });
   }
 
   /// End-of-life cleanup. Closes all subjects, cancels the serial
@@ -209,6 +275,8 @@ class UnifiedDe1Transport {
     // Cancel serial subscription if active
     await _transportSubscription?.cancel();
     _transportSubscription = null;
+    _serialKeepalive?.cancel();
+    _serialKeepalive = null;
 
     // Close all BehaviorSubjects so downstream listeners see onDone
     if (!_stateSubject.isClosed) _stateSubject.close();
@@ -217,6 +285,9 @@ class UnifiedDe1Transport {
     if (!_waterLevelsSubject.isClosed) _waterLevelsSubject.close();
     if (!_mmrSubject.isClosed) _mmrSubject.close();
     if (!_fwMapRequestSubject.isClosed) _fwMapRequestSubject.close();
+    if (!_versionsController.isClosed) _versionsController.close();
+    if (!_temperaturesController.isClosed) _temperaturesController.close();
+    if (!_calibrationController.isClosed) _calibrationController.close();
 
     await _transport.dispose();
   }
@@ -232,12 +303,17 @@ class UnifiedDe1Transport {
   Future<void> detach() async {
     await _transportSubscription?.cancel();
     _transportSubscription = null;
+    _serialKeepalive?.cancel();
+    _serialKeepalive = null;
     if (!_stateSubject.isClosed) _stateSubject.close();
     if (!_shotSampleSubject.isClosed) _shotSampleSubject.close();
     if (!shotSettingsSubject.isClosed) shotSettingsSubject.close();
     if (!_waterLevelsSubject.isClosed) _waterLevelsSubject.close();
     if (!_mmrSubject.isClosed) _mmrSubject.close();
     if (!_fwMapRequestSubject.isClosed) _fwMapRequestSubject.close();
+    if (!_versionsController.isClosed) _versionsController.close();
+    if (!_temperaturesController.isClosed) _temperaturesController.close();
+    if (!_calibrationController.isClosed) _calibrationController.close();
   }
 
   Future<void> disconnect() async {
@@ -253,6 +329,8 @@ class UnifiedDe1Transport {
         }
         await _transportSubscription?.cancel();
         _transportSubscription = null;
+        _serialKeepalive?.cancel();
+        _serialKeepalive = null;
         // Start notifications - regular setup
         await _transport.writeCommand(
           "<-${Endpoint.stateInfo.representation}>",
@@ -375,6 +453,15 @@ class UnifiedDe1Transport {
           _mmrNotification(data);
         case "[I]":
           _fwMapNotification(data);
+        // single-notify read replies. Only ever solicited by
+        // _serialSingleNotifyRead's own `<+X>`, so no length guard here —
+        // the awaiting reader owns interpretation.
+        case "[A]":
+          _versionsController.add(data);
+        case "[J]":
+          _temperaturesController.add(data);
+        case "[R]":
+          _calibrationController.add(data);
         default:
           _log.warning("unhandled de1 message: $input");
           break;
@@ -497,49 +584,98 @@ class UnifiedDe1Transport {
     return response;
   }
 
+  /// Serial reads come in three shapes:
+  ///
+  /// 1. **Continuously-subscribed streams** (`<+X>` sent in
+  ///    `_serialConnect`) — the BehaviorSubject's current value *is* the
+  ///    latest frame; return it.
+  /// 2. **Single-notify round trips** — the DE1 serial view has no read
+  ///    verb; an add-notify (`<+X>`) makes the firmware emit one `[X]`
+  ///    frame immediately, so a read is `<+X>` → await fresh frame →
+  ///    `<-X>` ([_serialSingleNotifyRead]).
+  /// 3. **No read path** — the firmware never emits the char (its
+  ///    the firmware notify loop serves only N/M/Q/I/E/R — plus J/K with the
+  ///    serial-parity firmware; the firmware has no version-frame support,
+  ///    so a `versions` read times out cleanly on every firmware today —
+  ///    and F/G/H are write-only commands). A descriptive
+  ///    [UnsupportedError] beats `UnimplementedError`: the raw WS API
+  ///    surfaces it to the client instead of crashing the read.
   Future<ByteData> _serialRead(Endpoint e) async {
     if (transportType != TransportType.serial) {
       throw "Invalid transport type, expected Serial";
     }
 
     switch (e) {
-      case Endpoint.versions:
-        throw UnimplementedError();
+      // -- continuously subscribed: current value is the latest frame.
       case Endpoint.requestedState:
-        return _stateSubject.first;
-      case Endpoint.setTime:
-        throw UnimplementedError();
-      case Endpoint.shotDirectory:
-        throw UnimplementedError();
-      case Endpoint.readFromMMR:
-        return _mmrSubject.first;
-      case Endpoint.writeToMMR:
-        throw UnimplementedError();
-      case Endpoint.shotMapRequest:
-        throw UnimplementedError();
-      case Endpoint.deleteShotRange:
-        throw UnimplementedError();
-      case Endpoint.fwMapRequest:
-        return _fwMapRequestSubject.first;
-      case Endpoint.temperatures:
-        throw UnimplementedError();
-      case Endpoint.shotSettings:
-        return shotSettingsSubject.first;
-      case Endpoint.deprecatedShotDesc:
-        throw UnimplementedError();
-      case Endpoint.shotSample:
-        return _shotSampleSubject.first;
       case Endpoint.stateInfo:
         return _stateSubject.first;
-      case Endpoint.headerWrite:
-        throw UnimplementedError();
-      case Endpoint.frameWrite:
-        throw UnimplementedError();
+      case Endpoint.readFromMMR:
+        return _mmrSubject.first;
+      case Endpoint.fwMapRequest:
+        return _fwMapRequestSubject.first;
+      case Endpoint.shotSettings:
+        // Note: the the Bengle firmware accepts <K> writes but does not emit
+        // [K] frames (no the firmware notify loop block), so on serial this stays the
+        // seeded zero frame until the firmware gains [K] support.
+        return shotSettingsSubject.first;
+      case Endpoint.shotSample:
+        return _shotSampleSubject.first;
       case Endpoint.waterLevels:
         return _waterLevelsSubject.first;
+
+      // -- single-notify round trips.
+      case Endpoint.versions:
+        return _serialSingleNotifyRead(e, _versionsController.stream);
+      case Endpoint.temperatures:
+        return _serialSingleNotifyRead(e, _temperaturesController.stream);
       case Endpoint.calibration:
-        // TODO: Handle this case.
-        throw UnimplementedError();
+        return _serialSingleNotifyRead(e, _calibrationController.stream);
+
+      // -- no serial read path.
+      case Endpoint.setTime:
+      case Endpoint.shotDirectory:
+      case Endpoint.writeToMMR:
+      case Endpoint.shotMapRequest:
+      case Endpoint.deleteShotRange:
+      case Endpoint.deprecatedShotDesc:
+      case Endpoint.headerWrite:
+      case Endpoint.frameWrite:
+        throw UnsupportedError(
+          'Endpoint ${e.name} has no serial read path: the DE1 serial view '
+          'never emits [${e.representation}] frames',
+        );
+    }
+  }
+
+  /// One-shot serial read of a characteristic that is not continuously
+  /// subscribed: arm a listener, provoke a single notify with
+  /// `<+X>`, await the fresh frame, then `<-X>` so the read leaves no
+  /// stream subscription behind. Bounded by [serialSingleReadTimeout] so
+  /// firmware that never emits the char yields a clean [TimeoutException]
+  /// instead of a hang.
+  Future<ByteData> _serialSingleNotifyRead(
+    Endpoint e,
+    Stream<ByteData> frames,
+  ) async {
+    final t = _transport;
+    if (t is! SerialTransport) {
+      throw StateError(
+        '_serialSingleNotifyRead(${e.name}) requires a serial transport',
+      );
+    }
+    // Arm BEFORE requesting so the reply can't slip between the write
+    // completing and the listener attaching (same race `_mmrReadRaw`
+    // guards against).
+    final response = frames.first.timeout(serialSingleReadTimeout);
+    // If the request write throws, nothing awaits `response` and its later
+    // timeout would surface as an unhandled async error — mark it handled.
+    response.ignore();
+    try {
+      await t.writeCommand('<+${e.representation}>');
+      return await response;
+    } finally {
+      await t.writeCommand('<-${e.representation}>');
     }
   }
 
@@ -662,7 +798,16 @@ class UnifiedDe1Transport {
     if (_transport is! SerialTransport) {
       throw "Invalid transport type, expected Serial";
     }
-    final payload = data
+    var frame = data;
+    // length-exact framing. Only writeToMMR has a short-frame
+    // producer (the DFU uploader's final image chunk); every other caller
+    // already emits struct-sized frames (`_mmrWriteRaw` pads to 20,
+    // Header/Frame writes are 5 B / 8 B by construction). See
+    // [_writeToMmrFrameBytes] for why the firmware requires this.
+    if (e == Endpoint.writeToMMR && data.length < _writeToMmrFrameBytes) {
+      frame = Uint8List(_writeToMmrFrameBytes)..setRange(0, data.length, data);
+    }
+    final payload = frame
         .map((e) => e.toRadixString(16).padLeft(2, '0'))
         .join('');
     await _transport.writeCommand('<${e.representation!}>$payload');

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -42,6 +42,12 @@ class UnifiedDe1Transport {
 
   String get id => _transport.id;
 
+  /// The underlying [DataTransport], exposed for connect-time model-based
+  /// class resolution only (see `resolveMachineForModel`): a re-resolved
+  /// machine is rebuilt over this same live transport. Not for I/O — use the
+  /// typed read/write/subscribe surface.
+  DataTransport get dataTransport => _transport;
+
   final BehaviorSubject<ByteData> _stateSubject = BehaviorSubject.seeded(
     ByteData(4),
   );
@@ -213,6 +219,25 @@ class UnifiedDe1Transport {
     if (!_fwMapRequestSubject.isClosed) _fwMapRequestSubject.close();
 
     await _transport.dispose();
+  }
+
+  /// Releases this wrapper's own resources (serial read subscription + local
+  /// subjects) WITHOUT disposing the underlying [dataTransport]. Used when a
+  /// machine is re-resolved to a different class over the same live transport
+  /// (`resolveMachineForModel`): the discarded interim wrapper must stop
+  /// listening — else a serial `readStream` listener lingers and
+  /// double-parses every line — but must NOT tear down the shared transport,
+  /// which the replacement wrapper now owns. Not for normal teardown; use
+  /// [dispose] for that.
+  Future<void> detach() async {
+    await _transportSubscription?.cancel();
+    _transportSubscription = null;
+    if (!_stateSubject.isClosed) _stateSubject.close();
+    if (!_shotSampleSubject.isClosed) _shotSampleSubject.close();
+    if (!shotSettingsSubject.isClosed) shotSettingsSubject.close();
+    if (!_waterLevelsSubject.isClosed) _waterLevelsSubject.close();
+    if (!_mmrSubject.isClosed) _mmrSubject.close();
+    if (!_fwMapRequestSubject.isClosed) _fwMapRequestSubject.close();
   }
 
   Future<void> disconnect() async {

--- a/lib/src/models/device/impl/simulated_shot_weight_model.dart
+++ b/lib/src/models/device/impl/simulated_shot_weight_model.dart
@@ -37,12 +37,19 @@ class SimulatedShotWeightModel {
   double _tareOffset = 0.0;
   bool _inShot = false;
   DateTime? _lastSampleTime;
+  double _flow = 0.0; // synthesised gravimetric flow, g/s
 
   double get _gross =>
       _settledWeight + max(0.0, _shotVolume - firstDropsMl);
 
   /// Current (tared) scale reading in grams. Never decreases mid-shot.
   double get weight => _gross - _tareOffset;
+
+  /// Synthesised gravimetric flow (dW/dt) in g/s, tracking [weight]. Zero
+  /// whenever the weight is not changing (idle, preinfusion, steam), so a
+  /// simulated Bengle can report its own flow the way the real firmware
+  /// reports gFlow — one source, no estimator.
+  double get flow => _flow;
 
   /// Zero the reading, like placing/taring a cup.
   void tare() => _tareOffset = _gross;
@@ -55,6 +62,7 @@ class SimulatedShotWeightModel {
     _tareOffset = 0.0;
     _inShot = false;
     _lastSampleTime = null;
+    _flow = 0.0;
   }
 
   /// Integrate one machine snapshot (uses the snapshot's own timestamp, so
@@ -78,15 +86,19 @@ class SimulatedShotWeightModel {
     final dtSec = now.difference(last).inMilliseconds / 1000.0;
     if (dtSec <= 0) return;
 
+    final grossBefore = _gross;
     if (inEspresso) {
-      if (s.profileFrame < targetVolumeCountStart) return;
-      _pourElapsed += dtSec;
-      final ramp = (_pourElapsed / saturationSecs).clamp(0.0, 1.0);
-      _shotVolume += s.flow * dtSec * ramp;
+      if (s.profileFrame >= targetVolumeCountStart) {
+        _pourElapsed += dtSec;
+        final ramp = (_pourElapsed / saturationSecs).clamp(0.0, 1.0);
+        _shotVolume += s.flow * dtSec * ramp;
+      }
     } else if (s.state.state == MachineState.hotWater) {
       // Hot water pours straight into the cup — no puck to absorb it or
       // hold back the first drops.
       _settledWeight += s.flow * dtSec;
     }
+    // dW/dt over this interval: the gravimetric flow the weight is rising at.
+    _flow = (_gross - grossBefore) / dtSec;
   }
 }

--- a/lib/src/models/device/machine.dart
+++ b/lib/src/models/device/machine.dart
@@ -48,6 +48,18 @@ class MachineSnapshot {
   final int profileFrame;
   final int steamTemperature;
 
+  /// Integrated-scale weight in grams (Bengle `0xA013`, already net of tare).
+  /// `0.0` on machines without an integrated scale.
+  final double weight;
+
+  /// Gravimetric flow in g/s from the integrated scale (Bengle `0xA013`
+  /// GFlow). `0.0` on machines without an integrated scale.
+  final double weightFlow;
+
+  /// Milk-probe temperature in °C (Bengle `0xA013`). `0.0` when the firmware
+  /// does not provide it (no probe / no fresh reading).
+  final double milkTemperature;
+
   MachineSnapshot({
     required this.timestamp,
     required this.state,
@@ -61,6 +73,9 @@ class MachineSnapshot {
     required this.targetGroupTemperature,
     required this.profileFrame,
     required this.steamTemperature,
+    this.weight = 0.0,
+    this.weightFlow = 0.0,
+    this.milkTemperature = 0.0,
   });
 
   // CopyWith Method
@@ -77,6 +92,9 @@ class MachineSnapshot {
     double? targetGroupTemperature,
     int? profileFrame,
     int? steamTemperature,
+    double? weight,
+    double? weightFlow,
+    double? milkTemperature,
   }) {
     return MachineSnapshot(
       timestamp: timestamp ?? this.timestamp,
@@ -92,6 +110,9 @@ class MachineSnapshot {
           targetGroupTemperature ?? this.targetGroupTemperature,
       profileFrame: profileFrame ?? this.profileFrame,
       steamTemperature: steamTemperature ?? this.steamTemperature,
+      weight: weight ?? this.weight,
+      weightFlow: weightFlow ?? this.weightFlow,
+      milkTemperature: milkTemperature ?? this.milkTemperature,
     );
   }
 
@@ -109,6 +130,9 @@ class MachineSnapshot {
       'targetGroupTemperature': targetGroupTemperature,
       'profileFrame': profileFrame,
       'steamTemperature': steamTemperature,
+      'weight': weight,
+      'weightFlow': weightFlow,
+      'milkTemperature': milkTemperature,
     };
   }
 
@@ -133,6 +157,10 @@ class MachineSnapshot {
       targetGroupTemperature: json["targetGroupTemperature"],
       profileFrame: json["profileFrame"],
       steamTemperature: json["steamTemperature"],
+      // Additive fields — default 0.0 so older payloads still decode.
+      weight: (json["weight"] ?? 0.0).toDouble(),
+      weightFlow: (json["weightFlow"] ?? 0.0).toDouble(),
+      milkTemperature: (json["milkTemperature"] ?? 0.0).toDouble(),
     );
   }
 }

--- a/lib/src/models/device/scale.dart
+++ b/lib/src/models/device/scale.dart
@@ -38,11 +38,25 @@ class ScaleSnapshot {
   final int batteryLevel;
   final Duration? timerValue;
 
+  /// Flow rate in g/s **as computed by the device itself**, or `null` when the
+  /// device cannot compute one.
+  ///
+  /// Almost every scale leaves this `null`: a BLE scale reports weight only, so
+  /// the app must estimate flow from the weight series — that is what
+  /// [ScaleController]'s estimators are for. A scale that derives flow
+  /// on-hardware from the load cell it owns (the Bengle's integrated scale, via
+  /// the `0xA013` `GFlow` field) reports it here, and [ScaleController] passes
+  /// it through verbatim instead of re-deriving it. Re-estimating a number the
+  /// device already computed is strictly worse — the estimators need roughly a
+  /// second to converge on a value the device has correct at the first sample.
+  final double? flow;
+
   ScaleSnapshot({
     required this.timestamp,
     required this.weight,
     required this.batteryLevel,
     this.timerValue,
+    this.flow,
   });
 
   Map<String, dynamic> toJson() {

--- a/lib/src/models/device/scale_calibration.dart
+++ b/lib/src/models/device/scale_calibration.dart
@@ -1,0 +1,177 @@
+// Public domain types for Bengle integrated-scale load-cell calibration
+// (FIX-07). Kept out of the `unified_de1` impl library so `BengleInterface`,
+// `MockBengle`, and the webserver handler can import them without depending on
+// the transport implementation (same layering as `scale.dart` /
+// `led_strip.dart`). The wire encoding + the state machine live in
+// `impl/de1/unified_de1/scale_calibration_capability.dart`.
+//
+// The firmware cal is a **two-point** load-cell calibration (redesigned
+// firmware calibration redesign): precision-zero on an empty platform,
+// then latch a known reference mass directly on EITHER bare cell (platform
+// OFF — the firmware AUTO-DETECTS the loaded cell), move it to the other
+// cell and latch again; the 2x2 solve recovers both per-cell sensitivities
+// so summed mass is position-independent. The detected cell is reported in
+// the SubState byte's high nibble (0 = none, 1 = cell A/left, 2 = cell
+// B/right) so a wizard can prompt the move.
+
+/// Decoded `Step` field of a `ScaleCalState` word (firmware `E_ScaleCalStep`).
+/// Poll until [complete] or [error].
+enum ScaleCalStep {
+  idle(0),
+  zeroing(1),
+  calLatch(2), // isolated-cell gain latch (auto-detect) in progress
+  taring(4),
+  complete(5),
+  error(6),
+  unknown(-1);
+
+  const ScaleCalStep(this.wire);
+  final int wire;
+
+  static ScaleCalStep fromWire(int w) =>
+      values.firstWhere((s) => s.wire == w, orElse: () => ScaleCalStep.unknown);
+}
+
+/// Decoded `SubState` field (firmware `C_LoadCellCal::getState()`):
+/// settling → averaging → done/error.
+enum ScaleCalSubState {
+  settling(0),
+  averaging(1),
+  done(2),
+  error(3),
+  unknown(-1);
+
+  const ScaleCalSubState(this.wire);
+  final int wire;
+
+  static ScaleCalSubState fromWire(int w) => values
+      .firstWhere((s) => s.wire == w, orElse: () => ScaleCalSubState.unknown);
+}
+
+/// The `CalStatus` low byte of `ScaleCalState` — firmware `E_CalStatus`, the
+/// result of the last cal latch attempt. Only meaningful during/after a
+/// gain latch ([ScaleCalStep.calLatch]); the firmware reports [none]
+/// (`0xFF`) for zero/tare.
+///
+/// [ok] = both points solved (firmware persisted + applied the cal).
+/// [incomplete] = this point latched fine; place the mass on the other half
+/// and latch the sibling point. The rest are rejections.
+enum ScaleCalPointStatus {
+  ok(0),
+  incomplete(1),
+  noZero(2), // load cells never zeroed — run zero first
+  notSettled(3), // counts drifted through the average window; re-run
+  badWeight(4), // reference weight implausible
+  badDelta(5), // non-positive / implausible per-cell delta
+  illConditioned(6), // solve backstop: placements indistinguishable
+  outOfRange(7), // solved cals outside +/-50% of nominal
+  notIsolated(8), // no dominant cell: platform still fitted / mass bridging
+  none(0xFF), // not a cal point (zero/tare) / in progress
+  unknown(-1);
+
+  const ScaleCalPointStatus(this.wire);
+  final int wire;
+
+  static ScaleCalPointStatus fromWire(int w) => values
+      .firstWhere((c) => c.wire == w, orElse: () => ScaleCalPointStatus.unknown);
+}
+
+/// Decoded `ScaleCalState` packed word
+/// (`Step[31:24] | SubState[23:16] | Remaining[15:8] | CalStatus[7:0]`).
+class ScaleCalStatus {
+  const ScaleCalStatus({
+    required this.step,
+    required this.subState,
+    required this.remainingSeconds,
+    required this.pointStatus,
+    required this.raw,
+    this.detectedCell,
+  });
+
+  final ScaleCalStep step;
+  final ScaleCalSubState subState;
+
+  /// Cell auto-detected by the last successful latch, from the SubState
+  /// byte's high nibble: 0 = cell A (left), 1 = cell B (right), null = none.
+  final int? detectedCell;
+
+  /// Whole seconds the firmware reports remaining in the current phase.
+  final int remainingSeconds;
+
+  /// Last cal-point latch result ([ScaleCalPointStatus.none] outside a
+  /// weight-cal point).
+  final ScaleCalPointStatus pointStatus;
+
+  /// The raw packed word (low 32 bits), for logging / forward-compat.
+  final int raw;
+
+  // Terminal detection keys off SubState, NOT Step.  The SubState field (`done=2`/`error=3`) is set
+  // atomically with Step and is stable across both firmware variants.
+  bool get isComplete => subState == ScaleCalSubState.done;
+  bool get isError => subState == ScaleCalSubState.error;
+  bool get isTerminal => isComplete || isError;
+
+  factory ScaleCalStatus.fromRaw(int rawSigned) {
+    final u = rawSigned & 0xFFFFFFFF; // treat as unsigned 32-bit
+    // SubState byte: phase in the low nibble; auto-detected cell in the
+    // high nibble (0 = none, 1 = cell A, 2 = cell B).
+    final cellNibble = (u >> 20) & 0x0F;
+    return ScaleCalStatus(
+      step: ScaleCalStep.fromWire((u >> 24) & 0xFF),
+      subState: ScaleCalSubState.fromWire((u >> 16) & 0x0F),
+      remainingSeconds: (u >> 8) & 0xFF,
+      pointStatus: ScaleCalPointStatus.fromWire(u & 0xFF),
+      raw: u,
+      detectedCell: cellNibble == 0 ? null : cellNibble - 1,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'step': step.name,
+        'subState': subState.name,
+        'remainingSeconds': remainingSeconds,
+        'pointStatus': pointStatus.name,
+        if (detectedCell != null) 'detectedCell': detectedCell,
+      };
+
+  @override
+  String toString() =>
+      'ScaleCalStatus(step: ${step.name}, subState: ${subState.name}, '
+      'remaining: ${remainingSeconds}s, pointStatus: ${pointStatus.name})';
+}
+
+/// Outcome of a bounded calibration step (zero, or one weight-cal point).
+class ScaleCalResult {
+  const ScaleCalResult({
+    required this.success,
+    required this.finalStep,
+    required this.pointStatus,
+    this.message,
+  });
+
+  final bool success;
+  final ScaleCalStep finalStep;
+
+  /// The firmware `CalStatus` at the terminal step. For a successful point-1
+  /// latch this is [ScaleCalPointStatus.incomplete] (latched, awaiting the
+  /// sibling); for a successful point-2 latch it is [ScaleCalPointStatus.ok]
+  /// (solved + persisted). [ScaleCalPointStatus.none] for zero/tare.
+  final ScaleCalPointStatus pointStatus;
+
+  /// Human-readable reason on failure (`timed out`, `firmware error`,
+  /// `aborted`, `already in progress`, or the rejecting CalStatus), null on
+  /// success.
+  final String? message;
+
+  Map<String, dynamic> toJson() => {
+        'success': success,
+        'finalStep': finalStep.name,
+        'pointStatus': pointStatus.name,
+        if (message != null) 'message': message,
+      };
+
+  @override
+  String toString() => 'ScaleCalResult(success: $success, '
+      'finalStep: ${finalStep.name}, pointStatus: ${pointStatus.name}'
+      '${message != null ? ', message: $message' : ''})';
+}

--- a/lib/src/models/wake_schedule_windows.dart
+++ b/lib/src/models/wake_schedule_windows.dart
@@ -1,0 +1,314 @@
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/wake_schedule.dart';
+
+/// Derivation of concrete wake WINDOWS from the app's [WakeSchedule] list,
+/// in the firmware's own semantics.
+///
+/// **This is the single source of truth for "when is a wake window open".**
+/// It suppresses the app's own idle-sleep timer
+/// (`PresenceController._onSleepTimeout`), and it is the derivation any
+/// machine-side scheduler should pack its own schedule table from — one
+/// derivation, so an autonomous scheduler and the app's sleep logic can never
+/// disagree about when a window is open.
+///
+/// Pure Dart: no Flutter, no device, no I/O. Everything here is testable
+/// against the firmware decoder.
+
+final Logger _log = Logger('WakeScheduleWindows');
+
+/// Window length used for a schedule with no `keepAwakeFor` ("wake-only").
+///
+/// The firmware cannot express "wake, then hand straight back to the idle
+/// timer" — it rejects `startMin >= endMin`, so a window must have real
+/// length. 30 minutes matches the app's default sleep timeout: the machine
+/// wakes on the window's rising edge, is held awake for 30 min, then
+/// `InactivitySleepTimeout` governs again. (A 1-minute window is
+/// semantically purer but a fragile target against any firmware-clock
+/// error, and a missed window means the machine never wakes at all.)
+const int kDefaultWakeWindowMinutes = 30;
+
+/// Firmware table capacity. The
+/// firmware SILENTLY drops the 33rd entry, so the app merges and caps
+/// (see [expandWindows]) rather than inheriting that behaviour.
+const int kMaxWakeWindows = 32;
+
+/// Minutes in a day. `endMin == kMinutesPerDay` (1440) is legal and means
+/// "up to, but not including, midnight" (`endMin` is exclusive).
+const int kMinutesPerDay = 1440;
+
+/// Seconds in a week. The firmware rejects `secOfWeek >= 604800`
+///, so the largest writable value is 604799.
+const int kSecondsPerWeek = 604800;
+
+/// Maps an ISO-8601 weekday (`DateTime.weekday`: 1 = Monday … 7 = Sunday)
+/// onto the firmware's day INDEX (0 = Sunday … 6 = Saturday).
+///
+/// The firmware compares the day for EQUALITY against
+/// `getLocalSecOfWeek() / 86400`, which is 0 on Sunday — it is NOT a
+/// bitmask. See [packWakeWindow].
+int fwDayOfWeek(int isoWeekday) => isoWeekday % 7;
+
+/// One firmware wake window, in firmware semantics.
+///
+/// [dow] is a day INDEX (0 = Sunday … 6 = Saturday), [startMin] is
+/// inclusive, [endMin] is exclusive, both minutes after LOCAL midnight.
+class WakeWindow {
+  const WakeWindow({
+    required this.dow,
+    required this.startMin,
+    required this.endMin,
+  });
+
+  /// Day index, 0 = Sunday … 6 = Saturday (NOT a bitmask).
+  final int dow;
+
+  /// Minutes after local midnight, inclusive. 0…1439.
+  final int startMin;
+
+  /// Minutes after local midnight, exclusive. 1…1440.
+  final int endMin;
+
+  /// This window packed for the `ScheduleEntry` register.
+  int get packed =>
+      packWakeWindow(dow: dow, startMin: startMin, endMin: endMin);
+
+  @override
+  bool operator ==(Object other) =>
+      other is WakeWindow &&
+      other.dow == dow &&
+      other.startMin == startMin &&
+      other.endMin == endMin;
+
+  @override
+  int get hashCode => Object.hash(dow, startMin, endMin);
+
+  @override
+  String toString() => 'WakeWindow(dow: $dow, $startMin..$endMin)';
+}
+
+/// Packs one wake window for the firmware `ScheduleEntry` register:
+/// `(dow << 22) | (startMin << 11) | endMin`.
+///
+/// **`dow` is a DAY INDEX (0 = Sunday … 6 = Saturday), NOT a bitmask.**
+/// The firmware does `(packed >> 22) & 0x7` and then compares the result
+/// for equality against today's day index, so a
+/// "Mon–Fri" schedule is five separate entries. Packing the ISO day set as
+/// a bitmask (`0b0111110` = 62) would decode to `62 & 7 == 6` — one window,
+/// on Saturday — and the firmware would report no error.
+///
+/// The firmware silently drops an entry with `dow > 6`,
+/// `startMin >= endMin` (so zero-length and midnight-crossing windows are
+/// impossible — the caller must split them) or `endMin > 1440`.
+int packWakeWindow({
+  required int dow,
+  required int startMin,
+  required int endMin,
+}) {
+  assert(dow >= 0 && dow <= 6, 'dow is a day index 0..6, not a bitmask');
+  assert(startMin >= 0 && startMin < endMin, 'firmware rejects start >= end');
+  assert(endMin <= kMinutesPerDay, 'firmware rejects endMin > 1440');
+  return (dow << 22) | (startMin << 11) | endMin;
+}
+
+/// Expands the app's [schedules] into the firmware's wake windows:
+/// one entry PER DAY, midnight-crossing windows split across two days,
+/// overlapping/touching windows merged, capped at [kMaxWakeWindows],
+/// deterministically ordered by `(dow, startMin)`.
+///
+/// Disabled schedules contribute nothing. An empty `daysOfWeek` means
+/// "every day" (7 entries). A schedule without `keepAwakeFor` gets a
+/// [kDefaultWakeWindowMinutes] window.
+List<WakeWindow> expandWindows(List<WakeSchedule> schedules) {
+  final raw = <WakeWindow>[];
+
+  for (final schedule in schedules) {
+    if (!schedule.enabled) continue;
+    final startMin = schedule.hour * 60 + schedule.minute;
+    if (startMin < 0 || startMin >= kMinutesPerDay) {
+      _log.warning('Skipping schedule ${schedule.id}: start minute $startMin '
+          'is outside 0..1439');
+      continue;
+    }
+    // WakeSchedule already normalises `0` to null; clamp defensively so a
+    // hand-edited settings blob can never emit an entry the firmware drops.
+    final windowMinutes =
+        (schedule.keepAwakeFor ?? kDefaultWakeWindowMinutes).clamp(1, 720);
+    final endMinRaw = startMin + windowMinutes;
+
+    final isoDays = schedule.daysOfWeek.isEmpty
+        ? const <int>{1, 2, 3, 4, 5, 6, 7} // empty set = every day
+        : schedule.daysOfWeek;
+
+    for (final iso in isoDays) {
+      if (iso < 1 || iso > 7) {
+        _log.warning('Skipping day $iso of schedule ${schedule.id}: not an '
+            'ISO weekday (1..7)');
+        continue;
+      }
+      final dow = fwDayOfWeek(iso);
+      if (endMinRaw <= kMinutesPerDay) {
+        raw.add(WakeWindow(dow: dow, startMin: startMin, endMin: endMinRaw));
+      } else {
+        // Midnight crossing: the firmware rejects startMin >= endMin, so the
+        // app splits the window across two consecutive day indices. Saturday
+        // wraps to Sunday — the table is a weekly repeat, so "next Sunday"
+        // and "this Sunday" are the same slot.
+        raw.add(WakeWindow(
+          dow: dow,
+          startMin: startMin,
+          endMin: kMinutesPerDay,
+        ));
+        raw.add(WakeWindow(
+          dow: (dow + 1) % 7,
+          startMin: 0,
+          endMin: endMinRaw - kMinutesPerDay,
+        ));
+      }
+    }
+  }
+
+  final merged = mergeWindows(raw);
+  if (merged.length <= kMaxWakeWindows) return merged;
+
+  _log.warning(
+    'Wake schedule produces ${merged.length} windows but the firmware table '
+    'holds $kMaxWakeWindows; dropping the last ${merged.length - kMaxWakeWindows}. '
+    'Reduce the number of schedules or merge overlapping ones.',
+  );
+  return merged.sublist(0, kMaxWakeWindows);
+}
+
+/// Merges overlapping OR touching windows within each day and returns them
+/// sorted by `(dow, startMin)`. Touching (`next.startMin == current.endMin`)
+/// windows merge too: two adjacent windows are one window, and every entry
+/// saved is a firmware table slot saved.
+List<WakeWindow> mergeWindows(List<WakeWindow> windows) {
+  final byDay = <int, List<WakeWindow>>{};
+  for (final w in windows) {
+    byDay.putIfAbsent(w.dow, () => <WakeWindow>[]).add(w);
+  }
+
+  final merged = <WakeWindow>[];
+  final days = byDay.keys.toList()..sort();
+  for (final dow in days) {
+    final day = byDay[dow]!..sort((a, b) {
+      final byStart = a.startMin.compareTo(b.startMin);
+      return byStart != 0 ? byStart : a.endMin.compareTo(b.endMin);
+    });
+    var start = day.first.startMin;
+    var end = day.first.endMin;
+    for (final w in day.skip(1)) {
+      if (w.startMin <= end) {
+        // Overlapping or touching — union them.
+        if (w.endMin > end) end = w.endMin;
+      } else {
+        merged.add(WakeWindow(dow: dow, startMin: start, endMin: end));
+        start = w.startMin;
+        end = w.endMin;
+      }
+    }
+    merged.add(WakeWindow(dow: dow, startMin: start, endMin: end));
+  }
+  return merged;
+}
+
+/// Whether [now] falls inside any of [windows]. Start inclusive, end
+/// exclusive — the same comparison the firmware makes
+///.
+bool isWithinWindow(List<WakeWindow> windows, DateTime now) {
+  final dow = fwDayOfWeek(now.weekday);
+  final minute = now.hour * 60 + now.minute;
+  for (final w in windows) {
+    if (w.dow == dow && minute >= w.startMin && minute < w.endMin) return true;
+  }
+  return false;
+}
+
+/// The wall-clock instant the window containing [now] closes, or `null` if
+/// [now] is not inside a window.
+///
+/// Chains across a midnight split: a window ending at 24:00 whose successor
+/// day starts at 00:00 reports the successor's end, so the caller sees the
+/// user's real "keep awake until" rather than the internal split boundary.
+///
+/// Component-based on purpose, like [isWithinWindow] and [localSecondsOfWeek]:
+/// the schedule is wall-clock, so the end must be built from calendar fields.
+/// Adding a [Duration] instead would add *absolute* elapsed time, and across a
+/// DST transition that lands an hour off the wall clock the user (and the
+/// firmware) actually schedules against — a 05:30–07:00 window on a
+/// spring-forward day would report 08:00.
+DateTime? windowEnd(List<WakeWindow> windows, DateTime now) {
+  final minute = now.hour * 60 + now.minute;
+  var dow = fwDayOfWeek(now.weekday);
+
+  WakeWindow? active;
+  for (final w in windows) {
+    if (w.dow == dow && minute >= w.startMin && minute < w.endMin) {
+      active = w;
+      break;
+    }
+  }
+  if (active == null) return null;
+
+  var dayOffset = 0;
+  var end = active.endMin;
+  // Follow midnight-split chains (bounded by the 7 days in the table, so a
+  // pathological all-day-every-day table cannot spin here).
+  for (var hop = 0; hop < 7 && end == kMinutesPerDay; hop++) {
+    final nextDow = (dow + 1) % 7;
+    WakeWindow? next;
+    for (final w in windows) {
+      if (w.dow == nextDow && w.startMin == 0) {
+        next = w;
+        break;
+      }
+    }
+    if (next == null) break;
+    dow = nextDow;
+    dayOffset++;
+    end = next.endMin;
+  }
+
+  // `end` may be kMinutesPerDay (a 24:00 close with no successor to chain to);
+  // DateTime normalises hour 24 to 00:00 of the following day, which is the
+  // instant we mean.
+  return DateTime(
+    now.year,
+    now.month,
+    now.day + dayOffset,
+    end ~/ 60,
+    end % 60,
+  );
+}
+
+/// LOCAL seconds since Sunday 00:00:00, for the firmware `SetLocalTimeOfWeek`
+/// register.
+///
+/// Component-based on purpose: epoch arithmetic breaks across a DST
+/// transition, and the firmware clock is a LOCAL wall-clock, not UTC.
+///
+/// Clamped to `1..604799`: the firmware rejects `>= 604800` outright, and the
+/// app never writes `0` because a read-back of `0` is the "rebooted, never
+/// synced" sentinel (the register is RAM-only with initval 0). Sunday
+/// 00:00:00 therefore reports 1 — a ≤ 1 s lie once a week, in exchange for an
+/// unambiguous reboot signal.
+int localSecondsOfWeek(DateTime now) {
+  final seconds = fwDayOfWeek(now.weekday) * 86400 +
+      now.hour * 3600 +
+      now.minute * 60 +
+      now.second;
+  return seconds.clamp(1, kSecondsPerWeek - 1);
+}
+
+/// Parses the settings blob (`SettingsController.wakeSchedules`) into
+/// windows, tolerating a malformed blob (logs and returns no windows rather
+/// than throwing into a connect flow or a timer callback).
+List<WakeWindow> windowsFromSettingsJson(String json) {
+  if (json.isEmpty || json == '[]') return const <WakeWindow>[];
+  try {
+    return expandWindows(WakeSchedule.deserializeList(json));
+  } catch (e) {
+    _log.warning('Failed to parse wake schedules; treating as none', e);
+    return const <WakeWindow>[];
+  }
+}

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io' show Platform;
 import 'dart:typed_data';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart' as device;
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
@@ -58,9 +59,17 @@ class UniversalBleTransport implements BLETransport {
   static const int _bluezDiscoveryRetries = 3;
   static const Duration _bluezDiscoveryRetryDelay = Duration(seconds: 1);
 
-  bool get _isLinux => Platform.isLinux;
+  bool get _isLinux => isLinuxOverride ?? Platform.isLinux;
 
-  UniversalBleTransport({required BleDevice device}) : _device = device {
+  /// Test seam for the Linux-vs-rest platform gate (`dart:io Platform` is
+  /// not fakeable in unit tests). Production code never sets it.
+  @visibleForTesting
+  final bool? isLinuxOverride;
+
+  UniversalBleTransport({
+    required BleDevice device,
+    @visibleForTesting this.isLinuxOverride,
+  }) : _device = device {
     _log = Logger("BLETransport-${device.deviceId}");
   }
 
@@ -105,12 +114,22 @@ class UniversalBleTransport implements BLETransport {
     }
     _startAdvertWatch();
 
-    // Android: post-connect settle + MTU bump.
-    // The 200ms settle avoids service-discovery races on tablet SoCs
-    // where the BLE stack finalises GATT setup asynchronously after
-    // connect. MTU 517 reduces GATT round-trips for reads/writes.
-    if (!_isLinux && Platform.isAndroid) {
-      await Future.delayed(_androidPostConnectDelay);
+    // Post-connect MTU bump: request a large ATT MTU on ALL platforms, not
+    // just Android. The 28-byte Bengle 0xA013 shot-sample notification needs
+    // an MTU above the 23-byte ATT default (else the notification truncates),
+    // and MTU 517 also reduces GATT round-trips for every read/write. The
+    // DE1/Bengle module self-negotiates up to 247 on connect regardless, so
+    // this client request is a belt-and-suspenders complement. Skipped on
+    // Linux — BlueZ manages the MTU itself and universal_ble does not expose
+    // requestMtu there. MTU is a BLE-only concept; the serial transport
+    // neither has nor needs one.
+    if (!_isLinux) {
+      // The 200ms settle avoids a service-discovery race on Android tablet
+      // SoCs that finalise GATT setup asynchronously after connect. Only
+      // needed there, so keep it Android-scoped.
+      if (Platform.isAndroid) {
+        await Future.delayed(_androidPostConnectDelay);
+      }
       try {
         await UniversalBle.requestMtu(
           _device.deviceId,

--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
@@ -187,11 +188,22 @@ class SerialServiceAndroid implements DeviceDiscoveryService {
     _machineSubject.add(_devices);
   }
 
+  /// 3 admission gate for [_detectDevice]: the old inline name check
+  /// dropped `productName == "Bengle"` before the v13Model probe ever ran,
+  /// making the Bengle shortcut below unreachable. A known Bengle VID:PID
+  /// also passes (current firmware enumerates with the TinyUSB default
+  /// strings, so the name alone says nothing); the probe stays the
+  /// authority on what the device actually is. Extracted as a static seam
+  /// so the OR-combination — the actual fix — is unit-testable; the
+  /// predicates alone don't lock the call-site wiring.
+  @visibleForTesting
+  static bool shouldProbeUsbDevice(UsbDevice device) =>
+      serialProbeAllowsProductName(device.productName) ||
+      isBengleProbeCandidate(vid: device.vid, pid: device.pid);
+
   Future<Device?> _detectDevice(UsbDevice device) async {
     _log.info("device name: ${device.productName}");
-    if (device.productName?.contains('Serial') == false &&
-        !(device.productName == 'DE1') &&
-        !(device.productName == 'Half Decent Scale')) {
+    if (!shouldProbeUsbDevice(device)) {
       return null;
     }
     UsbPort? port;
@@ -213,8 +225,8 @@ class SerialServiceAndroid implements DeviceDiscoveryService {
       return UnifiedDe1(transport: transport);
     }
 
-    // Bengle shortcut (productName likely lands as "Bengle" once FW
-    // exposes it; trivial future-proofing).
+    // Bengle shortcut — reachable now that the name gate admits "Bengle"
+    //.
     if (device.productName == "Bengle") {
       _log.info("short circuit to bengle");
       return Bengle(transport: transport);

--- a/lib/src/services/serial/usb_ids.dart
+++ b/lib/src/services/serial/usb_ids.dart
@@ -19,8 +19,26 @@ typedef UsbIdPair = (int vid, int pid);
 /// DE1 USB ID pairs. See doc on [UsbDeviceModel] for caveats.
 const List<UsbIdPair> de1UsbIds = [];
 
-/// Bengle USB ID pairs. Populated once captured from hardware.
+/// Bengle USB ID pairs. Deliberately EMPTY: the Bengle's TinyUSB stack
+/// currently enumerates with the pico-sdk DEFAULT ids (`0x2E8A:0x000A`,
+/// product string "TinyUSB Device" — captured from hardware),
+/// which any default pico-sdk CDC device also uses. Too generic for the
+/// direct-instantiation shortcut; see [bengleProbeCandidateIds] instead.
 const List<UsbIdPair> bengleUsbIds = [];
+
+/// VID:PID pairs that qualify a port for the identification PROBE (the
+/// v13Model read stays the authority on what the device is), without
+/// requiring the product-name gate to pass. This is how a Bengle whose
+/// firmware still ships the TinyUSB default descriptors ("TinyUSB
+/// Device") gets probed at all on Android.
+const List<UsbIdPair> bengleProbeCandidateIds = [(0x2E8A, 0x000A)];
+
+/// True when `(vid, pid)` is worth a DE1-protocol probe even though the
+/// product name says nothing useful. Null inputs yield false.
+bool isBengleProbeCandidate({required int? vid, required int? pid}) {
+  if (vid == null || pid == null) return false;
+  return bengleProbeCandidateIds.contains((vid, pid));
+}
 
 /// Default table consulted by serial services.
 const Map<UsbDeviceModel, List<UsbIdPair>> usbDeviceTable = {

--- a/lib/src/services/serial/utils.dart
+++ b/lib/src/services/serial/utils.dart
@@ -32,6 +32,19 @@ bool isDE1(List<String> data, List<int> bytes) {
   return data.any((e) => e.startsWith("[M]"));
 }
 
+/// Android USB product-name pre-filter for the serial probe.
+///
+/// The gate exists so the 3-second identification probe doesn't open every
+/// USB device on the bus, but it used to drop a board named `Bengle` before
+/// the v13Model probe ever ran (the auto-permission `device_filter.xml`
+/// already holds the Bengle VID:PID). Unknown (null) names stay allowed —
+/// the probe is the authority there. Desktop has no such gate.
+bool serialProbeAllowsProductName(String? productName) {
+  if (productName == null) return true;
+  if (productName.contains('Serial')) return true;
+  return const {'DE1', 'Bengle', 'Half Decent Scale'}.contains(productName);
+}
+
 /// Non-blocking replacement for the native `sp_drain`, which has no timeout
 /// and blocks the calling isolate forever when a USB-serial device never
 /// transmits the buffered bytes (observed when scan probes a non-Decent

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -197,6 +197,36 @@ class De1Handler {
       });
     });
 
+    // Live colour preview: show a colour on the strip now (regardless of
+    // awake/sleep) without changing the stored palette — body { front, back }
+    // as 12-char hex. `/clear` restores the cached awake palette.
+    app.post('/api/v1/machine/ledStrip/preview', (Request r) async {
+      return withDe1((de1) async {
+        if (de1 is! BengleInterface) {
+          return jsonNotFound({'error': 'ledStrip not supported'});
+        }
+        final json = jsonDecode(await r.readAsString());
+        if (json is! Map) {
+          return jsonBadRequest({'error': 'invalid JSON body'});
+        }
+        await de1.previewLedColor(
+          Color16.fromJson(json['front']),
+          Color16.fromJson(json['back']),
+        );
+        return jsonAccepted();
+      });
+    });
+
+    app.post('/api/v1/machine/ledStrip/preview/clear', (Request _) async {
+      return withDe1((de1) async {
+        if (de1 is! BengleInterface) {
+          return jsonNotFound({'error': 'ledStrip not supported'});
+        }
+        await de1.clearLedPreview();
+        return jsonAccepted();
+      });
+    });
+
     app.post('/api/v1/machine/waterLevels', (Request r) async {
       return withDe1((de1) async {
         var json = jsonDecode(await r.readAsString());

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -113,7 +113,11 @@ class De1Handler {
           return jsonNotFound({'error': 'cupWarmer not supported'});
         }
         final t = await de1.getCupWarmerTemperature();
-        return jsonOk({'temperature': t});
+        // Live mat temperature (MatCurrentTemp, read-only). `null` = no
+        // valid reading or older firmware without the register — clients
+        // render a placeholder, never fake data.
+        final current = await de1.getCupWarmerCurrentTemperature();
+        return jsonOk({'temperature': t, 'currentTemperature': current});
       });
     });
 

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -49,9 +49,61 @@ class De1Handler {
             'integratedScale',
             'ledStrip',
             'stopAtWeight',
+            'scaleCalibration',
           ]);
         }
         return jsonOk({'capabilities': caps});
+      });
+    });
+
+    // Scale calibration — Bengle two-point integrated-scale load-cell
+    // wizard. `command`: zero (empty platform) | left / right (latch the known
+    // `grams` reference mass on that half; both required) | abort.
+    app.post('/api/v1/machine/scale/calibrate', (Request r) async {
+      return withDe1((de1) async {
+        if (de1 is! BengleInterface) {
+          return jsonNotFound({'error': 'scale calibration not supported'});
+        }
+        final json = jsonDecode(await r.readAsString());
+        if (json is! Map) {
+          return jsonBadRequest({'error': 'expected a JSON object body'});
+        }
+        final command = json['command'];
+        switch (command) {
+          case 'zero':
+            return jsonOk((await de1.calibrateScaleZero()).toJson());
+          case 'left':
+            if (json['grams'] == null) {
+              return jsonBadRequest({
+                'error': 'weight calibration requires "grams"',
+              });
+            }
+            return jsonOk(
+              (await de1.calibrateScaleWeightLeft(
+                parseDouble(json['grams']),
+              )).toJson(),
+            );
+          case 'right':
+            if (json['grams'] == null) {
+              return jsonBadRequest({
+                'error': 'weight calibration requires "grams"',
+              });
+            }
+            return jsonOk(
+              (await de1.calibrateScaleWeightRight(
+                parseDouble(json['grams']),
+              )).toJson(),
+            );
+          case 'abort':
+            await de1.abortScaleCalibration();
+            return jsonAccepted();
+          default:
+            return jsonBadRequest({
+              'error':
+                  'unknown command "$command" — expected '
+                  'zero, left, right, or abort',
+            });
+        }
       });
     });
 

--- a/lib/src/settings/sleep_timeout_safety.dart
+++ b/lib/src/settings/sleep_timeout_safety.dart
@@ -1,0 +1,73 @@
+/// The machine's `InactivitySleepTimeout` is a THERMAL SAFETY NET, not a UI
+/// preference. This file is the single source of truth for what the app is
+/// allowed to write into it.
+///
+/// ## Why this exists (do not "simplify" it away)
+///
+/// The Bengle firmware sleeps itself after `InactivitySleepTimeout` minutes of
+/// no interaction (the firmware inactivity check), which is the ONLY
+/// thing that turns the heaters off when the tablet is gone — a dead battery, a
+/// crashed app, a blackout. It is the machine's answer to the DE1 failure where
+/// a machine whose tablet died stayed hot for days.
+///
+/// Two facts make writing `0` unacceptable:
+///
+///  1. **The firmware treats `<= 0` as "never sleep"** — the firmware:
+///     the timer never runs. The timer simply never runs.
+///  2. **The write STICKS.** The register is `PERM_RWD` (disk-backed); the MMR
+///     write path persists it to firmware NVM, and
+///     the firmware restores it at every boot. A `0` written
+///     once survives every power cycle until something writes a non-zero value
+///     back. And the machine boots HOT .
+///
+/// So an app that writes `0` leaves the machine **less safe than one that never
+/// met the app at all** (the firmware's own default is 60 min). That is a
+/// regression against doing nothing, and it is not a trade the user's sleep
+/// preference is entitled to make.
+///
+/// The floor costs the user nothing: the firmware ignores this timer entirely
+/// while a tablet is connected ("the tablet owns sleep"), so it only ever acts
+/// once the tablet is already gone — precisely the case it exists for.
+library;
+
+/// The protective floor written when the user's setting would otherwise disable
+/// the machine's safety net.
+///
+/// 60 minutes is the FIRMWARE'S OWN DEFAULT (`ModelIntParameters.def`:
+/// `ENTRY(InactivitySleepTimeout, 60, 0, 240, 60, ...)`). Matching it means the
+/// app can never make a machine less safe than a factory-fresh one.
+const int kSafetySleepFloorMinutes = 60;
+
+/// The firmware's accepted range for a timeout that actually runs. `0` is
+/// rejected here on purpose: to the firmware `0` means "disabled", and that is
+/// the one value the app must never send.
+const int kMinMachineSleepTimeoutMinutes = 1;
+const int kMaxSleepTimeoutMinutes = 240;
+
+/// The `InactivitySleepTimeout` to write into the machine, in minutes.
+/// **Guaranteed to be in `1..240` — never `0`, whatever the inputs.**
+///
+/// [userPresenceEnabled] is the "Auto sleep & wake" master toggle and
+/// [userTimeoutMinutes] the visible dropdown value (where `0` reads
+/// "Disabled").
+///
+/// Both of those govern *the app's* behaviour — whether the TABLET puts the
+/// machine to sleep on its own idle timer. Neither may disable *the machine's*
+/// last-resort thermal cut-out, so anything that would (`false`, `0`, a rogue
+/// negative from the REST API or an imported settings blob) collapses to
+/// [kSafetySleepFloorMinutes]. A positive user value is honoured as-is, merely
+/// clamped into the range the firmware accepts.
+int machineSleepTimeoutMinutes({
+  required bool userPresenceEnabled,
+  required int userTimeoutMinutes,
+}) {
+  // The master toggle off, or "Disabled" in the dropdown, means "the APP won't
+  // sleep it". It does not — and must not — mean "the MACHINE won't sleep it".
+  if (!userPresenceEnabled || userTimeoutMinutes <= 0) {
+    return kSafetySleepFloorMinutes;
+  }
+  return userTimeoutMinutes.clamp(
+    kMinMachineSleepTimeoutMinutes,
+    kMaxSleepTimeoutMinutes,
+  );
+}

--- a/test/controllers/bengle_schedule_sync_test.dart
+++ b/test/controllers/bengle_schedule_sync_test.dart
@@ -1,0 +1,741 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/bengle_schedule_sync.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/models/device/bengle_interface.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
+import 'package:reaprime/src/models/wake_schedule.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/settings/sleep_timeout_safety.dart';
+import 'package:rxdart/subjects.dart';
+
+import '../helpers/mock_settings_service.dart';
+
+/// `BengleScheduleSync`: the app writing the schedule registers so the
+/// machine runs its scheduler with NO tablet connected.
+///
+/// The contract these tests defend:
+///  * SAFETY — the app never writes an `InactivitySleepTimeout` that disables
+///    the machine's autonomous sleep, and never leaves a wake schedule armed
+///    when the user has turned auto-wake off (see the safety group below);
+///  * the WRITE ORDER on connect (clock, then timeout, then control 0 ->
+///    entries -> control 1) — the firmware clears the table on control 0 and
+///    ignores an enabled table while its clock is invalid;
+///  * the DIFF (an unrelated settings change must not re-push the table — a
+///    re-push re-arms the firmware's rising-edge wake and would re-wake a
+///    machine the user had just slept);
+///  * BENGLE-GATING — a plain DE1 must see not one write.
+
+/// Records every write the sync makes, in order, as a flat wire log.
+class _RecordingBengle implements BengleInterface {
+  _RecordingBengle({this.failWritesUntil = 0});
+
+  /// Fail the first N *write* calls, to exercise the retry path.
+  int failWritesUntil;
+  int _writeCount = 0;
+
+  /// The wire log: `clock:<sec>`, `timeout:<min>`, `control:<0|1>`,
+  /// `entry:0x<hex>`.
+  final List<String> log = [];
+
+  /// Simulated firmware state (RAM-only, exactly like the real registers).
+  int clockEcho = 0;
+  int scheduleControl = 0;
+
+  void _maybeFail() {
+    _writeCount++;
+    if (_writeCount <= failWritesUntil) {
+      throw StateError('simulated MMR write failure #$_writeCount');
+    }
+  }
+
+  @override
+  Future<void> setLocalTimeOfWeek(int secondsOfWeek) async {
+    _maybeFail();
+    log.add('clock:$secondsOfWeek');
+    clockEcho = secondsOfWeek;
+  }
+
+  @override
+  Future<void> setInactivitySleepTimeout(int minutes) async {
+    _maybeFail();
+    log.add('timeout:$minutes');
+  }
+
+  @override
+  Future<void> pushWakeSchedule(List<int> packedWindows) async {
+    _maybeFail();
+    log.add('control:0');
+    scheduleControl = 0;
+    if (packedWindows.isEmpty) return;
+    for (final p in packedWindows) {
+      log.add('entry:0x${p.toRadixString(16).toUpperCase().padLeft(8, '0')}');
+    }
+    log.add('control:1');
+    scheduleControl = 1;
+  }
+
+  @override
+  Future<int> readLocalTimeOfWeekEcho() async => clockEcho;
+
+  @override
+  Future<int> readScheduleControl() async => scheduleControl;
+
+  /// Simulate a power-cycle: the clock and the table are RAM-only.
+  void reboot() {
+    clockEcho = 0;
+    scheduleControl = 0;
+  }
+
+  @override
+  String get deviceId => 'rec-bengle';
+  @override
+  String get name => 'Bengle-rec';
+  @override
+  DeviceType get type => DeviceType.machine;
+  @override
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.connected);
+  @override
+  Stream<bool> get ready => Stream<bool>.value(false);
+  @override
+  Stream<De1ShotSettings> get shotSettings => const Stream.empty();
+  @override
+  Future<void> onConnect() async {}
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// A non-Bengle DE1 that records ANY method call. The Bengle-gating test
+/// asserts this log stays empty: nothing at all may reach a plain DE1.
+class _RecordingDe1 implements De1Interface {
+  final List<Symbol> calls = [];
+
+  @override
+  String get deviceId => 'plain-de1';
+  @override
+  String get name => 'DE1';
+  @override
+  DeviceType get type => DeviceType.machine;
+  @override
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.connected);
+  @override
+  Stream<bool> get ready => Stream<bool>.value(false);
+  @override
+  Stream<De1ShotSettings> get shotSettings => const Stream.empty();
+  @override
+  Future<void> onConnect() async {}
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    calls.add(invocation.memberName);
+    return null;
+  }
+}
+
+class _FakeDiscoveryService implements DeviceDiscoveryService {
+  @override
+  Stream<List<Device>> get devices => const Stream.empty();
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
+  @override
+  void stopScan() {}
+}
+
+/// De1Controller with a directly-drivable machine stream.
+class _TestDe1Controller extends De1Controller {
+  _TestDe1Controller({required super.controller});
+
+  final BehaviorSubject<De1Interface?> _subject =
+      BehaviorSubject<De1Interface?>.seeded(null);
+
+  @override
+  Stream<De1Interface?> get de1 => _subject.stream;
+
+  void setDe1(De1Interface? device) => _subject.add(device);
+}
+
+void main() {
+  late _TestDe1Controller de1Controller;
+  late SettingsController settings;
+
+  // 2026-07-14 is a Tuesday. 07:20:00 local = 2*86400 + 7*3600 + 20*60 =
+  // 199200 seconds of week (the spec's worked example).
+  DateTime now = DateTime(2026, 7, 14, 7, 20, 0);
+  const int nowSecOfWeek = 199200;
+
+  // Ben's schedule: Mon-Fri 05:30, keep awake 90 min.
+  final benSchedule = WakeSchedule(
+    id: 'ben',
+    hour: 5,
+    minute: 30,
+    daysOfWeek: const {1, 2, 3, 4, 5},
+    enabled: true,
+    keepAwakeFor: 90,
+  );
+  const benEntries = [
+    'entry:0x004A51A4',
+    'entry:0x008A51A4',
+    'entry:0x00CA51A4',
+    'entry:0x010A51A4',
+    'entry:0x014A51A4',
+  ];
+
+  setUp(() async {
+    now = DateTime(2026, 7, 14, 7, 20, 0);
+    de1Controller = _TestDe1Controller(
+      controller: DeviceController([_FakeDiscoveryService()]),
+    );
+    settings = SettingsController(MockSettingsService());
+    await settings.loadSettings();
+  });
+
+  BengleScheduleSync makeSync() => BengleScheduleSync(
+        de1Controller: de1Controller,
+        settingsController: settings,
+        clock: () => now,
+        retryDelays: const [Duration(seconds: 3)],
+      );
+
+  test('Bengle connect: clock -> timeout -> control(0) -> entries -> control(1)',
+      () {
+    fakeAsync((async) {
+      settings.setSleepTimeoutMinutes(30);
+      settings.setWakeSchedules(WakeSchedule.serializeList([benSchedule]));
+      async.flushMicrotasks();
+
+      final sync = makeSync()..initialize();
+      final bengle = _RecordingBengle();
+      de1Controller.setDe1(bengle);
+      async.flushMicrotasks();
+
+      // Spec §5.1, verbatim: the clock FIRST (the firmware ignores an enabled
+      // table while its clock is invalid), then the persisted sleep timeout,
+      // then the clear -> entries -> enable sequence.
+      expect(bengle.log, [
+        'clock:$nowSecOfWeek',
+        'timeout:30',
+        'control:0',
+        ...benEntries,
+        'control:1',
+      ]);
+
+      sync.dispose();
+    });
+  });
+
+  test('a non-Bengle DE1 gets NOTHING — not one call', () {
+    fakeAsync((async) {
+      settings.setSleepTimeoutMinutes(30);
+      settings.setWakeSchedules(WakeSchedule.serializeList([benSchedule]));
+      async.flushMicrotasks();
+
+      final sync = makeSync()..initialize();
+      final de1 = _RecordingDe1();
+      de1Controller.setDe1(de1);
+      async.flushMicrotasks();
+
+      // And a settings edit while it is connected still writes nothing.
+      settings.setSleepTimeoutMinutes(60);
+      async.elapse(const Duration(minutes: 40)); // past a clock-resync tick
+
+      expect(
+        de1.calls,
+        isEmpty,
+        reason: 'these registers do not exist on a stock DE1 — the whole '
+            'feature is Bengle-gated',
+      );
+
+      sync.dispose();
+    });
+  });
+
+  test('no enabled schedules: control(0) only — no entries, no enable', () {
+    fakeAsync((async) {
+      settings.setWakeSchedules(WakeSchedule.serializeList([
+        benSchedule.copyWith(enabled: false),
+      ]));
+      async.flushMicrotasks();
+
+      final sync = makeSync()..initialize();
+      final bengle = _RecordingBengle();
+      de1Controller.setDe1(bengle);
+      async.flushMicrotasks();
+
+      expect(bengle.log.where((e) => e.startsWith('entry:')), isEmpty);
+      expect(bengle.log, contains('control:0'));
+      expect(
+        bengle.log,
+        isNot(contains('control:1')),
+        reason: 'an enabled EMPTY table is a lie; clear + disable is the state',
+      );
+
+      sync.dispose();
+    });
+  });
+
+  test('an unrelated settings change does NOT re-push the table', () {
+    fakeAsync((async) {
+      settings.setSleepTimeoutMinutes(30);
+      settings.setWakeSchedules(WakeSchedule.serializeList([benSchedule]));
+      async.flushMicrotasks();
+
+      final sync = makeSync()..initialize();
+      final bengle = _RecordingBengle();
+      de1Controller.setDe1(bengle);
+      async.flushMicrotasks();
+      bengle.log.clear();
+
+      // SettingsController.addListener fires on ANY settings write. A re-push
+      // clears the table, which drops the firmware's WasInAwakeWindow edge and
+      // would re-wake a machine the user just slept — so the diff must hold.
+      settings.setLowBatteryBrightnessLimit(true);
+      async.flushMicrotasks();
+
+      expect(bengle.log, isEmpty);
+
+      sync.dispose();
+    });
+  });
+
+  test('editing a schedule re-pushes the whole table', () {
+    fakeAsync((async) {
+      settings.setSleepTimeoutMinutes(30);
+      settings.setWakeSchedules(WakeSchedule.serializeList([benSchedule]));
+      async.flushMicrotasks();
+
+      final sync = makeSync()..initialize();
+      final bengle = _RecordingBengle();
+      de1Controller.setDe1(bengle);
+      async.flushMicrotasks();
+      bengle.log.clear();
+
+      // Drop Friday.
+      settings.setWakeSchedules(WakeSchedule.serializeList([
+        benSchedule.copyWith(daysOfWeek: const {1, 2, 3, 4}),
+      ]));
+      async.flushMicrotasks();
+
+      expect(bengle.log, [
+        'control:0',
+        ...benEntries.take(4),
+        'control:1',
+      ]);
+      // The clock and the timeout are unchanged, so they are NOT re-written.
+      expect(bengle.log.where((e) => e.startsWith('clock:')), isEmpty);
+      expect(bengle.log.where((e) => e.startsWith('timeout:')), isEmpty);
+
+      sync.dispose();
+    });
+  });
+
+  test('editing the sleep timeout writes the timeout ONLY — no table churn',
+      () {
+    fakeAsync((async) {
+      settings.setSleepTimeoutMinutes(30);
+      settings.setWakeSchedules(WakeSchedule.serializeList([benSchedule]));
+      async.flushMicrotasks();
+
+      final sync = makeSync()..initialize();
+      final bengle = _RecordingBengle();
+      de1Controller.setDe1(bengle);
+      async.flushMicrotasks();
+      bengle.log.clear();
+
+      settings.setSleepTimeoutMinutes(90);
+      async.flushMicrotasks();
+
+      expect(bengle.log, ['timeout:90']);
+
+      sync.dispose();
+    });
+  });
+
+  /// SAFETY. `InactivitySleepTimeout` is the machine's thermal cut-out for when
+  /// this tablet is gone — dead battery, crashed app, blackout. The firmware
+  /// treats `<= 0` as "never sleep", and the value is PERSISTED TO FLASH and
+  /// reloaded at every boot, so a single `0` from this app leaves the machine
+  /// hot forever, across power cycles, and less safe than one that never met
+  /// the app at all (the firmware's own default is 60 min).
+  ///
+  /// These tests exist to make sure nobody ever "restores" that behaviour.
+  /// If one of them fails, do not relax it — the machine is the thing at stake.
+  group('never disables the machine\'s inactivity safety net', () {
+    /// Every timeout this app has ever written to the machine.
+    List<int> timeoutsWritten(_RecordingBengle b) => b.log
+        .where((e) => e.startsWith('timeout:'))
+        .map((e) => int.parse(e.split(':')[1]))
+        .toList();
+
+    test('arms the FW schedule so the machine wakes and sleeps autonomously '
+        'without a tablet', () {
+      fakeAsync((async) {
+        // THE INTENDED BEHAVIOUR, and it must not be broken by the safety work:
+        // with the tablet gone, the FIRMWARE wakes the machine at the window
+        // start, holds it awake for the window (`checkSchedule` calls
+        // its user-present hook every tick inside it, re-arming the idle clock),
+        // and then — once the window closes and that stops — the inactivity
+        // timer runs down and sleeps it. Wake AND sleep, no tablet involved.
+        //
+        // That needs BOTH halves armed, so assert both:
+        settings.setUserPresenceEnabled(true);
+        settings.setSleepTimeoutMinutes(30);
+        settings.setWakeSchedules(WakeSchedule.serializeList([benSchedule]));
+        async.flushMicrotasks();
+
+        final sync = makeSync()..initialize();
+        final bengle = _RecordingBengle();
+        de1Controller.setDe1(bengle);
+        async.flushMicrotasks();
+
+        // 1. the table is armed (entries + ScheduleControl=1) — this is what
+        //    lets the machine wake ITSELF at 05:30 with no tablet present, and
+        //    it is deliberately NOT gated on tablet connectivity;
+        expect(bengle.log.where((e) => e.startsWith('entry:')), hasLength(5));
+        expect(bengle.log.last, 'control:1');
+        expect(bengle.scheduleControl, 1);
+
+        // 2. a NON-ZERO inactivity timeout — this is what lets it sleep again
+        //    after the window closes. A 0 here (the old behaviour) would leave
+        //    it awake and hot forever after the first scheduled wake.
+        expect(timeoutsWritten(bengle), [30]);
+        expect(bengle.log, isNot(contains('timeout:0')));
+
+        sync.dispose();
+      });
+    });
+
+    test('presence OFF: protective floor is written, and the wake table is '
+        'EMPTY + disabled', () {
+      fakeAsync((async) {
+        settings.setSleepTimeoutMinutes(30);
+        settings.setUserPresenceEnabled(false);
+        // A schedule the user configured while the toggle was still on.
+        settings.setWakeSchedules(WakeSchedule.serializeList([benSchedule]));
+        async.flushMicrotasks();
+
+        final sync = makeSync()..initialize();
+        final bengle = _RecordingBengle();
+        de1Controller.setDe1(bengle);
+        async.flushMicrotasks();
+
+        // The master toggle governs whether the TABLET sleeps the machine. It
+        // is not licence to disarm the MACHINE.
+        expect(timeoutsWritten(bengle), [kSafetySleepFloorMinutes]);
+        expect(bengle.log, isNot(contains('timeout:0')));
+
+        // ...and the machine must not be left waking ITSELF every morning with
+        // a dead tablet and nobody there. Cleared (control:0) and NOT enabled.
+        expect(bengle.log.where((e) => e.startsWith('entry:')), isEmpty);
+        expect(bengle.log, contains('control:0'));
+        expect(
+          bengle.log,
+          isNot(contains('control:1')),
+          reason: 'the UI hides the schedule section when the master toggle is '
+              'off, so the user believes wake is off — it must BE off',
+        );
+        expect(bengle.scheduleControl, 0);
+
+        sync.dispose();
+      });
+    });
+
+    test('dropdown "Disabled" (0): protective floor is written, not 0', () {
+      fakeAsync((async) {
+        settings.setUserPresenceEnabled(true);
+        settings.setSleepTimeoutMinutes(0); // literally the "Disabled" item
+        async.flushMicrotasks();
+
+        final sync = makeSync()..initialize();
+        final bengle = _RecordingBengle();
+        de1Controller.setDe1(bengle);
+        async.flushMicrotasks();
+
+        // The user is disabling the APP's idle timer. They are not being
+        // offered — and would not understand — a choice to disable the
+        // machine's blackout backstop.
+        expect(timeoutsWritten(bengle), [kSafetySleepFloorMinutes]);
+        expect(bengle.log, isNot(contains('timeout:0')));
+
+        sync.dispose();
+      });
+    });
+
+    test('a valid user setting is honoured exactly (30 stays 30)', () {
+      fakeAsync((async) {
+        settings.setUserPresenceEnabled(true);
+        settings.setSleepTimeoutMinutes(30);
+        async.flushMicrotasks();
+
+        final sync = makeSync()..initialize();
+        final bengle = _RecordingBengle();
+        de1Controller.setDe1(bengle);
+        async.flushMicrotasks();
+
+        // The floor must not override a deliberate, safe user choice — not even
+        // one BELOW the floor. 30 min is safer than 60, not less safe.
+        expect(timeoutsWritten(bengle), [30]);
+
+        sync.dispose();
+      });
+    });
+
+    test('rogue values from ANY entry point never write 0 or an out-of-range '
+        'timeout', () {
+      // The REST API (`POST /api/v1/presence/settings`), an imported settings
+      // blob and the de1app TDB importer all funnel through
+      // `setSleepTimeoutMinutes`. Drive the poison in there and watch the WIRE.
+      for (final rogue in [0, -1, -999, 999, 100000]) {
+        fakeAsync((async) {
+          settings.setUserPresenceEnabled(true);
+          settings.setSleepTimeoutMinutes(rogue);
+          async.flushMicrotasks();
+
+          final sync = makeSync()..initialize();
+          final bengle = _RecordingBengle();
+          de1Controller.setDe1(bengle);
+          async.flushMicrotasks();
+
+          final written = timeoutsWritten(bengle);
+          expect(written, hasLength(1),
+              reason: 'rogue input $rogue: the machine is always told a value');
+          expect(
+            written.single,
+            inInclusiveRange(
+                kMinMachineSleepTimeoutMinutes, kMaxSleepTimeoutMinutes),
+            reason: 'rogue input $rogue must land in the firmware\'s 1..240 — '
+                'never 0 (= never sleep), never a value the FW would reject',
+          );
+
+          sync.dispose();
+        });
+      }
+    });
+
+    test('every Bengle connect is left at least as safe as it was found', () {
+      fakeAsync((async) {
+        // A user who has never opened the presence page at all: whatever the
+        // machine held before (a 0 burned into flash by an older build, say),
+        // simply connecting must restore a protective value.
+        final sync = makeSync()..initialize();
+        final bengle = _RecordingBengle();
+        de1Controller.setDe1(bengle);
+        async.flushMicrotasks();
+
+        final written = timeoutsWritten(bengle);
+        expect(written, hasLength(1),
+            reason: 'the timeout is pushed PROACTIVELY on every connect, not '
+                'only when the user has configured something');
+        expect(written.single, greaterThan(0));
+        expect(written.single,
+            inInclusiveRange(kMinMachineSleepTimeoutMinutes, kMaxSleepTimeoutMinutes));
+
+        sync.dispose();
+      });
+    });
+  });
+
+  test('the 15-minute tick re-writes the clock and NOTHING else', () {
+    fakeAsync((async) {
+      settings.setSleepTimeoutMinutes(30);
+      settings.setWakeSchedules(WakeSchedule.serializeList([benSchedule]));
+      async.flushMicrotasks();
+
+      final sync = makeSync()..initialize();
+      final bengle = _RecordingBengle();
+      de1Controller.setDe1(bengle);
+      async.flushMicrotasks();
+      bengle.log.clear();
+
+      now = now.add(const Duration(minutes: 15));
+      async.elapse(const Duration(minutes: 15));
+      async.flushMicrotasks();
+
+      expect(bengle.log, ['clock:${nowSecOfWeek + 15 * 60}']);
+      expect(
+        bengle.log.where((e) => e.startsWith('control:')),
+        isEmpty,
+        reason: 'a table re-push on a timer would re-arm the firmware wake '
+            'edge every 15 minutes',
+      );
+
+      sync.dispose();
+    });
+  });
+
+  test('reboot detected on the verify poll (clock echoes 0) => full re-push',
+      () {
+    fakeAsync((async) {
+      settings.setSleepTimeoutMinutes(30);
+      settings.setWakeSchedules(WakeSchedule.serializeList([benSchedule]));
+      async.flushMicrotasks();
+
+      final sync = makeSync()..initialize();
+      final bengle = _RecordingBengle();
+      de1Controller.setDe1(bengle);
+      async.flushMicrotasks();
+      bengle.log.clear();
+
+      // The machine power-cycles without the link dropping (possible on USB
+      // serial). Its clock and table are RAM-only and are gone.
+      bengle.reboot();
+
+      now = now.add(const Duration(minutes: 15));
+      async.elapse(const Duration(minutes: 15));
+      async.flushMicrotasks();
+
+      expect(bengle.log, [
+        'clock:${nowSecOfWeek + 15 * 60}',
+        'timeout:30',
+        'control:0',
+        ...benEntries,
+        'control:1',
+      ]);
+
+      sync.dispose();
+    });
+  });
+
+  test('ScheduleControl echoing 0 while a schedule is expected => re-push', () {
+    fakeAsync((async) {
+      settings.setWakeSchedules(WakeSchedule.serializeList([benSchedule]));
+      async.flushMicrotasks();
+
+      final sync = makeSync()..initialize();
+      final bengle = _RecordingBengle();
+      de1Controller.setDe1(bengle);
+      async.flushMicrotasks();
+      bengle.log.clear();
+
+      // Another client cleared the table (clock intact, so this is the only
+      // signal we get).
+      bengle.scheduleControl = 0;
+
+      async.elapse(const Duration(minutes: 15));
+      async.flushMicrotasks();
+
+      expect(bengle.log.where((e) => e.startsWith('entry:')), hasLength(5));
+      expect(bengle.log.last, 'control:1');
+
+      sync.dispose();
+    });
+  });
+
+  test('reconnect re-pushes everything (device state is never assumed)', () {
+    fakeAsync((async) {
+      settings.setSleepTimeoutMinutes(30);
+      settings.setWakeSchedules(WakeSchedule.serializeList([benSchedule]));
+      async.flushMicrotasks();
+
+      final sync = makeSync()..initialize();
+      final first = _RecordingBengle();
+      de1Controller.setDe1(first);
+      async.flushMicrotasks();
+      expect(first.log, isNotEmpty);
+
+      // Link drops, then the same schedule, a fresh machine instance.
+      de1Controller.setDe1(null);
+      async.flushMicrotasks();
+
+      final second = _RecordingBengle();
+      de1Controller.setDe1(second);
+      async.flushMicrotasks();
+
+      expect(second.log, [
+        'clock:$nowSecOfWeek',
+        'timeout:30',
+        'control:0',
+        ...benEntries,
+        'control:1',
+      ]);
+
+      sync.dispose();
+    });
+  });
+
+  test('disconnect cancels the clock timer', () {
+    fakeAsync((async) {
+      settings.setWakeSchedules(WakeSchedule.serializeList([benSchedule]));
+      async.flushMicrotasks();
+
+      final sync = makeSync()..initialize();
+      final bengle = _RecordingBengle();
+      de1Controller.setDe1(bengle);
+      async.flushMicrotasks();
+
+      de1Controller.setDe1(null);
+      async.flushMicrotasks();
+      bengle.log.clear();
+
+      async.elapse(const Duration(hours: 1));
+      expect(bengle.log, isEmpty);
+      expect(async.periodicTimerCount, 0);
+
+      sync.dispose();
+    });
+  });
+
+  test('a failed write is retried, not crashed on, and the order still holds',
+      () {
+    fakeAsync((async) {
+      settings.setSleepTimeoutMinutes(30);
+      settings.setWakeSchedules(WakeSchedule.serializeList([benSchedule]));
+      async.flushMicrotasks();
+
+      final sync = makeSync()..initialize();
+      // The very first write (the clock) fails: nothing may be stamped as
+      // pushed, and the connect flow must survive it.
+      final bengle = _RecordingBengle(failWritesUntil: 1);
+      de1Controller.setDe1(bengle);
+      async.flushMicrotasks();
+      expect(bengle.log, isEmpty);
+
+      async.elapse(const Duration(seconds: 3)); // the retry delay
+      async.flushMicrotasks();
+
+      expect(bengle.log, [
+        'clock:$nowSecOfWeek',
+        'timeout:30',
+        'control:0',
+        ...benEntries,
+        'control:1',
+      ]);
+
+      sync.dispose();
+    });
+  });
+
+  test('dispose cancels everything and stops listening to settings', () {
+    fakeAsync((async) {
+      settings.setWakeSchedules(WakeSchedule.serializeList([benSchedule]));
+      async.flushMicrotasks();
+
+      final sync = makeSync()..initialize();
+      final bengle = _RecordingBengle();
+      de1Controller.setDe1(bengle);
+      async.flushMicrotasks();
+      bengle.log.clear();
+
+      sync.dispose();
+
+      settings.setSleepTimeoutMinutes(120);
+      async.elapse(const Duration(hours: 1));
+
+      expect(bengle.log, isEmpty);
+      expect(async.periodicTimerCount, 0);
+    });
+  });
+}

--- a/test/controllers/connection_manager_wired_preferred_test.dart
+++ b/test/controllers/connection_manager_wired_preferred_test.dart
@@ -1,0 +1,161 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+
+import '../helpers/mock_de1_controller.dart';
+import '../helpers/mock_device_discovery_service.dart';
+import '../helpers/mock_device_scanner.dart';
+import '../helpers/mock_scale_controller.dart';
+import '../helpers/mock_settings_service.dart';
+
+/// Minimal De1Interface stub (mirrors connection_manager_test.dart's
+/// _FakeDe1) whose deviceId can look like a USB stable id or a BLE MAC.
+class _FakeDe1 implements De1Interface {
+  @override
+  final String deviceId;
+
+  @override
+  final String name;
+
+  @override
+  DeviceType get type => DeviceType.machine;
+
+  @override
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.connected);
+
+  @override
+  Stream<MachineSnapshot> get currentSnapshot => const Stream.empty();
+
+  _FakeDe1({required this.deviceId, String? name})
+    : name = name ?? 'DE1-$deviceId';
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// invariant 12f: the preferred machine is stored per TRANSPORT id
+/// (`connectMachine` saves `machine.deviceId`; a serial device's id is the
+/// `usb-<vid>-<pid>-<serial>` stable id, a BLE device's is its MAC).
+/// Nothing maps a BLE preference onto the same physical machine's USB
+/// identity — deliberately. So the first wired session ends at the picker;
+/// picking the USB machine once makes IT the preference, and later
+/// launches auto-connect over the wire. Do not "fix" this by aliasing
+/// identities.
+void main() {
+  const bleMac = 'AA:BB:CC:DD:EE:FF';
+  const usbStableId = 'usb-2e8a-a-unknown';
+
+  late MockDeviceScanner mockScanner;
+  late MockDe1Controller mockDe1Controller;
+  late MockScaleController mockScaleController;
+  late SettingsController settingsController;
+
+  ConnectionManager buildManager() => ConnectionManager(
+    deviceScanner: mockScanner,
+    de1Controller: mockDe1Controller,
+    scaleController: mockScaleController,
+    settingsController: settingsController,
+  );
+
+  setUp(() async {
+    mockScanner = MockDeviceScanner();
+    mockDe1Controller = MockDe1Controller(
+      controller: DeviceController([MockDeviceDiscoveryService()]),
+    );
+    mockScaleController = MockScaleController();
+    settingsController = SettingsController(MockSettingsService());
+    await settingsController.loadSettings();
+  });
+
+  tearDown(() {
+    mockScanner.dispose();
+  });
+
+  test('first wired session ends at the picker (BLE preference does not '
+      'match the USB identity)', () async {
+    // The user has been connecting over BLE — the stored preference is
+    // the machine's BLE MAC.
+    await settingsController.setPreferredMachineId(bleMac);
+
+    // Today only the wire finds the machine (e.g. Bluetooth off): the
+    // same physical machine appears under its USB stable id.
+    final wiredDe1 = _FakeDe1(deviceId: usbStableId, name: 'Bengle');
+    mockScanner.addDevice(wiredDe1);
+    await Future.delayed(Duration.zero);
+
+    final manager = buildManager();
+    addTearDown(manager.dispose);
+    await manager.connect();
+    await Future.delayed(Duration.zero);
+
+    expect(
+      mockDe1Controller.connectCalls,
+      isEmpty,
+      reason: 'the BLE preference must not auto-claim the USB identity',
+    );
+    expect(manager.currentStatus.phase, ConnectionPhase.idle);
+    expect(
+      manager.currentStatus.pendingAmbiguity,
+      AmbiguityReason.machinePicker,
+      reason: 'the wired-only first session must surface the picker',
+    );
+    expect(manager.currentStatus.foundMachines, [wiredDe1]);
+  });
+
+  test(
+    'picking the USB machine stores its stable id as the preference',
+    () async {
+      await settingsController.setPreferredMachineId(bleMac);
+      final wiredDe1 = _FakeDe1(deviceId: usbStableId, name: 'Bengle');
+
+      final manager = buildManager();
+      addTearDown(manager.dispose);
+      await manager.connectMachine(wiredDe1);
+
+      expect(mockDe1Controller.connectCalls, [same(wiredDe1)]);
+      expect(
+        settingsController.preferredMachineId,
+        usbStableId,
+        reason:
+            'the preference is per transport id — picking the wired '
+            'machine replaces the BLE MAC with the USB stable id',
+      );
+      expect(manager.currentStatus.phase, ConnectionPhase.ready);
+    },
+  );
+
+  test('a later launch auto-connects the preferred wired machine', () async {
+    // The previous session picked the USB machine; its stable id is now
+    // the preference.
+    await settingsController.setPreferredMachineId(usbStableId);
+
+    final wiredDe1 = _FakeDe1(deviceId: usbStableId, name: 'Bengle');
+    mockScanner.addDevice(wiredDe1);
+    await Future.delayed(Duration.zero);
+
+    // A fresh manager, as on app launch.
+    final manager = buildManager();
+    addTearDown(manager.dispose);
+    await manager.connect();
+    await Future.delayed(Duration.zero);
+
+    expect(mockDe1Controller.connectCalls, hasLength(1));
+    expect(mockDe1Controller.connectCalls.single.deviceId, usbStableId);
+    expect(manager.currentStatus.phase, ConnectionPhase.ready);
+    expect(
+      manager.currentStatus.pendingAmbiguity,
+      isNull,
+      reason: 'no picker on later launches — the wire auto-connects',
+    );
+  });
+}

--- a/test/controllers/de1_controller_resolve_test.dart
+++ b/test/controllers/de1_controller_resolve_test.dart
@@ -84,6 +84,10 @@ void main() {
     await expectDisposed(interim.weightSnapshot, 'IntegratedScale.weight');
     await expectDisposed(interim.stopAtWeightTarget, 'IntegratedScale.saw');
     await expectDisposed(interim.ledStripState, 'LedStrip.state');
+    await expectDisposed(
+      interim.scaleCalibrationProgress,
+      'ScaleCalibration.progress',
+    );
   });
 
   test('connectToDe1 is idempotent by deviceId after a class swap', () async {

--- a/test/controllers/de1_controller_resolve_test.dart
+++ b/test/controllers/de1_controller_resolve_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+
+import '../helpers/fake_ble_transport.dart';
+import '../helpers/mock_device_discovery_service.dart';
+
+/// Controller-level locks for the connect-time class re-resolution in
+/// `De1Controller.connectToDe1` (model-authoritative selection):
+///
+///  1. the controller finishes connecting the RE-RESOLVED machine, not the
+///     name-picked interim;
+///  2. a *demoted* Bengle interim has every capability its `onConnect`
+///     initialised disposed by the controller (the discarded interim never
+///     sees `Bengle.onDisconnect`, so leaving any capability out leaks its
+///     subjects — an earlier implementation shipped exactly that bug);
+///  3. the connect idempotency guard keys on deviceId, not object identity
+///     (post-swap `_de1` is a different object for the same machine).
+void main() {
+  late FakeBleTransport transport;
+  late De1Controller controller;
+
+  setUp(() async {
+    transport = FakeBleTransport();
+    transport.queueMmrResponseInt(MMRItem.calFlowEst, 100);
+    final deviceController = DeviceController([MockDeviceDiscoveryService()]);
+    await deviceController.initialize();
+    controller = De1Controller(controller: deviceController);
+  });
+
+  tearDown(() async {
+    await controller.dispose();
+    await transport.dispose();
+  });
+
+  test('connectToDe1 re-resolves a DE1-named machine reporting a Bengle model '
+      'and publishes the promoted instance', () async {
+    transport.queueOnConnectResponses(v13Model: 128);
+    final interim = UnifiedDe1(transport: transport);
+
+    await controller.connectToDe1(interim);
+
+    final connected = await controller.de1.first;
+    expect(connected, isA<Bengle>());
+    expect(
+      identical(connected, interim),
+      isFalse,
+      reason:
+          'the name-picked interim must be replaced by the resolved '
+          'Bengle',
+    );
+  });
+
+  test('a demoted Bengle interim has ALL its capability subjects disposed '
+      '(none may leak)', () async {
+    transport.queueOnConnectResponses(v13Model: 1);
+    final interim = Bengle(transport: transport);
+
+    await controller.connectToDe1(interim);
+
+    final connected = await controller.de1.first;
+    expect(connected, isA<UnifiedDe1>());
+    expect(connected, isNot(isA<Bengle>()));
+
+    // Every capability `Bengle.onConnect` initialises must be disposed on
+    // the discarded interim — its `Bengle.onDisconnect` never runs. A
+    // disposed capability closes its subjects, so each stream below must
+    // complete; a leaked (still-open) subject makes `toList()` hang and the
+    // bounded timeout fails the test. When a new capability mixin is added
+    // to Bengle, register its stream(s) here alongside the teardown in
+    // `De1Controller.connectToDe1`.
+    Future<void> expectDisposed(Stream<Object?> stream, String what) {
+      return expectLater(
+        stream.toList().timeout(const Duration(seconds: 2)),
+        completes,
+        reason: '$what subject leaked on the demoted Bengle interim',
+      );
+    }
+
+    await expectDisposed(interim.weightSnapshot, 'IntegratedScale.weight');
+    await expectDisposed(interim.stopAtWeightTarget, 'IntegratedScale.saw');
+    await expectDisposed(interim.ledStripState, 'LedStrip.state');
+  });
+
+  test('connectToDe1 is idempotent by deviceId after a class swap', () async {
+    transport.queueOnConnectResponses(v13Model: 128);
+    final interim = UnifiedDe1(transport: transport);
+    await controller.connectToDe1(interim);
+    final connected = await controller.de1.first;
+    expect(connected, isA<Bengle>());
+
+    // Re-passing the (discarded) name-picked interim: same physical
+    // deviceId, but a DIFFERENT object from the resolved machine. An
+    // object-identity guard would fall through and tear down + rebuild the
+    // live connection; the deviceId guard must exit early instead.
+    final events = <De1Interface?>[];
+    final sub = controller.de1.skip(1).listen(events.add);
+
+    await controller.connectToDe1(interim);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    expect(
+      events,
+      isEmpty,
+      reason:
+          'idempotency guard must key on deviceId, not identity — the '
+          'live connection was torn down',
+    );
+    expect(identical(await controller.de1.first, connected), isTrue);
+    await sub.cancel();
+  });
+}

--- a/test/controllers/de1_state_manager_shot_state_test.dart
+++ b/test/controllers/de1_state_manager_shot_state_test.dart
@@ -89,6 +89,10 @@ class _TestBengle extends TestDe1 implements BengleInterface {
   Future<void> commitLedStrip() async {}
   @override
   Future<void> resetLedStrip() async {}
+  @override
+  Future<void> previewLedColor(Color16 front, Color16 back) async {}
+  @override
+  Future<void> clearLedPreview() async {}
 
   @override
   Future<void> setStopAtTemperatureTarget(double celsius) async {}

--- a/test/controllers/de1_state_manager_shot_state_test.dart
+++ b/test/controllers/de1_state_manager_shot_state_test.dart
@@ -107,6 +107,19 @@ class _TestBengle extends TestDe1 implements BengleInterface {
   @override
   Stream<double> get probeTemperature => const Stream.empty();
 
+  // Wake schedule / autonomous sleep — inert here; exercised in
+  // `bengle_schedule_sync_test.dart` and `bengle_wake_schedule_test.dart`.
+  @override
+  Future<void> setInactivitySleepTimeout(int minutes) async {}
+  @override
+  Future<void> setLocalTimeOfWeek(int secondsOfWeek) async {}
+  @override
+  Future<void> pushWakeSchedule(List<int> packedWindows) async {}
+  @override
+  Future<int> readLocalTimeOfWeekEcho() async => 0;
+  @override
+  Future<int> readScheduleControl() async => 0;
+
   @override
   Future<ScaleCalResult> calibrateScaleZero() async => const ScaleCalResult(
       success: true,

--- a/test/controllers/de1_state_manager_shot_state_test.dart
+++ b/test/controllers/de1_state_manager_shot_state_test.dart
@@ -76,6 +76,8 @@ class _TestBengle extends TestDe1 implements BengleInterface {
   @override
   Future<double> getCupWarmerTemperature() async => 0.0;
   @override
+  Future<double?> getCupWarmerCurrentTemperature() async => null;
+  @override
   Stream<ScaleSnapshot> get weightSnapshot => const Stream.empty();
   @override
   Future<void> tareIntegratedScale() async {}

--- a/test/controllers/de1_state_manager_shot_state_test.dart
+++ b/test/controllers/de1_state_manager_shot_state_test.dart
@@ -18,6 +18,7 @@ import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/led_strip.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/device/scale_calibration.dart';
 import 'package:reaprime/src/services/storage/storage_service.dart';
 import 'package:reaprime/src/settings/gateway_mode.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
@@ -99,6 +100,28 @@ class _TestBengle extends TestDe1 implements BengleInterface {
   Stream<bool> get probeAttached => const Stream.empty();
   @override
   Stream<double> get probeTemperature => const Stream.empty();
+
+  @override
+  Future<ScaleCalResult> calibrateScaleZero() async => const ScaleCalResult(
+      success: true,
+      finalStep: ScaleCalStep.complete,
+      pointStatus: ScaleCalPointStatus.none);
+  @override
+  Future<ScaleCalResult> calibrateScaleWeightLeft(double grams) async =>
+      const ScaleCalResult(
+          success: true,
+          finalStep: ScaleCalStep.complete,
+          pointStatus: ScaleCalPointStatus.incomplete);
+  @override
+  Future<ScaleCalResult> calibrateScaleWeightRight(double grams) async =>
+      const ScaleCalResult(
+          success: true,
+          finalStep: ScaleCalStep.complete,
+          pointStatus: ScaleCalPointStatus.ok);
+  @override
+  Future<void> abortScaleCalibration() async {}
+  @override
+  Stream<ScaleCalStatus> get scaleCalibrationProgress => const Stream.empty();
 }
 
 /// StorageService that records persisted shots and stores nothing else.

--- a/test/controllers/de1_state_manager_shot_state_test.dart
+++ b/test/controllers/de1_state_manager_shot_state_test.dart
@@ -13,8 +13,11 @@ import 'package:reaprime/src/models/data/shot_record.dart';
 import 'package:reaprime/src/models/data/shot_state_event.dart';
 import 'package:reaprime/src/models/data/steam_record.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
+import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/led_strip.dart';
 import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/services/storage/storage_service.dart';
 import 'package:reaprime/src/settings/gateway_mode.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
@@ -52,6 +55,50 @@ class _TestDe1Controller extends De1Controller {
     current = null;
     de1Subject.add(null);
   }
+}
+
+/// Bengle-flavoured TestDe1 (same shape as the one in
+/// `shot_sequencer_bengle_bypass_test.dart`): reuses every DE1-side
+/// behavior but also implements [BengleInterface] so the state manager's
+/// `machine is BengleInterface` checks return `true`. Every Bengle-only
+/// member is an inert stub — this test only cares about the flag.
+class _TestBengle extends TestDe1 implements BengleInterface {
+  @override
+  Future<void> setStopAtWeightTarget(double grams) async {}
+  @override
+  Future<double> getStopAtWeightTarget() async => 0.0;
+  @override
+  Stream<double> get stopAtWeightTarget => const Stream.empty();
+
+  @override
+  Future<void> setCupWarmerTemperature(double celsius) async {}
+  @override
+  Future<double> getCupWarmerTemperature() async => 0.0;
+  @override
+  Stream<ScaleSnapshot> get weightSnapshot => const Stream.empty();
+  @override
+  Future<void> tareIntegratedScale() async {}
+  @override
+  Stream<LedStripState> get ledStripState => const Stream.empty();
+  @override
+  Future<LedStripState> getLedStripState() async => const LedStripState();
+  @override
+  Future<void> setLedStrip(LedStripState state) async {}
+  @override
+  Future<void> commitLedStrip() async {}
+  @override
+  Future<void> resetLedStrip() async {}
+
+  @override
+  Future<void> setStopAtTemperatureTarget(double celsius) async {}
+  @override
+  Future<double> getStopAtTemperatureTarget() async => 0.0;
+  @override
+  Stream<double> get stopAtTemperatureTarget => const Stream.empty();
+  @override
+  Stream<bool> get probeAttached => const Stream.empty();
+  @override
+  Stream<double> get probeTemperature => const Stream.empty();
 }
 
 /// StorageService that records persisted shots and stores nothing else.
@@ -327,5 +374,65 @@ void main() {
       isEmpty,
       reason: 'a disconnected shot is torn down, not persisted',
     );
+  });
+
+  test('shotState frames carry machineHasAutonomousSAW == false on a plain '
+      'DE1', () async {
+    await driveShot();
+
+    expect(events, isNotEmpty);
+    expect(
+      events.every((e) => !e.machineHasAutonomousSAW),
+      isTrue,
+      reason: 'a plain DE1 has no firmware SAW — every frame must say so',
+    );
+  });
+
+  test('shotState frames carry machineHasAutonomousSAW == true on a Bengle, '
+      'including the idle re-seed frame', () async {
+    final bengle = _TestBengle();
+    de1Controller.disconnect();
+    await pump();
+    de1Controller.connect(bengle);
+    await pump();
+
+    events.clear();
+    bengle.emitStateAndSubstate(
+      MachineState.espresso,
+      MachineSubstate.preparingForShot,
+    );
+    await pump();
+    bengle.emitStateAndSubstate(
+      MachineState.espresso,
+      MachineSubstate.pouring,
+    );
+    await pump();
+    bengle.emitStateAndSubstate(
+      MachineState.espresso,
+      MachineSubstate.pouringDone,
+    );
+    await pump();
+
+    expect(events, isNotEmpty);
+    expect(
+      events.every((e) => e.machineHasAutonomousSAW),
+      isTrue,
+      reason: 'every frame of a Bengle shot must advertise the FW-side SAW '
+          'so clients know the final yield stop is firmware-side',
+    );
+    expect(
+      events.last.state,
+      ShotState.idle,
+      reason: 'the feed re-seeds idle after cleanup',
+    );
+    expect(
+      events.last.machineHasAutonomousSAW,
+      isTrue,
+      reason: 'the idle re-seed frame derives the flag from the connected '
+          'machine (no live sequencer), so a client attaching between shots '
+          'still sees the real value',
+    );
+
+    await bengle.dispose();
   });
 }

--- a/test/controllers/shot_sequencer_bengle_bypass_test.dart
+++ b/test/controllers/shot_sequencer_bengle_bypass_test.dart
@@ -17,6 +17,7 @@ import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/led_strip.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/device/scale_calibration.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/services/storage/storage_service.dart';
 import 'package:rxdart/rxdart.dart';
@@ -71,6 +72,28 @@ class _TestBengle extends TestDe1 implements BengleInterface {
   Stream<bool> get probeAttached => const Stream.empty();
   @override
   Stream<double> get probeTemperature => const Stream.empty();
+
+  @override
+  Future<ScaleCalResult> calibrateScaleZero() async => const ScaleCalResult(
+      success: true,
+      finalStep: ScaleCalStep.complete,
+      pointStatus: ScaleCalPointStatus.none);
+  @override
+  Future<ScaleCalResult> calibrateScaleWeightLeft(double grams) async =>
+      const ScaleCalResult(
+          success: true,
+          finalStep: ScaleCalStep.complete,
+          pointStatus: ScaleCalPointStatus.incomplete);
+  @override
+  Future<ScaleCalResult> calibrateScaleWeightRight(double grams) async =>
+      const ScaleCalResult(
+          success: true,
+          finalStep: ScaleCalStep.complete,
+          pointStatus: ScaleCalPointStatus.ok);
+  @override
+  Future<void> abortScaleCalibration() async {}
+  @override
+  Stream<ScaleCalStatus> get scaleCalibrationProgress => const Stream.empty();
 }
 
 class _FakeDiscoveryService extends DeviceDiscoveryService {

--- a/test/controllers/shot_sequencer_bengle_bypass_test.dart
+++ b/test/controllers/shot_sequencer_bengle_bypass_test.dart
@@ -48,6 +48,8 @@ class _TestBengle extends TestDe1 implements BengleInterface {
   @override
   Future<double> getCupWarmerTemperature() async => 0.0;
   @override
+  Future<double?> getCupWarmerCurrentTemperature() async => null;
+  @override
   Stream<ScaleSnapshot> get weightSnapshot => const Stream.empty();
   @override
   Future<void> tareIntegratedScale() async {}

--- a/test/controllers/shot_sequencer_bengle_bypass_test.dart
+++ b/test/controllers/shot_sequencer_bengle_bypass_test.dart
@@ -79,6 +79,19 @@ class _TestBengle extends TestDe1 implements BengleInterface {
   @override
   Stream<double> get probeTemperature => const Stream.empty();
 
+  // Wake schedule / autonomous sleep — inert here; exercised in
+  // `bengle_schedule_sync_test.dart` and `bengle_wake_schedule_test.dart`.
+  @override
+  Future<void> setInactivitySleepTimeout(int minutes) async {}
+  @override
+  Future<void> setLocalTimeOfWeek(int secondsOfWeek) async {}
+  @override
+  Future<void> pushWakeSchedule(List<int> packedWindows) async {}
+  @override
+  Future<int> readLocalTimeOfWeekEcho() async => 0;
+  @override
+  Future<int> readScheduleControl() async => 0;
+
   @override
   Future<ScaleCalResult> calibrateScaleZero() async => const ScaleCalResult(
       success: true,

--- a/test/controllers/shot_sequencer_bengle_bypass_test.dart
+++ b/test/controllers/shot_sequencer_bengle_bypass_test.dart
@@ -61,6 +61,10 @@ class _TestBengle extends TestDe1 implements BengleInterface {
   Future<void> commitLedStrip() async {}
   @override
   Future<void> resetLedStrip() async {}
+  @override
+  Future<void> previewLedColor(Color16 front, Color16 back) async {}
+  @override
+  Future<void> clearLedPreview() async {}
 
   @override
   Future<void> setStopAtTemperatureTarget(double celsius) async {}

--- a/test/controllers/steam_sequencer_test.dart
+++ b/test/controllers/steam_sequencer_test.dart
@@ -268,16 +268,16 @@ void main() {
       m.dispose();
     });
 
-    test('false today because MMR slot is stubbed', () {
+    test('true when Bengle + probe attached + positive target (FW slot wired)',
+        () {
       final m = _BengleTestMachine();
-      // All three "real" preconditions met; predicate still false
-      // because BengleSteamMmr.stopAtTemperatureTarget.address == 0.
+      // All three preconditions met and TargetMilkTemp is wired,
+      // so the FW autonomous-stop branch applies.
       expect(
           sequencer.useFwAutonomousStop(
               machine: m, probeAttached: true, stopAtTemperature: 60),
-          isFalse,
-          reason:
-              'FW slot is still 0x00000000 — predicate must stay false');
+          isTrue,
+          reason: 'TargetMilkTemp is wired — FW autonomous stop applies');
       m.dispose();
     });
   });

--- a/test/device_discovery_feature/scan_flow_ble_off_test.dart
+++ b/test/device_discovery_feature/scan_flow_ble_off_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection_error.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/scan_state_guardian.dart';
+import 'package:reaprime/src/device_discovery_feature/scan_flow_view.dart';
+import 'package:reaprime/src/models/adapter_state.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+import '../helpers/mock_connection_manager.dart';
+import '../helpers/mock_de1_controller.dart';
+import '../helpers/mock_device_discovery_service.dart';
+import '../helpers/mock_device_scanner.dart';
+import '../helpers/mock_scale_controller.dart';
+import '../helpers/mock_settings_service.dart';
+import '../helpers/test_de1.dart';
+
+/// USB/serial discovery works with Bluetooth off, so the
+/// adapter-off error may only replace the scan flow while nothing that
+/// works WITHOUT Bluetooth is in flight. A wired-only setup must be able
+/// to reach the skin.
+void main() {
+  late MockConnectionManager mockConnectionManager;
+  late MockBleDiscoveryService mockBleService;
+  late ScanStateGuardian scanStateGuardian;
+  late SettingsController settingsController;
+  late MockDeviceScanner mockDeviceScanner;
+
+  setUp(() async {
+    mockDeviceScanner = MockDeviceScanner();
+    settingsController = SettingsController(MockSettingsService());
+    await settingsController.loadSettings();
+
+    mockConnectionManager = MockConnectionManager(
+      deviceScanner: mockDeviceScanner,
+      de1Controller: MockDe1Controller(controller: DeviceController([])),
+      scaleController: MockScaleController(),
+      settingsController: settingsController,
+    );
+
+    mockBleService = MockBleDiscoveryService();
+    scanStateGuardian = ScanStateGuardian(bleService: mockBleService);
+  });
+
+  tearDown(() {
+    mockConnectionManager.dispose();
+    scanStateGuardian.dispose();
+    mockBleService.dispose();
+    mockDeviceScanner.dispose();
+  });
+
+  Widget buildSubject() {
+    return ShadApp(
+      home: ScanFlowView(
+        connectionManager: mockConnectionManager,
+        deviceController: DeviceController([]),
+        settingsController: settingsController,
+        scanStateGuardian: scanStateGuardian,
+        onConnected: () {},
+        onExit: () {},
+      ),
+    );
+  }
+
+  Future<void> turnAdapterOff(WidgetTester tester) async {
+    mockBleService.setAdapterState(AdapterState.poweredOn);
+    await tester.runAsync(() => Future.delayed(Duration.zero));
+    await tester.pumpWidget(buildSubject());
+    await tester.pump();
+    mockBleService.setAdapterState(AdapterState.poweredOff);
+    await tester.runAsync(() => Future.delayed(Duration.zero));
+    await tester.pump();
+  }
+
+  testWidgets('adapter-off with nothing else in flight shows the error', (
+    tester,
+  ) async {
+    await turnAdapterOff(tester);
+
+    expect(find.text('Bluetooth Unavailable'), findsOneWidget);
+    expect(
+      find.textContaining('USB connections keep working'),
+      findsOneWidget,
+      reason: 'the error must tell wired users they are not blocked',
+    );
+  });
+
+  testWidgets('adapter-off with a found (serial) machine keeps the flow '
+      'visible', (tester) async {
+    await turnAdapterOff(tester);
+    expect(find.text('Bluetooth Unavailable'), findsOneWidget);
+
+    // A serial machine found with Bluetooth off — e.g. the Bengle over
+    // its USB port — must surface the normal flow, not the error.
+    mockConnectionManager.emitStatus(
+      ConnectionStatus(
+        phase: ConnectionPhase.idle,
+        foundMachines: [TestDe1()],
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Bluetooth Unavailable'), findsNothing);
+  });
+
+  testWidgets('sticky adapter-off ConnectionError does not hide a found '
+      'machine', (tester) async {
+    await turnAdapterOff(tester);
+
+    // The connection manager's sticky idle error (what the UI renders as
+    // "Connection error: Bluetooth is turned off.") must not out-rank a
+    // machine found over USB — the wired flow ends at the picker.
+    mockConnectionManager.emitStatus(
+      ConnectionStatus(
+        phase: ConnectionPhase.idle,
+        foundMachines: [TestDe1()],
+        error: ConnectionError(
+          kind: ConnectionErrorKind.adapterOff,
+          severity: ConnectionErrorSeverity.error,
+          timestamp: DateTime.now().toUtc(),
+          message: 'Bluetooth is turned off.',
+          suggestion: 'Turn Bluetooth on to scan for devices.',
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Bluetooth Unavailable'), findsNothing);
+    expect(
+      find.textContaining('Bluetooth is turned off'),
+      findsNothing,
+      reason: 'the picker, not the error view, must be shown',
+    );
+  });
+
+  testWidgets('adapter-off during a machine connect keeps the flow visible', (
+    tester,
+  ) async {
+    mockBleService.setAdapterState(AdapterState.poweredOn);
+    await tester.runAsync(() => Future.delayed(Duration.zero));
+    await tester.pumpWidget(buildSubject());
+    await tester.pump();
+
+    mockConnectionManager.emitStatus(
+      const ConnectionStatus(phase: ConnectionPhase.connectingMachine),
+    );
+    await tester.pump();
+
+    mockBleService.setAdapterState(AdapterState.poweredOff);
+    await tester.runAsync(() => Future.delayed(Duration.zero));
+    await tester.pump();
+
+    expect(find.text('Bluetooth Unavailable'), findsNothing);
+  });
+}

--- a/test/helpers/fake_ble_transport.dart
+++ b/test/helpers/fake_ble_transport.dart
@@ -5,6 +5,8 @@ import 'dart:typed_data';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart'
+    show BengleLedMmr;
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:rxdart/rxdart.dart';
@@ -261,8 +263,10 @@ class FakeBleTransport extends BLETransport {
 
   /// Queue the standard set of MMR responses needed for `onConnect()` to
   /// complete (`v13Model`, `ghcInfo`, `serialN`, `cpuFirmwareBuild`,
-  /// `heaterV`, `refillKitPresent`). Override individual values via
-  /// keyword arguments.
+  /// `heaterV`, `refillKitPresent`), plus the four LED palette registers
+  /// (packed `0x00RRGGBB`) that a Bengle connect hydrates its LED cache
+  /// from — default 0 (all-off; unconsumed on plain-DE1 connects). Override
+  /// individual values via keyword arguments.
   void queueOnConnectResponses({
     int v13Model = 1,
     int ghcInfo = 0,
@@ -270,6 +274,10 @@ class FakeBleTransport extends BLETransport {
     int cpuFirmwareBuild = 1300,
     int heaterV = 230,
     int refillKitPresent = 0,
+    int ledFrontAwake = 0,
+    int ledFrontSleep = 0,
+    int ledRearAwake = 0,
+    int ledRearSleep = 0,
   }) {
     queueMmrResponseInt(MMRItem.v13Model, v13Model);
     queueMmrResponseInt(MMRItem.ghcInfo, ghcInfo);
@@ -277,6 +285,10 @@ class FakeBleTransport extends BLETransport {
     queueMmrResponseInt(MMRItem.cpuFirmwareBuild, cpuFirmwareBuild);
     queueMmrResponseInt(MMRItem.heaterV, heaterV);
     queueMmrResponseInt(MMRItem.refillKitPresent, refillKitPresent);
+    queueMmrResponseInt(BengleLedMmr.frontAwake, ledFrontAwake);
+    queueMmrResponseInt(BengleLedMmr.frontSleep, ledFrontSleep);
+    queueMmrResponseInt(BengleLedMmr.rearAwake, ledRearAwake);
+    queueMmrResponseInt(BengleLedMmr.rearSleep, ledRearSleep);
   }
 
   @override

--- a/test/helpers/fake_ble_transport.dart
+++ b/test/helpers/fake_ble_transport.dart
@@ -54,6 +54,12 @@ class FakeBleTransport extends BLETransport {
   /// both are queued for the same address.
   final Map<int, List<int>> _rawResponses = {};
 
+  /// Address -> ordered ints emitted on successive matching MMR reads (for
+  /// polling loops, e.g. `ScaleCalState`). The final value is sticky (repeats)
+  /// once the queue drains to one, so a poll that reads past the sequence keeps
+  /// seeing the terminal word instead of timing out.
+  final Map<int, Queue<int>> _intResponseSeq = {};
+
   /// Per-UUID queued `read()` payloads.
   final Map<String, Queue<Uint8List>> _readQueue = {};
 
@@ -76,6 +82,12 @@ class FakeBleTransport extends BLETransport {
   /// request to [item] hits the MMR write characteristic.
   void queueMmrResponseRaw(MmrAddress item, List<int> payload) {
     _rawResponses[item.address] = payload;
+  }
+
+  /// Queue an ordered sequence of ints returned on successive reads of [item]
+  /// (for polling loops, e.g. `ScaleCalState`). The final value repeats.
+  void queueMmrResponseIntSequence(MmrAddress item, List<int> values) {
+    _intResponseSeq[item.address] = Queue<int>.of(values);
   }
 
   /// Queue [bytes] for the next `read()` call against [characteristicUUID].
@@ -185,6 +197,34 @@ class FakeBleTransport extends BLETransport {
       for (var i = 0; i < payload.length && i + 4 < 20; i++) {
         resp[i + 4] = payload[i];
       }
+      final cb = subscribers[Endpoint.readFromMMR.uuid];
+      if (cb != null) {
+        scheduleMicrotask(() => cb(resp));
+      }
+      return;
+    }
+
+    int? matchedSeqAddr;
+    for (final addr in _intResponseSeq.keys) {
+      final bytes = ByteData(4)..setInt32(0, addr, Endian.big);
+      if (bytes.getUint8(1) == addrMid1 &&
+          bytes.getUint8(2) == addrMid2 &&
+          bytes.getUint8(3) == addrLow) {
+        matchedSeqAddr = addr;
+        break;
+      }
+    }
+    if (matchedSeqAddr != null) {
+      final q = _intResponseSeq[matchedSeqAddr]!;
+      // Sticky-last: keep returning the final value once drained to one.
+      final value = q.length > 1 ? q.removeFirst() : q.first;
+      final resp = Uint8List(20);
+      final view = ByteData.sublistView(resp);
+      view.setUint8(0, data[0]);
+      view.setUint8(1, addrMid1);
+      view.setUint8(2, addrMid2);
+      view.setUint8(3, addrLow);
+      view.setInt32(4, value, Endian.little);
       final cb = subscribers[Endpoint.readFromMMR.uuid];
       if (cb != null) {
         scheduleMicrotask(() => cb(resp));

--- a/test/helpers/fake_serial_transport.dart
+++ b/test/helpers/fake_serial_transport.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/transport/serial_port.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// Inbound-capable fake [SerialTransport] for transport-level tests.
+///
+/// The repo's older recording fake is write-only (`readStream` never emits),
+/// so it can't exercise the serial RX parser. This one drives [readStream]
+/// from a broadcast controller via [injectSerial] and records every outbound
+/// [writeCommand] string in [writes] — the serial analogue of
+/// `FakeBleTransport`'s `writes` capture. Added for the serial-transport work
+/// serial-parity suite.
+class FakeSerialTransport extends SerialTransport {
+  final _connState = BehaviorSubject<ConnectionState>.seeded(
+    ConnectionState.connected,
+  );
+  final _readCtl = StreamController<String>.broadcast();
+
+  /// Outbound `writeCommand` strings, in order (e.g. `<+N>`, `<-M>`).
+  final List<String> writes = [];
+
+  @override
+  String get id => 'fake-serial';
+  @override
+  String get name => 'FakeSerial';
+  @override
+  Stream<ConnectionState> get connectionState => _connState.stream;
+  @override
+  Future<void> connect() async {}
+  @override
+  Future<void> disconnect() async {}
+  @override
+  Stream<String> get readStream => _readCtl.stream;
+  @override
+  Stream<Uint8List> get rawStream => const Stream.empty();
+  @override
+  Future<void> writeHexCommand(Uint8List command) async {}
+  @override
+  Future<void> writeCommand(String command) async => writes.add(command);
+
+  /// Feed a raw serial chunk into the transport's input parser.
+  void injectSerial(String chunk) => _readCtl.add(chunk);
+
+  @override
+  Future<void> dispose() async {
+    await _connState.close();
+    await _readCtl.close();
+  }
+}

--- a/test/models/device/bengle_cup_warmer_test.dart
+++ b/test/models/device/bengle_cup_warmer_test.dart
@@ -33,10 +33,10 @@ void main() {
     });
 
     test(
-      'setCupWarmerTemperature writes a scaled uint32 to BengleMmr.matSetPoint',
+      'setCupWarmerTemperature writes a whole-°C uint32 to BengleMmr.matSetPoint',
       () async {
         transport.writes.clear();
-        await bengle.setCupWarmerTemperature(60.0);
+        await bengle.setCupWarmerTemperature(70.0);
 
         final frame = transport.writes.firstWhere(
           (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
@@ -49,15 +49,15 @@ void main() {
         expect(frame.data[2], addr.getUint8(2));
         expect(frame.data[3], addr.getUint8(3));
 
-        // Payload bytes [4..7] = uint32 scaled 60.0.
+        // firmware mult=1, so 70 °C encodes as LE 70 (not 700).
         final payload = ByteData.sublistView(frame.data, 4, 8);
-        expect(payload.getUint32(0, Endian.little), equals(600));
+        expect(payload.getUint32(0, Endian.little), equals(70));
       },
     );
 
-    test('getCupWarmerTemperature reads a scaled uint32 back from the wire', () async {
-      // Pre-queue a 50.0 °C scaled uint32 response at the matSetPoint address.
-      final bytes = ByteData(4)..setUint32(0, 500, Endian.little);
+    test('getCupWarmerTemperature reads a whole-°C uint32 back from the wire', () async {
+      // Pre-queue a 50 °C reading (raw uint32, mult=1) at the matSetPoint addr.
+      final bytes = ByteData(4)..setUint32(0, 50, Endian.little);
       transport.queueMmrResponseRaw(
         BengleMmr.matSetPoint,
         List<int>.generate(4, (i) => bytes.getUint8(i)),
@@ -69,13 +69,13 @@ void main() {
 
     test('setCupWarmerTemperature clamps over-range writes', () async {
       transport.writes.clear();
-      await bengle.setCupWarmerTemperature(120.0); // FW max is 80.0
+      await bengle.setCupWarmerTemperature(120.0); // FW max is 80 °C
 
       final frame = transport.writes.firstWhere(
         (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
       );
       final payload = ByteData.sublistView(frame.data, 4, 8);
-      expect(payload.getUint32(0, Endian.little), equals(800));
+      expect(payload.getUint32(0, Endian.little), equals(80));
     });
   });
 }

--- a/test/models/device/bengle_cup_warmer_test.dart
+++ b/test/models/device/bengle_cup_warmer_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 
 import '../../helpers/fake_ble_transport.dart';
 
@@ -76,6 +77,87 @@ void main() {
       );
       final payload = ByteData.sublistView(frame.data, 4, 8);
       expect(payload.getUint32(0, Endian.little), equals(80));
+    });
+
+    // --- CupWarmerMode enable + re-send on connect ---
+
+    Iterable<FakeBleWrite> writesTo(int address) {
+      final ba = ByteData(4)..setInt32(0, address, Endian.big);
+      return transport.writes.where((w) =>
+          w.characteristicUUID == Endpoint.writeToMMR.uuid &&
+          w.data[1] == ba.getUint8(1) &&
+          w.data[2] == ba.getUint8(2) &&
+          w.data[3] == ba.getUint8(3));
+    }
+
+    int payloadOf(FakeBleWrite w) =>
+        ByteData.sublistView(w.data, 4, 8).getUint32(0, Endian.little);
+
+    test('setCupWarmerTemperature also enables CupWarmerMode', () async {
+      transport.writes.clear();
+      await bengle.setCupWarmerTemperature(70.0);
+      final mode = writesTo(BengleMmr.cupWarmerMode.address);
+      expect(mode, isNotEmpty,
+          reason: 'CupWarmerMode (0x008038AC) must be written — temperature '
+              'alone does nothing');
+      expect(payloadOf(mode.last), equals(1));
+    });
+
+    test('setCupWarmerTemperature(0) disables CupWarmerMode', () async {
+      transport.writes.clear();
+      await bengle.setCupWarmerTemperature(0.0);
+      expect(payloadOf(writesTo(BengleMmr.cupWarmerMode.address).last),
+          equals(0));
+    });
+
+    test('CupWarmerMode + target are re-asserted on reconnect when enabled',
+        () async {
+      await bengle.setCupWarmerTemperature(70.0); // enable
+      await bengle.disconnect();
+
+      transport.queueOnConnectResponses(v13Model: 128);
+      transport.writes.clear();
+      await bengle.onConnect();
+
+      expect(writesTo(BengleMmr.matSetPoint.address), isNotEmpty,
+          reason: 'matSetPoint re-pushed on connect');
+      final mode = writesTo(BengleMmr.cupWarmerMode.address);
+      expect(mode, isNotEmpty, reason: 'CupWarmerMode re-pushed on connect');
+      expect(payloadOf(mode.last), equals(1));
+    });
+
+    test('a disabled warmer does not re-push on reconnect', () async {
+      // never enabled → _cupWarmerTarget stays 0
+      await bengle.disconnect();
+      transport.queueOnConnectResponses(v13Model: 128);
+      transport.writes.clear();
+      await bengle.onConnect();
+      expect(writesTo(BengleMmr.cupWarmerMode.address), isEmpty);
+    });
+  });
+
+  group('cup-warmer registers stay Bengle-only', () {
+    test('a plain DE1 connect never touches MatSetPoint or CupWarmerMode',
+        () async {
+      final transport = FakeBleTransport();
+      final de1 = UnifiedDe1(transport: transport);
+      transport.queueOnConnectResponses(); // v13Model: 1 — plain DE1
+      await de1.onConnect();
+
+      Iterable<FakeBleWrite> writesTo(int address) {
+        final ba = ByteData(4)..setInt32(0, address, Endian.big);
+        return transport.writes.where((w) =>
+            w.characteristicUUID == Endpoint.writeToMMR.uuid &&
+            w.data[1] == ba.getUint8(1) &&
+            w.data[2] == ba.getUint8(2) &&
+            w.data[3] == ba.getUint8(3));
+      }
+
+      expect(writesTo(BengleMmr.matSetPoint.address), isEmpty,
+          reason: 'cup-warmer re-assert is Bengle.onConnect machinery — the '
+              'shared DE1 connect path must never write it');
+      expect(writesTo(BengleMmr.cupWarmerMode.address), isEmpty);
+      transport.dispose();
     });
   });
 }

--- a/test/models/device/bengle_cup_warmer_test.dart
+++ b/test/models/device/bengle_cup_warmer_test.dart
@@ -134,6 +134,36 @@ void main() {
       await bengle.onConnect();
       expect(writesTo(BengleMmr.cupWarmerMode.address), isEmpty);
     });
+
+    // --- MatCurrentTemp live mat temperature (defensive read) ---
+
+    test('getCupWarmerCurrentTemperature unscales a live ×10 reading',
+        () async {
+      transport.queueMmrResponseInt(
+          BengleMmr.matCurrentTemp, 425); // 42.5 °C × 10
+      expect(
+          await bengle.getCupWarmerCurrentTemperature(), closeTo(42.5, 1e-6));
+    });
+
+    test('getCupWarmerCurrentTemperature maps raw 0 to null (no reading)',
+        () async {
+      transport.queueMmrResponseInt(BengleMmr.matCurrentTemp, 0);
+      expect(await bengle.getCupWarmerCurrentTemperature(), isNull,
+          reason: 'raw 0 = NTC open/short — never fake a temperature');
+    });
+
+    test('getCupWarmerCurrentTemperature returns null when the read fails',
+        () async {
+      // Older firmware has no MatCurrentTemp register: simulate the read
+      // request failing at the transport rather than waiting out the
+      // MMR-read timeout ladder.
+      final failing = _MatTempReadFailsTransport();
+      final b = Bengle(transport: failing);
+      failing.queueOnConnectResponses(v13Model: 128);
+      await b.onConnect();
+      expect(await b.getCupWarmerCurrentTemperature(), isNull);
+      failing.dispose();
+    });
   });
 
   group('cup-warmer registers stay Bengle-only', () {
@@ -160,4 +190,26 @@ void main() {
       transport.dispose();
     });
   });
+}
+
+/// Fails any MMR read request that targets `MatCurrentTemp` — simulates
+/// older firmware where the register does not exist and the transport/
+/// read path errors instead of answering.
+class _MatTempReadFailsTransport extends FakeBleTransport {
+  @override
+  Future<void> write(
+      String serviceUUID, String characteristicUUID, Uint8List data,
+      {bool withResponse = true, Duration? timeout}) async {
+    if (characteristicUUID == Endpoint.readFromMMR.uuid && data.length >= 4) {
+      final ba = ByteData(4)
+        ..setInt32(0, BengleMmr.matCurrentTemp.address, Endian.big);
+      if (data[1] == ba.getUint8(1) &&
+          data[2] == ba.getUint8(2) &&
+          data[3] == ba.getUint8(3)) {
+        throw Exception('simulated: MatCurrentTemp not mapped on this FW');
+      }
+    }
+    return super.write(serviceUUID, characteristicUUID, data,
+        withResponse: withResponse, timeout: timeout);
+  }
 }

--- a/test/models/device/bengle_saw_test.dart
+++ b/test/models/device/bengle_saw_test.dart
@@ -1,69 +1,118 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 
 import '../../helpers/fake_ble_transport.dart';
 
-/// Wires the `BengleInterface` SAW surface (implemented in
-/// `IntegratedScaleCapability`) through `FakeBleTransport`. The FW
-/// slot for SAW is still stubbed
-/// (`BengleScaleMmr.stopAtWeightTarget.address == 0x00000000`), so
-/// the write does NOT hit the MMR endpoint — instead the value is
-/// cached locally on the mixin's BehaviorSubject. These tests pin
-/// that contract so the day FW publishes the real slot, the test
-/// flips into the "MMR write asserted" branch and forces the
-/// reviewer to confirm the wire spec.
+/// autonomous stop-at-weight.
+///
+/// `IntegratedScaleCapability.setStopAtWeightTarget` maps the app's SAW
+/// target (grams) onto the firmware `EndOfShotWeight` register
+/// (`0x00803864`, RWD, scale ×100, `0` = disable, max 10000 g). Writes
+/// go through the shared `writeMmrScaled` helper, which rounds the
+/// scaled value to match de1plus. These tests assert the wire bytes are
+/// byte-exact against the firmware register.
 void main() {
-  group('Bengle SAW wiring (FW slot stubbed)', () {
+  group('Bengle SAW → EndOfShotWeight MMR', () {
     late FakeBleTransport transport;
     late Bengle bengle;
 
     setUp(() async {
       transport = FakeBleTransport();
+      // calFlowEst keeps onConnect from eating the MMR read-retry timeout.
+      transport.queueMmrResponseInt(MMRItem.calFlowEst, 100);
+      transport.queueOnConnectResponses(v13Model: 128); // real Bengle
       bengle = Bengle(transport: transport);
-      transport.queueOnConnectResponses(v13Model: 128); // Bengle marker
       await bengle.onConnect();
+      transport.writes.clear();
     });
 
     tearDown(() {
       transport.dispose();
     });
 
-    test('FW slot address is still TBD', () {
-      // Pin the precondition for the local-cache branch. When this
-      // breaks, the production wire is real and the rest of this
-      // group needs the assertions inverted.
-      expect(BengleScaleMmr.stopAtWeightTarget.address, 0x00000000);
+    /// Most recent write to the MMR write characteristic, or null.
+    FakeBleWrite? lastMmrWrite() {
+      for (final w in transport.writes.reversed) {
+        if (w.characteristicUUID == Endpoint.writeToMMR.uuid) return w;
+      }
+      return null;
+    }
+
+    test('SAW target maps to the real EndOfShotWeight register', () {
+      final addr = BengleScaleMmr.stopAtWeightTarget;
+      expect(addr.address, 0x00803864);
+      expect(addr.kind, MmrValueKind.scaledFloat);
+      expect(addr.writeScale, 100.0);
+      expect(addr.readScale, 0.01);
+      expect(addr.min, 0);
+      expect(addr.max, 1000000); // 10000.0 g × 100
     });
 
-    test('setStopAtWeightTarget caches locally and does not write MMR',
-        () async {
+    test(
+      'setStopAtWeightTarget writes the scaled LE int32 to 0x00803864',
+      () async {
+        await bengle.setStopAtWeightTarget(36.0);
+
+        final w = lastMmrWrite();
+        expect(w, isNotNull, reason: 'a real MMR write must hit the wire');
+        final d = w!.data;
+        // Length byte + big-endian address low 3 bytes (0x80,0x38,0x64).
+        expect(d[0], 4);
+        expect(d[1], 0x80);
+        expect(d[2], 0x38);
+        expect(d[3], 0x64);
+        // Payload: 36.0 g × 100 = 3600 = 0x0E10, little-endian.
+        expect(d.sublist(4, 8), [0x10, 0x0E, 0x00, 0x00]);
+      },
+    );
+
+    test('rounds the ×100 write (2.3 g → 230, not 229)', () async {
+      // 2.3 * 100 == 229.999… under doubles; truncating drops a whole
+      // centigram. writeMmrScaled rounds, so the wire carries 230 (0xE6).
+      await bengle.setStopAtWeightTarget(2.3);
+
+      final d = lastMmrWrite()!.data;
+      expect(d.sublist(4, 8), [0xE6, 0x00, 0x00, 0x00]); // 230, not 229 (0xE5)
+    });
+
+    test('0.0 disables SAW (writes 0)', () async {
+      await bengle.setStopAtWeightTarget(0.0);
+      final d = lastMmrWrite()!.data;
+      expect(d.sublist(4, 8), [0x00, 0x00, 0x00, 0x00]);
+    });
+
+    test('clamps grams to 0..10000 before scaling', () async {
+      await bengle.setStopAtWeightTarget(20000.0);
+      // 10000 g × 100 = 1_000_000 = 0x0F4240, little-endian.
+      expect(lastMmrWrite()!.data.sublist(4, 8), [0x40, 0x42, 0x0F, 0x00]);
+      expect(await bengle.stopAtWeightTarget.first, 10000.0);
+
       transport.writes.clear();
-      await bengle.setStopAtWeightTarget(30.0);
-
-      final mmrWrites = transport.writes
-          .where((w) => w.characteristicUUID == Endpoint.writeToMMR.uuid)
-          .toList();
-      expect(mmrWrites, isEmpty,
-          reason: 'FW slot is stubbed — no MMR write should hit the wire');
-
-      expect(await bengle.getStopAtWeightTarget(), closeTo(30.0, 1e-6));
-    });
-
-    test('setStopAtWeightTarget clamps to 0..500', () async {
-      await bengle.setStopAtWeightTarget(1000.0);
-      expect(await bengle.getStopAtWeightTarget(), 500.0);
-
       await bengle.setStopAtWeightTarget(-5.0);
-      expect(await bengle.getStopAtWeightTarget(), 0.0);
+      expect(lastMmrWrite()!.data.sublist(4, 8), [0x00, 0x00, 0x00, 0x00]);
+      expect(await bengle.stopAtWeightTarget.first, 0.0);
     });
 
-    test('stopAtWeightTarget stream emits cached value to subscribers',
-        () async {
-      await bengle.setStopAtWeightTarget(42.0);
-      final value = await bengle.stopAtWeightTarget.first;
-      expect(value, 42.0);
-    });
+    test(
+      'getStopAtWeightTarget reads back from the wire and hydrates cache',
+      () async {
+        // Firmware reports raw 3000 → 3000 × 0.01 = 30.0 g.
+        transport.queueMmrResponseInt(BengleScaleMmr.stopAtWeightTarget, 3000);
+        expect(await bengle.getStopAtWeightTarget(), closeTo(30.0, 1e-9));
+        // Cache hydrated, so the stream now replays 30.0.
+        expect(await bengle.stopAtWeightTarget.first, closeTo(30.0, 1e-9));
+      },
+    );
+
+    test(
+      'stopAtWeightTarget stream emits the cached target to subscribers',
+      () async {
+        await bengle.setStopAtWeightTarget(42.0);
+        expect(await bengle.stopAtWeightTarget.first, 42.0);
+      },
+    );
   });
 }

--- a/test/models/device/bengle_steam_stop_test.dart
+++ b/test/models/device/bengle_steam_stop_test.dart
@@ -2,16 +2,18 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
 
 import '../../helpers/fake_ble_transport.dart';
 
-/// Pins the real-`Bengle` stop-at-temperature stub contract. FW slot
-/// for `BengleSteamMmr.stopAtTemperatureTarget` is still `0x00000000`,
-/// so writes cache locally and never hit the MMR endpoint. When FW
-/// publishes the real slot, the pin test flips and the rest of the
-/// group needs the assertions inverted.
+/// milk-probe steam stop target.
+///
+/// `Bengle.setStopAtTemperatureTarget` maps the app's target (°C) onto the
+/// firmware `TargetMilkTemp` register (`0x008038A8`, RWD, scale ×10 decicelsius,
+/// `0` = disable, max 850 = 85 °C). The live probe reading is separate (rides
+/// `0xA013`, not an MMR). These tests assert the wire bytes.
 void main() {
-  group('Bengle stop-at-temperature wiring (FW slot stubbed)', () {
+  group('Bengle stop-at-temperature → TargetMilkTemp MMR', () {
     late FakeBleTransport transport;
     late Bengle bengle;
 
@@ -20,50 +22,79 @@ void main() {
       bengle = Bengle(transport: transport);
       transport.queueOnConnectResponses(v13Model: 128); // Bengle marker
       await bengle.onConnect();
+      transport.writes.clear();
     });
 
     tearDown(() {
       transport.dispose();
     });
 
-    test('FW slot address is still TBD', () {
-      expect(BengleSteamMmr.stopAtTemperatureTarget.address, 0x00000000);
+    FakeBleWrite? lastMmrWrite() {
+      for (final w in transport.writes.reversed) {
+        if (w.characteristicUUID == Endpoint.writeToMMR.uuid) return w;
+      }
+      return null;
+    }
+
+    test('target maps to the real TargetMilkTemp register', () {
+      final addr = BengleSteamMmr.stopAtTemperatureTarget;
+      expect(addr.address, 0x008038A8);
+      expect(addr.kind, MmrValueKind.scaledFloat);
+      expect(addr.writeScale, 10.0);
+      expect(addr.readScale, 0.1);
+      expect(addr.min, 0);
+      expect(addr.max, 850); // 85.0 °C × 10
     });
 
-    test('setStopAtTemperatureTarget caches locally and does not write MMR',
+    test('setStopAtTemperatureTarget writes the scaled LE int32 to 0x008038A8',
         () async {
-      transport.writes.clear();
       await bengle.setStopAtTemperatureTarget(65.0);
 
-      final mmrWrites = transport.writes
-          .where((w) => w.characteristicUUID == Endpoint.writeToMMR.uuid)
-          .toList();
-      expect(mmrWrites, isEmpty,
-          reason: 'FW slot is stubbed — no MMR write should hit the wire');
-
-      expect(
-          await bengle.getStopAtTemperatureTarget(), closeTo(65.0, 1e-6));
+      final w = lastMmrWrite();
+      expect(w, isNotNull, reason: 'a real MMR write must hit the wire');
+      final d = w!.data;
+      // Length byte + big-endian address low 3 bytes (0x80,0x38,0xA8).
+      expect(d[0], 4);
+      expect(d.sublist(1, 4), [0x80, 0x38, 0xA8]);
+      // Payload: 65.0 °C × 10 = 650 = 0x028A, little-endian.
+      expect(d.sublist(4, 8), [0x8A, 0x02, 0x00, 0x00]);
     });
 
-    test('setStopAtTemperatureTarget clamps to 0..80', () async {
+    test('0.0 disables autonomous stop (writes 0)', () async {
+      await bengle.setStopAtTemperatureTarget(0.0);
+      expect(lastMmrWrite()!.data.sublist(4, 8), [0x00, 0x00, 0x00, 0x00]);
+    });
+
+    test('clamps °C to 0..85 before scaling', () async {
       await bengle.setStopAtTemperatureTarget(120.0);
-      expect(await bengle.getStopAtTemperatureTarget(), 80.0);
+      // 85 °C × 10 = 850 = 0x0352, little-endian.
+      expect(lastMmrWrite()!.data.sublist(4, 8), [0x52, 0x03, 0x00, 0x00]);
+      expect(await bengle.stopAtTemperatureTarget.first, 85.0);
 
+      transport.writes.clear();
       await bengle.setStopAtTemperatureTarget(-5.0);
-      expect(await bengle.getStopAtTemperatureTarget(), 0.0);
+      expect(lastMmrWrite()!.data.sublist(4, 8), [0x00, 0x00, 0x00, 0x00]);
+      expect(await bengle.stopAtTemperatureTarget.first, 0.0);
     });
 
-    test('stopAtTemperatureTarget stream emits cached value to subscribers',
-        () async {
+    test('stream emits the set value to subscribers', () async {
       await bengle.setStopAtTemperatureTarget(55.0);
-      final value = await bengle.stopAtTemperatureTarget.first;
-      expect(value, 55.0);
+      expect(await bengle.stopAtTemperatureTarget.first, 55.0);
     });
 
-    test('probeAttached stays false on real Bengle (FW signal TBD)',
+    test('getStopAtTemperatureTarget reads, unscales, and echoes the register',
         () async {
-      final value = await bengle.probeAttached.first;
-      expect(value, isFalse);
+      transport.queueMmrResponseInt(
+          BengleSteamMmr.stopAtTemperatureTarget, 600); // 60.0 °C × 10
+      expect(await bengle.getStopAtTemperatureTarget(), closeTo(60.0, 1e-6));
+      // The read side-effects the BehaviorSubject so replay subscribers
+      // see post-read truth.
+      expect(await bengle.stopAtTemperatureTarget.first, closeTo(60.0, 1e-6));
+    });
+
+    test('probeAttached stays false on real Bengle (reading rides 0xA013)',
+        () async {
+      expect(await bengle.probeAttached.first, isFalse);
     });
   });
 }

--- a/test/models/device/bengle_wake_schedule_test.dart
+++ b/test/models/device/bengle_wake_schedule_test.dart
@@ -1,0 +1,176 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
+
+import '../../helpers/fake_ble_transport.dart';
+
+/// The autonomous wake schedule + sleep timeout, at the WIRE.
+///
+/// The firmware protocol is order-sensitive and unforgiving: `ScheduleControl`
+/// = 0 clears the table AND disables it, entries append one at a time, and
+/// `ScheduleControl` = 1 enables. Get the order wrong and the entries land in
+/// a table that is then cleared; pack the day as a bitmask and the firmware
+/// silently schedules the wrong day. These tests assert the exact bytes and
+/// the exact sequence.
+void main() {
+  late FakeBleTransport transport;
+  late Bengle bengle;
+
+  setUp(() async {
+    transport = FakeBleTransport();
+    bengle = Bengle(transport: transport);
+    transport.queueOnConnectResponses(v13Model: 128); // Bengle marker
+    await bengle.onConnect();
+    transport.writes.clear();
+  });
+
+  tearDown(() {
+    transport.dispose();
+  });
+
+  /// Every MMR write, in order, as (address, little-endian int32 value).
+  List<({int address, int value})> mmrWrites() {
+    final out = <({int address, int value})>[];
+    for (final w in transport.writes) {
+      if (w.characteristicUUID != Endpoint.writeToMMR.uuid) continue;
+      final d = w.data;
+      // Frame: [len, addrHi, addrMid, addrLo, payload LE...]
+      final address = 0x00800000 | (d[2] << 8) | d[3];
+      final value =
+          d[4] | (d[5] << 8) | (d[6] << 16) | (d[7] << 24);
+      out.add((address: address, value: value));
+    }
+    return out;
+  }
+
+  group('BengleScheduleMmr register declarations', () {
+    test('addresses, kinds and (deliberately narrowed) bounds', () {
+      expect(BengleScheduleMmr.inactivitySleepTimeout.address, 0x008038BC);
+      expect(BengleScheduleMmr.inactivitySleepTimeout.max, 240);
+      expect(BengleScheduleMmr.setLocalTimeOfWeek.address, 0x008038C0);
+      // Narrower than the contract's 604800 on purpose: the FW setter rejects
+      // `>= SECONDS_PER_WEEK`, so 604800 would silently leave the clock invalid.
+      expect(BengleScheduleMmr.setLocalTimeOfWeek.max, 604799);
+      expect(BengleScheduleMmr.scheduleEntry.address, 0x008038C4);
+      expect(BengleScheduleMmr.scheduleControl.address, 0x008038C8);
+      // Narrower than the contract's 255: the FW reads only bit 0 on a
+      // non-zero write, so a stray 2 would disable WITHOUT clearing.
+      expect(BengleScheduleMmr.scheduleControl.max, 1);
+
+      for (final r in BengleScheduleMmr.values) {
+        expect(r.kind, MmrValueKind.int32);
+        expect(r.length, 4);
+        expect(r.readScale, 1.0);
+        expect(r.writeScale, 1.0);
+      }
+    });
+  });
+
+  group('setInactivitySleepTimeout', () {
+    test('writes the minutes as an LE int32 to 0x008038BC', () async {
+      await bengle.setInactivitySleepTimeout(30);
+      final w = transport.writes
+          .lastWhere((w) => w.characteristicUUID == Endpoint.writeToMMR.uuid);
+      expect(w.data[0], 4);
+      expect(w.data.sublist(1, 4), [0x80, 0x38, 0xBC]);
+      expect(w.data.sublist(4, 8), [0x1E, 0x00, 0x00, 0x00]); // 30
+    });
+
+    test('0 disables the firmware timer', () async {
+      await bengle.setInactivitySleepTimeout(0);
+      expect(mmrWrites().single, (address: 0x008038BC, value: 0));
+    });
+
+    test('clamps above the firmware max of 240 minutes', () async {
+      await bengle.setInactivitySleepTimeout(9999);
+      expect(mmrWrites().single.value, 240);
+    });
+  });
+
+  group('setLocalTimeOfWeek', () {
+    test('writes LOCAL seconds-of-week as an LE int32 to 0x008038C0', () async {
+      // Spec §5.1: Tuesday 07:20:00 = 199200 = 0x00030A20.
+      await bengle.setLocalTimeOfWeek(199200);
+      final w = transport.writes.single;
+      expect(w.data.sublist(1, 4), [0x80, 0x38, 0xC0]);
+      expect(w.data.sublist(4, 8), [0x20, 0x0A, 0x03, 0x00]);
+    });
+
+    test('never writes 0 — 0 is the "rebooted, never synced" sentinel',
+        () async {
+      await bengle.setLocalTimeOfWeek(0);
+      expect(mmrWrites().single.value, 1);
+    });
+
+    test('never writes 604800 — the firmware setter rejects it outright',
+        () async {
+      await bengle.setLocalTimeOfWeek(604800);
+      expect(mmrWrites().single.value, 604799);
+    });
+  });
+
+  group('pushWakeSchedule — the firmware write protocol', () {
+    test('control(0) -> entries -> control(1), in that exact order', () async {
+      // Spec §5.1: Mon-Fri 05:30 for 90 minutes.
+      await bengle.pushWakeSchedule([
+        0x004A51A4,
+        0x008A51A4,
+        0x00CA51A4,
+        0x010A51A4,
+        0x014A51A4,
+      ]);
+
+      expect(mmrWrites(), [
+        (address: 0x008038C8, value: 0), // clear the table + disable
+        (address: 0x008038C4, value: 0x004A51A4), // Mon
+        (address: 0x008038C4, value: 0x008A51A4), // Tue
+        (address: 0x008038C4, value: 0x00CA51A4), // Wed
+        (address: 0x008038C4, value: 0x010A51A4), // Thu
+        (address: 0x008038C4, value: 0x014A51A4), // Fri
+        (address: 0x008038C8, value: 1), // enable
+      ]);
+    });
+
+    test('the entry bytes are the little-endian packed int32', () async {
+      await bengle.pushWakeSchedule([0x004A51A4]);
+      final entry = transport.writes
+          .where((w) => w.characteristicUUID == Endpoint.writeToMMR.uuid)
+          .elementAt(1); // [0] is control=0
+      expect(entry.data.sublist(1, 4), [0x80, 0x38, 0xC4]);
+      expect(entry.data.sublist(4, 8), [0xA4, 0x51, 0x4A, 0x00]);
+    });
+
+    test('an empty table writes ONLY control(0) — clear + disable, no enable',
+        () async {
+      await bengle.pushWakeSchedule(const []);
+      expect(
+        mmrWrites(),
+        [(address: 0x008038C8, value: 0)],
+        reason: 'enabling an empty table would be a lie, and writing entries '
+            'after a clear with no enable would be dead state',
+      );
+    });
+
+    test('caps at the 32-entry firmware table (the 33rd is dropped silently)',
+        () async {
+      await bengle.pushWakeSchedule(List<int>.generate(40, (i) => i + 1));
+      final entries = mmrWrites().where((w) => w.address == 0x008038C4);
+      expect(entries, hasLength(32));
+      expect(entries.last.value, 32);
+    });
+  });
+
+  group('read-backs (write echoes, not device state)', () {
+    test('readLocalTimeOfWeekEcho reads 0x008038C0', () async {
+      transport.queueMmrResponseInt(BengleScheduleMmr.setLocalTimeOfWeek, 0);
+      expect(await bengle.readLocalTimeOfWeekEcho(), 0);
+    });
+
+    test('readScheduleControl reads 0x008038C8', () async {
+      transport.queueMmrResponseInt(BengleScheduleMmr.scheduleControl, 1);
+      expect(await bengle.readScheduleControl(), 1);
+    });
+  });
+}

--- a/test/models/device/de1_resolver_test.dart
+++ b/test/models/device/de1_resolver_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1_resolver.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+
+import '../../helpers/fake_ble_transport.dart';
+
+/// Model-authoritative class selection — BLE discovery picks the machine
+/// class by advertised name (`DeviceMatcher`), but `v13Model`, read on
+/// connect, is authoritative. `resolveMachineForModel` runs after
+/// `onConnect` and returns the concrete machine matching the detected model:
+/// the same instance when the name-picked class already agrees, otherwise a
+/// fresh instance of the right class over the same connected transport with
+/// the read identity carried over. This mirrors the serial path, which
+/// already instantiates `Bengle` vs `UnifiedDe1` from `v13Model >= 128`.
+void main() {
+  group('resolveMachineForModel', () {
+    late FakeBleTransport transport;
+
+    setUp(() {
+      transport = FakeBleTransport();
+      // onConnect warms the flow-cal cache (calFlowEst); queue it so onConnect
+      // returns immediately instead of eating the MMR read-retry timeout.
+      transport.queueMmrResponseInt(MMRItem.calFlowEst, 100);
+    });
+
+    tearDown(() => transport.dispose());
+
+    test(
+      'DE1-named device reporting v13Model >= 128 resolves to Bengle',
+      () async {
+        transport.queueOnConnectResponses(v13Model: 128, serialN: 4242);
+        final machine = UnifiedDe1(transport: transport);
+        await machine.onConnect();
+
+        final resolved = resolveMachineForModel(machine);
+
+        expect(resolved, isA<Bengle>());
+        expect(
+          identical(resolved, machine),
+          isFalse,
+          reason: 'must be a fresh Bengle, not the name-picked UnifiedDe1',
+        );
+        // Identity read on connect is carried over (no MMR re-read needed).
+        expect(resolved.machineInfo.serialNumber, '4242');
+        expect((resolved as Bengle).isBengle, isTrue);
+      },
+    );
+
+    test(
+      'plain DE1 (model 1) stays UnifiedDe1 — no swap, same instance',
+      () async {
+        transport.queueOnConnectResponses(v13Model: 1);
+        final machine = UnifiedDe1(transport: transport);
+        await machine.onConnect();
+
+        final resolved = resolveMachineForModel(machine);
+
+        expect(identical(resolved, machine), isTrue);
+        expect(resolved, isA<UnifiedDe1>());
+        expect(resolved, isNot(isA<Bengle>()));
+      },
+    );
+
+    test(
+      'Bengle-named device reporting model >= 128 stays Bengle — no swap',
+      () async {
+        transport.queueOnConnectResponses(v13Model: 128);
+        final machine = Bengle(transport: transport);
+        await machine.onConnect();
+
+        final resolved = resolveMachineForModel(machine);
+
+        expect(identical(resolved, machine), isTrue);
+        expect(resolved, isA<Bengle>());
+      },
+    );
+
+    test(
+      'Bengle-named device reporting a DE1 model demotes to UnifiedDe1',
+      () async {
+        transport.queueOnConnectResponses(v13Model: 1);
+        final machine = Bengle(transport: transport);
+        await machine.onConnect();
+
+        final resolved = resolveMachineForModel(machine);
+
+        expect(resolved, isA<UnifiedDe1>());
+        expect(resolved, isNot(isA<Bengle>()));
+        expect(identical(resolved, machine), isFalse);
+        expect((resolved as UnifiedDe1).isBengle, isFalse);
+      },
+    );
+
+    test(
+      'a re-resolved Bengle completes onConnect over the shared transport '
+      'after the MMR queue is drained (identity short-circuits re-reads)',
+      () async {
+        // The interim onConnect consumes the queued MMR responses. The crux of
+        // the design: the re-resolved instance carries the identity over, so its
+        // onConnect must short-circuit the MMR reads (its `_info` is set) and
+        // still complete — NOT hang on the now-empty queue.
+        transport.queueOnConnectResponses(v13Model: 128, serialN: 7);
+        final machine = UnifiedDe1(transport: transport);
+        await machine.onConnect();
+
+        final resolved = resolveMachineForModel(machine) as Bengle;
+        // Mirrors De1Controller.connectToDe1: finish connecting the resolved
+        // instance. With no re-queued responses this would time out (~12s) and
+        // throw if it re-read MMRs.
+        await resolved.onConnect().timeout(const Duration(seconds: 8));
+
+        expect(resolved.isBengle, isTrue);
+        expect(resolved.machineInfo.serialNumber, '7');
+      },
+    );
+
+    test(
+      'detaching the interim after a promotion leaves the resolved instance '
+      'working over the shared transport (detach must not dispose it)',
+      () async {
+        transport.queueOnConnectResponses(v13Model: 128, serialN: 9);
+        final interim = UnifiedDe1(transport: transport);
+        await interim.onConnect();
+        final resolved = resolveMachineForModel(interim) as Bengle;
+        await resolved.onConnect();
+
+        // Mirror De1Controller.connectToDe1: tear down the discarded interim.
+        await interim.detachTransport();
+
+        // The shared transport must still be alive — the resolved instance can
+        // still round-trip an MMR read. (If detach had disposed the transport,
+        // this would hang/throw.)
+        transport.queueMmrResponseInt(MMRItem.fanThreshold, 55);
+        expect(
+          await resolved.getFanThreshhold().timeout(const Duration(seconds: 8)),
+          55,
+        );
+      },
+    );
+  });
+}

--- a/test/models/device/impl/bengle/mock_bengle_led_test.dart
+++ b/test/models/device/impl/bengle/mock_bengle_led_test.dart
@@ -86,5 +86,18 @@ void main() {
       final after = await bengle.getLedStripState();
       expect(after, const LedStripState());
     });
+
+    test('previewLedColor / clearLedPreview are no-ops on the mock', () async {
+      // No live strip to preview — neither call may throw or disturb the
+      // stored config (real HW: live registers only, cache untouched).
+      final bengle = MockBengle();
+      final before = await bengle.getLedStripState();
+
+      await bengle.previewLedColor(
+          const Color16(65535, 0, 0), const Color16(0, 0, 65535));
+      await bengle.clearLedPreview();
+
+      expect(await bengle.getLedStripState(), before);
+    });
   });
 }

--- a/test/models/device/impl/bengle/mock_bengle_steam_probe_test.dart
+++ b/test/models/device/impl/bengle/mock_bengle_steam_probe_test.dart
@@ -22,9 +22,10 @@ void main() {
       expect(streamed, 60.0);
     });
 
-    test('setStopAtTemperatureTarget clamps to 0..80', () async {
+    test('setStopAtTemperatureTarget clamps to 0..85 (matches real Bengle)',
+        () async {
       await bengle.setStopAtTemperatureTarget(120.0);
-      expect(await bengle.getStopAtTemperatureTarget(), 80.0);
+      expect(await bengle.getStopAtTemperatureTarget(), 85.0);
       await bengle.setStopAtTemperatureTarget(-5.0);
       expect(await bengle.getStopAtTemperatureTarget(), 0.0);
     });

--- a/test/models/device/machine_snapshot_test.dart
+++ b/test/models/device/machine_snapshot_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+
+/// Locks the additive-compat contract of the `MachineSnapshot`
+/// fields (`weight`, `weightFlow`, `milkTemperature`): payloads predating the
+/// fields must still decode, defaulting all three to `0.0`.
+void main() {
+  MachineSnapshot snapshot() => MachineSnapshot(
+    timestamp: DateTime.utc(2026, 7, 11, 12, 0, 0),
+    state: MachineStateSnapshot(
+      state: MachineState.espresso,
+      substate: MachineSubstate.pouring,
+    ),
+    flow: 2.5,
+    pressure: 9.0,
+    targetFlow: 2.0,
+    targetPressure: 6.0,
+    mixTemperature: 92.5,
+    groupTemperature: 88.0,
+    targetMixTemperature: 93.0,
+    targetGroupTemperature: 90.0,
+    profileFrame: 7,
+    steamTemperature: 135,
+    weight: 36.5,
+    weightFlow: 1.8,
+    milkTemperature: 61.98,
+  );
+
+  group('MachineSnapshot json (additive fields)', () {
+    test('fromJson defaults weight/weightFlow/milkTemperature to 0.0 when '
+        'absent (pre-FIX payloads decode)', () {
+      final json = snapshot().toJson()
+        ..remove('weight')
+        ..remove('weightFlow')
+        ..remove('milkTemperature');
+
+      final decoded = MachineSnapshot.fromJson(json);
+
+      expect(decoded.weight, 0.0);
+      expect(decoded.weightFlow, 0.0);
+      expect(decoded.milkTemperature, 0.0);
+      // The legacy fields still decode unchanged.
+      expect(decoded.pressure, closeTo(9.0, 1e-9));
+      expect(decoded.steamTemperature, 135);
+    });
+
+    test('toJson -> fromJson round-trips the three fields', () {
+      final decoded = MachineSnapshot.fromJson(snapshot().toJson());
+
+      expect(decoded.weight, closeTo(36.5, 1e-9));
+      expect(decoded.weightFlow, closeTo(1.8, 1e-9));
+      expect(decoded.milkTemperature, closeTo(61.98, 1e-9));
+    });
+
+    test('fromJson tolerates integer-typed values (json num -> double)', () {
+      final json = snapshot().toJson()
+        ..['weight'] = 36
+        ..['weightFlow'] = 2
+        ..['milkTemperature'] = 0;
+
+      final decoded = MachineSnapshot.fromJson(json);
+
+      expect(decoded.weight, 36.0);
+      expect(decoded.weightFlow, 2.0);
+      expect(decoded.milkTemperature, 0.0);
+    });
+
+    test('copyWith carries and overrides the three fields', () {
+      final base = snapshot();
+      expect(base.copyWith().weight, closeTo(36.5, 1e-9));
+      expect(base.copyWith(weight: 40.0).weight, closeTo(40.0, 1e-9));
+      expect(base.copyWith(weightFlow: 2.2).weightFlow, closeTo(2.2, 1e-9));
+      expect(
+        base.copyWith(milkTemperature: 55.0).milkTemperature,
+        closeTo(55.0, 1e-9),
+      );
+    });
+  });
+}

--- a/test/models/device/mock_bengle_test.dart
+++ b/test/models/device/mock_bengle_test.dart
@@ -3,6 +3,7 @@ import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+import 'package:reaprime/src/models/device/scale_calibration.dart';
 
 void main() {
   group('MockBengle', () {
@@ -66,6 +67,30 @@ void main() {
       final m = MockBengle();
       await m.setStopAtWeightTarget(36.0);
       expect(await m.stopAtWeightTarget.first, 36.0);
+    });
+  });
+
+  group('MockBengle scale calibration', () {
+    test('calibrateScaleZero completes successfully', () async {
+      final m = MockBengle();
+      final r = await m.calibrateScaleZero();
+      expect(r.success, isTrue);
+      expect(r.finalStep, ScaleCalStep.complete);
+    });
+
+    test('two-point weight cal completes and emits progress', () async {
+      final m = MockBengle();
+      final seen = <ScaleCalStatus>[];
+      final sub = m.scaleCalibrationProgress.listen(seen.add);
+      final left = await m.calibrateScaleWeightLeft(500.0);
+      final right = await m.calibrateScaleWeightRight(500.0);
+      await pumpEventQueue();
+      await sub.cancel();
+      expect(left.success, isTrue);
+      expect(left.pointStatus, ScaleCalPointStatus.incomplete);
+      expect(right.success, isTrue);
+      expect(right.pointStatus, ScaleCalPointStatus.ok);
+      expect(seen.last.isComplete, isTrue);
     });
   });
 

--- a/test/models/device/mock_bengle_test.dart
+++ b/test/models/device/mock_bengle_test.dart
@@ -50,10 +50,10 @@ void main() {
       expect(await m.getStopAtWeightTarget(), 30.0);
     });
 
-    test('clamps over-range values to 500.0', () async {
+    test('clamps over-range values to 10000.0', () async {
       final m = MockBengle();
-      await m.setStopAtWeightTarget(1000.0);
-      expect(await m.getStopAtWeightTarget(), 500.0);
+      await m.setStopAtWeightTarget(20000.0);
+      expect(await m.getStopAtWeightTarget(), 10000.0);
     });
 
     test('clamps negative values to 0.0', () async {

--- a/test/models/device/unified_de1_bengle_profile_v2_test.dart
+++ b/test/models/device/unified_de1_bengle_profile_v2_test.dart
@@ -1,0 +1,272 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+
+import '../../helpers/fake_ble_transport.dart';
+
+/// byte-exact shot-profile upload encoding.
+///
+/// A Bengle (BLE protocol v2) needs `HeaderV = 2` and **U8D1** (`byte × 0.1`)
+/// flow/pressure encoding; a DE1 keeps `HeaderV = 1` and **U8P4** (`byte / 16`).
+/// Encoding a v2 value with the v1 scale silently mis-commands the machine
+/// (`6 ml/s` → v1 `96` → the Bengle reads `9.6`) and any value > 15.9 wraps the
+/// byte. The Bengle firmware also rejects a `HeaderV != 2` header outright,
+/// wiping it, so a v1 upload produces no shot at all.
+///
+/// These drive a real [UnifiedDe1] over [FakeBleTransport] and assert the exact
+/// bytes captured on the `headerWrite` / `frameWrite` characteristics. The gate
+/// is S1's `isBengle` (`v13Model >= 128` read on connect), so the Bengle group
+/// connects with model 128 and the DE1 group stays on the default (model 1).
+///
+/// Golden bytes hand-computed and cross-checked against de1plus `binary.tcl`
+/// (`convert_float_to_U8D1`, `de1_packed_shot`) and the firmware struct layout
+/// in BENGLE_FIXES.md — de1plus is TCL and not callable from Dart.
+void main() {
+  // One profile exercising every flow/pressure field the fix touches.
+  const profile = Profile(
+    version: '2',
+    title: 'encoder profile',
+    notes: '',
+    author: 'test',
+    beverageType: BeverageType.espresso,
+    steps: [
+      // Frame 0: flow 6 ml/s, a flow-over exit at 4 ml/s, and an extension
+      // frame limiter (value 8, range 2).
+      ProfileStepFlow(
+        name: 'preinfuse',
+        transition: TransitionType.fast,
+        volume: 0,
+        seconds: 10,
+        temperature: 92,
+        sensor: TemperatureSensor.coffee,
+        flow: 6.0,
+        exit: StepExitCondition(
+          type: ExitType.flow,
+          condition: ExitCondition.over,
+          value: 4.0,
+        ),
+        limiter: StepLimiter(value: 8.0, range: 2.0),
+      ),
+      // Frame 1: flow 20 ml/s — must survive without wrapping on a Bengle.
+      ProfileStepFlow(
+        name: 'high-flow',
+        transition: TransitionType.fast,
+        volume: 0,
+        seconds: 20,
+        temperature: 90,
+        sensor: TemperatureSensor.coffee,
+        flow: 20.0,
+      ),
+      // Frame 2: flow 30 ml/s — over the Bengle 20 ml/s ceiling; clamps.
+      ProfileStepFlow(
+        name: 'over-ceiling',
+        transition: TransitionType.fast,
+        volume: 0,
+        seconds: 5,
+        temperature: 88,
+        sensor: TemperatureSensor.coffee,
+        flow: 30.0,
+      ),
+      // Frame 3: pressure 9 bar, a pressure-under exit at 3 bar.
+      ProfileStepPressure(
+        name: 'pour',
+        transition: TransitionType.smooth,
+        volume: 0,
+        seconds: 25,
+        temperature: 93,
+        sensor: TemperatureSensor.coffee,
+        pressure: 9.0,
+        exit: StepExitCondition(
+          type: ExitType.pressure,
+          condition: ExitCondition.under,
+          value: 3.0,
+        ),
+      ),
+    ],
+    targetVolumeCountStart: 0,
+    tankTemperature: 0,
+  );
+
+  /// Uploads [profile] once and returns the ordered writes seen on the
+  /// header and frame characteristics. When [asBengle] the device connects
+  /// with `v13Model = 128` so `isBengle` gates the v2 encoder.
+  Future<({List<FakeBleWrite> header, List<FakeBleWrite> frames, bool bengle})>
+  upload({required bool asBengle}) async {
+    final transport = FakeBleTransport();
+    final de1 = UnifiedDe1(transport: transport);
+    if (asBengle) {
+      // `queueOnConnectResponses` omits `calFlowEst` (the flow-cal warm-up
+      // read at the tail of onConnect); queue it so onConnect returns
+      // promptly instead of eating the MMR read-retry timeout.
+      transport.queueMmrResponseInt(MMRItem.calFlowEst, 100);
+      transport.queueOnConnectResponses(v13Model: 128);
+      await de1.onConnect();
+    }
+    await de1.setProfile(profile);
+    final header = transport.writes
+        .where((w) => w.characteristicUUID == Endpoint.headerWrite.uuid)
+        .toList();
+    final frames = transport.writes
+        .where((w) => w.characteristicUUID == Endpoint.frameWrite.uuid)
+        .toList();
+    final bengle = de1.isBengle;
+    await transport.dispose();
+    return (header: header, frames: frames, bengle: bengle);
+  }
+
+  group('Bengle (v13Model 128) uploads v2', () {
+    late List<FakeBleWrite> header;
+    late List<FakeBleWrite> frames;
+    late bool gatedBengle;
+
+    setUpAll(() async {
+      final r = await upload(asBengle: true);
+      header = r.header;
+      frames = r.frames;
+      gatedBengle = r.bengle;
+    });
+
+    test('connecting with model 128 gates the Bengle encoder', () {
+      expect(gatedBengle, isTrue);
+    });
+
+    test('header carries protocol version 2', () {
+      expect(header, hasLength(1));
+      expect(header.single.data[0], 2);
+    });
+
+    test(
+      'header MaximumFlow is U8D1(20 ml/s) = 0xC8, not the v1 12*16 byte',
+      () {
+        // the old hard-coded `12 * 16` (U8P4) is replaced with the
+        // raised 20 ml/s ceiling, U8D1-encoded.
+        expect(header.single.data[4], 0xC8);
+      },
+    );
+
+    test('write sequence is 4 frames + 1 extension + tail, in order', () {
+      expect(frames, hasLength(6));
+      expect(frames[0].data[0], 0, reason: 'frame 0');
+      expect(frames[1].data[0], 1, reason: 'frame 1');
+      expect(frames[2].data[0], 2, reason: 'frame 2');
+      expect(frames[3].data[0], 3, reason: 'frame 3');
+      expect(frames[4].data[0], 32, reason: 'extension frame for step 0');
+      expect(frames[5].data[0], 4, reason: 'tail = steps.length');
+    });
+
+    test('SetVal 6 ml/s -> 0x3C (U8D1), not 0x60 (U8P4)', () {
+      expect(frames[0].data[2], 0x3C);
+    });
+
+    test('SetVal 20 ml/s -> 0xC8, survives without wrapping', () {
+      expect(frames[1].data[2], 0xC8);
+    });
+
+    test('SetVal 30 ml/s clamps to the 20 ml/s ceiling -> 0xC8', () {
+      expect(frames[2].data[2], 0xC8);
+    });
+
+    test('SetVal pressure 9 bar -> 0x5A (U8D1)', () {
+      expect(frames[3].data[2], 0x5A);
+    });
+
+    test('TriggerVal flow-over exit 4 ml/s -> 0x28 (U8D1)', () {
+      expect(frames[0].data[5], 0x28);
+    });
+
+    test('TriggerVal pressure-under exit 3 bar -> 0x1E (U8D1)', () {
+      expect(frames[3].data[5], 0x1E);
+    });
+
+    test(
+      'extension frame MaxFlowOrPressure 8 -> 0x50, MaxFoPRange 2 -> 0x14',
+      () {
+        expect(frames[4].data[1], 0x50);
+        expect(frames[4].data[2], 0x14);
+      },
+    );
+  });
+
+  group('DE1 (default model) still uploads v1 — regression', () {
+    late List<FakeBleWrite> header;
+    late List<FakeBleWrite> frames;
+    late bool gatedBengle;
+
+    setUpAll(() async {
+      final r = await upload(asBengle: false);
+      header = r.header;
+      frames = r.frames;
+      gatedBengle = r.bengle;
+    });
+
+    test('a DE1 is not gated as Bengle', () {
+      expect(gatedBengle, isFalse);
+    });
+
+    test('header carries protocol version 1', () {
+      expect(header, hasLength(1));
+      expect(header.single.data[0], 1);
+    });
+
+    test('header MaximumFlow is the unchanged v1 12*16 = 0xC0', () {
+      expect(header.single.data[4], 0xC0);
+    });
+
+    test('SetVal 6 ml/s -> 0x60 (U8P4)', () {
+      expect(frames[0].data[2], 0x60);
+    });
+
+    test('SetVal 20 ml/s wraps under U8P4 (320 & 0xFF = 0x40)', () {
+      // Demonstrates exactly the bug this fix avoids on Bengle — kept as a
+      // regression witness that the DE1 path is byte-for-byte unchanged.
+      expect(frames[1].data[2], 0x40);
+    });
+
+    test('SetVal pressure 9 bar -> 0x90 (U8P4)', () {
+      expect(frames[3].data[2], 0x90);
+    });
+
+    test('TriggerVal flow-over exit 4 ml/s -> 0x40 (U8P4)', () {
+      expect(frames[0].data[5], 0x40);
+    });
+
+    test('extension frame limiter 8 -> 0x80, range 2 -> 0x20 (U8P4)', () {
+      expect(frames[4].data[1], 0x80);
+      expect(frames[4].data[2], 0x20);
+    });
+  });
+
+  group('Helper.convert_float_to_U8D1 boundaries', () {
+    // Direct unit coverage of the v2 encoder helper — the upload groups above
+    // only exercise it through whole profiles (clamp via SetVal 30, range via
+    // SetVal/TriggerVal goldens), not at the byte-range edges.
+    test('negative input saturates to 0, never wraps', () {
+      expect(Helper.convert_float_to_U8D1(-0.1), 0);
+      expect(Helper.convert_float_to_U8D1(-100.0), 0);
+    });
+
+    test('zero encodes to 0', () {
+      expect(Helper.convert_float_to_U8D1(0.0), 0);
+    });
+
+    test('upper bound 25.5 encodes to 255', () {
+      expect(Helper.convert_float_to_U8D1(25.5), 255);
+    });
+
+    test('above 25.5 saturates to 255, never wraps mod-256', () {
+      expect(Helper.convert_float_to_U8D1(25.6), 255);
+      expect(Helper.convert_float_to_U8D1(1000.0), 255);
+    });
+
+    test(
+      'rounds half-up to the nearest 0.1 step, matching the v1 +0.5 idiom',
+      () {
+        expect(Helper.convert_float_to_U8D1(0.05), 1); // half-up at the step
+        expect(Helper.convert_float_to_U8D1(0.04), 0); // below half rounds down
+        expect(Helper.convert_float_to_U8D1(9.25), 93);
+        expect(Helper.convert_float_to_U8D1(19.99), 200);
+      },
+    );
+  });
+}

--- a/test/models/device/unified_de1_presence_flags_test.dart
+++ b/test/models/device/unified_de1_presence_flags_test.dart
@@ -1,0 +1,73 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+
+import '../../helpers/fake_ble_transport.dart';
+
+/// (document-only) — the connect-time presence advertisement.
+///
+/// `UnifiedDe1.onConnect` ends with an UNCONDITIONAL
+/// `enableUserPresenceFeature()` → `AppFeatureFlags = 1` (0x00803858,
+/// bit0 = UserNotPresent feature) on EVERY machine, DE1 and Bengle alike.
+/// Advertising the bit commits the client to ongoing `UserPresent` writes;
+/// the upstream `PresenceController` fulfils that obligation when the user
+/// enables presence, and firmware's 120 s absence timeout emits substate
+/// 0x13, which the app already decodes safely. This test locks the
+/// advertisement so it cannot be "helpfully" removed — the machine-side
+/// feature set changes with it. (The audit's capability-derived
+/// alternative is recorded in HW-CONTRACT.md / the Phase-0 issue.)
+void main() {
+  Iterable<Uint8List> writesTo(FakeBleTransport transport, int address) {
+    final ba = ByteData(4)..setInt32(0, address, Endian.big);
+    return transport.writes
+        .where(
+          (w) =>
+              w.characteristicUUID == Endpoint.writeToMMR.uuid &&
+              w.data[1] == ba.getUint8(1) &&
+              w.data[2] == ba.getUint8(2) &&
+              w.data[3] == ba.getUint8(3),
+        )
+        .map((w) => w.data);
+  }
+
+  int payloadOf(Uint8List frame) =>
+      ByteData.sublistView(frame, 4, 8).getUint32(0, Endian.little);
+
+  group('connect-time AppFeatureFlags advertisement (doc-only)', () {
+    test('plain DE1 connect writes AppFeatureFlags = 1', () async {
+      final transport = FakeBleTransport();
+      final de1 = UnifiedDe1(transport: transport);
+      transport.queueOnConnectResponses(); // v13Model: 1 — plain DE1
+      await de1.onConnect();
+
+      final frames = writesTo(transport, MMRItem.appFeatureFlags.address);
+      expect(
+        frames,
+        isNotEmpty,
+        reason:
+            'onConnect must advertise the UserNotPresent feature '
+            '(AppFeatureFlags 0x00803858)',
+      );
+      expect(payloadOf(frames.last), 1);
+      transport.dispose();
+    });
+
+    test(
+      'Bengle connect writes AppFeatureFlags = 1 (advert is unconditional)',
+      () async {
+        final transport = FakeBleTransport();
+        final bengle = Bengle(transport: transport);
+        transport.queueOnConnectResponses(v13Model: 128); // Bengle marker
+        await bengle.onConnect();
+
+        final frames = writesTo(transport, MMRItem.appFeatureFlags.address);
+        expect(frames, isNotEmpty);
+        expect(payloadOf(frames.last), 1);
+        transport.dispose();
+      },
+    );
+  });
+}

--- a/test/models/wake_schedule_windows_test.dart
+++ b/test/models/wake_schedule_windows_test.dart
@@ -1,0 +1,506 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/wake_schedule.dart';
+import 'package:reaprime/src/models/wake_schedule_windows.dart';
+
+/// The wake-window derivation (spec §2, §5) — the single source of truth
+/// for BOTH the firmware schedule table and the app's idle-sleep suppression.
+///
+/// The load-bearing fact under test: the firmware `dow` field is a day INDEX
+/// (0 = Sunday .. 6 = Saturday) that it compares for EQUALITY, NOT a bitmask.
+/// Packing a Mon–Fri day set as a bitmask (0b0111110 = 62) would decode in the
+/// firmware to `62 & 0x7 == 6` — one window, on Saturday — and nothing would
+/// report an error. The byte-exact goldens below are what catch that.
+
+/// Mirrors the firmware decoder verbatim, so the tests
+/// can assert that every value the app emits is one the firmware ACCEPTS.
+({int dow, int startMin, int endMin}) fwDecode(int packed) => (
+      dow: (packed >> 22) & 0x7,
+      startMin: (packed >> 11) & 0x7FF,
+      endMin: packed & 0x7FF,
+    );
+
+/// The firmware's own accept test (`scheduleAddEntry`): anything else is
+/// SILENTLY dropped.
+bool fwAccepts(int packed) {
+  final d = fwDecode(packed);
+  return d.dow <= 6 && d.startMin < d.endMin && d.endMin <= 1440;
+}
+
+WakeSchedule schedule({
+  String id = 's',
+  int hour = 5,
+  int minute = 30,
+  Set<int> days = const {},
+  bool enabled = true,
+  int? keepAwakeFor,
+}) =>
+    WakeSchedule(
+      id: id,
+      hour: hour,
+      minute: minute,
+      daysOfWeek: days,
+      enabled: enabled,
+      keepAwakeFor: keepAwakeFor,
+    );
+
+void main() {
+  group('fwDayOfWeek (ISO -> firmware day index)', () {
+    test('maps every ISO weekday; Sunday 7 wraps to 0', () {
+      // ISO: 1=Mon..7=Sun.  FW: 0=Sun..6=Sat.
+      expect(fwDayOfWeek(1), 1, reason: 'Monday');
+      expect(fwDayOfWeek(2), 2, reason: 'Tuesday');
+      expect(fwDayOfWeek(3), 3, reason: 'Wednesday');
+      expect(fwDayOfWeek(4), 4, reason: 'Thursday');
+      expect(fwDayOfWeek(5), 5, reason: 'Friday');
+      expect(fwDayOfWeek(6), 6, reason: 'Saturday');
+      expect(fwDayOfWeek(7), 0, reason: 'Sunday is 0 in the firmware');
+    });
+
+    test('agrees with DateTime.weekday for a known week', () {
+      // 2026-07-12 is a Sunday.
+      expect(fwDayOfWeek(DateTime(2026, 7, 12).weekday), 0);
+      expect(fwDayOfWeek(DateTime(2026, 7, 13).weekday), 1); // Mon
+      expect(fwDayOfWeek(DateTime(2026, 7, 18).weekday), 6); // Sat
+    });
+  });
+
+  group('packWakeWindow', () {
+    test('weekday schedule: Mon-Fri 05:30 for 90 min — byte-exact goldens', () {
+      // Spec §5.1. startMin = 330 (0x14A), endMin = 420 (0x1A4).
+      // Low half, common to all five: (330 << 11) | 420 = 0x000A51A4.
+      final windows = expandWindows([
+        schedule(hour: 5, minute: 30, days: {1, 2, 3, 4, 5}, keepAwakeFor: 90),
+      ]);
+
+      expect(
+        windows.map((w) => w.packed).toList(),
+        [
+          0x004A51A4, // Mon (dow 1) 05:30-07:00
+          0x008A51A4, // Tue (dow 2)
+          0x00CA51A4, // Wed (dow 3)
+          0x010A51A4, // Thu (dow 4)
+          0x014A51A4, // Fri (dow 5)
+        ],
+        reason: 'five separate entries, one per day — NOT one bitmask entry',
+      );
+      // Decimal, as the spec's table states them.
+      expect(windows.first.packed, 4870564);
+      expect(windows.last.packed, 21647780);
+    });
+
+    test('the bitmask trap: a Mon-Fri bitmask would decode to Saturday only',
+        () {
+      // Documents WHY the goldens above are per-day. 0b0111110 = 62.
+      const bitmask = 62;
+      expect((bitmask >> 22) & 0x7, 0, reason: 'the days vanish entirely');
+      // And if a caller shifted the bitmask into the dow field:
+      final packedMask = (bitmask << 22) | (330 << 11) | 420;
+      expect(fwDecode(packedMask).dow, 6,
+          reason: 'the firmware would schedule Saturday, silently');
+    });
+
+    test('every emitted entry round-trips through the firmware decoder', () {
+      final windows = expandWindows([
+        schedule(id: 'a', hour: 0, minute: 0, keepAwakeFor: 1),
+        schedule(id: 'b', hour: 23, minute: 59, keepAwakeFor: 1),
+        schedule(id: 'c', hour: 23, minute: 0, days: {6}, keepAwakeFor: 120),
+        schedule(id: 'd', hour: 12, minute: 0, days: {3}, keepAwakeFor: 720),
+      ]);
+      expect(windows, isNotEmpty);
+      for (final w in windows) {
+        expect(fwAccepts(w.packed), isTrue,
+            reason: '$w packs to 0x${w.packed.toRadixString(16)} which the '
+                'firmware would silently DROP');
+        final d = fwDecode(w.packed);
+        expect(d.dow, w.dow);
+        expect(d.startMin, w.startMin);
+        expect(d.endMin, w.endMin);
+      }
+    });
+
+    test('the last minute of the day packs to a legal window', () {
+      final windows = expandWindows([
+        schedule(hour: 23, minute: 59, days: {1}, keepAwakeFor: 1),
+      ]);
+      expect(windows.single, const WakeWindow(dow: 1, startMin: 1439, endMin: 1440));
+      expect(fwAccepts(windows.single.packed), isTrue);
+    });
+  });
+
+  group('expandWindows — window derivation', () {
+    test('keepAwakeFor == null gets the 30-minute default window', () {
+      final windows = expandWindows([
+        schedule(hour: 7, minute: 0, days: {1}),
+      ]);
+      expect(windows.single,
+          const WakeWindow(dow: 1, startMin: 420, endMin: 450));
+    });
+
+    test('keepAwakeFor at both bounds (1 and 720)', () {
+      expect(
+        expandWindows([schedule(hour: 6, minute: 0, days: {2}, keepAwakeFor: 1)])
+            .single,
+        const WakeWindow(dow: 2, startMin: 360, endMin: 361),
+      );
+      expect(
+        expandWindows(
+                [schedule(hour: 6, minute: 0, days: {2}, keepAwakeFor: 720)])
+            .single,
+        const WakeWindow(dow: 2, startMin: 360, endMin: 1080),
+      );
+    });
+
+    test('empty daysOfWeek means every day: 7 entries, dow 0..6', () {
+      // Spec §5.3: 07:00 for 45 min.
+      final windows = expandWindows([
+        schedule(hour: 7, minute: 0, days: const {}, keepAwakeFor: 45),
+      ]);
+      expect(windows.map((w) => w.dow).toList(), [0, 1, 2, 3, 4, 5, 6]);
+      expect(
+        windows.map((w) => w.packed).toList(),
+        [
+          0x000D21D1,
+          0x004D21D1,
+          0x008D21D1,
+          0x00CD21D1,
+          0x010D21D1,
+          0x014D21D1,
+          0x018D21D1,
+        ],
+      );
+    });
+
+    test('disabled schedules contribute nothing', () {
+      expect(
+        expandWindows([
+          schedule(id: 'off', hour: 7, minute: 0, days: {1}, enabled: false),
+        ]),
+        isEmpty,
+      );
+    });
+
+    test('no schedules at all yields no windows', () {
+      expect(expandWindows(const []), isEmpty);
+    });
+
+    test('midnight crossing splits into two entries on consecutive days', () {
+      // Spec §5.2: Saturday 23:00, keep awake 2 h.
+      final windows = expandWindows([
+        schedule(hour: 23, minute: 0, days: {6}, keepAwakeFor: 120),
+      ]);
+      expect(windows, hasLength(2));
+      // Sorted by (dow, startMin): Sunday (dow 0) sorts before Saturday (6).
+      expect(windows, contains(const WakeWindow(dow: 6, startMin: 1380, endMin: 1440)));
+      expect(windows, contains(const WakeWindow(dow: 0, startMin: 0, endMin: 60)));
+      final packed = windows.map((w) => w.packed).toSet();
+      expect(packed, containsAll(<int>[0x01AB25A0, 0x0000003C]));
+      expect(packed, containsAll(<int>[27993504, 60]));
+    });
+
+    test('Saturday wraps to Sunday, not to a dow of 7', () {
+      final windows = expandWindows([
+        schedule(hour: 23, minute: 30, days: {6}, keepAwakeFor: 60),
+      ]);
+      expect(windows.map((w) => w.dow).toSet(), {0, 6});
+      for (final w in windows) {
+        expect(fwAccepts(w.packed), isTrue);
+      }
+    });
+
+    test('endMinRaw == 1440 exactly makes ONE entry, not a zero-length second',
+        () {
+      final windows = expandWindows([
+        schedule(hour: 23, minute: 0, days: {3}, keepAwakeFor: 60),
+      ]);
+      expect(windows.single,
+          const WakeWindow(dow: 3, startMin: 1380, endMin: 1440));
+    });
+  });
+
+  group('mergeWindows', () {
+    test('overlapping windows on the same day merge into one', () {
+      final windows = expandWindows([
+        schedule(id: 'a', hour: 7, minute: 0, days: {1}, keepAwakeFor: 60),
+        schedule(id: 'b', hour: 7, minute: 30, days: {1}, keepAwakeFor: 60),
+      ]);
+      expect(windows.single,
+          const WakeWindow(dow: 1, startMin: 420, endMin: 510));
+    });
+
+    test('touching windows (end == start) merge too', () {
+      final windows = expandWindows([
+        schedule(id: 'a', hour: 7, minute: 0, days: {1}, keepAwakeFor: 60),
+        schedule(id: 'b', hour: 8, minute: 0, days: {1}, keepAwakeFor: 60),
+      ]);
+      expect(windows.single,
+          const WakeWindow(dow: 1, startMin: 420, endMin: 540));
+    });
+
+    test('a fully-contained window does not shrink its container', () {
+      expect(
+        mergeWindows(const [
+          WakeWindow(dow: 2, startMin: 400, endMin: 600),
+          WakeWindow(dow: 2, startMin: 420, endMin: 450),
+        ]).single,
+        const WakeWindow(dow: 2, startMin: 400, endMin: 600),
+      );
+    });
+
+    test('windows on different days never merge', () {
+      final windows = expandWindows([
+        schedule(id: 'a', hour: 7, minute: 0, days: {1}, keepAwakeFor: 60),
+        schedule(id: 'b', hour: 7, minute: 0, days: {2}, keepAwakeFor: 60),
+      ]);
+      expect(windows, hasLength(2));
+    });
+
+    test('non-overlapping windows on one day stay separate, sorted', () {
+      final windows = expandWindows([
+        schedule(id: 'pm', hour: 17, minute: 0, days: {1}, keepAwakeFor: 30),
+        schedule(id: 'am', hour: 7, minute: 0, days: {1}, keepAwakeFor: 30),
+      ]);
+      expect(windows, [
+        const WakeWindow(dow: 1, startMin: 420, endMin: 450),
+        const WakeWindow(dow: 1, startMin: 1020, endMin: 1050),
+      ]);
+    });
+  });
+
+  group('cap at kMaxWakeWindows (the firmware silently drops the 33rd)', () {
+    test('every-day schedules with a midnight split cap at exactly 32', () {
+      // 5 every-day schedules, one of them crossing midnight, all disjoint so
+      // nothing merges: 4 x 7 + 7 x 2 = 42 raw windows for a 32-slot table.
+      final schedules = [
+        schedule(id: 'a', hour: 22, minute: 0, keepAwakeFor: 180), // 22:00-01:00
+        schedule(id: 'b', hour: 6, minute: 0, keepAwakeFor: 30),
+        schedule(id: 'c', hour: 9, minute: 0, keepAwakeFor: 30),
+        schedule(id: 'd', hour: 12, minute: 0, keepAwakeFor: 30),
+        schedule(id: 'e', hour: 15, minute: 0, keepAwakeFor: 30),
+      ];
+      final windows = expandWindows(schedules);
+      expect(windows, hasLength(kMaxWakeWindows));
+      // 6 windows per day survive the merge, so the 32-slot table holds days
+      // 0..4 whole plus 2 of day 5, and day 6 is dropped entirely — the cap
+      // really bit (the firmware would have dropped these silently).
+      expect(windows.where((w) => w.dow == 0), hasLength(6));
+      expect(windows.where((w) => w.dow == 5), hasLength(2));
+      expect(windows.where((w) => w.dow == 6), isEmpty);
+
+      // Deterministic order: sorted by (dow, startMin).
+      for (var i = 1; i < windows.length; i++) {
+        final prev = windows[i - 1];
+        final cur = windows[i];
+        expect(
+          prev.dow < cur.dow ||
+              (prev.dow == cur.dow && prev.startMin < cur.startMin),
+          isTrue,
+          reason: 'windows must be sorted by (dow, startMin): $prev then $cur',
+        );
+      }
+      // And every surviving entry is one the firmware will accept.
+      for (final w in windows) {
+        expect(fwAccepts(w.packed), isTrue);
+      }
+    });
+
+    test('a table that fits is not truncated', () {
+      final windows = expandWindows([
+        schedule(hour: 5, minute: 30, days: {1, 2, 3, 4, 5}, keepAwakeFor: 90),
+      ]);
+      expect(windows, hasLength(5));
+    });
+  });
+
+  group('localSecondsOfWeek', () {
+    test('Sunday 00:00:00 reports 1, never 0 (the reboot sentinel)', () {
+      // 2026-07-12 is a Sunday.
+      expect(localSecondsOfWeek(DateTime(2026, 7, 12, 0, 0, 0)), 1);
+    });
+
+    test('Saturday 23:59:59 is 604799 (the firmware rejects >= 604800)', () {
+      // 2026-07-18 is a Saturday.
+      expect(localSecondsOfWeek(DateTime(2026, 7, 18, 23, 59, 59)), 604799);
+      expect(localSecondsOfWeek(DateTime(2026, 7, 18, 23, 59, 59)),
+          lessThan(kSecondsPerWeek));
+    });
+
+    test('the spec\'s Tuesday 07:20:00 example is 199200', () {
+      // 2026-07-14 is a Tuesday. 2*86400 + 7*3600 + 20*60 = 199200.
+      expect(localSecondsOfWeek(DateTime(2026, 7, 14, 7, 20, 0)), 199200);
+    });
+
+    test('a day rollover advances by exactly 86400', () {
+      final satLate = DateTime(2026, 7, 11, 23, 59, 59); // Saturday
+      final sunEarly = DateTime(2026, 7, 12, 0, 0, 1); // Sunday
+      expect(localSecondsOfWeek(satLate), 604799);
+      // Sunday is day 0 — the week wraps, it does not keep counting up.
+      expect(localSecondsOfWeek(sunEarly), 1);
+
+      final monMidnight = DateTime(2026, 7, 13, 0, 0, 0); // Monday
+      final sunMidnight = DateTime(2026, 7, 12, 0, 0, 30);
+      expect(localSecondsOfWeek(monMidnight) - localSecondsOfWeek(sunMidnight),
+          86400 - 30);
+    });
+
+    test('every minute of a week stays in the writable range', () {
+      var t = DateTime(2026, 7, 12); // Sunday 00:00
+      for (var i = 0; i < 7 * 24 * 60; i += 7) {
+        final s = localSecondsOfWeek(t.add(Duration(minutes: i)));
+        expect(s, greaterThanOrEqualTo(1));
+        expect(s, lessThanOrEqualTo(604799));
+      }
+    });
+  });
+
+  group('isWithinWindow', () {
+    final windows = expandWindows([
+      schedule(hour: 5, minute: 30, days: {1, 2, 3, 4, 5}, keepAwakeFor: 90),
+    ]);
+    // 2026-07-13 is a Monday.
+
+    test('start is inclusive', () {
+      expect(isWithinWindow(windows, DateTime(2026, 7, 13, 5, 30)), isTrue);
+    });
+
+    test('inside the window', () {
+      expect(isWithinWindow(windows, DateTime(2026, 7, 13, 6, 0)), isTrue);
+      expect(isWithinWindow(windows, DateTime(2026, 7, 13, 6, 59, 59)), isTrue);
+    });
+
+    test('end is exclusive', () {
+      expect(isWithinWindow(windows, DateTime(2026, 7, 13, 7, 0)), isFalse);
+    });
+
+    test('before the window', () {
+      expect(isWithinWindow(windows, DateTime(2026, 7, 13, 5, 29)), isFalse);
+    });
+
+    test('a day not in the schedule never matches', () {
+      // 2026-07-12 Sunday, 2026-07-18 Saturday.
+      expect(isWithinWindow(windows, DateTime(2026, 7, 12, 6, 0)), isFalse);
+      expect(isWithinWindow(windows, DateTime(2026, 7, 18, 6, 0)), isFalse);
+    });
+
+    test('no windows never matches', () {
+      expect(isWithinWindow(const [], DateTime(2026, 7, 13, 6, 0)), isFalse);
+    });
+
+    test('the midnight-split pair covers both sides of midnight', () {
+      final split = expandWindows([
+        schedule(hour: 23, minute: 0, days: {6}, keepAwakeFor: 120),
+      ]);
+      // Saturday 2026-07-18 23:30 -> in the (dow 6, 1380..1440) half.
+      expect(isWithinWindow(split, DateTime(2026, 7, 18, 23, 30)), isTrue);
+      // Sunday 2026-07-19 00:30 -> in the (dow 0, 0..60) half.
+      expect(isWithinWindow(split, DateTime(2026, 7, 19, 0, 30)), isTrue);
+      // Sunday 01:00 -> past the end (exclusive).
+      expect(isWithinWindow(split, DateTime(2026, 7, 19, 1, 0)), isFalse);
+      // Saturday 22:59 -> before the start.
+      expect(isWithinWindow(split, DateTime(2026, 7, 18, 22, 59)), isFalse);
+    });
+  });
+
+  group('windowEnd', () {
+    test('reports the wall-clock end of the open window', () {
+      final windows = expandWindows([
+        schedule(hour: 5, minute: 30, days: {1}, keepAwakeFor: 90),
+      ]);
+      expect(
+        windowEnd(windows, DateTime(2026, 7, 13, 6, 0)),
+        DateTime(2026, 7, 13, 7, 0),
+      );
+    });
+
+    test('null outside any window', () {
+      final windows = expandWindows([
+        schedule(hour: 5, minute: 30, days: {1}, keepAwakeFor: 90),
+      ]);
+      expect(windowEnd(windows, DateTime(2026, 7, 13, 8, 0)), isNull);
+      expect(windowEnd(const [], DateTime(2026, 7, 13, 6, 0)), isNull);
+    });
+
+    test('chains across a midnight split to the real end', () {
+      final windows = expandWindows([
+        schedule(hour: 23, minute: 0, days: {6}, keepAwakeFor: 120),
+      ]);
+      // Saturday 23:30 -> the user's window really ends Sunday 01:00, not at
+      // the internal 24:00 split boundary.
+      expect(
+        windowEnd(windows, DateTime(2026, 7, 18, 23, 30)),
+        DateTime(2026, 7, 19, 1, 0),
+      );
+      // And from the far side of midnight.
+      expect(
+        windowEnd(windows, DateTime(2026, 7, 19, 0, 30)),
+        DateTime(2026, 7, 19, 1, 0),
+      );
+    });
+
+    // The schedule is WALL-CLOCK (so is the firmware's), so the end must be
+    // built from calendar components. Building it as `startOfDay + Duration`
+    // adds ABSOLUTE elapsed time, which on a DST-transition day lands an hour
+    // off: a 05:30–07:00 window would report 08:00 on a spring-forward Sunday
+    // and 06:00 on a fall-back one.
+    //
+    // These two tests only DISCRIMINATE when the host zone observes DST (in
+    // UTC they hold trivially either way) — but they never flake, and in any
+    // DST zone they fail on the Duration form.
+    test('reports wall-clock end across a DST transition', () {
+      final windows = expandWindows([
+        // Sunday 05:30 +90 -> 07:00. Every DST transition below happens
+        // overnight on a Sunday, BEFORE the window opens.
+        schedule(hour: 5, minute: 30, days: {7}, keepAwakeFor: 90),
+      ]);
+      const transitionSundays = [
+        (2026, 3, 8), // US spring forward
+        (2026, 3, 29), // EU spring forward
+        (2026, 10, 25), // EU fall back
+        (2026, 11, 1), // US fall back
+      ];
+      for (final (y, m, d) in transitionSundays) {
+        expect(
+          windowEnd(windows, DateTime(y, m, d, 6, 0)),
+          DateTime(y, m, d, 7, 0),
+          reason: 'wall-clock 07:00 on $y-$m-$d, not 07:00 of elapsed time',
+        );
+      }
+    });
+
+    test('end is on the wall clock on every day of the year', () {
+      final windows = expandWindows([
+        schedule(hour: 5, minute: 30, days: {1, 2, 3, 4, 5, 6, 7}, keepAwakeFor: 90),
+      ]);
+      // Whatever the host zone, and whichever day it shifts on, an open
+      // 05:30–07:00 window always closes at wall-clock 07:00.
+      for (var day = DateTime(2026, 1, 1);
+          day.year == 2026;
+          day = DateTime(2026, day.month, day.day + 1)) {
+        final end = windowEnd(windows, DateTime(day.year, day.month, day.day, 6, 0));
+        expect(end, isNotNull, reason: '$day');
+        expect(end!.hour, 7, reason: '$day');
+        expect(end.minute, 0, reason: '$day');
+      }
+    });
+  });
+
+  group('windowsFromSettingsJson', () {
+    test('parses the settings blob', () {
+      final json = WakeSchedule.serializeList([
+        schedule(hour: 5, minute: 30, days: {1, 2, 3, 4, 5}, keepAwakeFor: 90),
+      ]);
+      expect(windowsFromSettingsJson(json), hasLength(5));
+    });
+
+    test('empty / "[]" blob yields no windows', () {
+      expect(windowsFromSettingsJson(''), isEmpty);
+      expect(windowsFromSettingsJson('[]'), isEmpty);
+    });
+
+    test('a malformed blob yields no windows instead of throwing', () {
+      // This runs inside a timer callback and a connect flow — it must never
+      // throw.
+      expect(windowsFromSettingsJson('{not json'), isEmpty);
+      expect(windowsFromSettingsJson('[{"id":"x"}]'), isEmpty);
+    });
+  });
+}

--- a/test/services/ble/universal_ble_transport_mtu_test.dart
+++ b/test/services/ble/universal_ble_transport_mtu_test.dart
@@ -79,8 +79,7 @@ class _MtuRecordingBlePlatform extends UniversalBlePlatform {
   Future<List<BleService>> discoverServices(
     String deviceId,
     bool withDescriptors,
-  ) async =>
-      [];
+  ) async => [];
 
   @override
   Future<void> setNotifiable(
@@ -96,8 +95,7 @@ class _MtuRecordingBlePlatform extends UniversalBlePlatform {
     String service,
     String characteristic, {
     Duration? timeout,
-  }) async =>
-      Uint8List(0);
+  }) async => Uint8List(0);
 
   @override
   Future<void> writeValue(
@@ -133,8 +131,7 @@ class _MtuRecordingBlePlatform extends UniversalBlePlatform {
   @override
   Future<List<BleDevice>> getSystemDevices(
     List<String>? withServices,
-  ) async =>
-      [];
+  ) async => [];
 }
 
 void main() {
@@ -161,29 +158,35 @@ void main() {
     expect(
       platform.mtuRequests,
       [(deviceId, 517)],
-      reason: 'exactly one MTU request, value 517 — required for the '
+      reason:
+          'exactly one MTU request, value 517 — required for the '
           '28-byte 0xA013 notification (ATT default is 23)',
     );
     await transport.dispose();
   });
 
-  test('connect() skips the MTU request on Linux (BlueZ owns the MTU)',
-      () async {
-    final transport = UniversalBleTransport(
-      device: BleDevice(deviceId: deviceId, name: 'Bengle'),
-      isLinuxOverride: true,
-    );
+  test(
+    'connect() skips the MTU request on Linux (BlueZ owns the MTU)',
+    () async {
+      final transport = UniversalBleTransport(
+        device: BleDevice(deviceId: deviceId, name: 'Bengle'),
+        isLinuxOverride: true,
+      );
 
-    await transport.connect();
+      await transport.connect();
 
-    expect(platform.mtuRequests, isEmpty,
-        reason: 'universal_ble exposes no requestMtu on Linux; BlueZ '
-            'negotiates the MTU itself');
-    await transport.dispose();
-  });
+      expect(
+        platform.mtuRequests,
+        isEmpty,
+        reason:
+            'universal_ble exposes no requestMtu on Linux; BlueZ '
+            'negotiates the MTU itself',
+      );
+      await transport.dispose();
+    },
+  );
 
-  test('a failed MTU negotiation is non-fatal — connect() completes',
-      () async {
+  test('a failed MTU negotiation is non-fatal — connect() completes', () async {
     platform.throwOnRequestMtu = true;
     final transport = UniversalBleTransport(
       device: BleDevice(deviceId: deviceId, name: 'Bengle'),
@@ -195,8 +198,11 @@ void main() {
     // the larger MTU.
     await transport.connect();
 
-    expect(platform.mtuRequests, hasLength(1),
-        reason: 'the request must still be attempted');
+    expect(
+      platform.mtuRequests,
+      hasLength(1),
+      reason: 'the request must still be attempted',
+    );
     await transport.dispose();
   });
 }

--- a/test/services/ble/universal_ble_transport_mtu_test.dart
+++ b/test/services/ble/universal_ble_transport_mtu_test.dart
@@ -1,0 +1,202 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/ble/universal_ble_transport.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+/// Locks the post-connect large-ATT-MTU request in
+/// `UniversalBleTransport.connect()`:
+///
+///  * MTU **517** is requested on every non-Linux platform (it used to be
+///    Android-only; the 28-byte Bengle 0xA013 shot-sample notification
+///    truncates at the 23-byte ATT default, so the request must be attempted
+///    everywhere BLE runs);
+///  * **Linux is skipped** — BlueZ manages the MTU itself and universal_ble
+///    does not expose `requestMtu` there;
+///  * a **failed negotiation is non-fatal** — the DE1/Bengle BLE module
+///    self-negotiates up to 247 on connect regardless, so `connect()` must
+///    log-and-continue, never throw.
+///
+/// The platform gate itself (`Platform.isLinux`) is not fakeable in a unit
+/// test, so the transport exposes an `isLinuxOverride` test seam.
+class _MtuRecordingBlePlatform extends UniversalBlePlatform {
+  /// Recorded (deviceId, expectedMtu) pairs from [requestMtu].
+  final List<(String, int)> mtuRequests = [];
+
+  /// When true, [requestMtu] throws — simulating a stack that rejects the
+  /// negotiation.
+  bool throwOnRequestMtu = false;
+
+  @override
+  Future<int> requestMtu(String deviceId, int expectedMtu) async {
+    mtuRequests.add((deviceId, expectedMtu));
+    if (throwOnRequestMtu) {
+      throw UniversalBleException(
+        code: UniversalBleErrorCode.failed,
+        message: 'simulated MTU negotiation failure',
+      );
+    }
+    return expectedMtu;
+  }
+
+  @override
+  Future<AvailabilityState> getBluetoothAvailabilityState() async =>
+      AvailabilityState.poweredOn;
+
+  @override
+  Future<bool> enableBluetooth() async => true;
+
+  @override
+  Future<bool> disableBluetooth() async => false;
+
+  @override
+  Future<void> startScan({
+    ScanFilter? scanFilter,
+    PlatformConfig? platformConfig,
+  }) async {}
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  Future<bool> isScanning() async => false;
+
+  @override
+  Future<void> connect(
+    String deviceId, {
+    Duration? connectionTimeout,
+    bool autoConnect = false,
+  }) async {
+    updateConnection(deviceId, true);
+  }
+
+  @override
+  Future<void> disconnect(String deviceId) async {
+    updateConnection(deviceId, false);
+  }
+
+  @override
+  Future<List<BleService>> discoverServices(
+    String deviceId,
+    bool withDescriptors,
+  ) async =>
+      [];
+
+  @override
+  Future<void> setNotifiable(
+    String deviceId,
+    String service,
+    String characteristic,
+    BleInputProperty bleInputProperty,
+  ) async {}
+
+  @override
+  Future<Uint8List> readValue(
+    String deviceId,
+    String service,
+    String characteristic, {
+    Duration? timeout,
+  }) async =>
+      Uint8List(0);
+
+  @override
+  Future<void> writeValue(
+    String deviceId,
+    String service,
+    String characteristic,
+    Uint8List value,
+    BleOutputProperty bleOutputProperty,
+  ) async {}
+
+  @override
+  Future<int> readRssi(String deviceId) async => -50;
+
+  @override
+  Future<void> requestConnectionPriority(
+    String deviceId,
+    BleConnectionPriority priority,
+  ) async {}
+
+  @override
+  Future<bool> isPaired(String deviceId) async => false;
+
+  @override
+  Future<bool> pair(String deviceId) async => true;
+
+  @override
+  Future<void> unpair(String deviceId) async {}
+
+  @override
+  Future<BleConnectionState> getConnectionState(String deviceId) async =>
+      BleConnectionState.connected;
+
+  @override
+  Future<List<BleDevice>> getSystemDevices(
+    List<String>? withServices,
+  ) async =>
+      [];
+}
+
+void main() {
+  late _MtuRecordingBlePlatform platform;
+  var deviceCounter = 0;
+  late String deviceId;
+
+  setUp(() {
+    platform = _MtuRecordingBlePlatform();
+    UniversalBle.setInstance(platform);
+    UniversalBle.clearQueue();
+    // Unique id per test so per-device queue state can't bleed over.
+    deviceId = 'AA:BB:CC:DD:FF:${(deviceCounter++).toString().padLeft(2, '0')}';
+  });
+
+  test('connect() requests MTU 517 on non-Linux platforms', () async {
+    final transport = UniversalBleTransport(
+      device: BleDevice(deviceId: deviceId, name: 'Bengle'),
+      isLinuxOverride: false,
+    );
+
+    await transport.connect();
+
+    expect(
+      platform.mtuRequests,
+      [(deviceId, 517)],
+      reason: 'exactly one MTU request, value 517 — required for the '
+          '28-byte 0xA013 notification (ATT default is 23)',
+    );
+    await transport.dispose();
+  });
+
+  test('connect() skips the MTU request on Linux (BlueZ owns the MTU)',
+      () async {
+    final transport = UniversalBleTransport(
+      device: BleDevice(deviceId: deviceId, name: 'Bengle'),
+      isLinuxOverride: true,
+    );
+
+    await transport.connect();
+
+    expect(platform.mtuRequests, isEmpty,
+        reason: 'universal_ble exposes no requestMtu on Linux; BlueZ '
+            'negotiates the MTU itself');
+    await transport.dispose();
+  });
+
+  test('a failed MTU negotiation is non-fatal — connect() completes',
+      () async {
+    platform.throwOnRequestMtu = true;
+    final transport = UniversalBleTransport(
+      device: BleDevice(deviceId: deviceId, name: 'Bengle'),
+      isLinuxOverride: false,
+    );
+
+    // Must not throw: the module self-negotiates up to 247 on connect, so
+    // the client request is belt-and-suspenders and a rejection only costs
+    // the larger MTU.
+    await transport.connect();
+
+    expect(platform.mtuRequests, hasLength(1),
+        reason: 'the request must still be attempted');
+    await transport.dispose();
+  });
+}

--- a/test/services/serial/usb_ids_test.dart
+++ b/test/services/serial/usb_ids_test.dart
@@ -49,4 +49,25 @@ void main() {
       expect(matchUsbDevice(usbDeviceTable, vid: 0xFFFF, pid: 0xFFFF), isNull);
     });
   });
+
+  group('Bengle probe-candidate pair', () {
+    test('bengleUsbIds stays empty — TinyUSB defaults are too generic', () {
+      // 0x2E8A:0x000A is EVERY default pico-sdk CDC device. It may only
+      // qualify a port for the v13Model probe (bengleProbeCandidateIds),
+      // never identify one. Adding it here would claim random hobby
+      // boards as espresso machines.
+      expect(bengleUsbIds, isEmpty);
+      expect(bengleProbeCandidateIds, contains((0x2E8A, 0x000A)));
+    });
+
+    test('the TinyUSB-default pair never direct-instantiates', () {
+      expect(
+        matchUsbDevice(usbDeviceTable, vid: 0x2E8A, pid: 0x000A),
+        isNull,
+        reason:
+            'the pair feeds the probe path only — the v13Model read '
+            'stays the authority on what the device is',
+      );
+    });
+  });
 }

--- a/test/services/webserver/de1handler_cup_warmer_test.dart
+++ b/test/services/webserver/de1handler_cup_warmer_test.dart
@@ -97,6 +97,20 @@ void main() {
       final body = jsonDecode(await res.readAsString());
       expect(body['capabilities'], isNot(contains('integratedScale')));
     });
+
+    test('returns stopAtWeight when a Bengle is connected', () async {
+      await wireWith(MockBengle());
+      final res = await get('/api/v1/machine/capabilities');
+      final body = jsonDecode(await res.readAsString());
+      expect(body['capabilities'], contains('stopAtWeight'));
+    });
+
+    test('does not return stopAtWeight on plain DE1', () async {
+      await wireWith(MockDe1());
+      final res = await get('/api/v1/machine/capabilities');
+      final body = jsonDecode(await res.readAsString());
+      expect(body['capabilities'], isNot(contains('stopAtWeight')));
+    });
   });
 
   group('GET /api/v1/machine/cupWarmer', () {

--- a/test/services/webserver/de1handler_cup_warmer_test.dart
+++ b/test/services/webserver/de1handler_cup_warmer_test.dart
@@ -122,6 +122,29 @@ void main() {
       expect(body['temperature'], 0.0);
     });
 
+    test('currentTemperature is null when the firmware has no reading',
+        () async {
+      await wireWith(MockBengle());
+      final res = await get('/api/v1/machine/cupWarmer');
+      expect(res.statusCode, 200);
+      final body = jsonDecode(await res.readAsString()) as Map;
+      expect(body.containsKey('currentTemperature'), isTrue,
+          reason: 'the key is always present on a Bengle — null means '
+              'no valid reading, clients render a placeholder');
+      expect(body['currentTemperature'], isNull);
+    });
+
+    test('200 + live mat temperature when the firmware reports one',
+        () async {
+      final bengle = MockBengle();
+      bengle.setMatCurrentTemperature(42.5);
+      await wireWith(bengle);
+      final res = await get('/api/v1/machine/cupWarmer');
+      expect(res.statusCode, 200);
+      final body = jsonDecode(await res.readAsString());
+      expect(body['currentTemperature'], 42.5);
+    });
+
     test('404 on plain DE1 (machine connected but capability absent)',
         () async {
       await wireWith(MockDe1());

--- a/test/services/webserver/de1handler_led_strip_test.dart
+++ b/test/services/webserver/de1handler_led_strip_test.dart
@@ -14,6 +14,9 @@ import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/services/webserver_service.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+
+import '../../helpers/fake_ble_transport.dart';
 import '../../helpers/mock_device_discovery_service.dart';
 import '../../helpers/mock_settings_service.dart';
 import '../../helpers/test_scale.dart';
@@ -69,11 +72,11 @@ void main() {
         headers: {HttpHeaders.contentTypeHeader: 'application/json'},
       ));
 
-  Future<Response> post(String path) async =>
+  Future<Response> post(String path, [Object body = const {}]) async =>
       await handler(Request(
         'POST',
         Uri.parse('http://localhost$path'),
-        body: jsonEncode(const {}),
+        body: jsonEncode(body),
         headers: {HttpHeaders.contentTypeHeader: 'application/json'},
       ));
 
@@ -111,6 +114,36 @@ void main() {
       await wireWith(MockDe1());
       final res = await get('/api/v1/machine/ledStrip');
       expect(res.statusCode, 404);
+    });
+
+    test('200 + serves the machine-stored palette after connect-time '
+        'hydration (real Bengle over fake transport)', () async {
+      // The user-facing fix: after an app restart the first GET must show
+      // the colours stored on the machine, not all-off — no PUT/reset (and
+      // no skin change) needed first.
+      final transport = FakeBleTransport();
+      final bengle = Bengle(transport: transport);
+      transport.queueOnConnectResponses(
+        v13Model: 128, // Bengle marker
+        ledFrontAwake: 0x385A92,
+        ledFrontSleep: 0x112233,
+        ledRearAwake: 0xFF7A00,
+        ledRearSleep: 0x0000FF,
+      );
+      await bengle.onConnect();
+      addTearDown(transport.dispose);
+      await wireWith(bengle);
+
+      final res = await get('/api/v1/machine/ledStrip');
+      expect(res.statusCode, 200);
+      final body = jsonDecode(await res.readAsString());
+      expect(body['frontStrip']['awake'], '38385A5A9292');
+      expect(body['frontStrip']['sleeping'], '111122223333');
+      expect(body['backStrip']['awake'], 'FFFF7A7A0000');
+      expect(body['backStrip']['sleeping'], '00000000FFFF');
+      // Switch mirrors the front strip on read.
+      expect(body['frontSwitch']['awake'], '38385A5A9292');
+      expect(body['frontSwitch']['sleeping'], '111122223333');
     });
   });
 
@@ -206,6 +239,70 @@ void main() {
     test('404 on plain DE1', () async {
       await wireWith(MockDe1());
       final res = await post('/api/v1/machine/ledStrip/reset');
+      expect(res.statusCode, 404);
+    });
+  });
+
+  group('POST /api/v1/machine/ledStrip/preview', () {
+    test('202 on Bengle', () async {
+      await wireWith(MockBengle());
+      final res = await post('/api/v1/machine/ledStrip/preview', {
+        'front': 'FFFF00000000',
+        'back': '00000000FFFF',
+      });
+      expect(res.statusCode, 202);
+    });
+
+    test('202 + preview does not touch the stored config', () async {
+      final bengle = MockBengle();
+      await wireWith(bengle);
+
+      final res = await post('/api/v1/machine/ledStrip/preview', {
+        'front': 'FFFF00000000',
+        'back': '00000000FFFF',
+      });
+      expect(res.statusCode, 202);
+
+      // GET still serves the (all-off) stored config — preview bypasses it.
+      final got = await get('/api/v1/machine/ledStrip');
+      final body = jsonDecode(await got.readAsString());
+      expect(body['frontStrip']['awake'], '000000000000');
+    });
+
+    test('202 on empty body — missing keys preview as black', () async {
+      // Color16.fromJson is defensive-black: `{}` is accepted and blacks
+      // both strips (locked model semantics, not an error).
+      await wireWith(MockBengle());
+      final res = await post('/api/v1/machine/ledStrip/preview');
+      expect(res.statusCode, 202);
+    });
+
+    test('400 on non-map body', () async {
+      await wireWith(MockBengle());
+      final res = await post('/api/v1/machine/ledStrip/preview', [1, 2, 3]);
+      expect(res.statusCode, 400);
+    });
+
+    test('404 on plain DE1', () async {
+      await wireWith(MockDe1());
+      final res = await post('/api/v1/machine/ledStrip/preview', {
+        'front': 'FFFF00000000',
+        'back': '00000000FFFF',
+      });
+      expect(res.statusCode, 404);
+    });
+  });
+
+  group('POST /api/v1/machine/ledStrip/preview/clear', () {
+    test('202 on Bengle', () async {
+      await wireWith(MockBengle());
+      final res = await post('/api/v1/machine/ledStrip/preview/clear');
+      expect(res.statusCode, 202);
+    });
+
+    test('404 on plain DE1', () async {
+      await wireWith(MockDe1());
+      final res = await post('/api/v1/machine/ledStrip/preview/clear');
       expect(res.statusCode, 404);
     });
   });

--- a/test/services/webserver/de1handler_scale_calibrate_test.dart
+++ b/test/services/webserver/de1handler_scale_calibrate_test.dart
@@ -1,0 +1,196 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+import 'package:reaprime/src/models/errors.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+import '../../helpers/mock_device_discovery_service.dart';
+import '../../helpers/mock_settings_service.dart';
+import '../../helpers/test_scale.dart';
+import '../../helpers/test_scale_controller.dart';
+
+class _FixedDe1Controller extends De1Controller {
+  _FixedDe1Controller({required super.controller, this.device});
+
+  De1Interface? device;
+
+  @override
+  De1Interface connectedDe1() {
+    final d = device;
+    if (d == null) throw const DeviceNotConnectedException.machine();
+    return d;
+  }
+}
+
+void main() {
+  late Handler handler;
+  late _FixedDe1Controller controller;
+  late SettingsController settingsController;
+  late TestScaleController scaleController;
+
+  Future<void> wireWith(De1Interface? device) async {
+    final deviceController = DeviceController([MockDeviceDiscoveryService()]);
+    await deviceController.initialize();
+    controller = _FixedDe1Controller(
+      controller: deviceController,
+      device: device,
+    );
+
+    final mockSettings = MockSettingsService();
+    settingsController = SettingsController(mockSettings);
+    await settingsController.loadSettings();
+
+    final testScale = TestScale();
+    scaleController = TestScaleController(testScale);
+    final de1Handler = De1Handler(
+      controller: controller,
+      settingsController: settingsController,
+      scaleController: scaleController,
+      workflowController: WorkflowController(),
+    );
+    final app = Router().plus;
+    de1Handler.addRoutes(app);
+    handler = app.call;
+  }
+
+  Future<Response> get(String path) async =>
+      await handler(Request('GET', Uri.parse('http://localhost$path')));
+
+  Future<Response> post(String path, Object body) async => await handler(
+    Request(
+      'POST',
+      Uri.parse('http://localhost$path'),
+      body: jsonEncode(body),
+      headers: {HttpHeaders.contentTypeHeader: 'application/json'},
+    ),
+  );
+
+  group('GET /api/v1/machine/capabilities — scaleCalibration', () {
+    test('returns scaleCalibration when a Bengle is connected', () async {
+      await wireWith(MockBengle());
+      final res = await get('/api/v1/machine/capabilities');
+      expect(res.statusCode, 200);
+      final body = jsonDecode(await res.readAsString());
+      expect(body['capabilities'], contains('scaleCalibration'));
+    });
+
+    test('does not return scaleCalibration on plain DE1', () async {
+      await wireWith(MockDe1());
+      final res = await get('/api/v1/machine/capabilities');
+      final body = jsonDecode(await res.readAsString());
+      expect(body['capabilities'], isNot(contains('scaleCalibration')));
+    });
+  });
+
+  group('POST /api/v1/machine/scale/calibrate', () {
+    test('200 + zero result on MockBengle', () async {
+      await wireWith(MockBengle());
+      final res = await post('/api/v1/machine/scale/calibrate', {
+        'command': 'zero',
+      });
+      expect(res.statusCode, 200);
+      final body = jsonDecode(await res.readAsString());
+      expect(body['success'], isTrue);
+      expect(body['finalStep'], 'complete');
+      expect(body['pointStatus'], 'none');
+    });
+
+    test('200 + left latch reports pointStatus incomplete', () async {
+      await wireWith(MockBengle());
+      final res = await post('/api/v1/machine/scale/calibrate', {
+        'command': 'left',
+        'grams': 500,
+      });
+      expect(res.statusCode, 200);
+      final body = jsonDecode(await res.readAsString());
+      expect(body['success'], isTrue);
+      expect(body['pointStatus'], 'incomplete');
+    });
+
+    test('200 + right latch reports pointStatus ok (solved)', () async {
+      await wireWith(MockBengle());
+      final res = await post('/api/v1/machine/scale/calibrate', {
+        'command': 'right',
+        'grams': 500,
+      });
+      expect(res.statusCode, 200);
+      final body = jsonDecode(await res.readAsString());
+      expect(body['success'], isTrue);
+      expect(body['pointStatus'], 'ok');
+    });
+
+    test('202 on abort', () async {
+      await wireWith(MockBengle());
+      final res = await post('/api/v1/machine/scale/calibrate', {
+        'command': 'abort',
+      });
+      expect(res.statusCode, 202);
+    });
+
+    test('400 when left is missing grams', () async {
+      await wireWith(MockBengle());
+      final res = await post('/api/v1/machine/scale/calibrate', {
+        'command': 'left',
+      });
+      expect(res.statusCode, 400);
+      final body = jsonDecode(await res.readAsString());
+      expect(body['error'], contains('grams'));
+    });
+
+    test('400 when right is missing grams', () async {
+      await wireWith(MockBengle());
+      final res = await post('/api/v1/machine/scale/calibrate', {
+        'command': 'right',
+      });
+      expect(res.statusCode, 400);
+    });
+
+    test('400 on an unknown command', () async {
+      await wireWith(MockBengle());
+      final res = await post('/api/v1/machine/scale/calibrate', {
+        'command': 'wiggle',
+      });
+      expect(res.statusCode, 400);
+      final body = jsonDecode(await res.readAsString());
+      expect(body['error'], contains('wiggle'));
+    });
+
+    test('400 on a non-object JSON body', () async {
+      await wireWith(MockBengle());
+      // A bare JSON string is valid JSON but not an object — previously an
+      // undocumented 500 (thrown inside the handler) instead of a 400.
+      final res = await post('/api/v1/machine/scale/calibrate', 'zero');
+      expect(res.statusCode, 400);
+      final body = jsonDecode(await res.readAsString());
+      expect(body['error'], contains('JSON object'));
+    });
+
+    test(
+      '404 on plain DE1 (machine connected but capability absent)',
+      () async {
+        await wireWith(MockDe1());
+        final res = await post('/api/v1/machine/scale/calibrate', {
+          'command': 'zero',
+        });
+        expect(res.statusCode, 404);
+      },
+    );
+
+    test('500 when no machine is connected', () async {
+      await wireWith(null);
+      final res = await post('/api/v1/machine/scale/calibrate', {
+        'command': 'zero',
+      });
+      expect(res.statusCode, 500);
+    });
+  });
+}

--- a/test/settings/sleep_timeout_safety_test.dart
+++ b/test/settings/sleep_timeout_safety_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/settings/sleep_timeout_safety.dart';
+
+
+/// SAFETY. The machine's `InactivitySleepTimeout` is what turns the heaters off
+/// when this tablet is gone (dead battery, crashed app, blackout). The firmware
+/// reads `<= 0` as "never sleep", and persists the value to flash — so a single
+/// `0` from this app makes the machine hot-forever across power cycles, and
+/// LESS safe than one that never met the app (the firmware default is 60 min).
+///
+/// `machineSleepTimeoutMinutes` is the one function standing between every
+/// entry point (UI dropdown, REST, settings import, de1app TDB import) and that
+/// register. These tests pin its contract. Do not relax them.
+void main() {
+  group('machineSleepTimeoutMinutes: never returns 0', () {
+    test('presence OFF -> the protective floor, not 0', () {
+      expect(
+        machineSleepTimeoutMinutes(
+          userPresenceEnabled: false,
+          userTimeoutMinutes: 30,
+        ),
+        kSafetySleepFloorMinutes,
+      );
+    });
+
+    test('dropdown "Disabled" (0) -> the protective floor, not 0', () {
+      expect(
+        machineSleepTimeoutMinutes(
+          userPresenceEnabled: true,
+          userTimeoutMinutes: 0,
+        ),
+        kSafetySleepFloorMinutes,
+      );
+    });
+
+    test('the floor matches the FIRMWARE default, so the app can never make a '
+        'machine less safe than a factory-fresh one', () {
+      expect(kSafetySleepFloorMinutes, 60);
+    });
+
+    test('a valid user value is honoured exactly, including below the floor',
+        () {
+      for (final minutes in [1, 15, 30, 45, 60, 90, 120, 180, 240]) {
+        expect(
+          machineSleepTimeoutMinutes(
+            userPresenceEnabled: true,
+            userTimeoutMinutes: minutes,
+          ),
+          minutes,
+          reason: '$minutes is a safe, deliberate choice — 30 min is SAFER '
+              'than the 60 min floor, so the floor must not raise it',
+        );
+      }
+    });
+
+    test('every possible input pair lands in the firmware\'s 1..240, never 0',
+        () {
+      for (final enabled in [true, false]) {
+        for (final minutes in [
+          -100000, -241, -60, -1, 0, 1, 239, 240, 241, 100000,
+        ]) {
+          final result = machineSleepTimeoutMinutes(
+            userPresenceEnabled: enabled,
+            userTimeoutMinutes: minutes,
+          );
+          expect(
+            result,
+            inInclusiveRange(
+                kMinMachineSleepTimeoutMinutes, kMaxSleepTimeoutMinutes),
+            reason: 'presence=$enabled minutes=$minutes escaped the safe range',
+          );
+          expect(result, isNot(0),
+              reason: 'presence=$enabled minutes=$minutes disabled the machine '
+                  'safety net');
+        }
+      }
+    });
+  });
+}

--- a/test/unit/controllers/bengle_device_flow_test.dart
+++ b/test/unit/controllers/bengle_device_flow_test.dart
@@ -1,0 +1,175 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle_virtual_scale.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+
+import '../../helpers/fake_ble_transport.dart';
+
+/// A 0xA013 frame carrying an explicit weight and GFlow. GFlow is a big-endian
+/// u16 hundredths at offset 10; weight is a big-endian u16 in 1/32 g at offset
+/// 20. (Full byte-level breakdown lives in `bengle_shot_sample_test.dart`.)
+Uint8List _frame({required double weightG, required double gFlowGps}) {
+  final b = ByteData(28);
+  b.setUint16(2, 900, Endian.big); // group pressure 9.00 bar
+  b.setUint16(10, (gFlowGps * 100).round(), Endian.big);
+  b.setUint16(20, (weightG * 32).round(), Endian.big);
+  return b.buffer.asUint8List();
+}
+
+/// The Bengle computes gravimetric flow on-device, on the load cell it owns,
+/// and ships it in every 15 Hz 0xA013 frame. These tests lock the app to that
+/// number on the **scale** surface.
+///
+/// Without the lock, `ScaleController` runs a flow *estimator* over the Bengle's
+/// weight — re-deriving a quantity the firmware already computed from the very
+/// signal it derived it from. That estimate reads ~0 g/s at shot onset and needs
+/// roughly a second to converge, and the shot path consumes it: step-weight
+/// exits, the stopping-yield refinement, `ws/v1/scale/snapshot` and the shot
+/// record all read `WeightSnapshot.weightFlow`.
+///
+/// The lock is deliberately asserted **with the Kalman flag ON**, because Kalman
+/// is the upstream default and swapping the estimator must never again change
+/// what a Bengle reports.
+void main() {
+  const firmwareGFlow = 1.80; // g/s, as reported in the 0xA013 GFlow field
+
+  group('Bengle device-computed flow (0xA013 GFlow) reaches the scale surface',
+      () {
+    late FakeBleTransport transport;
+    late Bengle bengle;
+    late ScaleController controller;
+
+    Future<void> connect({required bool kalman}) async {
+      transport = FakeBleTransport();
+      // calFlowEst keeps onConnect from eating the MMR read-retry timeout.
+      transport.queueMmrResponseInt(MMRItem.calFlowEst, 100);
+      transport.queueOnConnectResponses(v13Model: 128); // a real Bengle
+      bengle = Bengle(transport: transport);
+      await bengle.onConnect();
+      controller = ScaleController()..setKalmanFlowEnabled(kalman);
+      await controller.connectToScale(BengleVirtualScale(bengle));
+    }
+
+    Future<void> shutdown() async {
+      controller.dispose();
+      transport.dispose();
+    }
+
+    for (final kalman in [true, false]) {
+      final label = kalman ? 'kalmanFlow ON (upstream default)' : 'kalmanFlow OFF';
+
+      test('$label: the firmware GFlow is emitted verbatim on the FIRST sample',
+          () async {
+        await connect(kalman: kalman);
+        final out = <WeightSnapshot>[];
+        final sub = controller.weightSnapshot.listen(out.add);
+        final push = transport.subscribers[Endpoint.bengleShotSample.uuid]!;
+
+        push(_frame(weightG: 20.0, gFlowGps: firmwareGFlow));
+        await pumpEventQueue();
+
+        expect(out, isNotEmpty);
+        expect(
+          out.last.weightFlow,
+          closeTo(firmwareGFlow, 1e-9),
+          reason: 'the app must not re-estimate a flow the firmware computed; '
+              'an estimator would read ~0 g/s on the first sample',
+        );
+        expect(out.last.weight, closeTo(20.0, 1e-6));
+
+        await sub.cancel();
+        await shutdown();
+      });
+
+      test('$label: no estimator lag — every sample of a steady pour is GFlow',
+          () async {
+        await connect(kalman: kalman);
+        final out = <WeightSnapshot>[];
+        final sub = controller.weightSnapshot.listen(out.add);
+        final push = transport.subscribers[Endpoint.bengleShotSample.uuid]!;
+
+        // 2 s of a 15 Hz pour: the weight really does climb at `firmwareGFlow`,
+        // and the firmware says so in every frame.
+        for (var i = 0; i < 30; i++) {
+          push(_frame(
+            weightG: 20.0 + firmwareGFlow * (i / 15.0),
+            gFlowGps: firmwareGFlow,
+          ));
+          await pumpEventQueue();
+        }
+
+        expect(out.length, greaterThanOrEqualTo(30));
+        for (final snap in out) {
+          expect(
+            snap.weightFlow,
+            closeTo(firmwareGFlow, 1e-9),
+            reason: 'an app-side estimator would ramp up to this value over '
+                '~1 s instead of reporting it immediately',
+          );
+        }
+
+        await sub.cancel();
+        await shutdown();
+      });
+    }
+
+    test('toggling the Kalman flag does not change what a Bengle reports',
+        () async {
+      final flows = <bool, double>{};
+      for (final kalman in [true, false]) {
+        await connect(kalman: kalman);
+        final out = <WeightSnapshot>[];
+        final sub = controller.weightSnapshot.listen(out.add);
+        final push = transport.subscribers[Endpoint.bengleShotSample.uuid]!;
+
+        push(_frame(weightG: 20.0, gFlowGps: firmwareGFlow));
+        await pumpEventQueue();
+
+        flows[kalman] = out.last.weightFlow;
+        await sub.cancel();
+        await shutdown();
+      }
+
+      expect(
+        flows[true],
+        closeTo(flows[false]!, 1e-9),
+        reason: 'the estimator choice must be inert on a device that computes '
+            'its own flow — this is the regression lock against a future '
+            'upstream estimator silently taking over the Bengle',
+      );
+      expect(flows[true], closeTo(firmwareGFlow, 1e-9));
+    });
+
+    test(
+      'the machine and scale surfaces report the SAME flow (single source)',
+      () async {
+        await connect(kalman: true);
+        final machineSnaps = <MachineSnapshot>[];
+        final scaleSnaps = <WeightSnapshot>[];
+        final mSub = bengle.currentSnapshot.listen(machineSnaps.add);
+        final sSub = controller.weightSnapshot.listen(scaleSnaps.add);
+        final push = transport.subscribers[Endpoint.bengleShotSample.uuid]!;
+
+        push(_frame(weightG: 20.0, gFlowGps: firmwareGFlow));
+        await pumpEventQueue();
+
+        expect(machineSnaps.last.weightFlow, closeTo(firmwareGFlow, 1e-9));
+        expect(scaleSnaps.last.weightFlow, closeTo(firmwareGFlow, 1e-9));
+        expect(
+          scaleSnaps.last.weightFlow,
+          closeTo(machineSnaps.last.weightFlow, 1e-9),
+          reason: 'ws/v1/machine/snapshot and ws/v1/scale/snapshot must not '
+              'disagree about the flow of the same shot',
+        );
+
+        await mSub.cancel();
+        await sSub.cancel();
+        await shutdown();
+      },
+    );
+  });
+}

--- a/test/unit/models/device/impl/bengle/bengle_firmware_prelude_test.dart
+++ b/test/unit/models/device/impl/bengle/bengle_firmware_prelude_test.dart
@@ -68,5 +68,43 @@ void main() {
       expect(fwWrites[1].data[0],
           De1StateEnum.fromMachineState(MachineState.fwUpgrade).hexValue);
     });
+
+    test('spaces the fwUpgrade request by the full 500 ms prelude delay',
+        () async {
+      // The DFU prelude timing: requestState(sleeping)
+      // -> 500 ms -> requestState(fwUpgrade). Only the ordering was locked
+      // until now; this pins the spacing so the delay cannot be silently
+      // dropped or shortened.
+      //
+      // Deliberately wall-clock, not fakeAsync: the transport write path gates
+      // on `connectionState.first`, and a rxdart subject's `first` never
+      // completes inside a fakeAsync zone (its completion chains on the
+      // subscription's cancel() future). The lower bound is still
+      // deterministic — Dart timers never fire early — so this cannot flake;
+      // a loaded runner only makes the elapsed time larger.
+      final transport = FakeBleTransport();
+      addTearDown(transport.dispose);
+      final bengle = Bengle(transport: transport);
+
+      final stopwatch = Stopwatch()..start();
+      // Tests live in the same package; @protected lint is irrelevant here.
+      // ignore: invalid_use_of_protected_member
+      await bengle.beforeFirmwareUpload();
+      stopwatch.stop();
+
+      // Future.delayed flattens the inner async closure, so awaiting the hook
+      // must cover the delayed requestState write — assert it already landed.
+      final stateWrites = transport.writes
+          .where((w) => w.characteristicUUID == Endpoint.requestedState.uuid)
+          .toList();
+      expect(stateWrites, hasLength(1));
+      expect(transport.lastRequestedState, MachineState.fwUpgrade);
+      expect(stateWrites.single.data[0],
+          De1StateEnum.fromMachineState(MachineState.fwUpgrade).hexValue,
+          reason: 'the delayed write must be the fwUpgrade wire byte');
+      expect(stopwatch.elapsedMilliseconds, greaterThanOrEqualTo(500),
+          reason: 'the fwUpgrade request must not fire before the 500 ms '
+              'spacing after requestState(sleeping) has elapsed');
+    });
   });
 }

--- a/test/unit/models/device/impl/bengle/mmr_contract_test.dart
+++ b/test/unit/models/device/impl/bengle/mmr_contract_test.dart
@@ -157,6 +157,7 @@ const List<ContractEntry> entriesUnderTest = <ContractEntry>[
   // ---------------------------------------------------------------------------
   ContractEntry(BengleMmr.matSetPoint, 'MatSetPoint'),
   ContractEntry(BengleMmr.cupWarmerMode, 'CupWarmerMode'),
+  ContractEntry(BengleMmr.matCurrentTemp, 'MatCurrentTemp'),
   ContractEntry(BengleSteamMmr.stopAtTemperatureTarget, 'TargetMilkTemp'),
 ];
 

--- a/test/unit/models/device/impl/bengle/mmr_contract_test.dart
+++ b/test/unit/models/device/impl/bengle/mmr_contract_test.dart
@@ -59,11 +59,10 @@ import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart'
 // Thermal branch (spec 08) uncomments this import with its section below:
 // import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart'
 //     show BengleMmr, BengleSteamMmr;
-// The cal (spec 06) / LED (spec 07) branches extend this `show` list with
-// BengleCalMmr / BengleLedMmr as they land (the enums are parts of the
-// unified_de1 library):
+// The LED branch (spec 07) extends this `show` list with BengleLedMmr when it
+// lands (the enums are parts of the unified_de1 library):
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart'
-    show BengleScaleMmr;
+    show BengleScaleMmr, BengleCalMmr;
 
 const String _contractPath = 'assets/api/bengle_hw_v1.yml';
 
@@ -137,11 +136,10 @@ const List<ContractEntry> entriesUnderTest = <ContractEntry>[
   // ---------------------------------------------------------------------------
   // Calibration-wizard branch (spec 06): `BengleCalMmr`
   // (in scale_calibration_capability.dart, part of unified_de1).
-  // UNCOMMENT these lines (and the unified_de1 import) when the branch lands:
   // ---------------------------------------------------------------------------
-  // ContractEntry(BengleCalMmr.cmd, 'ScaleCalCmd'),
-  // ContractEntry(BengleCalMmr.state, 'ScaleCalState'),
-  // ContractEntry(BengleCalMmr.weight, 'ScaleCalWeight'),
+  ContractEntry(BengleCalMmr.cmd, 'ScaleCalCmd'),
+  ContractEntry(BengleCalMmr.state, 'ScaleCalState'),
+  ContractEntry(BengleCalMmr.weight, 'ScaleCalWeight'),
 
   // ---------------------------------------------------------------------------
   // LED-strip branch (spec 07): `BengleLedMmr`

--- a/test/unit/models/device/impl/bengle/mmr_contract_test.dart
+++ b/test/unit/models/device/impl/bengle/mmr_contract_test.dart
@@ -1,0 +1,531 @@
+// Firmware <-> app MMR contract checker (CI drift gate).
+//
+// Validates every app-declared MMR register against the machine-readable
+// firmware contract `assets/api/bengle_hw_v1.yml` (contract_version 1,
+// distilled from firmware the firmware register table @ a firmware development branch
+// The MMR layout is hand-declared twice (firmware C, app Dart); this test is
+// the machine check that the two copies cannot silently drift apart.
+//
+// Run: flutter test test/unit/models/device/impl/bengle/mmr_contract_test.dart
+// (rides the normal `flutter test` CI job; reads the contract with plain File
+// IO relative to the package root, which is where `flutter test` runs).
+//
+// WHAT IS ASSERTED (v1 semantics):
+//   * address -- exact match.
+//   * length  -- exact match.
+//   * scale   -- app writeScale == contract mult AND app readScale == 1/mult.
+//               Non-scaled registers carry the default 1.0/1.0 and contract
+//               mult 1, so the same rule covers every kind.
+//   * range   -- app SUBSET of contract: a min/max bound the app declares must
+//               sit inside the contract's bound. The app declaring NO bound is
+//               legal (contract bounds are documentation -- the firmware never
+//               range-checks Bengle macro-path writes; the app is the guard),
+//               and the app being strictly narrower is legal (e.g. CalFlowEst
+//               app raw min 130 vs contract 125).
+//   * perms are NOT asserted in v1: the app enums carry no perms field (a
+//     `perms` getter on MmrAddress is proposed via the Phase-0 issue).
+//   * Direction: every app-declared register must exist in the contract and
+//     match; contract rows with no app entry are legal -- the app grows into
+//     the contract branch by branch (unconsumed rows are printed
+//     informationally below).
+//
+// EXTENSION PROTOCOL (how capability branches extend this test):
+//   The single registration table is `entriesUnderTest` below, grouped into
+//   clearly-marked sections, one per capability branch. On the foundation
+//   branch only the MMRItem section (and its import) is active; each later
+//   capability branch that introduces an MMR enum:
+//     1. uncomments (or appends) its section's `ContractEntry` lines -- one
+//        line per register, mapping the enum entry to its contract row by the
+//        FIRMWARE register name;
+//     2. uncomments the import its section needs (marked alongside);
+//     3. never edits the assertions -- if the checker fails, the enum or the
+//        contract (with a contract_version bump) is wrong, not the test.
+//   An app desc string that deliberately differs from the firmware name is
+//   recorded in the contract as `app_alias` (today: TargetMilkTemp vs the
+//   app's 'StopAtTemperatureTarget').
+//
+// CONTRACT CHANGE PROTOCOL: firmware changes a register -> regenerate
+// bengle_hw_v1.yml from the new the firmware register table (never from a stale working tree) ->
+// bump contract_version -> update the app enums -> update
+// `_expectedContractVersion` here. Firmware and app PRs both cite the version.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart'
+    show MMRItem;
+import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart'
+    show MmrAddress;
+// Thermal branch (spec 08) uncomments this import with its section below:
+// import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart'
+//     show BengleMmr, BengleSteamMmr;
+// The first of the SAW/tare (spec 05) / cal (spec 06) / LED (spec 07)
+// branches to land uncomments this import (the enums are parts of the
+// unified_de1 library) and extends the `show` list as the others follow:
+// import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart'
+//     show BengleCalMmr, BengleLedMmr, BengleScaleMmr;
+
+const String _contractPath = 'assets/api/bengle_hw_v1.yml';
+
+/// The contract_version this registration table was written against.
+/// Bump deliberately, together with the enum updates the new contract needs.
+const int _expectedContractVersion = 1;
+
+/// One app-declared register under test: the app enum entry and the FIRMWARE
+/// register name of its row in bengle_hw_v1.yml.
+class ContractEntry {
+  const ContractEntry(this.register, this.contractName);
+
+  final MmrAddress register;
+
+  /// Firmware register name (the `name:` field of the contract row).
+  final String contractName;
+
+  String get label => '${register.runtimeType}.${register.name}';
+}
+
+// =============================================================================
+// REGISTRATION TABLE -- one line per app-declared MMR register.
+// Capability branches extend this list (see EXTENSION PROTOCOL above).
+// =============================================================================
+const List<ContractEntry> entriesUnderTest = <ContractEntry>[
+  // ---------------------------------------------------------------------------
+  // Foundation branch (spec 01): shared-DE1 `MMRItem` baseline.
+  // ---------------------------------------------------------------------------
+  ContractEntry(MMRItem.externalFlash, 'ExternalFlash'),
+  ContractEntry(MMRItem.hwConfig, 'HWConfig'),
+  ContractEntry(MMRItem.model, 'Model'),
+  ContractEntry(MMRItem.cpuBoardModel, 'CPUBoardModel'),
+  ContractEntry(MMRItem.v13Model, 'v13Model'),
+  ContractEntry(MMRItem.cpuFirmwareBuild, 'CPUFirmwareBuild'),
+  ContractEntry(MMRItem.debugLen, 'DebugLen'),
+  ContractEntry(MMRItem.debugBuffer, 'DebugBuffer'),
+  ContractEntry(MMRItem.debugConfig, 'DebugConfig'),
+  ContractEntry(MMRItem.fanThreshold, 'FanThreshold'),
+  ContractEntry(MMRItem.tankTemp, 'TankTemp'),
+  ContractEntry(MMRItem.heaterUp1Flow, 'HeaterUp1Flow'),
+  ContractEntry(MMRItem.heaterUp2Flow, 'HeaterUp2Flow'),
+  ContractEntry(MMRItem.waterHeaterIdleTemp, 'WaterHeaterIdleTemp'),
+  ContractEntry(MMRItem.ghcInfo, 'GHCInfo'),
+  ContractEntry(MMRItem.targetSteamFlow, 'TargetSteamFlow'),
+  // The expected SteamStartSecs scales are readScale 0.01 / writeScale 100.0
+  // (== fw mult 100). The entry historically carried the latent default-1.0
+  // scales (known drift, the contract change protocol) and MUST fail here if that ever
+  // regresses.
+  ContractEntry(MMRItem.steamStartSecs, 'SteamStartSecs'),
+  ContractEntry(MMRItem.serialN, 'SerialN'),
+  ContractEntry(MMRItem.heaterV, 'HeaterV'),
+  ContractEntry(MMRItem.heaterUp2Timeout, 'HeaterUp2Timeout'),
+  ContractEntry(MMRItem.calFlowEst, 'CalFlowEst'),
+  ContractEntry(MMRItem.flushFlowRate, 'FlushFlowRate'),
+  ContractEntry(MMRItem.flushTemp, 'FlushTemp'),
+  ContractEntry(MMRItem.flushTimeout, 'FlushTimeout'),
+  ContractEntry(MMRItem.hotWaterFlowRate, 'HotWaterFlowRate'),
+  ContractEntry(MMRItem.steamPurgeMode, 'SteamPurgeMode'),
+  ContractEntry(MMRItem.allowUSBCharging, 'AllowUSBCharging'),
+  ContractEntry(MMRItem.appFeatureFlags, 'AppFeatureFlags'),
+  ContractEntry(MMRItem.refillKitPresent, 'RefillKitPresent'),
+  ContractEntry(MMRItem.userPresent, 'UserPresent'),
+
+  // ---------------------------------------------------------------------------
+  // SAW/tare branch (spec 05): `BengleScaleMmr`
+  // (in integrated_scale_capability.dart, part of unified_de1).
+  // UNCOMMENT these lines (and the unified_de1 import) when the branch lands:
+  // ---------------------------------------------------------------------------
+  // ContractEntry(BengleScaleMmr.stopAtWeightTarget, 'EndOfShotWeight'),
+  // ContractEntry(BengleScaleMmr.scaleTare, 'ScaleTare'),
+
+  // ---------------------------------------------------------------------------
+  // Calibration-wizard branch (spec 06): `BengleCalMmr`
+  // (in scale_calibration_capability.dart, part of unified_de1).
+  // UNCOMMENT these lines (and the unified_de1 import) when the branch lands:
+  // ---------------------------------------------------------------------------
+  // ContractEntry(BengleCalMmr.cmd, 'ScaleCalCmd'),
+  // ContractEntry(BengleCalMmr.state, 'ScaleCalState'),
+  // ContractEntry(BengleCalMmr.weight, 'ScaleCalWeight'),
+
+  // ---------------------------------------------------------------------------
+  // LED-strip branch (spec 07): `BengleLedMmr`
+  // (in led_strip_capability.dart, part of unified_de1).
+  // UNCOMMENT these lines (and the unified_de1 import) when the branch lands:
+  // ---------------------------------------------------------------------------
+  // ContractEntry(BengleLedMmr.frontLive, 'FrontLEDColor'),
+  // ContractEntry(BengleLedMmr.rearLive, 'RearLEDColor'),
+  // ContractEntry(BengleLedMmr.frontAwake, 'FrontLEDAwake'),
+  // ContractEntry(BengleLedMmr.rearAwake, 'RearLEDAwake'),
+  // ContractEntry(BengleLedMmr.frontSleep, 'FrontLEDSleep'),
+  // ContractEntry(BengleLedMmr.rearSleep, 'RearLEDSleep'),
+
+  // ---------------------------------------------------------------------------
+  // Thermal branch (spec 08: cup-warmer mode + milk temp + mat-temp read):
+  // `BengleMmr` + `BengleSteamMmr` (bengle_mmr.dart). The app desc string
+  // 'StopAtTemperatureTarget' is the contract row's `app_alias`.
+  // UNCOMMENT these lines (and the bengle_mmr import) when the branch lands:
+  // ---------------------------------------------------------------------------
+  // ContractEntry(BengleMmr.matSetPoint, 'MatSetPoint'),
+  // ContractEntry(BengleMmr.cupWarmerMode, 'CupWarmerMode'),
+  // ContractEntry(BengleSteamMmr.stopAtTemperatureTarget, 'TargetMilkTemp'),
+];
+
+// =============================================================================
+// Minimal contract parser.
+//
+// Deliberately hand-rolled: `package:yaml` is only a TRANSITIVE dependency of
+// this package, and depending on it directly would need a pubspec change.
+// The parser supports exactly the subset bengle_hw_v1.yml is written in --
+// top-level scalar keys, the two-space-indented `firmware:` block map, and
+// the `registers:` list of `- key: value` block maps with `#` comments
+// (whole-line or trailing, quote-aware). The packet_0xA013 / serial_verbs
+// sections are documentation for humans and are intentionally skipped.
+// =============================================================================
+
+class ContractRegister {
+  const ContractRegister({
+    required this.name,
+    required this.fwRow,
+    required this.address,
+    required this.length,
+    required this.perms,
+    required this.mult,
+    required this.valueKind,
+    required this.min,
+    required this.max,
+    required this.appAlias,
+  });
+
+  final String name;
+  final int? fwRow;
+  final int address;
+  final int length;
+  final String perms;
+  final int mult;
+  final String valueKind;
+  final int? min;
+  final int? max;
+  final String? appAlias;
+}
+
+class HwContract {
+  const HwContract({
+    required this.contractVersion,
+    required this.firmwareCommit,
+    required this.registers,
+  });
+
+  final int contractVersion;
+  final String firmwareCommit;
+
+  /// Keyed by firmware register name.
+  final Map<String, ContractRegister> registers;
+}
+
+/// Drops a `#` comment (whole-line or trailing) unless the `#` sits inside a
+/// double-quoted scalar. Trailing comments in the contract are always
+/// whitespace-separated from the value.
+String _stripComment(String line) {
+  var inQuotes = false;
+  for (var i = 0; i < line.length; i++) {
+    final ch = line[i];
+    if (ch == '"') inQuotes = !inQuotes;
+    if (ch == '#' &&
+        !inQuotes &&
+        (i == 0 || line[i - 1] == ' ' || line[i - 1] == '\t')) {
+      return line.substring(0, i);
+    }
+  }
+  return line;
+}
+
+String _unquote(String value) {
+  final t = value.trim();
+  if (t.length >= 2 && t.startsWith('"') && t.endsWith('"')) {
+    return t.substring(1, t.length - 1);
+  }
+  return t;
+}
+
+/// Parses `null`, decimal, or 0x-prefixed hex scalars (optionally quoted).
+int? _intOrNull(String? value) {
+  if (value == null) return null;
+  final t = _unquote(value);
+  if (t.isEmpty || t == 'null' || t == '~') return null;
+  if (t.startsWith('0x') || t.startsWith('0X')) {
+    return int.parse(t.substring(2), radix: 16);
+  }
+  return int.parse(t);
+}
+
+HwContract parseBengleHwContract(String text) {
+  int? version;
+  String? commit;
+  final registers = <String, ContractRegister>{};
+
+  var topKey = '';
+  Map<String, String>? current;
+
+  void flushCurrent() {
+    final fields = current;
+    current = null;
+    if (fields == null) return;
+    final name = _unquote(
+      fields['name'] ?? (throw FormatException('register row without a name')),
+    );
+    registers[name] = ContractRegister(
+      name: name,
+      fwRow: _intOrNull(fields['fw_row']),
+      address:
+          _intOrNull(fields['address']) ??
+          (throw FormatException('register $name has no address')),
+      length:
+          _intOrNull(fields['length']) ??
+          (throw FormatException('register $name has no length')),
+      perms: _unquote(fields['perms'] ?? ''),
+      mult:
+          _intOrNull(fields['mult']) ??
+          (throw FormatException('register $name has no mult')),
+      valueKind: _unquote(fields['value_kind'] ?? ''),
+      min: _intOrNull(fields['min']),
+      max: _intOrNull(fields['max']),
+      appAlias: fields['app_alias'] == null
+          ? null
+          : _unquote(fields['app_alias']!),
+    );
+  }
+
+  for (final raw in text.split('\n')) {
+    final line = _stripComment(raw).trimRight();
+    if (line.trim().isEmpty) continue;
+
+    if (!line.startsWith(' ')) {
+      // New top-level key ends any open register row.
+      flushCurrent();
+      final sep = line.indexOf(':');
+      if (sep < 0) continue;
+      topKey = line.substring(0, sep).trim();
+      final value = line.substring(sep + 1).trim();
+      if (topKey == 'contract_version' && value.isNotEmpty) {
+        version = int.parse(value);
+      }
+      continue;
+    }
+
+    if (topKey == 'firmware') {
+      final sep = line.indexOf(':');
+      if (sep > 0 && line.substring(0, sep).trim() == 'commit') {
+        commit = _unquote(line.substring(sep + 1));
+      }
+      continue;
+    }
+
+    if (topKey != 'registers') continue;
+
+    var body = line.trimLeft();
+    if (body.startsWith('- ')) {
+      flushCurrent();
+      current = <String, String>{};
+      body = body.substring(2);
+    }
+    final fields = current;
+    if (fields == null) continue;
+    final sep = body.indexOf(':');
+    if (sep <= 0) continue;
+    fields[body.substring(0, sep).trim()] = body.substring(sep + 1).trim();
+  }
+  flushCurrent();
+
+  if (version == null) {
+    throw const FormatException('contract_version missing from contract');
+  }
+  if (commit == null) {
+    throw const FormatException('firmware.commit missing from contract');
+  }
+  if (registers.isEmpty) {
+    throw const FormatException('no registers parsed from contract');
+  }
+  return HwContract(
+    contractVersion: version,
+    firmwareCommit: commit,
+    registers: registers,
+  );
+}
+
+// =============================================================================
+// Checker
+// =============================================================================
+
+HwContract? _cached;
+HwContract _contract() =>
+    _cached ??= parseBengleHwContract(File(_contractPath).readAsStringSync());
+
+String _hex(int value) =>
+    '0x${value.toRadixString(16).toUpperCase().padLeft(8, '0')}';
+
+void main() {
+  group('bengle_hw_v1.yml', () {
+    test('parses, pins a firmware commit, and matches the checker version', () {
+      final c = _contract();
+      expect(
+        c.contractVersion,
+        _expectedContractVersion,
+        reason:
+            'contract_version drift: the contract file is '
+            'v${c.contractVersion} but this registration table was written '
+            'against v$_expectedContractVersion. Update the enums against the '
+            'new contract, then bump _expectedContractVersion deliberately.',
+      );
+      expect(
+        c.firmwareCommit,
+        hasLength(40),
+        reason: 'firmware.commit must pin a full 40-char firmware SHA',
+      );
+      stdout.writeln(
+        '  contract v${c.contractVersion}, firmware pin ${c.firmwareCommit}, '
+        '${c.registers.length} contract rows, '
+        '${entriesUnderTest.length} app registers under test',
+      );
+    });
+
+    test('every app register maps to a distinct contract row', () {
+      final names = entriesUnderTest.map((e) => e.contractName).toList();
+      expect(
+        names.toSet().length,
+        names.length,
+        reason: 'two registration entries claim the same contract row',
+      );
+      final registers = entriesUnderTest.map((e) => e.register).toList();
+      expect(
+        registers.toSet().length,
+        registers.length,
+        reason: 'an app register is registered twice',
+      );
+    });
+  });
+
+  group('app register matches contract (address/length/scale/range)', () {
+    for (final entry in entriesUnderTest) {
+      test('${entry.label} <-> ${entry.contractName}', () {
+        final row = _contract().registers[entry.contractName];
+        expect(
+          row,
+          isNotNull,
+          reason:
+              'app register ${entry.label} is missing from the contract: '
+              'no row named "${entry.contractName}" in $_contractPath. Every '
+              'app-declared register must exist in the contract.',
+        );
+        final contract = row!;
+        final app = entry.register;
+
+        expect(
+          _hex(app.address),
+          _hex(contract.address),
+          reason:
+              'ADDRESS drift on ${entry.label}: app ${_hex(app.address)} '
+              'vs contract ${_hex(contract.address)}',
+        );
+        expect(
+          app.length,
+          contract.length,
+          reason:
+              'LENGTH drift on ${entry.label}: app ${app.length} vs '
+              'contract ${contract.length}',
+        );
+
+        // Scale: writeScale must equal the firmware mult; readScale must be
+        // its inverse. Non-scaled registers have mult 1 and default 1.0
+        // scales, so the same rule covers every value kind.
+        expect(
+          app.writeScale,
+          contract.mult.toDouble(),
+          reason:
+              'SCALE drift on ${entry.label}: app writeScale '
+              '${app.writeScale} vs contract mult ${contract.mult} '
+              '(wire value = engineering value x mult)',
+        );
+        expect(
+          app.readScale,
+          closeTo(1.0 / contract.mult, 1e-9),
+          reason:
+              'SCALE drift on ${entry.label}: app readScale '
+              '${app.readScale} vs contract 1/mult '
+              '(${1.0 / contract.mult})',
+        );
+
+        // Range: app bounds (raw wire units) must be a SUBSET of the contract
+        // bounds. Declaring no bound is legal; narrower is legal.
+        final appMin = app.min;
+        final appMax = app.max;
+        if (appMin != null && contract.min != null) {
+          expect(
+            appMin >= contract.min!,
+            isTrue,
+            reason:
+                'RANGE drift on ${entry.label}: app min $appMin lies '
+                'below contract min ${contract.min} (app range must be a '
+                'subset of the contract range)',
+          );
+        }
+        if (appMax != null && contract.max != null) {
+          expect(
+            appMax <= contract.max!,
+            isTrue,
+            reason:
+                'RANGE drift on ${entry.label}: app max $appMax lies '
+                'above contract max ${contract.max} (app range must be a '
+                'subset of the contract range)',
+          );
+        }
+      });
+    }
+  });
+
+  group('contract coverage (informational, never fails)', () {
+    test('contract rows not yet consumed by the app', () {
+      final covered = entriesUnderTest.map((e) => e.contractName).toSet();
+      final unconsumed =
+          _contract().registers.values
+              .where((r) => !covered.contains(r.name))
+              .toList()
+            ..sort((a, b) => (a.fwRow ?? -1).compareTo(b.fwRow ?? -1));
+      stdout.writeln(
+        '  ${unconsumed.length} contract rows have no app entry '
+        '(legal -- the app grows into the contract):',
+      );
+      for (final r in unconsumed) {
+        stdout.writeln(
+          '    row ${r.fwRow} ${r.name} @ ${_hex(r.address)} '
+          '(${r.perms}, mult ${r.mult})',
+        );
+      }
+    });
+
+    test('contract rows carrying an app_alias (desc differs from FW name)', () {
+      for (final r in _contract().registers.values) {
+        if (r.appAlias != null) {
+          stdout.writeln(
+            '    ${r.name}: app declares desc "${r.appAlias}" (documented '
+            'alias, not drift)',
+          );
+        }
+      }
+    });
+
+    test('app ranges strictly narrower than the contract (legal)', () {
+      for (final entry in entriesUnderTest) {
+        final row = _contract().registers[entry.contractName];
+        if (row == null) continue;
+        final app = entry.register;
+        final narrowerMin =
+            app.min != null && row.min != null && app.min! > row.min!;
+        final narrowerMax =
+            app.max != null && row.max != null && app.max! < row.max!;
+        if (narrowerMin || narrowerMax) {
+          stdout.writeln(
+            '    ${entry.label}: app [${app.min}..${app.max}] inside '
+            'contract [${row.min}..${row.max}]',
+          );
+        }
+      }
+    });
+  });
+}

--- a/test/unit/models/device/impl/bengle/mmr_contract_test.dart
+++ b/test/unit/models/device/impl/bengle/mmr_contract_test.dart
@@ -56,9 +56,8 @@ import 'package:reaprime/src/models/device/impl/de1/de1.models.dart'
     show MMRItem;
 import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart'
     show MmrAddress;
-// Thermal branch (spec 08) uncomments this import with its section below:
-// import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart'
-//     show BengleMmr, BengleSteamMmr;
+import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart'
+    show BengleMmr;
 // (The Bengle capability enums are parts of the unified_de1 library.)
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart'
     show BengleScaleMmr, BengleCalMmr, BengleLedMmr;
@@ -155,11 +154,8 @@ const List<ContractEntry> entriesUnderTest = <ContractEntry>[
   // Thermal branch (spec 08: cup-warmer mode + milk temp + mat-temp read):
   // `BengleMmr` + `BengleSteamMmr` (bengle_mmr.dart). The app desc string
   // 'StopAtTemperatureTarget' is the contract row's `app_alias`.
-  // UNCOMMENT these lines (and the bengle_mmr import) when the branch lands:
   // ---------------------------------------------------------------------------
-  // ContractEntry(BengleMmr.matSetPoint, 'MatSetPoint'),
-  // ContractEntry(BengleMmr.cupWarmerMode, 'CupWarmerMode'),
-  // ContractEntry(BengleSteamMmr.stopAtTemperatureTarget, 'TargetMilkTemp'),
+  ContractEntry(BengleMmr.matSetPoint, 'MatSetPoint'),
 ];
 
 // =============================================================================

--- a/test/unit/models/device/impl/bengle/mmr_contract_test.dart
+++ b/test/unit/models/device/impl/bengle/mmr_contract_test.dart
@@ -59,10 +59,9 @@ import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart'
 // Thermal branch (spec 08) uncomments this import with its section below:
 // import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart'
 //     show BengleMmr, BengleSteamMmr;
-// The LED branch (spec 07) extends this `show` list with BengleLedMmr when it
-// lands (the enums are parts of the unified_de1 library):
+// (The Bengle capability enums are parts of the unified_de1 library.)
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart'
-    show BengleScaleMmr, BengleCalMmr;
+    show BengleScaleMmr, BengleCalMmr, BengleLedMmr;
 
 const String _contractPath = 'assets/api/bengle_hw_v1.yml';
 
@@ -144,14 +143,13 @@ const List<ContractEntry> entriesUnderTest = <ContractEntry>[
   // ---------------------------------------------------------------------------
   // LED-strip branch (spec 07): `BengleLedMmr`
   // (in led_strip_capability.dart, part of unified_de1).
-  // UNCOMMENT these lines (and the unified_de1 import) when the branch lands:
   // ---------------------------------------------------------------------------
-  // ContractEntry(BengleLedMmr.frontLive, 'FrontLEDColor'),
-  // ContractEntry(BengleLedMmr.rearLive, 'RearLEDColor'),
-  // ContractEntry(BengleLedMmr.frontAwake, 'FrontLEDAwake'),
-  // ContractEntry(BengleLedMmr.rearAwake, 'RearLEDAwake'),
-  // ContractEntry(BengleLedMmr.frontSleep, 'FrontLEDSleep'),
-  // ContractEntry(BengleLedMmr.rearSleep, 'RearLEDSleep'),
+  ContractEntry(BengleLedMmr.frontLive, 'FrontLEDColor'),
+  ContractEntry(BengleLedMmr.rearLive, 'RearLEDColor'),
+  ContractEntry(BengleLedMmr.frontAwake, 'FrontLEDAwake'),
+  ContractEntry(BengleLedMmr.rearAwake, 'RearLEDAwake'),
+  ContractEntry(BengleLedMmr.frontSleep, 'FrontLEDSleep'),
+  ContractEntry(BengleLedMmr.rearSleep, 'RearLEDSleep'),
 
   // ---------------------------------------------------------------------------
   // Thermal branch (spec 08: cup-warmer mode + milk temp + mat-temp read):

--- a/test/unit/models/device/impl/bengle/mmr_contract_test.dart
+++ b/test/unit/models/device/impl/bengle/mmr_contract_test.dart
@@ -156,6 +156,7 @@ const List<ContractEntry> entriesUnderTest = <ContractEntry>[
   // 'StopAtTemperatureTarget' is the contract row's `app_alias`.
   // ---------------------------------------------------------------------------
   ContractEntry(BengleMmr.matSetPoint, 'MatSetPoint'),
+  ContractEntry(BengleMmr.cupWarmerMode, 'CupWarmerMode'),
 ];
 
 // =============================================================================

--- a/test/unit/models/device/impl/bengle/mmr_contract_test.dart
+++ b/test/unit/models/device/impl/bengle/mmr_contract_test.dart
@@ -59,11 +59,11 @@ import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart'
 // Thermal branch (spec 08) uncomments this import with its section below:
 // import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart'
 //     show BengleMmr, BengleSteamMmr;
-// The first of the SAW/tare (spec 05) / cal (spec 06) / LED (spec 07)
-// branches to land uncomments this import (the enums are parts of the
-// unified_de1 library) and extends the `show` list as the others follow:
-// import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart'
-//     show BengleCalMmr, BengleLedMmr, BengleScaleMmr;
+// The cal (spec 06) / LED (spec 07) branches extend this `show` list with
+// BengleCalMmr / BengleLedMmr as they land (the enums are parts of the
+// unified_de1 library):
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart'
+    show BengleScaleMmr;
 
 const String _contractPath = 'assets/api/bengle_hw_v1.yml';
 
@@ -130,10 +130,9 @@ const List<ContractEntry> entriesUnderTest = <ContractEntry>[
   // ---------------------------------------------------------------------------
   // SAW/tare branch (spec 05): `BengleScaleMmr`
   // (in integrated_scale_capability.dart, part of unified_de1).
-  // UNCOMMENT these lines (and the unified_de1 import) when the branch lands:
   // ---------------------------------------------------------------------------
-  // ContractEntry(BengleScaleMmr.stopAtWeightTarget, 'EndOfShotWeight'),
-  // ContractEntry(BengleScaleMmr.scaleTare, 'ScaleTare'),
+  ContractEntry(BengleScaleMmr.stopAtWeightTarget, 'EndOfShotWeight'),
+  // ContractEntry(BengleScaleMmr.scaleTare, 'ScaleTare'), // commit
 
   // ---------------------------------------------------------------------------
   // Calibration-wizard branch (spec 06): `BengleCalMmr`

--- a/test/unit/models/device/impl/bengle/mmr_contract_test.dart
+++ b/test/unit/models/device/impl/bengle/mmr_contract_test.dart
@@ -132,7 +132,7 @@ const List<ContractEntry> entriesUnderTest = <ContractEntry>[
   // (in integrated_scale_capability.dart, part of unified_de1).
   // ---------------------------------------------------------------------------
   ContractEntry(BengleScaleMmr.stopAtWeightTarget, 'EndOfShotWeight'),
-  // ContractEntry(BengleScaleMmr.scaleTare, 'ScaleTare'), // commit
+  ContractEntry(BengleScaleMmr.scaleTare, 'ScaleTare'),
 
   // ---------------------------------------------------------------------------
   // Calibration-wizard branch (spec 06): `BengleCalMmr`

--- a/test/unit/models/device/impl/bengle/mmr_contract_test.dart
+++ b/test/unit/models/device/impl/bengle/mmr_contract_test.dart
@@ -57,7 +57,7 @@ import 'package:reaprime/src/models/device/impl/de1/de1.models.dart'
 import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart'
     show MmrAddress;
 import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart'
-    show BengleMmr;
+    show BengleMmr, BengleSteamMmr;
 // (The Bengle capability enums are parts of the unified_de1 library.)
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart'
     show BengleScaleMmr, BengleCalMmr, BengleLedMmr;
@@ -157,6 +157,7 @@ const List<ContractEntry> entriesUnderTest = <ContractEntry>[
   // ---------------------------------------------------------------------------
   ContractEntry(BengleMmr.matSetPoint, 'MatSetPoint'),
   ContractEntry(BengleMmr.cupWarmerMode, 'CupWarmerMode'),
+  ContractEntry(BengleSteamMmr.stopAtTemperatureTarget, 'TargetMilkTemp'),
 ];
 
 // =============================================================================

--- a/test/unit/models/device/impl/bengle/mmr_contract_test.dart
+++ b/test/unit/models/device/impl/bengle/mmr_contract_test.dart
@@ -57,7 +57,7 @@ import 'package:reaprime/src/models/device/impl/de1/de1.models.dart'
 import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart'
     show MmrAddress;
 import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart'
-    show BengleMmr, BengleSteamMmr;
+    show BengleMmr, BengleScheduleMmr, BengleSteamMmr;
 // (The Bengle capability enums are parts of the unified_de1 library.)
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart'
     show BengleScaleMmr, BengleCalMmr, BengleLedMmr;
@@ -159,6 +159,21 @@ const List<ContractEntry> entriesUnderTest = <ContractEntry>[
   ContractEntry(BengleMmr.cupWarmerMode, 'CupWarmerMode'),
   ContractEntry(BengleMmr.matCurrentTemp, 'MatCurrentTemp'),
   ContractEntry(BengleSteamMmr.stopAtTemperatureTarget, 'TargetMilkTemp'),
+
+  // ---------------------------------------------------------------------------
+  // Wake-schedule branch: `BengleScheduleMmr` (bengle_mmr.dart).
+  // Two app bounds are deliberately NARROWER than the contract (legal — the
+  // checker asserts app subset of contract): SetLocalTimeOfWeek max 604799
+  // (the FW setter rejects >= 604800) and ScheduleControl max 1 (the FW reads
+  // only bit 0, so a stray 2 would disable WITHOUT clearing).
+  // ---------------------------------------------------------------------------
+  ContractEntry(
+    BengleScheduleMmr.inactivitySleepTimeout,
+    'InactivitySleepTimeout',
+  ),
+  ContractEntry(BengleScheduleMmr.setLocalTimeOfWeek, 'SetLocalTimeOfWeek'),
+  ContractEntry(BengleScheduleMmr.scheduleEntry, 'ScheduleEntry'),
+  ContractEntry(BengleScheduleMmr.scheduleControl, 'ScheduleControl'),
 ];
 
 // =============================================================================

--- a/test/unit/models/device/impl/de1/unified_de1/bengle_detection_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/bengle_detection_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+
+import '../../../../../../helpers/fake_ble_transport.dart';
+
+/// The authoritative Bengle gate is `v13Model >= 128` read on connect, NOT
+/// the BLE advertised name. `DeviceMatcher` stays name-based (that selection
+/// is covered by `device_matcher_test.dart`); this proves the runtime
+/// capability flag `UnifiedDe1.isBengle` tracks the model the firmware
+/// reports over the wire, independent of which class the name happened to
+/// pick.
+void main() {
+  group('UnifiedDe1 Bengle detection', () {
+    late FakeBleTransport transport;
+
+    setUp(() {
+      transport = FakeBleTransport();
+      // `queueOnConnectResponses` doesn't cover `calFlowEst` (the flow-cal
+      // warm-up read at the tail of onConnect); queue it so onConnect
+      // returns immediately instead of eating the MMR read-retry timeout.
+      transport.queueMmrResponseInt(MMRItem.calFlowEst, 100);
+    });
+
+    tearDown(() => transport.dispose());
+
+    test('isBengle is false before onConnect has read the model', () {
+      final de1 = UnifiedDe1(transport: transport);
+      expect(de1.isBengle, isFalse);
+    });
+
+    test('v13Model >= 128 gates Bengle on a plain UnifiedDe1', () async {
+      final de1 = UnifiedDe1(transport: transport);
+      transport.queueOnConnectResponses(v13Model: 128);
+      await de1.onConnect();
+      expect(de1.isBengle, isTrue);
+    });
+
+    test('the boundary value 128 gates Bengle', () async {
+      final de1 = UnifiedDe1(transport: transport);
+      transport.queueOnConnectResponses(v13Model: 128);
+      await de1.onConnect();
+      expect(de1.isBengle, isTrue);
+    });
+
+    test('v13Model == 1 leaves a plain UnifiedDe1 as DE1', () async {
+      final de1 = UnifiedDe1(transport: transport);
+      transport.queueOnConnectResponses(v13Model: 1);
+      await de1.onConnect();
+      expect(de1.isBengle, isFalse);
+    });
+
+    test(
+      'a name-picked Bengle reading model 128 is authoritatively Bengle',
+      () async {
+        final bengle = Bengle(transport: transport);
+        transport.queueOnConnectResponses(v13Model: 128);
+        await bengle.onConnect();
+        expect(bengle.isBengle, isTrue);
+      },
+    );
+
+    test(
+      'self-verify: a name-picked Bengle reading a DE1 model is NOT Bengle',
+      () async {
+        // The incremental self-verify seam: the flag follows the wire, so a
+        // mis-named device that reports a DE1-family model (1..7) is flagged
+        // DE1 even though its advertised name matched "Bengle".
+        final bengle = Bengle(transport: transport);
+        transport.queueOnConnectResponses(v13Model: 1);
+        await bengle.onConnect();
+        expect(bengle.isBengle, isFalse);
+      },
+    );
+  });
+}

--- a/test/unit/models/device/impl/de1/unified_de1/bengle_shot_sample_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/bengle_shot_sample_test.dart
@@ -1,0 +1,125 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/bengle_shot_sample.dart';
+
+/// Hand-computed golden `0xA013` frame (28 bytes, big-endian), cross-checked
+/// against firmware `T_BengleShotSample`, the de1plus decoder
+/// (`de1_de1.tcl:912-941`) and the contract table in
+/// `assets/api/bengle_hw_v1.yml` (`packet_0xA013`).
+///
+/// | off | field            | raw (BE) | decoded          |
+/// |-----|------------------|----------|------------------|
+/// |  0  | SampleTime       | 0x03E8   | 1000             |
+/// |  2  | GroupPressure    | 0x0384   | 900/100 = 9.00   |
+/// |  4  | SetGroupPressure | 0x0258   | 600/100 = 6.00   |
+/// |  6  | GroupFlow        | 0x00FA   | 250/100 = 2.50   |
+/// |  8  | SetGroupFlow     | 0x00C8   | 200/100 = 2.00   |
+/// | 10  | GFlow            | 0x00B4   | 180/100 = 1.80   |
+/// | 12  | MixTemp          | 0x2422   | 9250/100 = 92.50 |
+/// | 14  | HeadTemp         | 0x2260   | 8800/100 = 88.00 |
+/// | 16  | SetMixTemp       | 0x2454   | 9300/100 = 93.00 |
+/// | 18  | SetHeadTemp      | 0x2328   | 9000/100 = 90.00 |
+/// | 20  | Weight (U16P5)   | 0x0490   | 1168/32  = 36.5  |
+/// | 22  | FrameNumber      | 0x07     | 7                |
+/// | 23  | SteamTemp        | 0x34BC   | 13500/100 = 135  |
+/// | 25  | MilkTemp         | 0x0000   | 0.0              |
+/// | 27  | Flags            | 0x00     | 0                |
+final List<int> _goldenBytes = [
+  0x03, 0xE8, // SampleTime
+  0x03, 0x84, // GroupPressure
+  0x02, 0x58, // SetGroupPressure
+  0x00, 0xFA, // GroupFlow
+  0x00, 0xC8, // SetGroupFlow
+  0x00, 0xB4, // GFlow
+  0x24, 0x22, // MixTemp
+  0x22, 0x60, // HeadTemp
+  0x24, 0x54, // SetMixTemp
+  0x23, 0x28, // SetHeadTemp
+  0x04, 0x90, // Weight
+  0x07, //       FrameNumber
+  0x34, 0xBC, // SteamTemp
+  0x00, 0x00, // MilkTemp
+  0x00, //       Flags
+];
+
+ByteData _bytes(List<int> b) => ByteData.sublistView(Uint8List.fromList(b));
+
+void main() {
+  group('parseBengleShotSample', () {
+    test('golden frame decodes byte-exact (big-endian, correct scaling)', () {
+      expect(_goldenBytes, hasLength(bengleShotSampleBytes));
+      final s = parseBengleShotSample(_bytes(_goldenBytes))!;
+
+      expect(s.sampleTime, 1000);
+      expect(s.groupPressure, closeTo(9.00, 1e-9));
+      expect(s.setGroupPressure, closeTo(6.00, 1e-9));
+      expect(s.groupFlow, closeTo(2.50, 1e-9));
+      expect(s.setGroupFlow, closeTo(2.00, 1e-9));
+      expect(s.gFlow, closeTo(1.80, 1e-9));
+      expect(s.mixTemp, closeTo(92.50, 1e-9));
+      expect(s.headTemp, closeTo(88.00, 1e-9));
+      expect(s.setMixTemp, closeTo(93.00, 1e-9));
+      expect(s.setHeadTemp, closeTo(90.00, 1e-9));
+      // Weight is U16P5 (÷32), NOT ÷100 — 1168/100 would give 11.68.
+      expect(s.weight, closeTo(36.5, 1e-9));
+      expect(s.frameNumber, 7);
+      expect(s.steamTemp, closeTo(135.00, 1e-9));
+      // 0 = no probe / no fresh reading (older firmware hardcodes 0).
+      expect(s.milkTemp, closeTo(0.0, 1e-9));
+      // Flags must never be gated on (bit0 is a LastTARE value proxy at best).
+      expect(s.flags, 0);
+    });
+
+    test('a non-zero MilkTemp decodes from offset 25 (u16 ÷ 100)', () {
+      // Bytes 25-26 = 0x18,0x36 -> 6198/100 = 61.98 °C. Locks both the
+      // unaligned offset (25, not 24/26) and the ÷100 scaling for the day the
+      // firmware starts serialising real probe readings.
+      final b = List<int>.from(_goldenBytes);
+      b[25] = 0x18;
+      b[26] = 0x36;
+      final s = parseBengleShotSample(_bytes(b))!;
+      expect(s.milkTemp, closeTo(61.98, 1e-9));
+      // The neighbouring fields must be untouched by the milk bytes.
+      expect(s.steamTemp, closeTo(135.00, 1e-9));
+      expect(s.flags, 0);
+    });
+
+    test('weight uses ÷32 (U16P5), not ÷100 — a diverging case', () {
+      // raw 0x0100 = 256 -> 256/32 = 8.0 g (÷100 would give 2.56).
+      final b = List<int>.from(_goldenBytes);
+      b[20] = 0x01;
+      b[21] = 0x00;
+      final s = parseBengleShotSample(_bytes(b))!;
+      expect(s.weight, closeTo(8.0, 1e-9));
+    });
+
+    test('multi-byte fields are big-endian (byte order matters)', () {
+      // SampleTime bytes 0x12,0x34 -> big-endian 0x1234 = 4660
+      // (little-endian would be 0x3412 = 13330).
+      final b = List<int>.from(_goldenBytes);
+      b[0] = 0x12;
+      b[1] = 0x34;
+      final s = parseBengleShotSample(_bytes(b))!;
+      expect(s.sampleTime, 0x1234);
+    });
+
+    test('frames shorter than 28 bytes are dropped (null, no RangeError)', () {
+      expect(
+        parseBengleShotSample(_bytes(_goldenBytes.sublist(0, 27))),
+        isNull,
+      );
+      expect(
+        parseBengleShotSample(_bytes(_goldenBytes.sublist(0, 19))),
+        isNull,
+      );
+      expect(parseBengleShotSample(_bytes(const [])), isNull);
+    });
+
+    test('trailing bytes beyond 28 are ignored', () {
+      final s = parseBengleShotSample(_bytes([..._goldenBytes, 0xFF, 0xFF]))!;
+      expect(s.weight, closeTo(36.5, 1e-9));
+      expect(s.flags, 0);
+    });
+  });
+}

--- a/test/unit/models/device/impl/de1/unified_de1/bengle_shotsample_pipeline_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/bengle_shotsample_pipeline_test.dart
@@ -1,0 +1,189 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+
+import '../../../../../../helpers/fake_ble_transport.dart';
+
+/// Golden 0xA013 frame: weight 36.5 g, group pressure 9.00 bar, GFlow 1.80 g/s,
+/// milk 0. (Full byte breakdown lives in `bengle_shot_sample_test.dart`.)
+final Uint8List _golden0xA013 = Uint8List.fromList(const [
+  0x03, 0xE8, 0x03, 0x84, 0x02, 0x58, 0x00, 0xFA, 0x00, 0xC8, 0x00, 0xB4, //
+  0x24, 0x22, 0x22, 0x60, 0x24, 0x54, 0x23, 0x28, 0x04, 0x90, 0x07, 0x34, //
+  0xBC, 0x00, 0x00, 0x00,
+]);
+
+void main() {
+  group('Bengle 0xA013 snapshot pipeline', () {
+    late FakeBleTransport transport;
+    late Bengle bengle;
+
+    setUp(() async {
+      transport = FakeBleTransport();
+      // `queueOnConnectResponses` doesn't cover `calFlowEst` (the flow-cal
+      // warm-up read at the tail of onConnect); queue it so onConnect returns
+      // promptly instead of eating the MMR read-retry timeout.
+      transport.queueMmrResponseInt(MMRItem.calFlowEst, 100);
+      transport.queueOnConnectResponses(v13Model: 128);
+      bengle = Bengle(transport: transport);
+      await bengle.onConnect();
+      expect(bengle.isBengle, isTrue);
+    });
+
+    tearDown(() => transport.dispose());
+
+    test(
+      '0xA013 is the SOLE snapshot source — 0xA00D is parse-and-dropped',
+      () async {
+        final snapshots = <MachineSnapshot>[];
+        final sub = bengle.currentSnapshot.listen(snapshots.add);
+        await pumpEventQueue();
+        // The seeded 28-zero frame emits one initial snapshot.
+        final baseline = snapshots.length;
+
+        // Inject a 0xA00D shot sample — on a Bengle this must NOT become a
+        // snapshot (firmware streams both 0xA00D and 0xA013 at 15 Hz; charting
+        // both would double-sample).
+        final cb00D = transport.subscribers[Endpoint.shotSample.uuid];
+        expect(
+          cb00D,
+          isNotNull,
+          reason: '0xA00D stays subscribed even on a Bengle',
+        );
+        cb00D!(Uint8List(19)..[0] = 0x05);
+        await pumpEventQueue();
+        expect(
+          snapshots.length,
+          baseline,
+          reason: '0xA00D must be parse-and-dropped on a Bengle',
+        );
+
+        // Inject a 0xA013 frame — exactly one snapshot, carrying the decoded
+        // weight / gravimetric flow / group pressure.
+        final cb013 = transport.subscribers[Endpoint.bengleShotSample.uuid];
+        expect(
+          cb013,
+          isNotNull,
+          reason: 'onConnect must subscribe 0xA013 on a Bengle',
+        );
+        cb013!(_golden0xA013);
+        await pumpEventQueue();
+
+        expect(
+          snapshots.length,
+          baseline + 1,
+          reason: 'exactly one snapshot, from 0xA013',
+        );
+        final snap = snapshots.last;
+        expect(snap.pressure, closeTo(9.00, 1e-9));
+        expect(snap.weight, closeTo(36.5, 1e-9));
+        expect(snap.weightFlow, closeTo(1.80, 1e-9));
+        expect(snap.milkTemperature, closeTo(0.0, 1e-9));
+
+        await sub.cancel();
+      },
+    );
+
+    test(
+      'every MachineSnapshot field maps from the 0xA013 frame + state frame '
+      '(incl. steamTemperature rounding)',
+      () async {
+        final snapshots = <MachineSnapshot>[];
+        final sub = bengle.currentSnapshot.listen(snapshots.add);
+        await pumpEventQueue();
+        final baseline = snapshots.length;
+
+        // Latest state frame: espresso (0x04) / pour (0x05) — read exactly
+        // like the 0xA00D path (state layout is transport-shared).
+        transport.subscribers[Endpoint.stateInfo.uuid]!(
+          Uint8List.fromList([0x04, 0x05]),
+        );
+        // Golden frame with SteamTemp raw 13550 (0x34EE) -> 135.5 °C: the
+        // int snapshot field must carry `.round()` = 136, matching the
+        // whole-degree 0xA00D field (G14 — don't widen the shared type).
+        final frame = Uint8List.fromList(_golden0xA013);
+        frame[23] = 0x34;
+        frame[24] = 0xEE;
+        transport.subscribers[Endpoint.bengleShotSample.uuid]!(frame);
+        await pumpEventQueue();
+
+        expect(snapshots.length, baseline + 1);
+        final snap = snapshots.last;
+        expect(snap.state.state, MachineState.espresso);
+        expect(snap.state.substate, MachineSubstate.pouring);
+        expect(snap.pressure, closeTo(9.00, 1e-9));
+        expect(snap.flow, closeTo(2.50, 1e-9));
+        expect(snap.mixTemperature, closeTo(92.50, 1e-9));
+        expect(snap.groupTemperature, closeTo(88.00, 1e-9));
+        expect(snap.targetMixTemperature, closeTo(93.00, 1e-9));
+        expect(snap.targetGroupTemperature, closeTo(90.00, 1e-9));
+        expect(snap.targetPressure, closeTo(6.00, 1e-9));
+        expect(snap.targetFlow, closeTo(2.00, 1e-9));
+        expect(snap.profileFrame, 7);
+        expect(
+          snap.steamTemperature,
+          136,
+          reason: '135.5 °C must round, not truncate',
+        );
+        expect(snap.weight, closeTo(36.5, 1e-9));
+        expect(snap.weightFlow, closeTo(1.80, 1e-9));
+        expect(snap.milkTemperature, closeTo(0.0, 1e-9));
+
+        await sub.cancel();
+      },
+    );
+
+    test(
+      'a truncated (<28 byte) 0xA013 frame is dropped, not decoded',
+      () async {
+        final snapshots = <MachineSnapshot>[];
+        final sub = bengle.currentSnapshot.listen(snapshots.add);
+        await pumpEventQueue();
+        final baseline = snapshots.length;
+
+        final cb013 = transport.subscribers[Endpoint.bengleShotSample.uuid]!;
+        // 20 bytes < 28 — must be dropped without a RangeError or a snapshot.
+        cb013(Uint8List(20));
+        await pumpEventQueue();
+
+        expect(
+          snapshots.length,
+          baseline,
+          reason: 'short frame dropped — no new snapshot, no crash',
+        );
+
+        await sub.cancel();
+      },
+    );
+  });
+
+  group('plain DE1 (v13Model < 128)', () {
+    test('never subscribes the 0xA013 characteristic', () async {
+      // Blind-enabling a characteristic a plain DE1 lacks throws and
+      // permanently stalls the BLE command queue (de1plus
+      // de1_comms.tcl:777-785) — the subscribe must be identity-gated.
+      final transport = FakeBleTransport();
+      transport.queueMmrResponseInt(MMRItem.calFlowEst, 100);
+      transport.queueOnConnectResponses(v13Model: 1);
+      final de1 = UnifiedDe1(transport: transport);
+      await de1.onConnect();
+
+      expect(de1.isBengle, isFalse);
+      expect(
+        transport.subscribers[Endpoint.bengleShotSample.uuid],
+        isNull,
+        reason: 'a plain DE1 must NOT get a 0xA013 CCCD subscribe',
+      );
+      expect(
+        transport.subscribers[Endpoint.shotSample.uuid],
+        isNotNull,
+        reason: 'the 0xA00D pipeline is untouched on a plain DE1',
+      );
+
+      await transport.dispose();
+    });
+  });
+}

--- a/test/unit/models/device/impl/de1/unified_de1/bengle_shotsample_serial_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/bengle_shotsample_serial_test.dart
@@ -1,0 +1,93 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart';
+
+import '../../../../../../helpers/fake_serial_transport.dart';
+
+String _hex(List<int> bytes) =>
+    bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+
+/// Golden 0xA013 frame: weight 36.5 g (see `bengle_shot_sample_test.dart`).
+const List<int> _golden0xA013 = [
+  0x03, 0xE8, 0x03, 0x84, 0x02, 0x58, 0x00, 0xFA, 0x00, 0xC8, 0x00, 0xB4, //
+  0x24, 0x22, 0x22, 0x60, 0x24, 0x54, 0x23, 0x28, 0x04, 0x90, 0x07, 0x34, //
+  0xBC, 0x00, 0x00, 0x00,
+];
+
+void main() {
+  group('0xA013 serial dispatch', () {
+    late FakeSerialTransport serial;
+    late UnifiedDe1Transport transport;
+
+    setUp(() {
+      serial = FakeSerialTransport();
+      transport = UnifiedDe1Transport(transport: serial);
+    });
+
+    tearDown(() => transport.dispose());
+
+    test('connect() enables the 0xA013 stream with <+S>', () async {
+      await transport.connect();
+      expect(
+        serial.writes,
+        contains('<+${Endpoint.bengleShotSample.representation}>'),
+      );
+    });
+
+    test(
+      'an inbound [S] frame routes to the bengleShotSample subject',
+      () async {
+        await transport.connect();
+
+        final frames = <ByteData>[];
+        final sub = transport.bengleShotSample.listen(frames.add);
+        await pumpEventQueue();
+        final baseline = frames.length; // seeded 28-zero frame
+
+        serial.injectSerial('[S]${_hex(_golden0xA013)}\n');
+        await pumpEventQueue();
+
+        expect(
+          frames.length,
+          baseline + 1,
+          reason: '[S] must route to _bengleShotSampleNotification',
+        );
+        final frame = frames.last;
+        expect(frame.lengthInBytes, 28);
+        // Weight is offset 20, U16P5 (big-endian ÷32).
+        expect(frame.getUint16(20, Endian.big) / 32.0, closeTo(36.5, 1e-9));
+
+        await sub.cancel();
+      },
+    );
+
+    test('a truncated [S] frame is dropped, not routed', () async {
+      await transport.connect();
+
+      final frames = <ByteData>[];
+      final sub = transport.bengleShotSample.listen(frames.add);
+      await pumpEventQueue();
+      final baseline = frames.length;
+
+      // 20 bytes (40 hex chars) < 28 — must be dropped.
+      serial.injectSerial('[S]${_hex(List<int>.filled(20, 0))}\n');
+      await pumpEventQueue();
+
+      expect(frames.length, baseline, reason: 'short [S] frame dropped');
+
+      await sub.cancel();
+    });
+
+    test('disconnect() unsubscribes the 0xA013 stream with <-S>', () async {
+      await transport.connect();
+      serial.writes.clear();
+      await transport.disconnect();
+      expect(
+        serial.writes,
+        contains('<-${Endpoint.bengleShotSample.representation}>'),
+      );
+    });
+  });
+}

--- a/test/unit/models/device/impl/de1/unified_de1/integrated_scale_capability_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/integrated_scale_capability_test.dart
@@ -1,12 +1,21 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
-import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 
 import '../../../../../../helpers/fake_ble_transport.dart';
+
+/// Golden 0xA013 frame: weight 36.5 g (full breakdown in
+/// `bengle_shot_sample_test.dart`).
+final Uint8List _golden0xA013 = Uint8List.fromList(const [
+  0x03, 0xE8, 0x03, 0x84, 0x02, 0x58, 0x00, 0xFA, 0x00, 0xC8, 0x00, 0xB4, //
+  0x24, 0x22, 0x22, 0x60, 0x24, 0x54, 0x23, 0x28, 0x04, 0x90, 0x07, 0x34, //
+  0xBC, 0x00, 0x00, 0x00,
+]);
 
 void main() {
   group('IntegratedScaleCapability', () {
@@ -20,8 +29,10 @@ void main() {
       Logger.root.level = Level.ALL;
       logSub = Logger.root.onRecord.listen(logRecords.add);
       transport = FakeBleTransport();
+      // calFlowEst keeps onConnect from eating the MMR read-retry timeout.
+      transport.queueMmrResponseInt(MMRItem.calFlowEst, 100);
+      transport.queueOnConnectResponses(v13Model: 128); // real Bengle
       bengle = Bengle(transport: transport);
-      transport.queueOnConnectResponses();
       await bengle.onConnect();
     });
 
@@ -34,80 +45,87 @@ void main() {
       expect(bengle.weightSnapshot, isA<Stream<ScaleSnapshot>>());
     });
 
-    test('initIntegratedScale logs and no-ops when wires are unwired', () {
-      // initIntegratedScale was already called via onConnect in setUp.
-      // Confirm a log message was emitted noting the unwired endpoint.
-      expect(
-        logRecords.any((r) =>
-            r.message.contains('IntegratedScaleCapability') &&
-            r.message.contains('unwired')),
-        isTrue,
-        reason: 'expected init log entry about unwired endpoint',
-      );
-    });
+    test(
+      'initIntegratedScale bridges 0xA013 Weight into the scale',
+      () async {
+        final weights = <ScaleSnapshot>[];
+        final sub = bengle.weightSnapshot.listen(weights.add);
+        await pumpEventQueue();
+
+        final cb = transport.subscribers[Endpoint.bengleShotSample.uuid];
+        expect(
+          cb,
+          isNotNull,
+          reason: 'onConnect must subscribe the 0xA013 characteristic',
+        );
+        cb!(_golden0xA013);
+        await pumpEventQueue();
+
+        expect(weights, isNotEmpty);
+        // Weight is already tare-netted in firmware — trust it directly.
+        expect(weights.last.weight, closeTo(36.5, 1e-9));
+        // Mains-powered sentinel keeps ScaleSnapshot.batteryLevel
+        // non-nullable (design D6).
+        expect(weights.last.batteryLevel, 100);
+
+        await sub.cancel();
+      },
+    );
 
     test('disposeIntegratedScale closes the subject', () async {
       await bengle.onDisconnect();
-      // Listening to a closed BehaviorSubject completes without emitting.
-      await expectLater(bengle.weightSnapshot, emitsDone);
+      // The subject is closed; a late listener sees the replayed last value
+      // (if any) followed by done. `emitsThrough(emitsDone)` asserts closure.
+      await expectLater(bengle.weightSnapshot, emitsThrough(emitsDone));
     });
 
-    test('tareIntegratedScale logs and no-ops when wires are unwired',
-        () async {
+    test('tareIntegratedScale logs and no-ops until it is wired', () async {
+      // The ScaleTare MMR write-trigger belongs to the stop-at-weight/tare
+      // branch; until then tare must not write anything to the wire.
       logRecords.clear();
+      transport.writes.clear();
       await bengle.tareIntegratedScale();
       expect(
-        logRecords.any((r) =>
-            r.message.contains('IntegratedScaleCapability') &&
-            r.message.contains('tare')),
+        logRecords.any(
+          (r) =>
+              r.message.contains('IntegratedScaleCapability') &&
+              r.message.contains('tare'),
+        ),
         isTrue,
-        reason: 'expected tare log entry about unwired control endpoint',
+        reason: 'expected tare log entry about the pending tare wiring',
+      );
+      expect(
+        transport.writes,
+        isEmpty,
+        reason: 'tare must stay off the wire until then',
       );
     });
 
-    test('BengleScaleEndpoint.weight.uuid and representation are null', () {
-      expect(BengleScaleEndpoint.weight.uuid, isNull);
-      expect(BengleScaleEndpoint.weight.representation, isNull);
-    });
-
-    test('BengleScaleEndpoint.control.uuid and representation are null', () {
-      expect(BengleScaleEndpoint.control.uuid, isNull);
-      expect(BengleScaleEndpoint.control.representation, isNull);
-    });
-
     test('connect → disconnect → connect lifecycle is leak-free', () async {
-      // First lifecycle was set up in setUp(). Disconnect (which now
-      // routes through UnifiedDe1.disconnect → onDisconnect →
-      // disposeIntegratedScale) should close the subject.
+      // First lifecycle was set up in setUp(). Disconnect routes through
+      // UnifiedDe1.disconnect → onDisconnect → disposeIntegratedScale, which
+      // closes the subject.
       await bengle.disconnect();
-      await expectLater(bengle.weightSnapshot, emitsDone);
+      await expectLater(bengle.weightSnapshot, emitsThrough(emitsDone));
 
-      // Reconnect on the same instance. The mixin must re-init the
-      // subject; otherwise a fresh listener would observe `done`
-      // immediately and the capability would be dead until the device
-      // is re-instantiated.
-      transport.queueOnConnectResponses();
+      // Reconnect on the same instance. Bengle.onConnect re-runs
+      // initIntegratedScale, which must recreate the closed BehaviorSubject —
+      // otherwise a fresh listener would observe `done` immediately and the
+      // capability would be dead until re-instantiation. (The reconnect
+      // short-circuits the MMR reads, so no re-queue is needed.)
       await bengle.onConnect();
 
-      // Listening to weightSnapshot after the second onConnect should
-      // NOT immediately fire `done`. If the mixin failed to re-init the
-      // closed BehaviorSubject, `.first` would complete with a
-      // StateError ("No element") because the stream would be done with
-      // no values. With re-init, no values arrive within the window,
-      // so we time out — which is the success signal here.
-      var streamCompletedWithoutValue = false;
-      try {
-        await bengle.weightSnapshot
-            .first
-            .timeout(const Duration(milliseconds: 50));
-      } on TimeoutException {
-        // Expected: stream is open but quiet — capability is alive.
-      } on StateError {
-        streamCompletedWithoutValue = true;
-      }
-      expect(streamCompletedWithoutValue, isFalse,
-          reason: 'weightSnapshot was closed after reconnect — mixin '
-              'failed to re-init its BehaviorSubject');
+      // A live re-inited subject emits (at least the bridged replay of the
+      // transport's seeded frame); a stale closed one would complete without
+      // a value (StateError on `.first`).
+      final v = await bengle.weightSnapshot.first.timeout(
+        const Duration(seconds: 1),
+      );
+      expect(
+        v,
+        isA<ScaleSnapshot>(),
+        reason: 'weightSnapshot must be live after reconnect',
+      );
     });
   });
 }

--- a/test/unit/models/device/impl/de1/unified_de1/integrated_scale_capability_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/integrated_scale_capability_test.dart
@@ -79,26 +79,28 @@ void main() {
       await expectLater(bengle.weightSnapshot, emitsThrough(emitsDone));
     });
 
-    test('tareIntegratedScale logs and no-ops until it is wired', () async {
-      // The ScaleTare MMR write-trigger belongs to the stop-at-weight/tare
-      // branch; until then tare must not write anything to the wire.
-      logRecords.clear();
+    test('tareIntegratedScale triggers the ScaleTare MMR', () async {
+      // tare is a write-trigger to ScaleTare (0x0080388C) — write any
+      // value (de1plus writes 1). The firmware performs an immediate tare.
       transport.writes.clear();
       await bengle.tareIntegratedScale();
+
+      final mmrWrites = transport.writes
+          .where((w) => w.characteristicUUID == Endpoint.writeToMMR.uuid)
+          .toList();
       expect(
-        logRecords.any(
-          (r) =>
-              r.message.contains('IntegratedScaleCapability') &&
-              r.message.contains('tare'),
-        ),
-        isTrue,
-        reason: 'expected tare log entry about the pending tare wiring',
+        mmrWrites,
+        hasLength(1),
+        reason: 'tare must write exactly one MMR frame',
       );
-      expect(
-        transport.writes,
-        isEmpty,
-        reason: 'tare must stay off the wire until then',
-      );
+      final d = mmrWrites.single.data;
+      // Length byte + big-endian address low 3 bytes (0x80,0x38,0x8C).
+      expect(d[0], 4);
+      expect(d[1], 0x80);
+      expect(d[2], 0x38);
+      expect(d[3], 0x8C);
+      // Payload = 1, little-endian.
+      expect(d.sublist(4, 8), [0x01, 0x00, 0x00, 0x00]);
     });
 
     test('connect → disconnect → connect lifecycle is leak-free', () async {

--- a/test/unit/models/device/impl/de1/unified_de1/led_strip_capability_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/led_strip_capability_test.dart
@@ -1,78 +1,351 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/led_strip.dart';
 
 import '../../../../../../helpers/fake_ble_transport.dart';
 
+/// Rejects every MMR read request that targets an LED register (address
+/// prefix 0x8038, low byte 0x90..0xA4) with an immediate error, while the
+/// foundation `onConnect` reads (0x8000xx) pass through — simulates firmware
+/// without the LED registers so the failed-hydration fallback can be tested
+/// without waiting out the 4 s × 3 read-timeout ladder.
+class _LedReadFailingTransport extends FakeBleTransport {
+  @override
+  Future<void> write(
+    String serviceUUID,
+    String characteristicUUID,
+    Uint8List data, {
+    bool withResponse = true,
+    Duration? timeout,
+  }) {
+    if (characteristicUUID == Endpoint.readFromMMR.uuid &&
+        data.length >= 4 &&
+        data[1] == 0x80 &&
+        data[2] == 0x38 &&
+        data[3] >= 0x90 &&
+        data[3] <= 0xA4) {
+      throw Exception('simulated LED register read failure');
+    }
+    return super.write(
+      serviceUUID,
+      characteristicUUID,
+      data,
+      withResponse: withResponse,
+      timeout: timeout,
+    );
+  }
+}
+
+/// LED strip via MMR.
+///
+/// `LedStripCapability` maps the app's [LedStripState] onto the firmware LED
+/// palette registers (front/rear × awake/sleep, raw `0x00RRGGBB` int32). There
+/// is no switch register — the switch mirrors the front strip. These tests
+/// assert the wire bytes are byte-exact against the firmware registers.
 void main() {
-  group('LedStripCapability', () {
+  group('LedStripCapability → LED palette MMR', () {
     late FakeBleTransport transport;
     late Bengle bengle;
-    late List<LogRecord> logRecords;
-    late StreamSubscription<LogRecord> logSub;
 
     setUp(() async {
-      logRecords = <LogRecord>[];
-      Logger.root.level = Level.ALL;
-      logSub = Logger.root.onRecord.listen(logRecords.add);
       transport = FakeBleTransport();
       bengle = Bengle(transport: transport);
-      transport.queueOnConnectResponses();
+      transport.queueOnConnectResponses(v13Model: 128); // Bengle marker
       await bengle.onConnect();
+      transport.writes.clear();
     });
 
-    tearDown(() async {
-      await logSub.cancel();
+    tearDown(() {
       transport.dispose();
     });
 
-    test('ledStripState returns a Stream<LedStripState>', () {
-      expect(bengle.ledStripState, isA<Stream<LedStripState>>());
+    List<FakeBleWrite> mmrWrites() => transport.writes
+        .where((w) => w.characteristicUUID == Endpoint.writeToMMR.uuid)
+        .toList();
+
+    test('LED registers map to the real firmware addresses', () {
+      expect(BengleLedMmr.frontAwake.address, 0x00803898);
+      expect(BengleLedMmr.frontSleep.address, 0x008038A0);
+      expect(BengleLedMmr.rearAwake.address, 0x0080389C);
+      expect(BengleLedMmr.rearSleep.address, 0x008038A4);
+      expect(BengleLedMmr.frontLive.address, 0x00803890);
+      expect(BengleLedMmr.rearLive.address, 0x00803894);
     });
 
-    test('initial state is all-off', () async {
-      final state = await bengle.getLedStripState();
-      expect(state.frontStrip.sleeping, Color16.off);
-      expect(state.frontStrip.awake, Color16.off);
-      expect(state.backStrip.sleeping, Color16.off);
-      expect(state.backStrip.awake, Color16.off);
-      expect(state.frontSwitch.sleeping, Color16.off);
-      expect(state.frontSwitch.awake, Color16.off);
+    test(
+      'setLedStrip writes 4 palette registers with packed 0x00RRGGBB',
+      () async {
+        await bengle.setLedStrip(
+          const LedStripState(
+            frontStrip: ZoneLedState(
+              awake: Color16(
+                0x3838,
+                0x5A5A,
+                0x9292,
+              ), // #385A92 (16-bit/channel)
+              sleeping: Color16.off,
+            ),
+            backStrip: ZoneLedState(
+              awake: Color16(0xFFFF, 0x7A7A, 0x0000), // #FF7A00
+              sleeping: Color16.off,
+            ),
+          ),
+        );
+
+        final w = mmrWrites();
+        expect(w.length, 4, reason: 'front+rear × awake+sleep');
+
+        // frontAwake 0x803898 ← 0x385A92 (little-endian payload)
+        expect(w[0].data[0], 4);
+        expect(w[0].data.sublist(1, 4), [0x80, 0x38, 0x98]);
+        expect(w[0].data.sublist(4, 8), [0x92, 0x5A, 0x38, 0x00]);
+        // frontSleep 0x8038A0 ← off
+        expect(w[1].data.sublist(1, 4), [0x80, 0x38, 0xA0]);
+        expect(w[1].data.sublist(4, 8), [0x00, 0x00, 0x00, 0x00]);
+        // rearAwake 0x80389C ← 0xFF7A00
+        expect(w[2].data.sublist(1, 4), [0x80, 0x38, 0x9C]);
+        expect(w[2].data.sublist(4, 8), [0x00, 0x7A, 0xFF, 0x00]);
+        // rearSleep 0x8038A4 ← off
+        expect(w[3].data.sublist(1, 4), [0x80, 0x38, 0xA4]);
+        expect(w[3].data.sublist(4, 8), [0x00, 0x00, 0x00, 0x00]);
+      },
+    );
+
+    test('16-bit channels are truncated to the FW 8-bit high byte', () async {
+      // Only the high byte of each 16-bit channel reaches the wire.
+      await bengle.setLedStrip(
+        const LedStripState(
+          frontStrip: ZoneLedState(awake: Color16(0xABCD, 0x1234, 0x89FF)),
+        ),
+      );
+      // packed = 0x00 AB 12 89 → little-endian [0x89, 0x12, 0xAB, 0x00]
+      expect(mmrWrites()[0].data.sublist(4, 8), [0x89, 0x12, 0xAB, 0x00]);
     });
 
-    test('initLedStrip logs and no-ops when wires are unwired', () {
+    test('cache reflects the written state', () async {
+      const state = LedStripState(
+        frontStrip: ZoneLedState(awake: Color16(0x3838, 0x5A5A, 0x9292)),
+      );
+      await bengle.setLedStrip(state);
+      final got = await bengle.getLedStripState();
+      expect(got.frontStrip.awake, const Color16(0x3838, 0x5A5A, 0x9292));
+    });
+
+    test('resetLedStrip reads the 4 registers back into the cache', () async {
+      // FW returns 0x00RRGGBB; decode byte-replicates to 16-bit (0xAB → 0xABAB).
+      transport.queueMmrResponseInt(BengleLedMmr.frontAwake, 0x385A92);
+      transport.queueMmrResponseInt(BengleLedMmr.frontSleep, 0x000000);
+      transport.queueMmrResponseInt(BengleLedMmr.rearAwake, 0xFF7A00);
+      transport.queueMmrResponseInt(BengleLedMmr.rearSleep, 0x000000);
+
+      await bengle.resetLedStrip();
+      final s = await bengle.getLedStripState();
+      expect(s.frontStrip.awake, const Color16(0x3838, 0x5A5A, 0x9292));
+      expect(s.backStrip.awake, const Color16(0xFFFF, 0x7A7A, 0x0000));
+      // switch mirrors front
+      expect(s.frontSwitch.awake, s.frontStrip.awake);
+    });
+
+    test('commitLedStrip re-writes the cached palette', () async {
+      await bengle.setLedStrip(
+        const LedStripState(
+          frontStrip: ZoneLedState(awake: Color16(0x3838, 0x5A5A, 0x9292)),
+        ),
+      );
+      transport.writes.clear();
+      await bengle.commitLedStrip();
+      expect(mmrWrites().length, 4);
+    });
+
+    test('previewLedColor writes only the 2 live registers — palette and cache '
+        'untouched', () async {
+      // Seed a known palette first so "cache untouched" is observable.
+      const palette = LedStripState(
+        frontStrip: ZoneLedState(awake: Color16(0x3838, 0x5A5A, 0x9292)),
+        backStrip: ZoneLedState(awake: Color16(0xFFFF, 0x7A7A, 0x0000)),
+      );
+      await bengle.setLedStrip(palette);
+      transport.writes.clear();
+
+      final emitted = <LedStripState>[];
+      final sub = bengle.ledStripState.skip(1).listen(emitted.add);
+      addTearDown(sub.cancel);
+
+      await bengle.previewLedColor(
+        const Color16(0xFFFF, 0x0000, 0x0000), // #FF0000
+        const Color16(0x0000, 0x0000, 0xFFFF), // #0000FF
+      );
+
+      final w = mmrWrites();
+      expect(w.length, 2, reason: 'frontLive + rearLive only — no palette');
+      // frontLive 0x803890 ← 0xFF0000 (little-endian payload)
+      expect(w[0].data[0], 4);
+      expect(w[0].data.sublist(1, 4), [0x80, 0x38, 0x90]);
+      expect(w[0].data.sublist(4, 8), [0x00, 0x00, 0xFF, 0x00]);
+      // rearLive 0x803894 ← 0x0000FF
+      expect(w[1].data.sublist(1, 4), [0x80, 0x38, 0x94]);
+      expect(w[1].data.sublist(4, 8), [0xFF, 0x00, 0x00, 0x00]);
+
+      // Stored palette cache is untouched and nothing was emitted.
+      final cached = await bengle.getLedStripState();
+      expect(cached.frontStrip.awake, const Color16(0x3838, 0x5A5A, 0x9292));
+      await Future(() {}); // let any stray emission propagate
       expect(
-        logRecords.any((r) =>
-            r.message.contains('LedStripCapability') &&
-            r.message.contains('unwired')),
-        isTrue,
-        reason: 'expected init log entry about unwired endpoints',
+        emitted,
+        isEmpty,
+        reason: 'preview must not emit on ledStripState',
       );
     });
 
-    test('setLedStrip updates cache when wires are unwired', () async {
-      await bengle.setLedStrip(LedStripState(
-        frontStrip: ZoneLedState(
-            sleeping: const Color16(65535, 32768, 0),
-            awake: Color16.off),
-      ));
-      // Cache was updated regardless of stub.
+    test('clearLedPreview restores the cached awake pair into the live '
+        'registers', () async {
+      await bengle.setLedStrip(
+        const LedStripState(
+          frontStrip: ZoneLedState(awake: Color16(0x3838, 0x5A5A, 0x9292)),
+          backStrip: ZoneLedState(awake: Color16(0xFFFF, 0x7A7A, 0x0000)),
+        ),
+      );
+      transport.writes.clear();
+
+      await bengle.clearLedPreview();
+
+      final w = mmrWrites();
+      expect(w.length, 2);
+      // frontLive 0x803890 ← cached front awake 0x385A92
+      expect(w[0].data.sublist(1, 4), [0x80, 0x38, 0x90]);
+      expect(w[0].data.sublist(4, 8), [0x92, 0x5A, 0x38, 0x00]);
+      // rearLive 0x803894 ← cached rear awake 0xFF7A00
+      expect(w[1].data.sublist(1, 4), [0x80, 0x38, 0x94]);
+      expect(w[1].data.sublist(4, 8), [0x00, 0x7A, 0xFF, 0x00]);
+    });
+
+    test('initial state is all-off when the machine stores an all-off '
+        'palette', () async {
+      // setUp queued the default (all-zero) palette responses, so the
+      // connect-time hydration read back black for every slot.
       final state = await bengle.getLedStripState();
-      expect(state.frontStrip.sleeping,
-          const Color16(65535, 32768, 0));
+      expect(state.frontStrip.awake, Color16.off);
+      expect(state.backStrip.awake, Color16.off);
     });
 
-    test('commitLedStrip is safe when wires are unwired', () async {
-      // No crash — already verified by the stub-warning log from init.
-      await bengle.commitLedStrip();
+    test('connect hydrates the cache from the four stored palette registers',
+        () async {
+      // Hydration must serve the machine's stored colours on the first GET
+      // after an app restart — byte-exact: FW packed 0x00RRGGBB decodes by
+      // byte-replication (0xAB → 0xABAB) for every palette slot.
+      final t = FakeBleTransport();
+      final b = Bengle(transport: t);
+      t.queueOnConnectResponses(
+        v13Model: 128,
+        ledFrontAwake: 0x385A92,
+        ledFrontSleep: 0x112233,
+        ledRearAwake: 0xFF7A00,
+        ledRearSleep: 0x0000FF,
+      );
+      await b.onConnect();
+      addTearDown(t.dispose);
+
+      final s = await b.getLedStripState();
+      expect(s.frontStrip.awake, const Color16(0x3838, 0x5A5A, 0x9292));
+      expect(s.frontStrip.sleeping, const Color16(0x1111, 0x2222, 0x3333));
+      expect(s.backStrip.awake, const Color16(0xFFFF, 0x7A7A, 0x0000));
+      expect(s.backStrip.sleeping, const Color16(0x0000, 0x0000, 0xFFFF));
+      // Switch mirrors the front strip on read (no switch register).
+      expect(s.frontSwitch.awake, s.frontStrip.awake);
+      expect(s.frontSwitch.sleeping, s.frontStrip.sleeping);
     });
 
-    test('resetLedStrip is safe when wires are unwired', () async {
-      await bengle.resetLedStrip();
+    test('connect-time hydration is read-only — no LED register writes, '
+        'live/preview pair untouched', () async {
+      final t = FakeBleTransport();
+      final b = Bengle(transport: t);
+      t.queueOnConnectResponses(
+        v13Model: 128,
+        ledFrontAwake: 0x385A92,
+        ledRearAwake: 0xFF7A00,
+      );
+      await b.onConnect();
+      addTearDown(t.dispose);
+
+      List<int> addrBytes(BengleLedMmr reg) => [
+        (reg.address >> 16) & 0xFF,
+        (reg.address >> 8) & 0xFF,
+        reg.address & 0xFF,
+      ];
+      bool targets(FakeBleWrite w, BengleLedMmr reg) {
+        final a = addrBytes(reg);
+        return w.data.length >= 4 &&
+            w.data[1] == a[0] &&
+            w.data[2] == a[1] &&
+            w.data[3] == a[2];
+      }
+
+      // No writeToMMR frame may target ANY LED register — hydration must
+      // never change machine state.
+      final ledWrites = t.writes.where(
+        (w) =>
+            w.characteristicUUID == Endpoint.writeToMMR.uuid &&
+            BengleLedMmr.values.any((reg) => targets(w, reg)),
+      );
+      expect(
+        ledWrites,
+        isEmpty,
+        reason: 'hydration must not write any LED register',
+      );
+
+      // The live/preview pair must see no traffic at all — not even reads —
+      // so hydration can never disturb an in-flight preview or flash the
+      // strips.
+      final liveTraffic = t.writes.where(
+        (w) =>
+            (w.characteristicUUID == Endpoint.writeToMMR.uuid ||
+                w.characteristicUUID == Endpoint.readFromMMR.uuid) &&
+            (targets(w, BengleLedMmr.frontLive) ||
+                targets(w, BengleLedMmr.rearLive)),
+      );
+      expect(
+        liveTraffic,
+        isEmpty,
+        reason: 'hydration must not touch the live/preview registers',
+      );
+
+      // And the four palette registers were read (readFromMMR), once each.
+      for (final reg in const [
+        BengleLedMmr.frontAwake,
+        BengleLedMmr.frontSleep,
+        BengleLedMmr.rearAwake,
+        BengleLedMmr.rearSleep,
+      ]) {
+        final reads = t.writes.where(
+          (w) =>
+              w.characteristicUUID == Endpoint.readFromMMR.uuid &&
+              targets(w, reg),
+        );
+        expect(reads.length, 1, reason: 'one hydration read of ${reg.name}');
+      }
+    });
+
+    test('failed hydration read leaves the cache all-off and the connect '
+        'completes', () async {
+      // Failure-tolerant: on FW without the LED registers (or a dropped
+      // read) the cache keeps its pre-hydration all-off seed and GET falls
+      // back to the old behavior — the connect itself must not throw.
+      final t = _LedReadFailingTransport();
+      final b = Bengle(transport: t);
+      t.queueOnConnectResponses(v13Model: 128);
+      await b.onConnect(); // must not throw
+      addTearDown(t.dispose);
+
+      final s = await b.getLedStripState();
+      expect(s.frontStrip.awake, Color16.off);
+      expect(s.frontStrip.sleeping, Color16.off);
+      expect(s.backStrip.awake, Color16.off);
+      expect(s.backStrip.sleeping, Color16.off);
     });
 
     test('disposeLedStrip closes the subject', () async {
@@ -83,39 +356,28 @@ void main() {
       );
     });
 
-    test('all BengleLedEndpoint entries have null uuid and representation',
-        () {
-      for (final ep in BengleLedEndpoint.values) {
-        expect(ep.uuid, isNull,
-            reason: '${ep.name}.uuid should be null (TBD with FW)');
-        expect(ep.representation, isNull,
-            reason: '${ep.name}.representation should be null (TBD with FW)');
-      }
-    });
-
-    test('connect → disconnect → connect lifecycle is leak-free', () async {
+    test('reconnect re-inits the subject leak-free', () async {
       await bengle.disconnect();
-      await expectLater(
-        bengle.ledStripState,
-        emitsInOrder([isA<LedStripState>(), emitsDone]),
-      );
-
-      transport.queueOnConnectResponses();
+      transport.queueOnConnectResponses(v13Model: 128);
       await bengle.onConnect();
 
-      var streamCompletedWithoutValue = false;
+      var closed = false;
       try {
-        await bengle.ledStripState
-            .first
-            .timeout(const Duration(milliseconds: 50));
+        await bengle.ledStripState.first.timeout(
+          const Duration(milliseconds: 50),
+        );
       } on TimeoutException {
-        // Expected: stream is open but quiet — capability is alive.
+        // Expected: open but quiet — capability is alive.
       } on StateError {
-        streamCompletedWithoutValue = true;
+        closed = true;
       }
-      expect(streamCompletedWithoutValue, isFalse,
-          reason: 'ledStripState was closed after reconnect — mixin '
-              'failed to re-init its BehaviorSubject');
+      expect(
+        closed,
+        isFalse,
+        reason:
+            'ledStripState closed after reconnect — mixin failed to '
+            're-init its BehaviorSubject',
+      );
     });
   });
 }

--- a/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
@@ -228,6 +228,50 @@ void main() {
       expect(payload.getInt32(0, Endian.little), 500);
     });
 
+    test('writeMmrScaled rounds, not truncates, the scaled value (Bengle path)',
+        () async {
+      // 2.3 * 100 == 229.999… in IEEE-754: the old toInt() truncated to
+      // 229; round() gives the correct 230. Every Bengle scaled write
+      // rides this non-MMRItem branch, so this guards the load-bearing
+      // helper for the whole Bengle feature set.
+      const addr = _CapabilityAddr(
+        address: 0x00805000,
+        length: 4,
+        name: 'roundProbe',
+        kind: MmrValueKind.scaledFloat,
+        writeScale: 100.0,
+      );
+      transport.writes.clear();
+      await de1.capWriteScaled(addr, 2.3);
+      final frame = transport.writes.firstWhere(
+        (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
+      );
+      final payload = ByteData.sublistView(frame.data, 4, 8);
+      expect(payload.getInt32(0, Endian.little), 230);
+    });
+
+    test('_writeMMRScaled truncates like de1plus (base-DE1 setter path)',
+        () async {
+      // The base-DE1 scaled setters (flush/hot-water/steam/heater/cal flow)
+      // must stay byte-identical to a plain DE1 and to de1plus, which
+      // truncates via int(...). targetSteamFlow uses writeScale 100 with no
+      // clamp, so setSteamFlow(2.3) lands 229 (2.3*100 == 229.999… truncated),
+      // NOT the rounded 230 — rounding is correct only for the Bengle ×100
+      // weight write on the separate public writeMmrScaled helper.
+      transport.writes.clear();
+      await de1.setSteamFlow(2.3);
+      final frame = transport.writes.firstWhere(
+        (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
+      );
+      final addrBytes = ByteData(4)
+        ..setInt32(0, MMRItem.targetSteamFlow.address, Endian.big);
+      expect(frame.data[1], addrBytes.getUint8(1));
+      expect(frame.data[2], addrBytes.getUint8(2));
+      expect(frame.data[3], addrBytes.getUint8(3));
+      final payload = ByteData.sublistView(frame.data, 4, 8);
+      expect(payload.getInt32(0, Endian.little), 229);
+    });
+
     test('notificationsFor(shotSample) routes to transport shotSample',
         () async {
       // The transport's BLE subscriber for the shotSample characteristic

--- a/test/unit/models/device/impl/de1/unified_de1/scale_calibration_capability_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/scale_calibration_capability_test.dart
@@ -1,0 +1,285 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+import 'package:reaprime/src/models/device/scale_calibration.dart';
+
+import '../../../../../../helpers/fake_ble_transport.dart';
+
+/// Pack a ScaleCalState word: Step[31:24] SubState[23:16] Remaining[15:8]
+/// CalStatus[7:0] (firmware layout). `status` = E_CalStatus (0xFF = none).
+int _packState({
+  required int step,
+  int sub = 0,
+  int remaining = 0,
+  int status = 0xFF,
+}) =>
+    (step << 24) | (sub << 16) | (remaining << 8) | (status & 0xFF);
+
+void main() {
+  group('ScaleCalibrationCapability (FIX-07, two-point)', () {
+    late FakeBleTransport transport;
+    late Bengle bengle;
+
+    setUp(() async {
+      transport = FakeBleTransport();
+      // calFlowEst keeps onConnect from eating the MMR read-retry timeout.
+      transport.queueMmrResponseInt(MMRItem.calFlowEst, 100);
+      transport.queueOnConnectResponses(v13Model: 128);
+      bengle = Bengle(transport: transport);
+      await bengle.onConnect();
+      bengle.configureScaleCalibrationTiming(
+        pollInterval: const Duration(milliseconds: 1),
+        deadline: const Duration(milliseconds: 50),
+      );
+      transport.writes.clear();
+    });
+
+    tearDown(() => transport.dispose());
+
+    List<FakeBleWrite> mmrWrites() => transport.writes
+        .where((w) => w.characteristicUUID == Endpoint.writeToMMR.uuid)
+        .toList();
+
+    FakeBleWrite? mmrWriteTo(int addr) {
+      final b = [(addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF];
+      for (final w in mmrWrites()) {
+        if (w.data[1] == b[0] && w.data[2] == b[1] && w.data[3] == b[2]) {
+          return w;
+        }
+      }
+      return null;
+    }
+
+    test('cal MMR slots map to the firmware registers', () {
+      expect(BengleCalMmr.cmd.address, 0x00803880);
+      expect(BengleCalMmr.state.address, 0x00803884);
+      expect(BengleCalMmr.weight.address, 0x00803888);
+      expect(BengleCalMmr.weight.writeScale, 10.0);
+      expect(BengleCalMmr.weight.readScale, 0.1);
+    });
+
+    test('command wire values match firmware (zero=1, latch=2)', () {
+      expect(ScaleCalCommand.abort.wire, 0);
+      expect(ScaleCalCommand.zero.wire, 1);
+      expect(ScaleCalCommand.latch.wire, 2);
+    });
+
+    test('fromRaw pins Step to the HIGH byte and CalStatus to the LOW byte',
+        () {
+      // Literal word (NOT built by _packState) anchors the byte positions to
+      // the spec layout Step[31:24]|SubState[23:16]|Remaining[15:8]|CalStatus[7:0].
+      final s = ScaleCalStatus.fromRaw(0x05020301);
+      expect(s.step, ScaleCalStep.complete); // 0x05
+      expect(s.subState, ScaleCalSubState.done); // 0x02
+      expect(s.remainingSeconds, 3); // 0x03
+      expect(s.pointStatus, ScaleCalPointStatus.incomplete); // 0x01
+    });
+
+    test('fromRaw decodes a two-point solved word and coerces the high bit',
+        () {
+      final ok = ScaleCalStatus.fromRaw(
+          _packState(step: 5, sub: 2, remaining: 0, status: 0));
+      expect(ok.step, ScaleCalStep.complete);
+      expect(ok.pointStatus, ScaleCalPointStatus.ok);
+      expect(ok.isComplete, isTrue);
+
+      // Sign-extended int32 (bit 31 set): mask must recover the byte fields.
+      final hi = ScaleCalStatus.fromRaw(-1); // 0xFFFFFFFF
+      expect(hi.step, ScaleCalStep.unknown); // 0xFF
+      expect(hi.pointStatus, ScaleCalPointStatus.none); // 0xFF
+      expect(hi.remainingSeconds, 255);
+    });
+
+    test('calibrateScaleZero writes cmd=1 and polls to Complete', () async {
+      transport.queueMmrResponseIntSequence(BengleCalMmr.state, [
+        _packState(step: 1, sub: 0, remaining: 3), // zeroing/settling
+        _packState(step: 1, sub: 1, remaining: 1), // zeroing/averaging
+        _packState(step: 5, sub: 2, remaining: 0), // complete
+      ]);
+
+      final result = await bengle.calibrateScaleZero();
+
+      expect(result.success, isTrue);
+      expect(result.finalStep, ScaleCalStep.complete);
+      final cmd = mmrWriteTo(0x00803880);
+      expect(cmd, isNotNull);
+      expect(cmd!.data.sublist(4, 8), [0x01, 0x00, 0x00, 0x00]);
+    });
+
+    test('calibrateScaleWeightLeft writes weight ×10 + cmd=2, first latch',
+        () async {
+      // 500.0 g × 10 = 5000 read back to confirm.
+      transport.queueMmrResponseInt(BengleCalMmr.weight, 5000);
+      transport.queueMmrResponseIntSequence(BengleCalMmr.state, [
+        _packState(step: 2, sub: 1, remaining: 2), // calLatch/averaging
+        _packState(step: 5, sub: 2, remaining: 0, status: 1), // complete/incomplete
+      ]);
+
+      final result = await bengle.calibrateScaleWeightLeft(500.0);
+
+      expect(result.success, isTrue);
+      expect(result.pointStatus, ScaleCalPointStatus.incomplete);
+      // Reference weight write: 5000 = 0x1388, little-endian.
+      final wWrite = mmrWriteTo(0x00803888);
+      expect(wWrite, isNotNull);
+      expect(wWrite!.data.sublist(4, 8), [0x88, 0x13, 0x00, 0x00]);
+      // Command trigger = 2 (auto-detect latch).
+      expect(
+          mmrWriteTo(0x00803880)!.data.sublist(4, 8), [0x02, 0x00, 0x00, 0x00]);
+    });
+
+    test('calibrateScaleWeightRight writes cmd=2, solves (status Ok)', () async {
+      transport.queueMmrResponseInt(BengleCalMmr.weight, 5000);
+      transport.queueMmrResponseIntSequence(BengleCalMmr.state, [
+        _packState(step: 2, sub: 1, remaining: 2), // calLatch/averaging
+        _packState(step: 5, sub: 2, remaining: 0, status: 0), // complete/ok
+      ]);
+
+      final result = await bengle.calibrateScaleWeightRight(500.0);
+
+      expect(result.success, isTrue);
+      expect(result.pointStatus, ScaleCalPointStatus.ok);
+      expect(
+          mmrWriteTo(0x00803880)!.data.sublist(4, 8), [0x02, 0x00, 0x00, 0x00]);
+    });
+
+    test('fromRaw decodes the detected-cell nibble in the SubState byte', () {
+      // done (0x2) with cell A in the high nibble (0x1) -> SubState byte 0x12.
+      final a = ScaleCalStatus.fromRaw(0x05120001);
+      expect(a.isComplete, isTrue); // low nibble still decodes the phase
+      expect(a.detectedCell, 0); // cell A / left
+      // cell B (0x2 nibble) -> SubState byte 0x22.
+      final b = ScaleCalStatus.fromRaw(0x05220001);
+      expect(b.detectedCell, 1); // cell B / right
+      // no cell yet.
+      final none = ScaleCalStatus.fromRaw(0x05020001);
+      expect(none.detectedCell, isNull);
+    });
+
+    test('a NotIsolated reject decodes and fails with the reason', () async {
+      transport.queueMmrResponseInt(BengleCalMmr.weight, 5000);
+      transport.queueMmrResponseIntSequence(BengleCalMmr.state, [
+        // Compute-time reject: Error step, NotIsolated (8) status.
+        _packState(step: 6, sub: 3, remaining: 0, status: 8),
+      ]);
+
+      final result = await bengle.calibrateScaleWeightLeft(500.0);
+      expect(result.success, isFalse);
+      expect(result.pointStatus, ScaleCalPointStatus.notIsolated);
+      expect(result.message, contains('notIsolated'));
+    });
+
+    test('a rejected latch (Complete + non-ok CalStatus) fails with the reason',
+        () async {
+      transport.queueMmrResponseInt(BengleCalMmr.weight, 5000);
+      transport.queueMmrResponseIntSequence(BengleCalMmr.state, [
+        // Compute-time reject: Complete step but IllConditioned status.
+        _packState(step: 5, sub: 2, remaining: 0, status: 6),
+      ]);
+
+      final result = await bengle.calibrateScaleWeightRight(500.0);
+      expect(result.success, isFalse);
+      expect(result.pointStatus, ScaleCalPointStatus.illConditioned);
+      expect(result.message, contains('illConditioned'));
+    });
+
+    test('an Error step (upfront reject, e.g. NoZero) fails with the status',
+        () async {
+      transport.queueMmrResponseInt(BengleCalMmr.weight, 5000);
+      transport.queueMmrResponseIntSequence(BengleCalMmr.state, [
+        _packState(step: 6, sub: 3, remaining: 0, status: 2), // error / NoZero
+      ]);
+
+      final result = await bengle.calibrateScaleWeightLeft(500.0);
+      expect(result.success, isFalse);
+      expect(result.finalStep, ScaleCalStep.error);
+      expect(result.message, contains('noZero'));
+    });
+
+    test('calibrateScaleWeightLeft rejects a reference-weight readback mismatch '
+        'and never triggers cmd=4', () async {
+      transport.queueMmrResponseInt(BengleCalMmr.weight, 9990); // 999.0 g
+
+      final result = await bengle.calibrateScaleWeightLeft(500.0);
+
+      expect(result.success, isFalse);
+      expect(result.message, contains('not confirmed'));
+      expect(mmrWriteTo(0x00803888), isNotNull, reason: 'weight was written');
+      expect(mmrWriteTo(0x00803880), isNull,
+          reason: 'a rejected readback must not trigger the latch');
+    });
+
+    test('single-flight guard rejects a concurrent calibration', () async {
+      transport.queueMmrResponseIntSequence(
+          BengleCalMmr.state, [_packState(step: 1, sub: 0, remaining: 5)]);
+
+      final first = bengle.calibrateScaleZero();
+      final second = await bengle.calibrateScaleZero();
+      expect(second.success, isFalse);
+      expect(second.message, contains('in progress'));
+
+      final firstResult = await first;
+      expect(firstResult.success, isFalse); // times out on the sticky state
+    });
+
+    test('abortScaleCalibration stops an in-flight poll promptly with an '
+        '"aborted" result (not a timeout)', () async {
+      bengle.configureScaleCalibrationTiming(
+        pollInterval: const Duration(milliseconds: 1),
+        deadline: const Duration(seconds: 10),
+      );
+      transport.queueMmrResponseIntSequence(
+          BengleCalMmr.state, [_packState(step: 1, sub: 0, remaining: 5)]);
+
+      final run = bengle.calibrateScaleZero();
+      await pumpEventQueue();
+      await bengle.abortScaleCalibration();
+      final result = await run;
+
+      expect(result.success, isFalse);
+      expect(result.message, 'aborted');
+      expect(mmrWrites().last.data.sublist(4, 8), [0x00, 0x00, 0x00, 0x00]);
+      expect(bengle.scaleCalibrationInProgress, isFalse);
+    });
+
+    test('disposeScaleCalibration unwinds an in-flight poll; a reconnected '
+        'stream sees no stale status', () async {
+      bengle.configureScaleCalibrationTiming(
+        pollInterval: const Duration(milliseconds: 1),
+        deadline: const Duration(seconds: 10),
+      );
+      transport.queueMmrResponseIntSequence(
+          BengleCalMmr.state, [_packState(step: 1, sub: 0, remaining: 5)]);
+
+      final run = bengle.calibrateScaleZero();
+      await pumpEventQueue();
+      await bengle.disposeScaleCalibration();
+      await bengle.initScaleCalibration();
+
+      final seen = <ScaleCalStatus>[];
+      final sub = bengle.scaleCalibrationProgress.listen(seen.add);
+      final result = await run;
+      await pumpEventQueue();
+      await sub.cancel();
+
+      expect(result.success, isFalse);
+      expect(result.message, 'aborted');
+      expect(seen, isEmpty);
+    });
+
+    test('progress stream emits each polled status', () async {
+      transport.queueMmrResponseIntSequence(BengleCalMmr.state, [
+        _packState(step: 1, sub: 0, remaining: 2),
+        _packState(step: 5, sub: 2, remaining: 0),
+      ]);
+      final seen = <ScaleCalStatus>[];
+      final sub = bengle.scaleCalibrationProgress.listen(seen.add);
+      await bengle.calibrateScaleZero();
+      await pumpEventQueue();
+      await sub.cancel();
+      expect(seen, isNotEmpty);
+      expect(seen.last.isComplete, isTrue);
+    });
+  });
+}

--- a/test/unit/models/device/impl/de1/unified_de1/serial_parity_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/serial_parity_test.dart
@@ -1,0 +1,418 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart';
+
+import '../../../../../../helpers/fake_serial_transport.dart';
+
+String _hex(List<int> bytes) =>
+    bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+
+/// A [FakeSerialTransport] whose [writeCommand] throws for one specific
+/// command — used to prove a failing `<+X>` request can't leak an
+/// unhandled async timeout out of the armed one-shot read future.
+class _FailingWriteSerialTransport extends FakeSerialTransport {
+  final String failOn;
+  _FailingWriteSerialTransport({required this.failOn});
+
+  @override
+  Future<void> writeCommand(String command) async {
+    if (command == failOn) {
+      throw StateError('injected write failure: $command');
+    }
+    return super.writeCommand(command);
+  }
+}
+
+void main() {
+  group('length-exact <F> (writeToMMR) frames on serial', () {
+    late FakeSerialTransport serial;
+    late UnifiedDe1Transport transport;
+
+    setUp(() {
+      serial = FakeSerialTransport();
+      transport = UnifiedDe1Transport(transport: serial);
+    });
+
+    tearDown(() => transport.dispose());
+
+    test('a short final DFU chunk is zero-padded to 20 bytes', () async {
+      await transport.connect();
+      serial.writes.clear();
+
+      // 6-byte final image chunk: Len=6, addr 0x000120, 6 data bytes —
+      // exactly what uploadFW emits for a trailing partial chunk.
+      final chunk = Uint8List.fromList([
+        6,
+        0x00,
+        0x01,
+        0x20,
+        0xDE,
+        0xAD,
+        0xBE,
+        0xEF,
+        0x01,
+        0x02,
+      ]);
+      await transport.writeWithResponse(Endpoint.writeToMMR, chunk);
+
+      final expected = '<F>${_hex(chunk).padRight(2 * 20, '0')}'; // 40 hex
+      expect(
+        serial.writes.single,
+        expected,
+        reason:
+            'firmware parser reads exactly sizeof(the MMR write frame)=20 '
+            'bytes per <F> frame; a short frame desyncs it',
+      );
+    });
+
+    test('a full 20-byte frame is passed through unmodified', () async {
+      await transport.connect();
+      serial.writes.clear();
+
+      final chunk = Uint8List.fromList(List<int>.generate(20, (i) => i + 1));
+      await transport.writeWithResponse(Endpoint.writeToMMR, chunk);
+
+      expect(serial.writes.single, '<F>${_hex(chunk)}');
+    });
+
+    test('other endpoints are not padded', () async {
+      await transport.connect();
+      serial.writes.clear();
+
+      final settings = Uint8List.fromList(List<int>.filled(9, 0x42));
+      await transport.writeWithResponse(Endpoint.shotSettings, settings);
+
+      expect(serial.writes.single, '<K>${_hex(settings)}');
+    });
+  });
+
+  group('serial reads', () {
+    late FakeSerialTransport serial;
+    late UnifiedDe1Transport transport;
+
+    setUp(() {
+      serial = FakeSerialTransport();
+      transport = UnifiedDe1Transport(transport: serial);
+    });
+
+    tearDown(() => transport.dispose());
+
+    test('read(calibration) is a <+R> single-notify round trip', () async {
+      await transport.connect();
+      serial.writes.clear();
+
+      final pending = transport.read(Endpoint.calibration);
+      await pumpEventQueue();
+      expect(
+        serial.writes,
+        contains('<+R>'),
+        reason:
+            'the serial view has no read verb; a read is an '
+            'add-notify that provokes one [R] frame',
+      );
+
+      final payload = List<int>.generate(14, (i) => 0xA0 + i);
+      serial.injectSerial('[R]${_hex(payload)}\n');
+
+      final result = await pending;
+      expect(result.buffer.asUint8List(), payload);
+      expect(
+        serial.writes.last,
+        '<-R>',
+        reason: 'the one-shot read must not leave a subscription behind',
+      );
+    });
+
+    test('read(versions) round-trips via <+A>', () async {
+      await transport.connect();
+      serial.writes.clear();
+
+      final pending = transport.read(Endpoint.versions);
+      await pumpEventQueue();
+      expect(serial.writes, contains('<+A>'));
+
+      final payload = List<int>.generate(18, (i) => i);
+      serial.injectSerial('[A]${_hex(payload)}\n');
+
+      final result = await pending;
+      expect(result.buffer.asUint8List(), payload);
+      expect(serial.writes.last, '<-A>');
+    });
+
+    test('read(temperatures) round-trips via <+J>', () async {
+      await transport.connect();
+      serial.writes.clear();
+
+      final pending = transport.read(Endpoint.temperatures);
+      await pumpEventQueue();
+      expect(serial.writes, contains('<+J>'));
+
+      final payload = List<int>.generate(20, (i) => 0x10 + i);
+      serial.injectSerial('[J]${_hex(payload)}\n');
+
+      final result = await pending;
+      expect(result.buffer.asUint8List(), payload);
+      expect(serial.writes.last, '<-J>');
+    });
+
+    test(
+      'a single-notify read times out cleanly when firmware never answers',
+      () async {
+        // Real (shortened) time: fakeAsync stalls on the root-zone
+        // `_nullFuture` returned by broadcast-subscription cancels inside
+        // `Stream.first`, so the timeout is injected small instead.
+        final serial2 = FakeSerialTransport();
+        final transport2 = UnifiedDe1Transport(
+          transport: serial2,
+          serialSingleReadTimeout: const Duration(milliseconds: 50),
+        );
+        addTearDown(transport2.dispose);
+        await transport2.connect();
+
+        await expectLater(
+          transport2.read(Endpoint.versions),
+          throwsA(isA<TimeoutException>()),
+          reason: 'firmware that never emits [A] must not hang the caller',
+        );
+        expect(
+          serial2.writes,
+          contains('<-A>'),
+          reason: 'the failed read still cleans up its notify',
+        );
+      },
+    );
+
+    test(
+      'a failing <+X> request write does not leak an unhandled timeout',
+      () async {
+        // Locks the `response.ignore()` line in _serialSingleNotifyRead:
+        // when the `<+A>` write throws, nothing ever awaits the armed
+        // `frames.first.timeout(...)` future — without ignore() its
+        // eventual TimeoutException surfaces as an unhandled async error
+        // and fails this test when it fires below.
+        final serial2 = _FailingWriteSerialTransport(failOn: '<+A>');
+        final transport2 = UnifiedDe1Transport(
+          transport: serial2,
+          serialSingleReadTimeout: const Duration(milliseconds: 40),
+        );
+        addTearDown(transport2.dispose);
+        await transport2.connect();
+
+        await expectLater(
+          transport2.read(Endpoint.versions),
+          throwsA(isA<StateError>()),
+          reason: 'the write failure itself must surface to the caller',
+        );
+        expect(
+          serial2.writes,
+          contains('<-A>'),
+          reason: 'the failed read still cleans up its notify (finally)',
+        );
+
+        // Let the armed timeout fire inside the test body; an unhandled
+        // async TimeoutException here fails the test.
+        await Future<void>.delayed(const Duration(milliseconds: 120));
+      },
+    );
+
+    test(
+      'endpoints with no serial read path throw UnsupportedError',
+      () async {
+        await transport.connect();
+
+        for (final e in [
+          Endpoint.setTime,
+          Endpoint.shotDirectory,
+          Endpoint.writeToMMR,
+          Endpoint.shotMapRequest,
+          Endpoint.deleteShotRange,
+          Endpoint.deprecatedShotDesc,
+          Endpoint.headerWrite,
+          Endpoint.frameWrite,
+        ]) {
+          await expectLater(
+            transport.read(e),
+            throwsA(isA<UnsupportedError>()),
+            reason: '${e.name} is write-only / never emitted by the firmware',
+          );
+        }
+      },
+    );
+
+    test(
+      'read(requestedState) serves the stateInfo subject ([N] carries state)',
+      () async {
+        // There is no [B] notify on the wire; requestedState deliberately
+        // aliases the stateInfo subject over serial. Pinned here so a
+        // future refactor can't silently break the raw-API read.
+        await transport.connect();
+        serial.injectSerial('[N]0402\n');
+        await pumpEventQueue();
+
+        final viaRequestedState = await transport.read(
+          Endpoint.requestedState,
+        );
+        final viaStateInfo = await transport.read(Endpoint.stateInfo);
+        expect(
+          viaRequestedState.buffer.asUint8List(),
+          viaStateInfo.buffer.asUint8List(),
+        );
+        expect(viaRequestedState.buffer.asUint8List(), [0x04, 0x02]);
+      },
+    );
+  });
+
+  group('serial RX framing — parser edge cases', () {
+    late FakeSerialTransport serial;
+    late UnifiedDe1Transport transport;
+
+    setUp(() {
+      serial = FakeSerialTransport();
+      transport = UnifiedDe1Transport(transport: serial);
+    });
+
+    tearDown(() => transport.dispose());
+
+    test('a frame split across chunks reassembles', () async {
+      await transport.connect();
+
+      // [E] reply split mid-payload: first chunk has no terminator so it
+      // must stay buffered, not be dropped.
+      serial.injectSerial('[E]0480');
+      await pumpEventQueue();
+      serial.injectSerial('000c80000000\n');
+      await pumpEventQueue();
+
+      final mmr = await transport.read(Endpoint.readFromMMR);
+      expect(mmr.buffer.asUint8List(), [
+        0x04,
+        0x80,
+        0x00,
+        0x0C,
+        0x80,
+        0x00,
+        0x00,
+        0x00,
+      ]);
+    });
+
+    test('leading junk before the first [ is discarded', () async {
+      await transport.connect();
+
+      serial.injectSerial('OK\r\nboot junk[N]0403\n');
+      await pumpEventQueue();
+
+      final state = await transport.read(Endpoint.stateInfo);
+      expect(state.buffer.asUint8List(), [0x04, 0x03]);
+    });
+
+    test(
+      'a >4096-char unterminated buffer is dumped and parsing resyncs',
+      () async {
+        await transport.connect();
+
+        // A '[M]' start with no terminator ever: grows past the 4096 guard
+        // and must be discarded (no checksum/retransmit on this framing —
+        // the keepalive's forced [N] resyncs the stream afterwards).
+        serial.injectSerial('[M]${'00' * 2500}');
+        await pumpEventQueue();
+
+        // The stream recovers: the next complete frame parses normally.
+        serial.injectSerial('[N]0405\n');
+        await pumpEventQueue();
+
+        final state = await transport.read(Endpoint.stateInfo);
+        expect(state.buffer.asUint8List(), [0x04, 0x05]);
+
+        // The dumped garbage never surfaced as a shotSample frame.
+        final shot = await transport.read(Endpoint.shotSample);
+        expect(
+          shot.buffer.asUint8List(),
+          List<int>.filled(19, 0),
+          reason: 'the overflowed [M] bufferful must be dropped, not parsed',
+        );
+      },
+    );
+  });
+
+  group('serial keepalive (actively drive the shared link)', () {
+    // Real (shortened) time via the injectable interval: fakeAsync stalls
+    // on the root-zone `_nullFuture` that broadcast-subscription cancels
+    // return inside disconnect()/dispose().
+    const interval = Duration(milliseconds: 40);
+    const threePeriods = Duration(milliseconds: 140);
+
+    test('re-asserts the link with <+N> every keepalive period', () async {
+      final serial = FakeSerialTransport();
+      final transport = UnifiedDe1Transport(
+        transport: serial,
+        serialKeepaliveInterval: interval,
+      );
+      addTearDown(transport.dispose);
+      await transport.connect();
+      serial.writes.clear();
+
+      await Future<void>.delayed(threePeriods);
+      expect(
+        serial.writes.where((w) => w == '<+N>').length,
+        greaterThanOrEqualTo(2),
+        reason:
+            'a passively-listening USB client silently loses the '
+            'notify stream to the BLE source arbitration — the keepalive '
+            'must re-assert periodically, not once',
+      );
+    });
+
+    test('disconnect() stops the keepalive', () async {
+      final serial = FakeSerialTransport();
+      final transport = UnifiedDe1Transport(
+        transport: serial,
+        serialKeepaliveInterval: interval,
+      );
+      addTearDown(transport.dispose);
+      await transport.connect();
+
+      await transport.disconnect();
+      serial.writes.clear();
+
+      await Future<void>.delayed(threePeriods);
+      expect(serial.writes.where((w) => w == '<+N>'), isEmpty);
+    });
+
+    test('dispose() stops the keepalive', () async {
+      final serial = FakeSerialTransport();
+      final transport = UnifiedDe1Transport(
+        transport: serial,
+        serialKeepaliveInterval: interval,
+      );
+      await transport.connect();
+
+      await transport.dispose();
+      serial.writes.clear();
+
+      await Future<void>.delayed(threePeriods);
+      expect(serial.writes.where((w) => w == '<+N>'), isEmpty);
+    });
+
+    test('detach() stops the keepalive (re-resolution seam)', () async {
+      // A demoted/promoted machine hands its live transport to the
+      // replacement wrapper; the discarded wrapper's keepalive must not
+      // keep writing on the shared port.
+      final serial = FakeSerialTransport();
+      final transport = UnifiedDe1Transport(
+        transport: serial,
+        serialKeepaliveInterval: interval,
+      );
+      await transport.connect();
+
+      await transport.detach();
+      serial.writes.clear();
+
+      await Future<void>.delayed(threePeriods);
+      expect(serial.writes.where((w) => w == '<+N>'), isEmpty);
+    });
+  });
+}

--- a/test/unit/models/device/impl/de1/unified_de1/serial_parity_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/serial_parity_test.dart
@@ -89,6 +89,41 @@ void main() {
     });
   });
 
+  group('Bengle drops the redundant 0xA00D stream on serial', () {
+    late FakeSerialTransport serial;
+    late UnifiedDe1Transport transport;
+
+    setUp(() {
+      serial = FakeSerialTransport();
+      transport = UnifiedDe1Transport(transport: serial);
+    });
+
+    tearDown(() => transport.dispose());
+
+    test('connect still subscribes <+M> (identity not yet known)', () async {
+      await transport.connect();
+      expect(
+        serial.writes,
+        contains('<+${Endpoint.shotSample.representation}>'),
+      );
+    });
+
+    test('subscribeBengleShotSample sends <-M> on serial', () async {
+      await transport.connect();
+      serial.writes.clear();
+
+      await transport.subscribeBengleShotSample();
+
+      expect(
+        serial.writes,
+        contains('<-${Endpoint.shotSample.representation}>'),
+        reason:
+            '0xA013 is the sole snapshot source on a Bengle; '
+            '[M]+[S] together overrun the ~1920 B/s serial ceiling',
+      );
+    });
+  });
+
   group('serial reads', () {
     late FakeSerialTransport serial;
     late UnifiedDe1Transport transport;

--- a/test/unit/services/serial/serial_probe_name_gate_test.dart
+++ b/test/unit/services/serial/serial_probe_name_gate_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/serial/serial_service_android.dart';
+import 'package:reaprime/src/services/serial/usb_ids.dart';
+import 'package:reaprime/src/services/serial/utils.dart';
+
+// usb_serial is pulled in transitively via flutter_libserialport's git source.
+// ignore: depend_on_referenced_packages
+import 'package:usb_serial/usb_serial.dart';
+
+UsbDevice _usbDevice({String? productName, int? vid, int? pid}) => UsbDevice(
+  '/dev/bus/usb/001/002',
+  vid,
+  pid,
+  productName,
+  null, // manufacturerName
+  42, // deviceId
+  null, // serial
+  1, // interfaceCount
+);
+
+void main() {
+  group('serialProbeAllowsProductName', () {
+    test('allows "Bengle"', () {
+      expect(
+        serialProbeAllowsProductName('Bengle'),
+        isTrue,
+        reason:
+            'the pre-filter used to drop a Bengle board before the '
+            'v13Model probe ever ran',
+      );
+    });
+
+    test('allows "DE1"', () {
+      expect(serialProbeAllowsProductName('DE1'), isTrue);
+    });
+
+    test('allows "Half Decent Scale"', () {
+      expect(serialProbeAllowsProductName('Half Decent Scale'), isTrue);
+    });
+
+    test('allows generic serial adapters (name contains "Serial")', () {
+      expect(serialProbeAllowsProductName('USB Serial Port'), isTrue);
+      expect(serialProbeAllowsProductName('CP2102 USB to Serial'), isTrue);
+    });
+
+    test('allows unknown (null) product names — probe decides', () {
+      expect(serialProbeAllowsProductName(null), isTrue);
+    });
+
+    test('rejects unrelated devices', () {
+      expect(serialProbeAllowsProductName('Gaming Mouse'), isFalse);
+      expect(
+        serialProbeAllowsProductName('bengle'),
+        isFalse,
+        reason: 'exact match only — the USB descriptor string is fixed',
+      );
+    });
+  });
+
+  group('isBengleProbeCandidate', () {
+    test('admits the captured Bengle VID:PID (TinyUSB defaults)', () {
+      expect(
+        isBengleProbeCandidate(vid: 0x2E8A, pid: 0x000A),
+        isTrue,
+        reason:
+            'firmware enumerates as "TinyUSB Device", so the name '
+            'gate alone would drop a real Bengle',
+      );
+    });
+
+    test('rejects other ids and null', () {
+      expect(
+        isBengleProbeCandidate(vid: 0x2E8A, pid: 0x000C),
+        isFalse,
+        reason: 'Pi debug probe shares the vendor id',
+      );
+      expect(isBengleProbeCandidate(vid: null, pid: 0x000A), isFalse);
+    });
+  });
+
+  group('SerialServiceAndroid.shouldProbeUsbDevice — the OR call-site '
+      '', () {
+    // This is the gate `_detectDevice` actually evaluates: name gate OR
+    // probe candidate. The predicate tests above don't lock the
+    // combination, and the combination IS the fix — the old inline check
+    // dropped a TinyUSB-default Bengle before any shortcut/probe ran.
+    test(
+      'TinyUSB-default Bengle passes on VID:PID despite the useless name',
+      () {
+        expect(
+          SerialServiceAndroid.shouldProbeUsbDevice(
+            _usbDevice(
+              productName: 'TinyUSB Device',
+              vid: 0x2E8A,
+              pid: 0x000A,
+            ),
+          ),
+          isTrue,
+          reason:
+              '"TinyUSB Device" fails the name gate; the probe-candidate '
+              'VID:PID must still admit it',
+        );
+      },
+    );
+
+    test('a named Bengle passes even with unknown ids', () {
+      expect(
+        SerialServiceAndroid.shouldProbeUsbDevice(
+          _usbDevice(productName: 'Bengle', vid: 0x1234, pid: 0x5678),
+        ),
+        isTrue,
+      );
+    });
+
+    test('null name with null ids still reaches the probe', () {
+      expect(
+        SerialServiceAndroid.shouldProbeUsbDevice(_usbDevice()),
+        isTrue,
+        reason: 'Android often reports null before permission is granted',
+      );
+    });
+
+    test('unrelated name + unrelated ids is skipped', () {
+      expect(
+        SerialServiceAndroid.shouldProbeUsbDevice(
+          _usbDevice(productName: 'Gaming Mouse', vid: 0x046D, pid: 0xC08B),
+        ),
+        isFalse,
+      );
+    });
+
+    test('the Pi debug probe (shared vendor id) is skipped', () {
+      expect(
+        SerialServiceAndroid.shouldProbeUsbDevice(
+          _usbDevice(
+            productName: 'Debug Probe (CMSIS-DAP)',
+            vid: 0x2E8A,
+            pid: 0x000C,
+          ),
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
> **Stacked PR — B-9 of 10.** Builds on #466 (`feat/bengle-profile-v2-upload`). Until that merges this PR's diff includes its commits; please review/merge in order **B-1 → B-10**.


A Bengle can run its own wake schedule with no tablet in the room - the firmware holds a weekly table of wake windows and a wall clock, and wakes the machine on its own. Nothing in the app had ever written to them. On a bench machine all three registers read zero: no clock, no entries, schedule disabled. So the "wake at 6:30 on weekdays" feature that the app appears to offer was, in fact, a 30-second timer inside the app, running off the tablet's clock, and it only worked if the tablet was awake, connected, and running the app. Leave the tablet at your desk and your machine is cold when you get to it. This PR pushes the wall clock, the wake windows and the sleep timeout into the machine's own registers, so the firmware runs the schedule itself. It also refuses, categorically, to write a sleep timeout of zero - because that register is the machine's thermal safety net, not a user preference.

## Summary

- **Problem:** The Bengle firmware owns four registers for autonomous scheduling - `InactivitySleepTimeout`, `SetLocalTimeOfWeek`, `ScheduleEntry` and `ScheduleControl` (register-table rows 54 to 57). The app wrote none of them, so the machine's own scheduler never ran. The app-side wake schedule was a `PresenceController` timer that required a live tablet.
- **Why it matters:** The whole point of a machine-side scheduler is that it works when the tablet is not there. This is also the only path by which a machine can heat up before you walk into the kitchen.
- **What changed:** A new `BengleScheduleSync` controller watches the settings and the connected machine and pushes the local time-of-week, the wake-window table and the sleep timeout into the machine. It re-pushes on every connect, because the clock and the table are **RAM-only in firmware and do not survive a power cycle** - the app is the only durable store for them. A new pure module, `wake_schedule_windows.dart`, derives concrete windows from the app's `WakeSchedule` list in the firmware's own semantics, and `sleep_timeout_safety.dart` decides what may be written into the sleep-timeout register.
- **What did NOT change (scope boundary):** No REST endpoint, no WebSocket topic, no settings-UI change. This PR reads settings that already exist and pushes them to a machine that already had the registers. It is **Bengle-gated**: a plain DE1 connecting causes not one byte to go on the wire, and `PresenceController`'s app-side wake and sleep behaviour is untouched for it.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening (the sleep-timeout floor; see below)
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [x] Machine state / shot logic (machine sleep and wake)
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs

## Linked Issues

- Closes #
- Related # (Bengle stack B-1 through B-10)

## Root Cause (if bug fix)

N/A - this is a new capability, not a bug fix. The nearest thing to a root cause is that the firmware's scheduling registers were published and never consumed.

## Regression Test Plan (if bug fix or refactor)

N/A as a regression plan - but the new code is covered, and here is what by:

- **`test/controllers/bengle_schedule_sync_test.dart`** (741 lines): the push on connect; the re-push after a power cycle (detected by the firmware clock reading back as `0`, the "rebooted, never synced" sentinel); the sleep-timeout floor, including the `0`, the negative, and the master-toggle-off cases; and a machine swapped **mid-write**, where the drain re-targets the new machine rather than finishing the write against the old one and pushing nothing to the machine that is actually there.
- **`test/models/device/bengle_wake_schedule_test.dart`** (176 lines): the register writes themselves.
- **`test/models/wake_schedule_windows_test.dart`** (41 cases): window derivation, midnight-crossing splits, the 32-entry cap and merge, and two DST spring-forward regression cases.
- **`test/settings/sleep_timeout_safety_test.dart`** (79 lines).
- **`test/unit/models/device/impl/bengle/mmr_contract_test.dart`**: rows 54 to 57 registered with the firmware contract checker.

## Merge-order note - please read this before merging

This branch ships two modules that are **also introduced by two of the independent PRs** going to `main`. Each side adds the file from nothing, because each has to stand alone:

| File (+ its test) | Also introduced by | Resolution when the second one merges |
|---|---|---|
| `lib/src/models/wake_schedule_windows.dart` | `fix/presence-keep-awake-window` (I-E) | **Take either - the copies are byte-identical.** |
| `lib/src/settings/sleep_timeout_safety.dart` | `fix/settings-bound-sleep-timeout` (I-F) | **Hand-written UNION. Do not pick a side.** |

**Git does not de-duplicate these for you.** Measured with `git merge-tree --write-tree` against both branches, all four paths come back as **`CONFLICT (add/add)`**. Whichever PR merges second will land on them.

### `wake_schedule_windows.dart` + its test - take either, they are byte-identical

This branch's copy of both the lib file and its test is **byte-identical** to I-E's (verified: `md5sum` matches on both files against `fix/presence-keep-awake-window`). So the add/add conflict is trivial - take either side. There is nothing to choose between them.

This was not always true, and the history is worth one sentence so it stays fixed. An earlier cut of this branch carried an older `windowEnd()` that computed a window's end by adding an absolute `Duration`, which on a spring-forward day lands an hour off the wall clock (a 05:30-07:00 window reports 08:00), and it was missing the two DST regression tests that pin the corrected form. On this branch alone that was dormant - nothing here calls `windowEnd()`, since `bengle_schedule_sync.dart` uses only `expandWindows`, `packWakeWindow` and `localSecondsOfWeek`. But it would **not** have been dormant in the merged tree: it would have landed straight in the `keepAwakeUntil` that I-E ships. This branch's copy has since been rebuilt from I-E's, so both the corrected `windowEnd()` and its two DST tests are now present here (the test count is 41, up from 39). If a future edit makes the two copies drift apart again, stop and re-sync them - they are meant to be identical.

**Verified, not asserted:** the two files hash-match across the branches, this branch is `flutter analyze`-clean, and the full suite passes at 2295 (the two DST cases are the +2 over the previous 2293).

### `sleep_timeout_safety.dart` + its test - union, and mind the duplicate

The two copies are complementary halves of one file, split by symbol. Taking either side alone drops symbols the other PR's code imports, and the build breaks.

| Symbol | Declared by |
|---|---|
| `kSafetySleepFloorMinutes`, `kMinMachineSleepTimeoutMinutes`, `machineSleepTimeoutMinutes` | **this branch** (what may be written into the *machine's* safety register) |
| `kMinSleepTimeoutSetting`, `kMaxSleepTimeoutSetting`, `isValidSleepTimeoutSetting`, `sanitizeSleepTimeoutSetting` | **I-F** (bounds on the *stored preference*) |
| `kMaxSleepTimeoutMinutes` | **both** - and that is the trap |

Both copies declare `const int kMaxSleepTimeoutMinutes = 240;` (same value, different doc comment), and both carry their own `library;` directive with its own library doc block. **A naive concatenation of the two sides will not compile** - duplicate top-level declaration, duplicate `library;`. Resolve it like this:

1. Take **this branch's copy in full** (its library doc block, `kSafetySleepFloorMinutes`, `kMinMachineSleepTimeoutMinutes`, `kMaxSleepTimeoutMinutes`, `machineSleepTimeoutMinutes`).
2. Append **only these four symbols** from I-F's copy: `kMinSleepTimeoutSetting`, `kMaxSleepTimeoutSetting`, `isValidSleepTimeoutSetting`, `sanitizeSleepTimeoutSetting`.
3. Drop I-F's `library;` directive, its library doc block and its `kMaxSleepTimeoutMinutes` declaration - all three are duplicates.

The result has exactly one `library;` and one declaration of each of the eight symbols, and it is the file the two halves were split out of.

**The test file resolves the same way, one level down.** Both copies are a `void main()` with non-overlapping `group()`s - this branch contributes `machineSleepTimeoutMinutes: never returns 0`; I-F contributes `sanitizeSleepTimeoutSetting: bounds untrusted REST/import input` and `SettingsController.setSleepTimeoutMinutes bounds what it stores`. Keep **one** `void main()` containing all three groups, and take **I-F's import block** - it is a superset of this branch's.

**Verified, not asserted:** this exact union was built and merged (this branch's lib copy in full + I-F's four preference symbols; one `void main()` with all three test groups). The resulting tree is `flutter analyze`-clean and the full suite passes (2300/2300), with both PRs' consumers compiling against it.

If the independent PRs are not merged, this branch is self-contained and none of the above applies.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` / `websocket_v1.yml`
- [ ] API docs updated: `doc/Api.md`
- [ ] Plugin docs updated: `doc/Plugins.md`
- [ ] Skin docs updated: `doc/Skins.md`
- [ ] Profile docs updated: `doc/Profiles.md`
- [ ] Device docs updated: `doc/DeviceManagement.md`
- [x] N/A - no docs affected

**This branch touches zero files under `doc/` and zero API specs**, and I want to be explicit about why rather than just ticking N/A. No REST endpoint, WebSocket topic, plugin event, skin behaviour or profile handling changes. The four registers already exist in `assets/api/bengle_hw_v1.yml` at `contract_version: 1`; this PR adds app-side **registration entries** for them, so the contract file is not edited and the version is not bumped.

That said, a reviewer could reasonably argue that "the machine now runs its own wake schedule, and the app clamps the machine's sleep timeout to a 60-minute floor" is a device-behaviour change that belongs in `doc/DeviceManagement.md`. I did not write it because I was not sure where you would want it. **If you want that doc, say so and I will add it.**

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `Yes` - four Bengle-only MMR registers (rows 54 to 57), all registered with the contract checker. A non-Bengle DE1 gets nothing on the wire.
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`

**The safety-relevant part.** `InactivitySleepTimeout` is the timer that turns a Bengle's heaters off when nobody is there - a dead tablet battery, a crashed app, a blackout. Two firmware facts make writing `0` into it unacceptable rather than merely unwise:

1. The firmware treats a value less than or equal to zero as "never sleep". The timer simply never runs.
2. **The write sticks.** The register is `PERM_RWD` - disk-backed in firmware NVM and restored at every boot. A `0` written once survives every power cycle until something writes a non-zero value back. And the machine boots hot.

So an app that wrote `0` would leave a machine **less safe than one that had never met the app at all**, since the firmware's own default is 60 minutes. That is a regression against doing nothing. `machineSleepTimeoutMinutes()` therefore collapses everything that would disable the net - the master toggle off, a "Disabled" (`0`) in the dropdown, a rogue negative arriving from REST or an imported settings blob - to a **60-minute floor, which is the firmware's own default**, and clamps everything else into the 1-to-240 range the firmware accepts. The function is **guaranteed to return a value in 1 to 240, never 0, whatever the inputs**.

This costs the user nothing they can perceive. The firmware ignores this timer entirely while a tablet is connected, so it only ever acts once the tablet is already gone - precisely the case it exists for.

## User-Visible Changes

A Bengle now honours its wake schedule with the tablet switched off, closed, or in another room. Previously the schedule only worked while the app was running and connected.

The one thing a user could notice as a change rather than an addition: **the "Disabled" option for the sleep timeout no longer disables the machine's own sleep.** It still disables the app's idle-sleep timer, which is what the setting is for, but the machine will still put itself to sleep after 60 minutes of nobody touching it once the tablet is gone. A user who deliberately wanted an always-hot machine with no tablet attached cannot get that from this app. That is intentional and I would defend it, but it is a real behaviour change and it should not be buried.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` - clean (`No issues found!`)
- [x] `flutter test` - **2295 tests pass** on this branch at `35f630eb` (B-8 was 2213, so this branch adds 82).
- [x] `(cd packages/dye2-plugin && npm run build)` - plugin builds

### Manual verification (if applicable)

- OS / platform tested: Linux (analyzer and tests).
- Simulated devices? (`simulate=1`): `No`. `MockBengle` accepts the schedule writes but has no clock and no scheduler, so a simulated run would only re-confirm what the unit tests already assert.
- Real hardware? (DE1/Bengle/scale): `No` for this branch's code. The **premise** was established on hardware: all three RAM-only registers were read on a bench Bengle and all three came back zero, which is what "nothing was writing them" means in practice.
- What you personally verified and how: the writes and the sequencing, through the tests. The firmware semantics (the day field is an index and not a bitmask, `startMin` inclusive and `endMin` exclusive, `startMin >= endMin` silently dropped, the 32-entry table, the write-then-echo read behaviour, the boot-time zeroing) come from reading the firmware source at the pinned commit.
- Edge cases checked: a table with a midnight-crossing window (split app-side, because the firmware drops it otherwise); more than 32 windows (merged and capped app-side, because the firmware silently drops the 33rd); a machine that reboots mid-session (the 15-minute tick sees the clock read back `0` and re-pushes); a machine swapped mid-write; every path by which the sleep timeout could become `0`.
- What you did **not** verify: **no machine has actually woken itself up from a schedule pushed by this code.** That is the entire feature and it is unproven end to end. The write protocol, the packing and the register semantics are all inferred from the firmware source and asserted in unit tests, but a Bengle sitting on a bench overnight, waking at a scheduled time with the tablet powered off, is the test that matters and it has not been run. I also could not verify clock drift, because **no register exposes the running firmware clock** - the four registers are write-driven and a read echoes the last value written, not live device state. The 15-minute clock resync is a mitigation for a drift I cannot measure.

### Evidence

- [x] Test output (2295 pass)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? `Yes` for every API surface - nothing public changed. See "User-Visible Changes" for the one behavioural change (the sleep-timeout floor).
- Config / env changes needed? `No`
- Database migration needed? `No`

A Bengle whose `InactivitySleepTimeout` was left at some other value by a previous app or by hand will be overwritten on the next connect, to the user's setting, or to 60 if their setting would disable it.

## Deliberate choices worth your review

- **The 60-minute floor is a safety decision that overrides a user setting.** I want it looked at squarely rather than skimmed. The argument for it is in the Security Impact section above; the short version is that a thermal safety net must not be a UI preference, and 60 is not a number I chose - it is the firmware's own default, so the app can never make a machine less safe than a factory-fresh one. The argument against it is that a user asked for something and did not get it. I think the asymmetry settles it: the failure mode of the floor is a machine that goes to sleep when someone wanted it hot; the failure mode of honouring the `0` is a machine that stays hot forever, permanently, because the write persists.
- **The schedule table is re-pushed only when it actually changed, or when the machine demonstrably lost it.** A re-push clears the table first (`ScheduleControl` `0`, then the entries, then `ScheduleControl` `1`), and clearing it drops the firmware's "was in an awake window" edge - so a gratuitous re-push in the middle of a window would **re-wake a machine the user had just manually put to sleep**. Hence the diff, and hence the 15-minute clock tick deliberately never touches the table.
- **A wake-only schedule (no `keepAwakeFor`) becomes a 30-minute window.** The firmware cannot express "wake, then hand straight back to the idle timer" - it rejects a window whose start is not before its end, so a window must have real length. 30 minutes matches the app's default sleep timeout. A one-minute window is semantically purer, but it is a fragile target against any firmware-clock error, and a missed window means the machine never wakes at all. This is a guess at what the user meant, and it is the kind of guess worth a second opinion.
- **Two register bounds are declared narrower than the contract file allows, on purpose.** `SetLocalTimeOfWeek` is capped at 604799, not 604800, because the firmware rejects a value equal to the seconds-in-a-week and would silently leave the clock invalid. `ScheduleControl` is capped at `1`, not 255, because the firmware reads only bit 0 on a non-zero write - so a stray `2` would disable the schedule **without clearing it**. Declaring `max: 1` makes that structurally impossible, since `writeMmrInt` clamps to the declared range.
- **The controller is constructed in `main.dart` and never referenced again** (there is an `// ignore: unused_local_variable`). It self-wires by subscribing to the controller and the settings. That is the pattern the other bridges use, but the lint suppression is ugly and I would take a suggestion.

## Risks & Mitigations

- **Risk:** A future edit lets this branch's `wake_schedule_windows.dart` drift from I-E's again, reintroducing the DST bug through a bad conflict resolution.
  - **Mitigation:** Already handled at the source - this branch's copy of the lib file and its test have been rebuilt from I-E's and are now byte-identical (hash-verified), so the add/add conflict is trivial and the two DST regression tests are present on both sides. The remaining risk is only that someone later edits one copy and not the other; the merge-order note says to stop and re-sync if the two ever differ.
- **Risk:** The firmware clock drifts, or a DST transition passes, and a wake window fires an hour late.
  - **Mitigation:** The clock is re-written every 15 minutes while a Bengle is connected. This bounds DST error and crystal drift, and sits well inside the smallest useful window. It cannot help a machine that is disconnected from the tablet for a long time - which is exactly the case this feature exists for. **The size of that drift is unmeasured**, because no register exposes the running clock.
- **Risk:** A push fails mid-sequence and the machine is left with a cleared, disabled table.
  - **Mitigation:** Every write path is wrapped; a failure logs and retries with capped backoff (3s, 10s, 30s, then 30s repeating), and the desired state is only stamped as pushed **after** the write lands, so a failure during the connect flow cannot crash it and self-heals on the next trigger at the latest. The machine falls back to its `InactivitySleepTimeout`, which this PR guarantees is never `0`.

