### PR TITLE
Send both temperature goals to Visualizer

### DIFF
--- a/assets/plugins/visualizer.reaplugin/manifest.json
+++ b/assets/plugins/visualizer.reaplugin/manifest.json
@@ -3,7 +3,7 @@
   "author": "Decent Espresso",
   "name": "Visualizer upload",
   "description": "Uploads shots to Visualizer and syncs your edited shot metadata back",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "apiVersion": 1,
   "permissions": [
     "log",

--- a/assets/plugins/visualizer.reaplugin/plugin.js
+++ b/assets/plugins/visualizer.reaplugin/plugin.js
@@ -190,7 +190,7 @@ function createPlugin(host) {
       elapsed: [],
       pressure: { pressure: [], goal: [] },
       flow: { flow: [], goal: [], by_weight: [] },
-      temperature: { mix: [], basket: [], goal: [] },
+      temperature: { mix: [], basket: [], goal: [], mix_goal: [] },
       totals: { weight: [], water_dispensed: [] },
       state_change: [],
       profile: reaShot.workflow.profile,
@@ -236,7 +236,8 @@ function createPlugin(host) {
       visualizerShot.flow.by_weight.push(scale?.weightFlow ?? 0);
       visualizerShot.temperature.mix.push(machine.mixTemperature);
       visualizerShot.temperature.basket.push(machine.groupTemperature);
-      visualizerShot.temperature.goal.push(machine.targetMixTemperature);
+      visualizerShot.temperature.goal.push(machine.targetGroupTemperature);
+      visualizerShot.temperature.mix_goal.push(machine.targetMixTemperature);
       visualizerShot.totals.weight.push(scale?.weight ?? 0);
       visualizerShot.totals.water_dispensed.push(waterDispensed);
       visualizerShot.state_change.push(machine.state.substate);
@@ -972,7 +973,7 @@ function createPlugin(host) {
   // Return the plugin object
   return {
     id: "visualizer.reaplugin",
-    version: "1.4.0",
+    version: "1.5.0",
 
     onLoad(settings) {
       state.username = settings.Username;


### PR DESCRIPTION
## Summary

Resolves discussion in: https://3.basecamp.com/3671212/buckets/7351439/messages/10085980757

It's supported since https://github.com/miharekar/visualizer/commit/0bba67e7b7e0e3f62d93c66c22f958995cd10e67

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [x] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs

## Linked Issues

- Closes #
- Related #

## Root Cause (if bug fix)

For bugs: explain why this happened, not just what changed. Otherwise write `N/A`.

- Root cause:
- Missing detection or guardrail:
- Contributing context (if known):

## Regression Test Plan (if bug fix or refactor)

For bugs and refactors: name the smallest reliable test that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- If no new test added, why not:

## Documentation Obligations (required)

These are **not optional**. Stale specs mislead clients and agents.

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A — no docs affected

## Security Impact (required)

This app runs a local web server (port 8080) and connects to BLE/USB hardware.

- New or changed REST endpoints? (`Yes/No`)
- New or changed WebSocket topics? (`Yes/No`)
- New or changed network calls? (`Yes/No`)
- BLE/USB surface changed? (`Yes/No`)
- File system access changed? (`Yes/No`)
- Plugin sandbox boundary changed? (`Yes/No`)
- If any `Yes`, explain risk and mitigation:

## User-Visible Changes

List user-visible changes (including defaults, config, behavior). If none, write `None`.

## Verification

### Local gates (run before pushing)

- [ ] `flutter analyze` — clean (no new warnings)
- [ ] `flutter test` — all pass
- [ ] `(cd packages/dye2-plugin && npm run build)` — plugin builds

### Manual verification (if applicable)

- OS / platform tested:
- Simulated devices? (`simulate=1`): `Yes/No`
- Real hardware? (DE1/Bengle/scale): `Yes/No`
- What you personally verified and how:
- Edge cases checked:
- What you did **not** verify:

### Evidence

Attach at least one:

- [ ] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? (`Yes/No`)
- Config / env changes needed? (`Yes/No`)
- Database migration needed? (`Yes/No`)
- If any `No` or `Yes`, explain exact steps:

## Risks & Mitigations

List only real risks for this PR. If none, write `None`.

- Risk:
  - Mitigation:
