### PR TITLE
fix(devices): preserve connected devices during scan sessions

### DIFF
--- a/.agents/skills/decent-app/scenarios/device-scan-connection-policy.md
+++ b/.agents/skills/decent-app/scenarios/device-scan-connection-policy.md
@@ -1,0 +1,85 @@
+# Scenario: device scan connection policy
+
+Verifies that explicit REST and WebSocket scans preserve occupied machine and
+scale slots, that omitted `connect` defaults to `true`, and that
+`connect=false` remains discovery-only.
+
+## Preconditions
+
+```bash
+scripts/sb-dev.sh start --connect-machine MockDe1 --connect-scale MockScale
+BASE=http://localhost:8080
+```
+
+Wait for both simulated devices to report `connected`:
+
+```bash
+curl -sf "$BASE/api/v1/devices" | jq '[.[] | select(.state == "connected") | .id]'
+```
+
+Save the connected IDs:
+
+```bash
+BEFORE=$(curl -sf "$BASE/api/v1/devices" \
+  | jq -c '[.[] | select(.state == "connected") | .id] | sort')
+```
+
+## REST default scan
+
+```bash
+curl -sf "$BASE/api/v1/devices/scan"
+AFTER=$(curl -sf "$BASE/api/v1/devices" \
+  | jq -c '[.[] | select(.state == "connected") | .id] | sort')
+test "$AFTER" = "$BEFORE"
+```
+
+The request waits for a scan-first connection cycle. Both original IDs remain
+connected and no replacement connection is attempted.
+
+## REST discovery-only scan
+
+```bash
+curl -sf "$BASE/api/v1/devices/scan?connect=false"
+AFTER=$(curl -sf "$BASE/api/v1/devices" \
+  | jq -c '[.[] | select(.state == "connected") | .id] | sort')
+test "$AFTER" = "$BEFORE"
+```
+
+The scan updates discovery results without changing either occupied slot.
+
+## WebSocket default scan
+
+```bash
+printf '%s\n' '{"command":"scan","quick":false}' \
+  | websocat -n1 "ws://localhost:8080/ws/v1/devices"
+AFTER=$(curl -sf "$BASE/api/v1/devices" \
+  | jq -c '[.[] | select(.state == "connected") | .id] | sort')
+test "$AFTER" = "$BEFORE"
+```
+
+Omitting `connect` is equivalent to `connect=true`. `quick=false` waits for the
+scan result; it does not change connection policy.
+
+## WebSocket discovery-only scan
+
+```bash
+printf '%s\n' '{"command":"scan","connect":false,"quick":false}' \
+  | websocat -n1 "ws://localhost:8080/ws/v1/devices"
+AFTER=$(curl -sf "$BASE/api/v1/devices" \
+  | jq -c '[.[] | select(.state == "connected") | .id] | sort')
+test "$AFTER" = "$BEFORE"
+```
+
+## Postconditions
+
+```bash
+scripts/sb-dev.sh stop
+```
+
+## Real-hardware extension
+
+Repeat the REST and WebSocket default scans with an attached DE1 and scale.
+Confirm from the device LEDs, app status, and logs that neither BLE link drops
+or reconnects. Ambiguous multi-device selection and Bengle integrated-scale
+precedence require the corresponding physical devices and remain separate
+hardware validation steps.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -15,6 +15,10 @@ formatter:
   page_width: 80
   trailing_commas: preserve
 
+analyzer:
+  exclude:
+    - build/**
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -15,10 +15,6 @@ formatter:
   page_width: 80
   trailing_commas: preserve
 
-analyzer:
-  exclude:
-    - build/**
-
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -88,15 +88,15 @@ paths:
   /api/v1/devices/scan:
     get:
       summary: Scan for Devices
-      description: Triggers a discovery-only device scan by default. When connect=true, uses the ConnectionManager to scan and automatically connect to preferred or single devices.
+      description: Triggers a device scan. When connect=true (default), scans first and automatically fills missing machine and scale slots without replacing connected devices. When connect=false, performs discovery only.
       tags: [Devices]
       parameters:
         - name: connect
-          description: Whether to use the ConnectionManager to automatically connect to preferred/discovered devices during scanning. Defaults to false.
+          description: Whether to scan first and automatically connect missing preferred/discovered devices. Defaults to true.
           in: query
           schema:
             type: boolean
-            default: false
+            default: true
         - name: quick
           description: If this flag is set to true, REA will return immediately after calling this function, returning an empty array. Useful if you want to poll for new devices manually
           in: query

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -88,14 +88,15 @@ paths:
   /api/v1/devices/scan:
     get:
       summary: Scan for Devices
-      description: Triggers a device scan. When connect=true (default), uses the ConnectionManager to scan and automatically connect to preferred or single devices. When connect=false, performs a scan-only without automatic connections.
+      description: Triggers a discovery-only device scan by default. When connect=true, uses the ConnectionManager to scan and automatically connect to preferred or single devices.
       tags: [Devices]
       parameters:
         - name: connect
-          description: Whether to use the ConnectionManager to automatically connect to preferred/discovered devices during scanning. Default is 'true'.
+          description: Whether to use the ConnectionManager to automatically connect to preferred/discovered devices during scanning. Defaults to false.
           in: query
           schema:
             type: boolean
+            default: false
         - name: quick
           description: If this flag is set to true, REA will return immediately after calling this function, returning an empty array. Useful if you want to poll for new devices manually
           in: query

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -98,10 +98,11 @@ paths:
             type: boolean
             default: true
         - name: quick
-          description: If this flag is set to true, REA will return immediately after calling this function, returning an empty array. Useful if you want to poll for new devices manually
+          description: If true, Decent.app returns an empty array immediately while the same scan-first policy continues in the background. Useful when polling for device updates manually.
           in: query
           schema:
             type: boolean
+            default: false
       responses:
         "200":
           description: Scan started successfully

--- a/assets/api/websocket_v1.yml
+++ b/assets/api/websocket_v1.yml
@@ -853,8 +853,8 @@ components:
           description: Device identifier. Required for connect and disconnect commands.
         connect:
           type: boolean
-          description: Whether to auto-connect discovered devices (scan command only). Defaults to discovery-only.
-          default: false
+          description: Whether to scan first and automatically fill missing machine and scale slots without replacing connected devices (scan command only).
+          default: true
         quick:
           type: boolean
           description: Fire-and-forget scan without waiting for results (scan command only).

--- a/assets/api/websocket_v1.yml
+++ b/assets/api/websocket_v1.yml
@@ -853,7 +853,7 @@ components:
           description: Device identifier. Required for connect and disconnect commands.
         connect:
           type: boolean
-          description: Whether to auto-connect discovered devices (scan command only).
+          description: Whether to auto-connect discovered devices (scan command only). Defaults to discovery-only.
           default: false
         quick:
           type: boolean

--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -26,14 +26,69 @@ The single BLE transport is `UniversalBleTransport` in `lib/src/services/ble/uni
 
 ## Connection Flow
 
-`ConnectionManager.connect()` orchestrates the full connect sequence:
-1. Scan for devices
-2. Apply preferred-device policy (`PolicyResolver`)
-3. Connect machine (`connectMachine()`)
-4. Connect scale (`connectScale()`)
-5. Emit `ready` status
+`ConnectionManager` supports three distinct connection intents, selected via
+`ConnectionAttemptPolicy`:
 
-`StatusPublisher` drives `ConnectionStatus` stream with phases: `idle` → `scanning` → `connectingMachine` → `connectingScale` → `ready`.
+### automatic `connect()`
+
+Used by startup, machine recovery, and USB-attach recovery. Tries
+remembered-machine quick-connect first. If that fails, scans for devices.
+During the scan, preferred machines and scales are connected as they appear
+(`connectPreferredDuringScan: true`). The scan stops early once all
+preferences are satisfied (`stopScanAfterPreferredConnect: true`).
+Preferred-scale watch and deferred scale scan handle the wake-after-connect
+race.
+
+### explicit `scanAndConnect()`
+
+Used by the launcher scan page, REST/WS scan commands (when `connect=true`),
+and explicit retry buttons. Completes full discovery before policy runs
+(`connectPreferredDuringScan: false`), never quick-connects, and never
+stops early. Preserves occupied machine/scale slots. When discovery
+produces ambiguity (multiple candidates for an unoccupied slot),
+a `ConnectionSelectionSession` holds the immutable scan snapshot.
+`selectMachine()` and `selectScale()` continue the session against the
+session-owned canonical candidates — no new scan fires.
+
+### `scaleOnly` / scale recovery
+
+Triggered by the background scale watch, deferred scale scan, and queued
+scale-only reconnect callers. Skips the machine phase entirely. If a
+selection session is active with pending ambiguity, scale recovery is
+deferred to avoid racing with the user's choice. Only runs when the
+machine is connected or sleeping. On Android, uses a filtered scan to
+bypass background throttling.
+
+### Phase lifecycle
+
+`StatusPublisher` drives the `ConnectionStatus` stream with phases:
+`idle` → `scanning` → `connectingMachine` → `connectingScale` → `ready`.
+
+Errors transit through the status-publisher gatekeeper: transient errors
+(most `ConnectionErrorKind` values) are stripped when the phase moves
+into a clearing phase (`connectingMachine`, `connectingScale`, `ready`).
+Sticky errors (`scanFailed`, `bluetoothPermissionDenied`) survive
+transitions.
+
+### Slot policy
+
+Machine and scale are independently fillable. Occupied slots are never
+replaced automatically by a scan. A missing slot auto-connects its
+preferred device when found. Without a preferred ID, exactly one candidate
+auto-connects; more than one produces ambiguity.
+
+### Cancellation
+
+`cancelActiveScan()` bumps the generation token, stops the scanner,
+cancels any active selection session, and clears pending ambiguity. An
+in-flight `_connectImpl` detects the generation mismatch after `runScan`
+returns and skips policy. `cancelSelectionSession()` finalises an already-
+completed scan as cancelled without touching an in-flight scan.
+
+Cancel (launcher) and route-back interception both route through
+`cancelActiveScan()`. "View found devices" intentionally stops discovery
+and proceeds with partial results — that is a different action, not
+cancellation.
 
 ## Footgun #1: GATT-133 on Cold Boot
 
@@ -181,38 +236,3 @@ from a disconnected generation.
 ## Keeping Notes Fresh
 
 Add lessons that would have saved debugging time: new footguns, thread-safety constraints, connection-lifecycle changes, non-obvious symptoms, and cross-transport dependencies. Prune stale claims. Prefer fewer, sharper notes over long background.
-
-## Connection Policy (PR #476)
-
-Two intents govern how `ConnectionManager` starts a connect cycle:
-
-- **automatic `connect()`**: Used by startup, machine recovery, and USB-attach
-  recovery. Remembers-machine quick-connect, connects preferred devices during
-  the scan, and stops scanning early once preferences are satisfied. Fastest
-  restoration of the expected configuration.
-- **explicit `scanAndConnect()`**: Used by the launcher scan page, REST/WS
-  scan commands (when `connect=true`), and explicit retry buttons. Completes
-  full discovery before policy runs, never quick-connects during the scan,
-  and never stops early. Preserves working machine/scale slots.
-
-Slot policy: machine and scale are independently fillable. Occupied slots are
-never replaced automatically by a scan. A missing slot auto-connects its
-preferred device when found. Without a preferred ID, exactly one candidate
-auto-connects; more than one produces ambiguity.
-
-Session continuation: when a scan produces ambiguity (`machinePicker` or
-`scalePicker`), a `ConnectionSelectionSession` holds the immutable scan
-snapshot. `selectMachine()` and `selectScale()` resolve the session-owned
-candidate object (never the caller-supplied reference) and continue with
-retained scale candidates — no additional scan fires. `cancelSelectionSession()`
-clears pending ambiguity, finalises the report as cancelled, and re-arms
-scale reacquisition.
-
-Preferred-scale watch: the persistent background scale watch pauses while
-scale ambiguity is pending so it cannot auto-connect the old preferred scale
-while the user is choosing. Successful explicit scale selection persists the
-new preferred ID and the watch re-arms after session completion or cancellation.
-
-Live-machine quick-connect guard: `_machineConnected` prevents quick-connect
-from re-adopting a fresh object for the same already-connected peripheral.
-This avoids spurious DE1 disconnect/re-attach cycles.

--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -181,3 +181,38 @@ from a disconnected generation.
 ## Keeping Notes Fresh
 
 Add lessons that would have saved debugging time: new footguns, thread-safety constraints, connection-lifecycle changes, non-obvious symptoms, and cross-transport dependencies. Prune stale claims. Prefer fewer, sharper notes over long background.
+
+## Connection Policy (PR #476)
+
+Two intents govern how `ConnectionManager` starts a connect cycle:
+
+- **automatic `connect()`**: Used by startup, machine recovery, and USB-attach
+  recovery. Remembers-machine quick-connect, connects preferred devices during
+  the scan, and stops scanning early once preferences are satisfied. Fastest
+  restoration of the expected configuration.
+- **explicit `scanAndConnect()`**: Used by the launcher scan page, REST/WS
+  scan commands (when `connect=true`), and explicit retry buttons. Completes
+  full discovery before policy runs, never quick-connects during the scan,
+  and never stops early. Preserves working machine/scale slots.
+
+Slot policy: machine and scale are independently fillable. Occupied slots are
+never replaced automatically by a scan. A missing slot auto-connects its
+preferred device when found. Without a preferred ID, exactly one candidate
+auto-connects; more than one produces ambiguity.
+
+Session continuation: when a scan produces ambiguity (`machinePicker` or
+`scalePicker`), a `ConnectionSelectionSession` holds the immutable scan
+snapshot. `selectMachine()` and `selectScale()` resolve the session-owned
+candidate object (never the caller-supplied reference) and continue with
+retained scale candidates — no additional scan fires. `cancelSelectionSession()`
+clears pending ambiguity, finalises the report as cancelled, and re-arms
+scale reacquisition.
+
+Preferred-scale watch: the persistent background scale watch pauses while
+scale ambiguity is pending so it cannot auto-connect the old preferred scale
+while the user is choosing. Successful explicit scale selection persists the
+new preferred ID and the watch re-arms after session completion or cancellation.
+
+Live-machine quick-connect guard: `_machineConnected` prevents quick-connect
+from re-adopting a fresh object for the same already-connected peripheral.
+This avoids spurious DE1 disconnect/re-attach cycles.

--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -53,11 +53,12 @@ session-owned canonical candidates — no new scan fires.
 ### `scaleOnly` / scale recovery
 
 Triggered by the background scale watch, deferred scale scan, and queued
-scale-only reconnect callers. Skips the machine phase entirely. If a
-selection session is active with pending ambiguity, scale recovery is
-deferred to avoid racing with the user's choice. Only runs when the
-machine is connected or sleeping. On Android, uses a filtered scan to
-bypass background throttling.
+scale-only reconnect callers. Skips the machine phase entirely — a scale
+can connect independently of the machine. If a selection session is active
+with pending ambiguity, scale recovery is deferred to avoid racing with
+the user's choice. Scales powered off while the machine is sleeping are
+skipped to respect the radio-disconnect power mode. On Android, uses a
+filtered scan to bypass background throttling.
 
 ### Phase lifecycle
 
@@ -77,13 +78,21 @@ replaced automatically by a scan. A missing slot auto-connects its
 preferred device when found. Without a preferred ID, exactly one candidate
 auto-connects; more than one produces ambiguity.
 
-### Cancellation
+### Cancellation and superseding
 
 `cancelActiveScan()` bumps the generation token, stops the scanner,
-cancels any active selection session, and clears pending ambiguity. An
-in-flight `_connectImpl` detects the generation mismatch after `runScan`
-returns and skips policy. `cancelSelectionSession()` finalises an already-
-completed scan as cancelled without touching an in-flight scan.
+cancels any active selection session, discards any queued explicit
+replacement, and clears pending ambiguity. An in-flight `_connectImpl`
+detects the generation mismatch after `runScan` returns and skips policy.
+`cancelSelectionSession()` finalises an already-completed scan as cancelled
+without touching an in-flight scan.
+
+Repeated explicit scan requests ("ReScan", stale-scan recovery, repeated
+REST/UI calls) supersede the active scan and coalesce into a single
+queued replacement. The superseded scan emits one cancelled report; the
+replacement emits its normal report. If `cancelActiveScan()` fires while
+a replacement is queued, the replacement is discarded and its waiting
+callers complete cleanly.
 
 Cancel (launcher) and route-back interception both route through
 `cancelActiveScan()`. "View found devices" intentionally stops discovery

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -88,7 +88,7 @@ Pre-stream responses are `400` for malformed input, `404` for an unknown artifac
 | Method | Path | Description | Handler |
 |--------|------|-------------|---------|
 | GET | `/api/v1/devices` | List devices (present + remembered) | `devices_handler.dart` |
-| GET | `/api/v1/devices/scan` | Discover devices (`?quick=`); set `?connect=true` to auto-connect | |
+| GET | `/api/v1/devices/scan` | Scan and fill missing device slots; set `?connect=false` for discovery only | |
 | PUT | `/api/v1/devices/connect` | Connect to device by ID | |
 | PUT | `/api/v1/devices/disconnect` | Disconnect device | |
 | PUT | `/api/v1/devices/forget` | Forget a remembered device | |

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -96,6 +96,12 @@ Pre-stream responses are `400` for malformed input, `404` for an unknown artifac
 | POST | `/api/v1/devices/wifi` | Add a WiFi scale by IP/hostname (`{host}`) | |
 | DELETE | `/api/v1/devices/wifi` | Remove a manual WiFi endpoint (`{host}` body or `?host=`) | |
 
+`/api/v1/devices/scan` keeps the existing query shape and defaults:
+`connect=true` when omitted and `quick=false` when omitted. With connection
+enabled, the request scans first, preserves occupied slots, then fills missing
+machine and scale slots; this may take longer than the former quick-connect
+behavior. `quick=true` returns immediately but does not change that policy.
+
 Each device entry carries an **`available`** boolean. `true` = currently present
 in discovery; `false` = a **remembered** device that isn't present (reported with
 `state: "disconnected"`). Devices the user connects to are remembered and persist

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -88,7 +88,7 @@ Pre-stream responses are `400` for malformed input, `404` for an unknown artifac
 | Method | Path | Description | Handler |
 |--------|------|-------------|---------|
 | GET | `/api/v1/devices` | List devices (present + remembered) | `devices_handler.dart` |
-| GET | `/api/v1/devices/scan` | Start a device scan (`?quick=`, `?connect=`) | |
+| GET | `/api/v1/devices/scan` | Discover devices (`?quick=`); set `?connect=true` to auto-connect | |
 | PUT | `/api/v1/devices/connect` | Connect to device by ID | |
 | PUT | `/api/v1/devices/disconnect` | Disconnect device | |
 | PUT | `/api/v1/devices/forget` | Forget a remembered device | |

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -658,8 +658,9 @@ scale discovery:
 - **No preferred scale:** `_armPostQuickConnectScaleScan()` (single deferred
   scale-only scan after ~3s, same delay as the post-wake reconnect)
 
-Quick-connect is tried in **all** connect cycles (startup, manual
-reconnect, recovery mode). The phase stream shows
+Quick-connect is tried in connect cycles only while no machine is connected
+(startup, manual reconnect, recovery mode). An already-connected machine is
+preserved while a connect cycle scans for scales. The phase stream shows
 `idle → connectingMachine → ready` on success. On failure:
 `connectingMachine` is published before the attempt, then phase falls
 through to `scanning` (existing scan path).

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -302,13 +302,14 @@ Transition owners (where the `publish(phase: …)` call lives):
 | `scanning → idle` (scan failure)        | `ScanOrchestrator._emitScanStartError`                  |
 | `scanning → connectingMachine`          | `ConnectionManager.connectMachine` (policy stage)       |
 | `connectingMachine → connectingScale`   | `ConnectionManager.connectScale` (post-machine policy)  |
-| `connectingMachine → ready` (no scale)  | `ConnectionManager._finalizePhase`                      |
-| `connectingScale → ready`               | `ConnectionManager._finalizePhase`                      |
+| `connectingMachine → ready` (no scale)  | `ConnectionManager._settleAfterMachinePhase`           |
+| `connectingScale → ready`               | `ConnectionManager._settleAfterScalePhase`             |
 | `connectingScale → idle` (scale error)  | `StatusPublisher.emitError` → gatekeeper folds to idle  |
 | any `→ idle` on disconnect              | `DisconnectSupervisor._onMachineGone / _onScaleGone`    |
 
 `scaleOnly` reconnects (`connect(scaleOnly: true)`) skip every machine-phase
-edge and go `idle → scanning → connectingScale → ready`.
+edge. With a machine connected they settle at `ready`; without one they settle
+at `idle` after the scale connects.
 
 Non-phase status fields (`error`, `foundMachines`, `pendingAmbiguity`)
 are allowed to change on any edge; only the `phase` field follows the
@@ -327,6 +328,10 @@ Automatic `connect()` scans may early-connect preferred devices as they appear. 
    - No preferred, multiple → show picker (`machinePicker`)
 2. **Scale phase** — after machine resolution, apply the same policy to a missing scale. If no machine is found, an unambiguous scale can still connect while the overall phase remains `idle`. Machine ambiguity is resolved before scale ambiguity, and selecting a machine continues with scale candidates retained from the same scan. Bengle skips external-scale policy because its integrated scale always owns the slot.
 
+The `ScanReport` covers this full selection session. It is finalized after any
+picker continuation and retained scale work complete; a newer full scan or a
+disconnect finalizes the superseded session as cancelled.
+
 **Early stop.** With a preferred machine set, the scan stops as soon as
 its targets connect rather than running the full timeout: when a preferred
 scale is also configured, only once *both* connect; when no preferred scale
@@ -342,9 +347,9 @@ so a full scan that ran to completion never triggers one.
 
 - `connect()` — Startup/recovery quick-connect with scan fallback
 - `scanAndConnect()` — Explicit scan-first flow that fills missing slots
-- `scanAndConnectScale()` — Scale-only reconnect (skips machine phase)
-- `connectMachine(De1Interface)` — Connect to a specific machine
-- `connectScale(Scale)` — Connect to a specific scale
+- `connect(scaleOnly: true)` — Automatic scale recovery (skips machine phase)
+- `connectMachine(De1Interface)` / `connectScale(Scale)` — Deliberate direct connection
+- `selectMachine(De1Interface)` / `selectScale(Scale)` — Continue the active selection session; stale choices are rejected
 - `disconnectMachine()` / `disconnectScale()` — Explicit disconnects
 
 ### Disconnect Handling
@@ -707,24 +712,12 @@ through to `scanning` (existing scan path).
 
 If multiple machines or scales are found without a preferred device set, ConnectionManager emits `pendingAmbiguity: machinePicker` or `scalePicker`, and the UI shows a picker dialog.
 
-### Scale Reconnect from StatusTile (legacy home_feature)
+### Explicit Retry from Native Device UI
 
-> **Note:** This tap-to-reconnect affordance lives in the legacy `home_feature`
-> StatusTile. Since the native UI redesign, `LauncherView` (not `home_feature`)
-> is the default post-onboarding screen. When no machine is connected, the
-> launcher shows a **"Connect your machine"** hero card above the skin slot
-> that pushes a full-screen scan page (`LauncherScanPage`) reusing the
-> onboarding scan flow. Tapping it triggers `connectionManager.connect()`.
-
-```
-1. User taps "Scale" text in StatusTile (when no scale connected)
-   ↓
-2. connectionManager.scanAndConnectScale()
-   ↓
-3. BLE scan runs, preferred scale policy applied
-   ↓
-4. If multiple scales found → scalePicker dialog shown
-```
+The legacy `home_feature` StatusTile reconnect affordance is retired. Native
+scan and retry controls call `scanAndConnect()`, so they perform a complete
+scan before filling missing slots. The launcher’s **Connect your machine** hero
+opens `LauncherScanPage`, which reuses this scan-first flow.
 
 ### Machine Wake → Scale Reconnect Flow
 
@@ -735,7 +728,7 @@ If multiple machines or scales are found without a preferred device set, Connect
    ↓
 3. Check if scale connected → NO, scalePowerMode == disconnect → YES
    ↓
-4. Call connectionManager.scanAndConnectScale()
+4. Call `connectionManager.connect(scaleOnly: true)`
    ↓
 5. Scan runs, preferred scale connected automatically
 ```
@@ -858,7 +851,7 @@ All connection decisions are centralized in `ConnectionManager`. Individual cont
 
 ConnectionManager uses `SettingsController` to read preferred device IDs:
 
-1. **Preferred device set + found during scan** → auto-connect immediately (early connect during scan)
+1. **Preferred device set + found during scan** → auto-connect (during discovery for automatic recovery; after discovery completes for explicit scans)
 2. **Preferred device set + not found, but others available** → show picker dialog
 3. **No preferred device, 1 found** → auto-connect silently
 4. **No preferred device, multiple found** → show picker dialog
@@ -869,12 +862,12 @@ Preferred device IDs are auto-saved on successful connection and can be managed 
 ### Machine vs Scale Connection
 
 - Connected machine and scale slots are preserved; alternatives discovered by a scan never replace them automatically.
-- Machine policy resolves before scale policy so Bengle's integrated scale always wins.
+- Machine policy resolves before scale policy so Bengle's integrated scale always wins; selecting or reconnecting Bengle hands off an attached external scale to the integrated scale.
 - If no machine is found, a missing unambiguous scale still connects; phase remains `idle` and the scan UI shows the partial result.
 - Machine selection continues deterministically into the retained scale phase from the same scan.
 - Scale ambiguity pauses preferred-scale reacquisition until the user selects a scale; successful selection updates the preferred ID used by future watches.
 - **Scale failures are non-blocking** — if scale connection fails, machine stays connected and phase stays `ready`
-- **Scale-only reconnect** — `scanAndConnectScale()` skips the machine phase entirely (used by De1StateManager for wake-from-sleep and by StatusTile for manual reconnect)
+- **Scale-only reconnect** — `connect(scaleOnly: true)` skips the machine phase and retains automatic preferred-scale recovery behavior (used by De1StateManager for wake-from-sleep)
 
 ---
 

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -316,16 +316,16 @@ table above.
 
 ### Connection Policy
 
-When `connect()` is called:
+`connect()` is the automatic startup/recovery path: it may quick-connect a missing remembered machine before falling back to scanning. `scanAndConnect()` is the explicit user/API path: it always scans first, preserves connected machine and scale slots, then fills only missing slots.
 
-1. **Scan** for all devices via `DeviceController.scanForDevices()`
-2. **Early connect** — if preferred device IDs are set in settings, connect as soon as they appear during scan (don't wait for scan to finish)
-3. **Machine phase** — apply preferred machine policy:
+Automatic `connect()` scans may early-connect preferred devices as they appear. Explicit `scanAndConnect()` scans collect the complete result first, then apply policy:
+
+1. **Machine phase** — apply preferred machine policy:
    - Preferred set + found → auto-connect
    - Preferred set + not found, but others available → show picker (`machinePicker`)
    - No preferred, 1 machine → auto-connect
    - No preferred, multiple → show picker (`machinePicker`)
-4. **Scale phase** — apply preferred scale policy (same logic as machine)
+2. **Scale phase** — after machine resolution, apply the same policy to a missing scale. If no machine is found, an unambiguous scale can still connect while the overall phase remains `idle`. Machine ambiguity is resolved before scale ambiguity, and selecting a machine continues with scale candidates retained from the same scan. Bengle skips external-scale policy because its integrated scale always owns the slot.
 
 **Early stop.** With a preferred machine set, the scan stops as soon as
 its targets connect rather than running the full timeout: when a preferred
@@ -340,7 +340,8 @@ so a full scan that ran to completion never triggers one.
 
 ### Key Methods
 
-- `connect()` — Full scan + connect flow (machine + scale)
+- `connect()` — Startup/recovery quick-connect with scan fallback
+- `scanAndConnect()` — Explicit scan-first flow that fills missing slots
 - `scanAndConnectScale()` — Scale-only reconnect (skips machine phase)
 - `connectMachine(De1Interface)` — Connect to a specific machine
 - `connectScale(Scale)` — Connect to a specific scale
@@ -658,9 +659,9 @@ scale discovery:
 - **No preferred scale:** `_armPostQuickConnectScaleScan()` (single deferred
   scale-only scan after ~3s, same delay as the post-wake reconnect)
 
-Quick-connect is tried in connect cycles only while no machine is connected
-(startup, manual reconnect, recovery mode). An already-connected machine is
-preserved while a connect cycle scans for scales. The phase stream shows
+Quick-connect is reserved for automatic startup and recovery, including
+Android USB-attach recovery. Explicit native, REST, and WebSocket scans call
+`scanAndConnect()` and always scan before applying policy. The phase stream shows
 `idle → connectingMachine → ready` on success. On failure:
 `connectingMachine` is published before the attempt, then phase falls
 through to `scanning` (existing scan path).
@@ -867,7 +868,11 @@ Preferred device IDs are auto-saved on successful connection and can be managed 
 
 ### Machine vs Scale Connection
 
-- **Machine** connects first, then scale phase runs
+- Connected machine and scale slots are preserved; alternatives discovered by a scan never replace them automatically.
+- Machine policy resolves before scale policy so Bengle's integrated scale always wins.
+- If no machine is found, a missing unambiguous scale still connects; phase remains `idle` and the scan UI shows the partial result.
+- Machine selection continues deterministically into the retained scale phase from the same scan.
+- Scale ambiguity pauses preferred-scale reacquisition until the user selects a scale; successful selection updates the preferred ID used by future watches.
 - **Scale failures are non-blocking** — if scale connection fails, machine stays connected and phase stays `ready`
 - **Scale-only reconnect** — `scanAndConnectScale()` skips the machine phase entirely (used by De1StateManager for wake-from-sleep and by StatusTile for manual reconnect)
 

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -160,10 +160,10 @@ Returns all discovered devices with their connection states.
 
 #### Scan for Devices
 ```http
-GET /api/v1/devices/scan?connect=true&quick=false
+GET /api/v1/devices/scan
 ```
 
-Triggers a device scan. When `connect=true` (default), uses the ConnectionManager to scan and automatically connect to preferred or single devices (both machines and scales). When `connect=false`, performs a scan-only without automatic connections. Use `quick=true` to return immediately without waiting for scan results.
+Triggers a discovery-only device scan without disturbing connected devices. Discovered alternatives appear in the device list and remain disconnected until the skin explicitly connects one. Set `connect=true` to use the ConnectionManager to automatically connect preferred or single devices. Use `quick=true` to return immediately without waiting for scan results.
 
 #### Connect to Device
 ```http
@@ -2861,7 +2861,8 @@ Here's a complete minimal skin implementation:
 
 ### Scale Not Responding
 - Check scale is connected: `GET /api/v1/devices`
-- Try reconnecting scale: `GET /api/v1/devices/scan?connect=true`
+- Discover available scales: `GET /api/v1/devices/scan`
+- Connect the selected scale: `PUT /api/v1/devices/connect` with `{"deviceId":"..."}`
 - Check scale battery level via scale snapshot stream
 
 ---

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -163,7 +163,7 @@ Returns all discovered devices with their connection states.
 GET /api/v1/devices/scan
 ```
 
-Triggers a discovery-only device scan without disturbing connected devices. Discovered alternatives appear in the device list and remain disconnected until the skin explicitly connects one. Set `connect=true` to use the ConnectionManager to automatically connect preferred or single devices. Use `quick=true` to return immediately without waiting for scan results.
+Triggers a scan-first connection cycle. With the default `connect=true`, Decent.app preserves connected devices and automatically fills only missing machine and scale slots. Preferred devices connect without prompting when found; missing preferred devices or multiple candidates produce machine-first, then scale ambiguity on `ws/v1/devices`. Set `connect=false` for discovery only. Use `quick=true` to return immediately without waiting for scan results.
 
 #### Connect to Device
 ```http
@@ -2861,8 +2861,8 @@ Here's a complete minimal skin implementation:
 
 ### Scale Not Responding
 - Check scale is connected: `GET /api/v1/devices`
-- Discover available scales: `GET /api/v1/devices/scan`
-- Connect the selected scale: `PUT /api/v1/devices/connect` with `{"deviceId":"..."}`
+- Scan and reconnect a missing scale: `GET /api/v1/devices/scan`
+- If alternatives produce ambiguity, connect the selected scale: `PUT /api/v1/devices/connect` with `{"deviceId":"..."}`
 - Check scale battery level via scale snapshot stream
 
 ---

--- a/doc/plans/archive/device-scan-connection-policy/README.md
+++ b/doc/plans/archive/device-scan-connection-policy/README.md
@@ -1,0 +1,110 @@
+# Device scan and connection policy
+
+## Status
+
+Accepted for PR #476. Tracking issue: #477.
+
+This document records the design as directed by the maintainer during review of the original field bug. Items marked **Maintainer direction** were explicitly chosen in discussion. Items marked **Implementation consequence** follow from those choices.
+
+## Origin
+
+An explicit skin scan called the same `ConnectionManager.connect()` path used by startup and recovery. That path could remembered-machine quick-connect before discovery, create a fresh DE1 object for the same peripheral, and pass it to `De1Controller.adoptDevice()`. Replacing the existing controller object produced an observable DE1 disconnect/re-attach even though the physical BLE link had not failed.
+
+Adding `_machineConnected` to the quick-connect guard prevents that exact re-adoption. It was considered insufficient because an explicit scan is also expected to discover and connect a missing scale, surface non-preferred alternatives, preserve already-working slots, and sequence machine/scale decisions consistently.
+
+## Two connection intents
+
+### Automatic startup and recovery
+
+**Maintainer direction:** Startup, unexpected-machine recovery, and Android USB-attach recovery use the automatic `connect()` policy.
+
+These paths retain remembered-machine direct connection, preferred-device connection during scanning, and early stop. Their goal is fastest restoration of the expected configuration. USB attach remains in this category because the Android attach event is only an incomplete hint; after a short settle it still needs remembered-port probing or scan fallback.
+
+A live machine must never enter remembered-machine quick-connect. Occupied slots are authoritative controller state, not the presence of a discovered object.
+
+### Explicit scans
+
+**Maintainer direction:** Native user scans, REST scans, and `ws/v1/devices` scan commands use `scanAndConnect()` when `connect=true`. They complete discovery before connection policy runs. `connect=false` remains discovery-only.
+
+Explicit scans do not remembered-machine quick-connect, connect preferred devices during the scan, or early-stop discovery. This ensures the result set can include newly introduced scales and non-preferred alternatives before policy makes a choice.
+
+## Slot policy
+
+**Maintainer direction:** Machine and scale are independently fillable slots.
+
+- A genuinely connected controller slot is preserved. Discovery never replaces it automatically, even when its ID differs from the saved preference.
+- A missing slot auto-connects its preferred device when found.
+- If the preferred device is absent or fails and alternatives exist, selection is ambiguous.
+- Without a preferred ID, exactly one candidate auto-connects; multiple candidates are ambiguous.
+- Explicit `PUT /api/v1/devices/connect` or the matching WebSocket command remains the intentional way to select a replacement.
+
+**Maintainer direction:** A scale may connect when no machine is found. The overall phase remains `idle`, because `ready` still requires a machine. The scan UI shows the connected/found scale as a partial result rather than claiming that no devices were found.
+
+## Ordered ambiguity and retained candidates
+
+**Maintainer direction:** Machine ambiguity resolves before scale ambiguity. Machine and scale ambiguity are not exposed independently or simultaneously.
+
+A scan selection session retains the immutable scan snapshot, machine and scale candidates, preferred IDs captured at scan time, and scan-report state. When a machine picker is shown, scale policy waits. A successful machine selection continues deterministically with the retained scale candidates:
+
+1. Connect the selected machine.
+2. If it is Bengle, attach its integrated scale and finish.
+3. Otherwise auto-connect an unambiguous missing scale or emit scale ambiguity.
+
+A newer full scan, disconnect, cancellation, or disposal invalidates the old selection session. Picker selection is accepted only for the current session's candidate set, preventing stale UI actions from completing superseded policy.
+
+## Bengle precedence
+
+**Maintainer direction:** Bengle always owns the scale slot through its integrated scale. External scale candidates discovered before machine selection are retained but ignored if the selected machine is Bengle. If an external scale is already attached when Bengle becomes the machine, the scale controller performs a handoff to the integrated scale; this is the sole occupied-scale exception. This is why machine policy must resolve before scale policy.
+
+## Preferred-scale watch
+
+**Maintainer direction:** Preferred-scale background reacquisition pauses while scale ambiguity is pending. It must not auto-connect the old preferred scale while the user is choosing. Successful explicit scale selection persists the new preferred ID. While that scale is connected no watch is needed; on a later disconnect, reacquisition targets the new preferred ID.
+
+A queued scale-only recovery remains an automatic policy operation. When drained after another connection cycle it keeps preferred-scale early-connect behavior; it must not inherit explicit-scan settings merely because it was queued behind one.
+
+## Scan report contract
+
+The scan report represents the complete scan-and-connect selection session, not discovery alone. It is emitted when automatic connection work and any required picker continuation complete. If a newer scan supersedes a pending selection, the old session is finalized as cancelled. Connection attempts made after picker selection belong to the same report.
+
+This contract avoids publishing an apparently final immutable report and then mutating hidden builder state with later machine or scale results.
+
+## Retry semantics
+
+**Maintainer direction:** Visible scan controls and explicit discovery actions use `scanAndConnect()`. Automatic recovery paths use `connect()`.
+
+A generic connection-error retry is classified by intent:
+
+- unexpected-disconnect recovery retries use `connect()`;
+- failed explicit connection attempts and visible “scan again” controls use `scanAndConnect()`;
+- adapter-off, permission-denied, and scan-start failures show remediation text rather than a retry button.
+
+Machine connection failure must remain visible if scale policy continues. A phase transition caused by scale connection must not erase the explanation for the missing machine.
+
+## REST and WebSocket compatibility
+
+**Maintainer direction:** Wire shapes and defaults remain unchanged.
+
+- REST `/api/v1/devices/scan` defaults `connect` to `true`.
+- WebSocket `{"command":"scan"}` defaults `connect` to `true`.
+- Explicit `connect=false` remains discovery-only.
+- `quick=true` remains fire-and-forget at the transport interface; it does not re-enable remembered-machine quick-connect or in-scan early connection for an explicit scan.
+
+Behavioral compatibility is intentionally not exact: blocking explicit scans now wait for complete discovery and may return later, occupied slots are preserved, and ambiguity/automatic selection follows the missing-slot policy above.
+
+## Rejected alternatives
+
+### Only guard remembered-machine quick-connect
+
+Rejected by maintainer direction. It fixes the false DE1 re-adoption but does not define missing-scale auto-connect, complete alternative discovery, ordered ambiguity, or retained selection state.
+
+### Make explicit scans discovery-only
+
+Initially implemented, then explicitly reversed by the maintainer. `connect=true` remains the default and explicit scans fill missing slots automatically.
+
+### Independent or simultaneous machine and scale ambiguity
+
+Rejected by maintainer direction. It conflicts with Bengle integrated-scale precedence and complicates clients. Machine selection completes first, then scale policy runs.
+
+### Automatically replace an occupied slot
+
+Rejected by maintainer direction. A working machine or scale remains connected regardless of discovered alternatives or preference mismatch. Replacement requires explicit selection.

--- a/lib/src/controllers/connection/connection_attempt_policy.dart
+++ b/lib/src/controllers/connection/connection_attempt_policy.dart
@@ -1,0 +1,29 @@
+class ConnectionAttemptPolicy {
+  final bool directRememberedMachine;
+  final bool connectPreferredDuringScan;
+  final bool stopScanAfterPreferredConnect;
+
+  const ConnectionAttemptPolicy._({
+    required this.directRememberedMachine,
+    required this.connectPreferredDuringScan,
+    required this.stopScanAfterPreferredConnect,
+  });
+
+  static const automatic = ConnectionAttemptPolicy._(
+    directRememberedMachine: true,
+    connectPreferredDuringScan: true,
+    stopScanAfterPreferredConnect: true,
+  );
+
+  static const explicitScan = ConnectionAttemptPolicy._(
+    directRememberedMachine: false,
+    connectPreferredDuringScan: false,
+    stopScanAfterPreferredConnect: false,
+  );
+
+  static const scaleRecovery = ConnectionAttemptPolicy._(
+    directRememberedMachine: false,
+    connectPreferredDuringScan: true,
+    stopScanAfterPreferredConnect: false,
+  );
+}

--- a/lib/src/controllers/connection/connection_selection_session.dart
+++ b/lib/src/controllers/connection/connection_selection_session.dart
@@ -1,0 +1,60 @@
+import 'package:reaprime/src/controllers/connection/scan_report_builder.dart';
+import 'package:reaprime/src/models/adapter_state.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/scan_report.dart';
+
+enum ConnectionSelectionSessionState { active, completed, cancelled }
+
+class ConnectionSelectionSession {
+  final List<De1Interface> machines;
+  final List<Scale> scales;
+  final String? preferredMachineId;
+  final String? preferredScaleId;
+  final ScanReportBuilder scanReport;
+
+  ConnectionSelectionSessionState _state =
+      ConnectionSelectionSessionState.active;
+
+  ConnectionSelectionSession({
+    required List<De1Interface> machines,
+    required List<Scale> scales,
+    required this.preferredMachineId,
+    required this.preferredScaleId,
+    required this.scanReport,
+  }) : machines = List.unmodifiable(machines),
+       scales = List.unmodifiable(scales);
+
+  ConnectionSelectionSessionState get state => _state;
+  bool get isActive => _state == ConnectionSelectionSessionState.active;
+
+  bool acceptsMachine(De1Interface machine) =>
+      isActive &&
+      machines.any((candidate) => candidate.deviceId == machine.deviceId);
+
+  bool acceptsScale(Scale scale) =>
+      isActive &&
+      scales.any((candidate) => candidate.deviceId == scale.deviceId);
+
+  ScanReport? finish({
+    required ScanTerminationReason reason,
+    required AdapterState adapterStateAtEnd,
+  }) {
+    if (!isActive) return null;
+    _state = reason == ScanTerminationReason.cancelledByUser
+        ? ConnectionSelectionSessionState.cancelled
+        : ConnectionSelectionSessionState.completed;
+    return scanReport.build(
+      preferredMachineId: preferredMachineId,
+      preferredScaleId: preferredScaleId,
+      terminationReason: reason,
+      adapterStateAtEnd: adapterStateAtEnd,
+    );
+  }
+
+  void invalidate() {
+    if (isActive) {
+      _state = ConnectionSelectionSessionState.cancelled;
+    }
+  }
+}

--- a/lib/src/controllers/connection/connection_selection_session.dart
+++ b/lib/src/controllers/connection/connection_selection_session.dart
@@ -52,6 +52,20 @@ class ConnectionSelectionSession {
     );
   }
 
+  De1Interface? resolveMachine(String deviceId) {
+    return machines.cast<De1Interface?>().firstWhere(
+      (candidate) => candidate?.deviceId == deviceId,
+      orElse: () => null,
+    );
+  }
+
+  Scale? resolveScale(String deviceId) {
+    return scales.cast<Scale?>().firstWhere(
+      (candidate) => candidate?.deviceId == deviceId,
+      orElse: () => null,
+    );
+  }
+
   void invalidate() {
     if (isActive) {
       _state = ConnectionSelectionSessionState.cancelled;

--- a/lib/src/controllers/connection/policy_resolver.dart
+++ b/lib/src/controllers/connection/policy_resolver.dart
@@ -36,10 +36,8 @@ final class NoMachineAction extends MachinePolicyAction {
 /// Decide what to do with the machine phase given the scan snapshot.
 ///
 /// Rules:
-///   - If `preferredMachineId` is set, early-connect would have
-///     handled the happy path — reaching post-scan means the
-///     preferred device wasn't discovered. Show a picker if any
-///     other machines appeared, otherwise idle.
+///   - If `preferredMachineId` is set and found, connect it. Otherwise,
+///     show a picker if any other machines appeared, or stay idle.
 ///   - If no preferred is set: auto-connect iff exactly one machine
 ///     was found; otherwise picker (>1) or idle (0).
 MachinePolicyAction resolveMachinePolicy({
@@ -47,6 +45,10 @@ MachinePolicyAction resolveMachinePolicy({
   required String? preferredMachineId,
 }) {
   if (preferredMachineId != null) {
+    final match = machines
+        .where((machine) => machine.deviceId == preferredMachineId)
+        .firstOrNull;
+    if (match != null) return ConnectMachineAction(match);
     if (machines.isNotEmpty) return const MachinePickerAction();
     return const NoMachineAction(hasOtherMachines: false);
   }

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -582,7 +582,7 @@ class ConnectionManager {
     // remembered metadata. Scales are excluded — the machine-only critical
     // path publishes ready immediately after adoption, then kicks off
     // background scale discovery.
-    if (!scaleOnly && rememberedDevices != null) {
+    if (!scaleOnly && !_machineConnected && rememberedDevices != null) {
       _publishStatus(currentStatus.copyWith(
           phase: ConnectionPhase.connectingMachine));
       final qcMachine = await _tryQuickConnectMachine();

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -5,6 +5,8 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/connection/attach_reconnect_coordinator.dart';
+import 'package:reaprime/src/controllers/connection/connection_attempt_policy.dart';
+import 'package:reaprime/src/controllers/connection/connection_selection_session.dart';
 import 'package:reaprime/src/controllers/connection/disconnect_expectations.dart';
 import 'package:reaprime/src/controllers/connection/disconnect_supervisor.dart';
 import 'package:reaprime/src/controllers/connection/policy_resolver.dart';
@@ -73,23 +75,12 @@ class ConnectionStatus {
       phase: phase ?? this.phase,
       foundMachines: foundMachines ?? this.foundMachines,
       foundScales: foundScales ?? this.foundScales,
-      pendingAmbiguity:
-          pendingAmbiguity != null ? pendingAmbiguity() : this.pendingAmbiguity,
+      pendingAmbiguity: pendingAmbiguity != null
+          ? pendingAmbiguity()
+          : this.pendingAmbiguity,
       error: error != null ? error() : this.error,
     );
   }
-}
-
-class _PendingScalePhase {
-  final List<Scale> scales;
-  final String? preferredScaleId;
-  final ScanReportBuilder scanReport;
-
-  const _PendingScalePhase({
-    required this.scales,
-    required this.preferredScaleId,
-    required this.scanReport,
-  });
 }
 
 class ConnectionManager {
@@ -125,7 +116,7 @@ class ConnectionManager {
   bool _isConnectingMachine = false;
   bool _isConnectingScale = false;
   bool _activeScaleOnlyScan = false;
-  _PendingScalePhase? _pendingScalePhase;
+  ConnectionSelectionSession? _selectionSession;
 
   /// End-to-end timeout for a single `connectMachine` / `connectScale`
   /// call. Phase 1 bounded the MMR-read hang at 2s; this is the
@@ -246,7 +237,8 @@ class ConnectionManager {
   /// Whether the scanner supports the persistent background scale watch
   /// (Android). De1StateManager consults this to skip its wake-time
   /// scale-only burst scan when the watch already covers reacquisition.
-  bool get supportsBackgroundScaleWatch => deviceScanner.supportsBackgroundWatch;
+  bool get supportsBackgroundScaleWatch =>
+      deviceScanner.supportsBackgroundWatch;
 
   ConnectionManager({
     required this.deviceScanner,
@@ -269,7 +261,7 @@ class ConnectionManager {
       onMachineDisconnected: _handleMachineDisconnected,
       onUnexpectedMachineDisconnect: _startMachineRecovery,
       onScaleConnected: _cancelScaleReacquisition,
-      onScaleDisconnected: _ensureScaleReacquisition,
+      onScaleDisconnected: _handleScaleDisconnected,
     );
     _scaleWatch = ScaleWatch(
       scanner: deviceScanner,
@@ -338,23 +330,27 @@ class ConnectionManager {
   void _listenForAdapter() {
     _adapterSub = deviceScanner.adapterStateStream.listen((state) {
       if (state == AdapterState.poweredOff) {
-        _emit(ConnectionError(
-          kind: ConnectionErrorKind.adapterOff,
-          severity: ConnectionErrorSeverity.error,
-          timestamp: DateTime.now().toUtc(),
-          message: 'Bluetooth is turned off.',
-          suggestion: 'Turn Bluetooth on to scan for devices.',
-        ));
+        _emit(
+          ConnectionError(
+            kind: ConnectionErrorKind.adapterOff,
+            severity: ConnectionErrorSeverity.error,
+            timestamp: DateTime.now().toUtc(),
+            message: 'Bluetooth is turned off.',
+            suggestion: 'Turn Bluetooth on to scan for devices.',
+          ),
+        );
       } else if (state == AdapterState.unauthorized) {
-        _emit(ConnectionError(
-          kind: ConnectionErrorKind.bluetoothPermissionDenied,
-          severity: ConnectionErrorSeverity.error,
-          timestamp: DateTime.now().toUtc(),
-          message: 'Bluetooth permission was denied.',
-          suggestion:
-              'Go to Settings > Privacy & Security > Bluetooth and enable '
-              'permission for Decent.app.',
-        ));
+        _emit(
+          ConnectionError(
+            kind: ConnectionErrorKind.bluetoothPermissionDenied,
+            severity: ConnectionErrorSeverity.error,
+            timestamp: DateTime.now().toUtc(),
+            message: 'Bluetooth permission was denied.',
+            suggestion:
+                'Go to Settings > Privacy & Security > Bluetooth and enable '
+                'permission for Decent.app.',
+          ),
+        );
       } else if (state == AdapterState.poweredOn &&
           (currentStatus.error?.kind == ConnectionErrorKind.adapterOff ||
               currentStatus.error?.kind ==
@@ -442,16 +438,18 @@ class ConnectionManager {
     Map<String, dynamic>? details,
     DateTime? timestamp,
   }) {
-    _emit(ConnectionError(
-      kind: kind,
-      severity: severity,
-      timestamp: (timestamp ?? DateTime.now()).toUtc(),
-      message: message,
-      deviceId: deviceId,
-      deviceName: deviceName,
-      suggestion: suggestion,
-      details: details,
-    ));
+    _emit(
+      ConnectionError(
+        kind: kind,
+        severity: severity,
+        timestamp: (timestamp ?? DateTime.now()).toUtc(),
+        message: message,
+        deviceId: deviceId,
+        deviceName: deviceName,
+        suggestion: suggestion,
+        details: details,
+      ),
+    );
   }
 
   @visibleForTesting
@@ -502,19 +500,21 @@ class ConnectionManager {
   /// during an in-flight connect are still dropped silently
   /// (comms-harden #9).
   Future<void> connect({bool scaleOnly = false}) => _runConnect(
-        scaleOnly: scaleOnly,
-        allowQuickConnect: true,
-      );
+    scaleOnly: scaleOnly,
+    policy: scaleOnly
+        ? ConnectionAttemptPolicy.scaleRecovery
+        : ConnectionAttemptPolicy.automatic,
+  );
 
   /// Complete an explicit scan before connecting missing device slots.
   Future<void> scanAndConnect() => _runConnect(
-        scaleOnly: false,
-        allowQuickConnect: false,
-      );
+    scaleOnly: false,
+    policy: ConnectionAttemptPolicy.explicitScan,
+  );
 
   Future<void> _runConnect({
     required bool scaleOnly,
-    required bool allowQuickConnect,
+    required ConnectionAttemptPolicy policy,
   }) async {
     if (_isConnecting) {
       if (scaleOnly) {
@@ -525,16 +525,16 @@ class ConnectionManager {
     }
 
     try {
-      await _executeConnect(
-        scaleOnly,
-        allowQuickConnect: allowQuickConnect,
-      );
+      await _executeConnect(scaleOnly, policy: policy);
     } finally {
       while (_queuedScaleOnly != null) {
         final drain = _queuedScaleOnly!;
         _queuedScaleOnly = null;
         try {
-          await _executeConnect(true, allowQuickConnect: false);
+          await _executeConnect(
+            true,
+            policy: ConnectionAttemptPolicy.scaleRecovery,
+          );
           drain.complete();
         } catch (e, st) {
           drain.completeError(e, st);
@@ -545,17 +545,14 @@ class ConnectionManager {
 
   Future<void> _executeConnect(
     bool scaleOnly, {
-    required bool allowQuickConnect,
+    required ConnectionAttemptPolicy policy,
   }) async {
     _isConnecting = true;
     if (scaleOnly) {
       _activeScaleOnlyScan = true;
     }
     try {
-      await _connectImpl(
-        scaleOnly: scaleOnly,
-        allowQuickConnect: allowQuickConnect,
-      );
+      await _connectImpl(scaleOnly: scaleOnly, policy: policy);
     } finally {
       if (scaleOnly) {
         _activeScaleOnlyScan = false;
@@ -571,8 +568,9 @@ class ConnectionManager {
     if (registry == null) return null;
     final machineId = settingsController.preferredMachineId;
     if (machineId == null || machineId.isEmpty) return null;
-    final remembered = registry.remembered
-        .firstWhereOrNull((d) => d.id == machineId);
+    final remembered = registry.remembered.firstWhereOrNull(
+      (d) => d.id == machineId,
+    );
     if (remembered == null) return null;
     try {
       final device = await deviceScanner.tryQuickConnect(remembered);
@@ -591,7 +589,7 @@ class ConnectionManager {
 
   Future<void> _connectImpl({
     required bool scaleOnly,
-    required bool allowQuickConnect,
+    required ConnectionAttemptPolicy policy,
   }) async {
     // Also disarms the watch: during a full scan EarlyConnectWatcher
     // observes the same deviceStream and owns preferred-scale connects —
@@ -604,24 +602,31 @@ class ConnectionManager {
       );
       return;
     }
+    if (scaleOnly &&
+        _selectionSession?.isActive == true &&
+        currentStatus.pendingAmbiguity != null) {
+      _log.fine('Skipping scale recovery while device selection is pending');
+      return;
+    }
     if (!scaleOnly) {
       // A fresh full connect supersedes any pending deferred rescan.
       _deferredScaleScan?.cancel();
       _deferredScaleScan = null;
       _earlyStopFired = false;
-      _pendingScalePhase = null;
+      _cancelSelectionSession(emitReport: true);
     }
 
     // Quick-connect: try direct connection to the preferred machine from
     // remembered metadata. Scales are excluded — the machine-only critical
     // path publishes ready immediately after adoption, then kicks off
     // background scale discovery.
-    if (allowQuickConnect &&
+    if (policy.directRememberedMachine &&
         !scaleOnly &&
         !_machineConnected &&
         rememberedDevices != null) {
-      _publishStatus(currentStatus.copyWith(
-          phase: ConnectionPhase.connectingMachine));
+      _publishStatus(
+        currentStatus.copyWith(phase: ConnectionPhase.connectingMachine),
+      );
       final qcMachine = await _tryQuickConnectMachine();
       if (qcMachine != null) {
         _log.info('Quick-connect: machine connected, proceeding to ready');
@@ -644,14 +649,15 @@ class ConnectionManager {
       }
     }
 
-    final preferredMachineId =
-        scaleOnly ? null : settingsController.preferredMachineId;
+    final preferredMachineId = scaleOnly
+        ? null
+        : settingsController.preferredMachineId;
     final preferredScaleId = settingsController.preferredScaleId;
     // Early stop is enabled for any full (non-scaleOnly) connect.
     // Previously gated on preferredMachineId != null, which meant
     // auto-discovered machines never stopped the scan early even
     // with both devices found and connected.
-    final earlyStopEnabled = !scaleOnly && allowQuickConnect;
+    final earlyStopEnabled = !scaleOnly && policy.stopScanAfterPreferredConnect;
 
     final scanStartTime = DateTime.now();
 
@@ -665,8 +671,12 @@ class ConnectionManager {
         : null;
 
     final scanRun = await _scanOrchestrator.runScan(
-      preferredMachineId: allowQuickConnect ? preferredMachineId : null,
-      preferredScaleId: allowQuickConnect ? preferredScaleId : null,
+      preferredMachineId: policy.connectPreferredDuringScan
+          ? preferredMachineId
+          : null,
+      preferredScaleId: policy.connectPreferredDuringScan
+          ? preferredScaleId
+          : null,
       earlyStopEnabled: earlyStopEnabled,
       onEarlyAttemptComplete: () => _checkEarlyStop(earlyStopEnabled),
       scanStartTime: scanStartTime,
@@ -681,6 +691,14 @@ class ConnectionManager {
     final machines = scanRun.machines;
     final scales = scanRun.scales;
     final scanReport = scanRun.reportBuilder;
+    final selectionSession = ConnectionSelectionSession(
+      machines: machines,
+      scales: scales,
+      preferredMachineId: preferredMachineId,
+      preferredScaleId: preferredScaleId,
+      scanReport: scanReport,
+    );
+    _selectionSession = selectionSession;
 
     if (scaleOnly) {
       _publishStatus(currentStatus.copyWith(foundScales: scales));
@@ -695,17 +713,15 @@ class ConnectionManager {
       // no-op (no scale found) settle it from machine state so the UI
       // doesn't stay stuck on `scanning`.
       if (currentStatus.phase == ConnectionPhase.scanning) {
-        _publishStatus(currentStatus.copyWith(
-          phase:
-              _machineConnected ? ConnectionPhase.ready : ConnectionPhase.idle,
-        ));
+        _publishStatus(
+          currentStatus.copyWith(
+            phase: _machineConnected
+                ? ConnectionPhase.ready
+                : ConnectionPhase.idle,
+          ),
+        );
       }
-      _emitScanReport(
-        scanReport: scanReport,
-        preferredMachineId: null,
-        preferredScaleId: preferredScaleId,
-        terminationReason: ScanTerminationReason.completed,
-      );
+      _completeSelectionSessionIfResolved(selectionSession);
       _ensureScaleReacquisition();
       return;
     }
@@ -725,19 +741,15 @@ class ConnectionManager {
       _settleAfterScalePhase();
       _maybeArmDeferredScaleScan();
       _ensureScaleReacquisition();
-      _emitScanReport(
-        scanReport: scanReport,
-        preferredMachineId: preferredMachineId,
-        preferredScaleId: preferredScaleId,
-        terminationReason: ScanTerminationReason.completed,
-      );
+      _completeSelectionSessionIfResolved(selectionSession);
       return;
     }
 
-    final policyMachines = allowQuickConnect && preferredMachineId != null
+    final policyMachines =
+        policy.connectPreferredDuringScan && preferredMachineId != null
         ? machines
-            .where((machine) => machine.deviceId != preferredMachineId)
-            .toList()
+              .where((machine) => machine.deviceId != preferredMachineId)
+              .toList()
         : machines;
     final machineAction = resolveMachinePolicy(
       machines: policyMachines,
@@ -746,19 +758,16 @@ class ConnectionManager {
     switch (machineAction) {
       case ConnectMachineAction(machine: final m):
         await _connectMachineTracked(m, scanReport);
-        final alternatives =
-            machines.where((machine) => machine != m).toList();
+        final alternatives = machines.where((machine) => machine != m).toList();
         if (!_machineConnected && alternatives.isNotEmpty) {
-          _pendingScalePhase = _PendingScalePhase(
-            scales: scales,
-            preferredScaleId: preferredScaleId,
-            scanReport: scanReport,
+          _publishStatus(
+            currentStatus.copyWith(
+              phase: ConnectionPhase.idle,
+              pendingAmbiguity: () => AmbiguityReason.machinePicker,
+            ),
           );
-          _publishStatus(currentStatus.copyWith(
-            phase: ConnectionPhase.idle,
-            pendingAmbiguity: () => AmbiguityReason.machinePicker,
-          ));
         } else {
+          final machineError = !_machineConnected ? currentStatus.error : null;
           await _runScalePhase(
             _disconnectSupervisor.latestMachine,
             scales,
@@ -768,29 +777,22 @@ class ConnectionManager {
           _settleAfterScalePhase();
           _maybeArmDeferredScaleScan();
           _ensureScaleReacquisition();
+          if (machineError != null) _emit(machineError);
         }
       case MachinePickerAction():
-        _pendingScalePhase = _PendingScalePhase(
-          scales: scales,
-          preferredScaleId: preferredScaleId,
-          scanReport: scanReport,
+        _publishStatus(
+          currentStatus.copyWith(
+            phase: ConnectionPhase.idle,
+            pendingAmbiguity: () => AmbiguityReason.machinePicker,
+          ),
         );
-        _publishStatus(currentStatus.copyWith(
-          phase: ConnectionPhase.idle,
-          pendingAmbiguity: () => AmbiguityReason.machinePicker,
-        ));
       case NoMachineAction():
         await _runScalePhase(null, scales, preferredScaleId, scanReport);
         _settleAfterScalePhase();
         _ensureScaleReacquisition();
     }
 
-    _emitScanReport(
-      scanReport: scanReport,
-      preferredMachineId: preferredMachineId,
-      preferredScaleId: preferredScaleId,
-      terminationReason: ScanTerminationReason.completed,
-    );
+    _completeSelectionSessionIfResolved(selectionSession);
   }
 
   /// Stop scan early when all preferred devices are connected.
@@ -957,6 +959,11 @@ class ConnectionManager {
     _scaleReconnectFailures = 0;
   }
 
+  void _handleScaleDisconnected() {
+    _cancelSelectionSession(emitReport: true);
+    _ensureScaleReacquisition();
+  }
+
   void _handleMachineConnected() {
     _stopMachineRecovery();
     _watchConnectedMachineState();
@@ -964,6 +971,7 @@ class ConnectionManager {
   }
 
   void _handleMachineDisconnected() {
+    _cancelSelectionSession(emitReport: true);
     // Deliberate disconnects route only through here (disconnectMachine
     // pre-nulls the supervisor view), so recovery stays off for them.
     // For unexpected drops the supervisor fires
@@ -1048,26 +1056,29 @@ class ConnectionManager {
     // if the first push is lost, the watchdog fires and forces a clean
     // reconnect that re-establishes notifications.
     _armStateWatchdog(machine.deviceId);
-    _machineSnapshotSub = snapshots.listen((snapshot) {
-      // Every frame — including a deduped duplicate of the current state —
-      // proves the push channel is alive. Re-arm BEFORE the dedupe check
-      // so a steady non-transitioning state doesn't false-trigger.
-      _armStateWatchdog(machine.deviceId);
-      final state = snapshot.state.state;
-      if (_latestMachineState == state) return;
-      _latestMachineState = state;
-      if (_scaleReconnectBlockedByPowerMode) {
-        _log.fine(
-          'Machine is sleeping and scale power mode is disconnect; '
-          'pausing preferred scale reconnect',
-        );
-        _pauseScaleReconnectForPowerMode();
-      } else {
-        _ensureScaleReacquisition();
-      }
-    }, onError: (Object e, StackTrace st) {
-      _log.fine('Machine snapshot stream error', e, st);
-    });
+    _machineSnapshotSub = snapshots.listen(
+      (snapshot) {
+        // Every frame — including a deduped duplicate of the current state —
+        // proves the push channel is alive. Re-arm BEFORE the dedupe check
+        // so a steady non-transitioning state doesn't false-trigger.
+        _armStateWatchdog(machine.deviceId);
+        final state = snapshot.state.state;
+        if (_latestMachineState == state) return;
+        _latestMachineState = state;
+        if (_scaleReconnectBlockedByPowerMode) {
+          _log.fine(
+            'Machine is sleeping and scale power mode is disconnect; '
+            'pausing preferred scale reconnect',
+          );
+          _pauseScaleReconnectForPowerMode();
+        } else {
+          _ensureScaleReacquisition();
+        }
+      },
+      onError: (Object e, StackTrace st) {
+        _log.fine('Machine snapshot stream error', e, st);
+      },
+    );
   }
 
   void _armStateWatchdog(String deviceId) {
@@ -1136,8 +1147,9 @@ class ConnectionManager {
   }
 
   void _settleAfterScalePhase() {
-    final phase =
-        _machineConnected ? ConnectionPhase.ready : ConnectionPhase.idle;
+    final phase = _machineConnected
+        ? ConnectionPhase.ready
+        : ConnectionPhase.idle;
     if (currentStatus.phase != phase) {
       _publishStatus(currentStatus.copyWith(phase: phase));
     }
@@ -1167,16 +1179,11 @@ class ConnectionManager {
   /// attach it via [ScaleController]. Failures are logged but do not
   /// propagate — the machine remains connected and usable.
   Future<void> _attachBengleVirtualScale(BengleInterface machine) async {
-    // TODO(multi-scale, P2): when a user has an external scale already
-    // connected and Bengle reconnects, the virtual scale should take
-    // over. Today this short-circuit leaves the external scale in
-    // place — narrow edge case (Bengle is normally first in a
-    // session); revisit when multi-scale support lands.
-    if (_scaleConnected) {
-      _log.fine('Scale already connected, skipping Bengle virtual scale');
+    final virtual = BengleVirtualScale(machine);
+    if (_scaleConnected &&
+        scaleController.lastConnectedDeviceId == virtual.deviceId) {
       return;
     }
-    final virtual = BengleVirtualScale(machine);
     try {
       await scaleController.connectToScale(virtual);
     } catch (e, st) {
@@ -1212,20 +1219,37 @@ class ConnectionManager {
       case ConnectScaleAction(scale: final s):
         final result = await _connectScaleTracked(s, scanReport);
         final alternatives = scales.where((scale) => scale != s).toList();
-        if (!result.success && result.error != null && alternatives.isNotEmpty) {
+        if (!result.success &&
+            result.error != null &&
+            alternatives.isNotEmpty) {
           _cancelScaleReacquisition();
-          _publishStatus(currentStatus.copyWith(
-            pendingAmbiguity: () => AmbiguityReason.scalePicker,
-          ));
+          _publishStatus(
+            currentStatus.copyWith(
+              pendingAmbiguity: () => AmbiguityReason.scalePicker,
+            ),
+          );
         }
       case ScalePickerAction():
         _cancelScaleReacquisition();
-        _publishStatus(currentStatus.copyWith(
-          pendingAmbiguity: () => AmbiguityReason.scalePicker,
-        ));
+        _publishStatus(
+          currentStatus.copyWith(
+            pendingAmbiguity: () => AmbiguityReason.scalePicker,
+          ),
+        );
       case NoScaleAction():
         break;
     }
+  }
+
+  Future<void> selectMachine(De1Interface machine) async {
+    final session = _selectionSession;
+    if (session == null ||
+        currentStatus.pendingAmbiguity != AmbiguityReason.machinePicker ||
+        !session.acceptsMachine(machine)) {
+      _log.fine('Ignoring stale machine selection ${machine.deviceId}');
+      return;
+    }
+    await connectMachine(machine);
   }
 
   Future<void> connectMachine(De1Interface machine) async {
@@ -1234,6 +1258,11 @@ class ConnectionManager {
       return;
     }
     _isConnectingMachine = true;
+    final selectionSession =
+        currentStatus.pendingAmbiguity == AmbiguityReason.machinePicker
+        ? _selectionSession
+        : null;
+    selectionSession?.scanReport.markAttempted(machine.deviceId);
     _log.fine(
       'connectMachine: connecting to ${machine.name} (${machine.deviceId})',
     );
@@ -1246,49 +1275,59 @@ class ConnectionManager {
       ),
     );
 
-    final pendingScalePhase = _pendingScalePhase;
     try {
-      await de1Controller
-          .connectToDe1(machine)
-          .timeout(_connectTimeout);
+      await de1Controller.connectToDe1(machine).timeout(_connectTimeout);
       await settingsController.setPreferredMachineId(machine.deviceId);
-      if (pendingScalePhase != null) {
-        _pendingScalePhase = null;
+      selectionSession?.scanReport.recordResult(
+        machine.deviceId,
+        const ConnectionResult.succeeded(),
+      );
+      if (selectionSession != null && selectionSession.isActive) {
         await _runScalePhase(
           machine,
-          pendingScalePhase.scales,
-          pendingScalePhase.preferredScaleId,
-          pendingScalePhase.scanReport,
+          selectionSession.scales,
+          selectionSession.preferredScaleId,
+          selectionSession.scanReport,
         );
         _settleAfterScalePhase();
         _ensureScaleReacquisition();
+        _completeSelectionSessionIfResolved(selectionSession);
       } else if (!_isConnecting) {
         _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.ready));
       }
     } catch (e) {
+      selectionSession?.scanReport.recordResult(
+        machine.deviceId,
+        ConnectionResult.failed(e.toString()),
+      );
       // Unlike connectScale, this path reverts to `idle` (not a clearing
       // phase), so the _publishStatus/_emit ordering isn't load-bearing —
       // kept consistent with connectScale for readability.
-      _publishStatus(currentStatus.copyWith(
-        phase: ConnectionPhase.idle,
-        pendingAmbiguity: pendingScalePhase == null
-            ? null
-            : () => AmbiguityReason.machinePicker,
-      ));
+      _publishStatus(
+        currentStatus.copyWith(
+          phase: ConnectionPhase.idle,
+          pendingAmbiguity:
+              selectionSession == null || !selectionSession.isActive
+              ? null
+              : () => AmbiguityReason.machinePicker,
+        ),
+      );
       final timedOut = e is TimeoutException;
-      _emit(_buildConnectError(
-        kind: ConnectionErrorKind.machineConnectFailed,
-        deviceId: machine.deviceId,
-        deviceName: machine.name,
-        message: timedOut
-            ? 'Machine ${machine.name} did not respond within '
-                '${_connectTimeout.inSeconds}s.'
-            : 'Machine ${machine.name} failed to connect.',
-        suggestion: timedOut
-            ? 'Try again. If the problem persists, power-cycle the machine.'
-            : 'Make sure the DE1 is powered on and in range, then retry.',
-        exception: e,
-      ));
+      _emit(
+        _buildConnectError(
+          kind: ConnectionErrorKind.machineConnectFailed,
+          deviceId: machine.deviceId,
+          deviceName: machine.name,
+          message: timedOut
+              ? 'Machine ${machine.name} did not respond within '
+                    '${_connectTimeout.inSeconds}s.'
+              : 'Machine ${machine.name} failed to connect.',
+          suggestion: timedOut
+              ? 'Try again. If the problem persists, power-cycle the machine.'
+              : 'Make sure the DE1 is powered on and in range, then retry.',
+          exception: e,
+        ),
+      );
       rethrow;
     } finally {
       _isConnectingMachine = false;
@@ -1321,32 +1360,35 @@ class ConnectionManager {
     );
 
     try {
-      await scaleController
-          .connectToScale(scale)
-          .timeout(_connectTimeout);
+      await scaleController.connectToScale(scale).timeout(_connectTimeout);
       if (_scaleReconnectBlockedByPowerMode) {
         markExpectingDisconnect(scale.deviceId);
         _publishStatus(
           currentStatus.copyWith(
-            phase:
-                _machineConnected ? ConnectionPhase.ready : ConnectionPhase.idle,
+            phase: _machineConnected
+                ? ConnectionPhase.ready
+                : ConnectionPhase.idle,
           ),
         );
         await scale.disconnect();
         return const ConnectionResult.succeeded();
       }
       await settingsController.setPreferredScaleId(scale.deviceId);
-      _publishStatus(currentStatus.copyWith(
-        phase:
-            _machineConnected ? ConnectionPhase.ready : ConnectionPhase.idle,
-      ));
+      _publishStatus(
+        currentStatus.copyWith(
+          phase: _machineConnected
+              ? ConnectionPhase.ready
+              : ConnectionPhase.idle,
+        ),
+      );
       return const ConnectionResult.succeeded();
     } catch (e) {
       // Scale failure is non-blocking — stay at ready if machine connected, else idle.
       _publishStatus(
         currentStatus.copyWith(
-          phase:
-              _machineConnected ? ConnectionPhase.ready : ConnectionPhase.idle,
+          phase: _machineConnected
+              ? ConnectionPhase.ready
+              : ConnectionPhase.idle,
         ),
       );
       // DO NOT REORDER — `ready` is a clearing phase and `scaleConnectFailed`
@@ -1355,24 +1397,50 @@ class ConnectionManager {
       // phase first (no error present) then calling `_emit` (bypasses the
       // gatekeeper) is the only order that keeps the error visible.
       final timedOut = e is TimeoutException;
-      _emit(_buildConnectError(
-        kind: ConnectionErrorKind.scaleConnectFailed,
-        deviceId: scale.deviceId,
-        deviceName: scale.name,
-        message: timedOut
-            ? 'Scale ${scale.name} did not respond within '
-                '${_connectTimeout.inSeconds}s.'
-            : 'Scale ${scale.name} failed to connect.',
-        suggestion: timedOut
-            ? 'Try again. If the problem persists, power-cycle the scale.'
-            : 'Wake the scale and try again. If the problem persists, '
-                'toggle Bluetooth off and on.',
-        exception: e,
-      ));
+      _emit(
+        _buildConnectError(
+          kind: ConnectionErrorKind.scaleConnectFailed,
+          deviceId: scale.deviceId,
+          deviceName: scale.name,
+          message: timedOut
+              ? 'Scale ${scale.name} did not respond within '
+                    '${_connectTimeout.inSeconds}s.'
+              : 'Scale ${scale.name} failed to connect.',
+          suggestion: timedOut
+              ? 'Try again. If the problem persists, power-cycle the scale.'
+              : 'Wake the scale and try again. If the problem persists, '
+                    'toggle Bluetooth off and on.',
+          exception: e,
+        ),
+      );
       return ConnectionResult.failed(e.toString());
     } finally {
       _isConnectingScale = false;
     }
+  }
+
+  Future<ConnectionResult> selectScale(Scale scale) async {
+    final session = _selectionSession;
+    if (session == null ||
+        currentStatus.pendingAmbiguity != AmbiguityReason.scalePicker ||
+        !session.acceptsScale(scale)) {
+      _log.fine('Ignoring stale scale selection ${scale.deviceId}');
+      return const ConnectionResult.skipped();
+    }
+    session.scanReport.markAttempted(scale.deviceId);
+    final result = await connectScale(scale);
+    session.scanReport.recordResult(scale.deviceId, result);
+    if (result.success) {
+      _completeSelectionSessionIfResolved(session);
+    } else {
+      _cancelScaleReacquisition();
+      _publishStatus(
+        currentStatus.copyWith(
+          pendingAmbiguity: () => AmbiguityReason.scalePicker,
+        ),
+      );
+    }
+    return result;
   }
 
   /// Connect a machine and record the attempt outcome on the scan
@@ -1482,22 +1550,40 @@ class ConnectionManager {
     return result;
   }
 
-  /// Build a [ScanReport] from [scanReport] and publish it on the
-  /// scan-report stream + log the human-readable form.
-  void _emitScanReport({
-    required ScanReportBuilder scanReport,
-    required String? preferredMachineId,
-    required String? preferredScaleId,
-    required ScanTerminationReason terminationReason,
-  }) {
-    final report = scanReport.build(
-      preferredMachineId: preferredMachineId,
-      preferredScaleId: preferredScaleId,
-      terminationReason: terminationReason,
+  void _completeSelectionSessionIfResolved(
+    ConnectionSelectionSession session,
+  ) {
+    if (currentStatus.pendingAmbiguity != null) return;
+    _finishSelectionSession(session, ScanTerminationReason.completed);
+  }
+
+  void _finishSelectionSession(
+    ConnectionSelectionSession session,
+    ScanTerminationReason reason,
+  ) {
+    if (!identical(_selectionSession, session)) return;
+    final report = session.finish(
+      reason: reason,
       adapterStateAtEnd: deviceScanner.currentAdapterState,
     );
+    if (report == null) return;
+    _selectionSession = null;
     _scanReportSubject.add(report);
     _log.info(ScanReportBuilder.format(report));
+  }
+
+  void _cancelSelectionSession({required bool emitReport}) {
+    final session = _selectionSession;
+    if (session == null) return;
+    if (emitReport) {
+      _finishSelectionSession(
+        session,
+        ScanTerminationReason.cancelledByUser,
+      );
+    } else {
+      session.invalidate();
+      _selectionSession = null;
+    }
   }
 
   Future<void> disconnectMachine() async {
@@ -1516,6 +1602,7 @@ class ConnectionManager {
   }
 
   Future<void> disconnectScale() async {
+    _cancelSelectionSession(emitReport: true);
     _cancelScaleReacquisition();
     try {
       final scale = scaleController.connectedScale();
@@ -1530,6 +1617,7 @@ class ConnectionManager {
   }
 
   Future<void> dispose() async {
+    _cancelSelectionSession(emitReport: false);
     _stopMachineRecovery();
     _deferredScaleScan?.cancel();
     _cancelPreferredScaleReconnect();

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -157,6 +157,12 @@ class ConnectionManager {
   /// outer connect()'s finally block (comms-harden #9).
   Completer<void>? _queuedScaleOnly;
 
+  /// Completer shared by all `scanAndConnect()` callers that arrive while
+  /// another connect is already running. Drained BEFORE
+  /// [_queuedScaleOnly] so explicit user-requested discovery is not
+  /// delayed behind background scale reacquisition.
+  Completer<void>? _queuedExplicitScan;
+
   /// Deferred scale-only rescan armed when the preferred machine
   /// connects but no preferred scale is configured. The initial scan
   /// stops the instant the machine connects (see [_checkEarlyStop]), so
@@ -513,7 +519,23 @@ class ConnectionManager {
   );
 
   /// Complete an explicit scan before connecting missing device slots.
-  Future<void> scanAndConnect() {
+  ///
+  /// When a connection cycle is already in progress, the active scan is
+  /// superseded: its generation is invalidated, the scanner is stopped,
+  /// and exactly one replacement explicit scan is queued. Multiple
+  /// concurrent callers share the queued future. The superseded scan
+  /// emits one cancelled report; the replacement emits its normal report.
+  Future<void> scanAndConnect() async {
+    // Multiple concurrent explicit requests coalesce into one replacement.
+    if (_queuedExplicitScan != null) {
+      return _queuedExplicitScan!.future;
+    }
+    if (_isConnecting) {
+      _explicitScanGeneration++;
+      deviceScanner.stopScan();
+      _queuedExplicitScan = Completer<void>();
+      return _queuedExplicitScan!.future;
+    }
     _explicitScanGeneration++;
     return _runConnect(
       scaleOnly: false,
@@ -536,6 +558,21 @@ class ConnectionManager {
     try {
       await _executeConnect(scaleOnly, policy: policy);
     } finally {
+      // Drain queued explicit scan first so user-requested discovery
+      // is not delayed behind background scale reacquisition.
+      while (_queuedExplicitScan != null) {
+        final drain = _queuedExplicitScan!;
+        _queuedExplicitScan = null;
+        try {
+          await _executeConnect(
+            false,
+            policy: ConnectionAttemptPolicy.explicitScan,
+          );
+          drain.complete();
+        } catch (e, st) {
+          drain.completeError(e, st);
+        }
+      }
       while (_queuedScaleOnly != null) {
         final drain = _queuedScaleOnly!;
         _queuedScaleOnly = null;
@@ -1655,6 +1692,9 @@ class ConnectionManager {
   void cancelActiveScan() {
     _explicitScanGeneration++;
     deviceScanner.stopScan();
+    final queued = _queuedExplicitScan;
+    _queuedExplicitScan = null;
+    queued?.complete();
     final session = _selectionSession;
     if (session != null) {
       _publishStatus(currentStatus.copyWith(

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -118,6 +118,12 @@ class ConnectionManager {
   bool _activeScaleOnlyScan = false;
   ConnectionSelectionSession? _selectionSession;
 
+  /// Generation counter bumped on each new explicit [scanAndConnect] or
+  /// [cancelActiveScan] call. [_connectImpl] checks it after [runScan]
+  /// returns; if it changed the in-flight scan was cancelled and policy
+  /// must not run.
+  int _explicitScanGeneration = 0;
+
   /// End-to-end timeout for a single `connectMachine` / `connectScale`
   /// call. Phase 1 bounded the MMR-read hang at 2s; this is the
   /// belt-and-braces that keeps any other transport-level hang from
@@ -507,10 +513,13 @@ class ConnectionManager {
   );
 
   /// Complete an explicit scan before connecting missing device slots.
-  Future<void> scanAndConnect() => _runConnect(
-    scaleOnly: false,
-    policy: ConnectionAttemptPolicy.explicitScan,
-  );
+  Future<void> scanAndConnect() {
+    _explicitScanGeneration++;
+    return _runConnect(
+      scaleOnly: false,
+      policy: ConnectionAttemptPolicy.explicitScan,
+    );
+  }
 
   Future<void> _runConnect({
     required bool scaleOnly,
@@ -670,6 +679,10 @@ class ConnectionManager {
           )
         : null;
 
+    // Capture the generation at scan start so the post-scan check detects
+    // cancellation that happened while the scan was in-flight.
+    final scanGen = _explicitScanGeneration;
+
     final scanRun = await _scanOrchestrator.runScan(
       preferredMachineId: policy.connectPreferredDuringScan
           ? preferredMachineId
@@ -685,6 +698,23 @@ class ConnectionManager {
     if (scanRun == null) {
       // Scan failed catastrophically; orchestrator already emitted
       // the sticky error + phase=idle.
+      return;
+    }
+
+    // Explicit scan was cancelled while the scan was in-flight — emit a
+    // cancelled report and bail without applying policy.
+    if (_explicitScanGeneration != scanGen) {
+      _scanReportSubject.add(scanRun.reportBuilder.build(
+        preferredMachineId: preferredMachineId,
+        preferredScaleId: preferredScaleId,
+        terminationReason: ScanTerminationReason.cancelledByUser,
+        adapterStateAtEnd: deviceScanner.currentAdapterState,
+      ));
+      _publishStatus(currentStatus.copyWith(
+        pendingAmbiguity: () => null,
+        phase: _machineConnected ? ConnectionPhase.ready : ConnectionPhase.idle,
+      ));
+      _ensureScaleReacquisition();
       return;
     }
 
@@ -1253,7 +1283,14 @@ class ConnectionManager {
       _log.fine('Ignoring stale machine selection ${machine.deviceId}');
       return;
     }
-    await connectMachine(resolved);
+    try {
+      await connectMachine(resolved);
+    } catch (_) {
+      // connectMachine already emitted the classified error and either
+      // re-presented the machine picker (alternatives remain) or
+      // transitioned to the scale phase (no alternatives, scale candidates
+      // present). The widget must not see the exception.
+    }
   }
 
   Future<void> connectMachine(De1Interface machine) async {
@@ -1605,6 +1642,31 @@ class ConnectionManager {
     _selectionSession = null;
     _scanReportSubject.add(report);
     _log.info(ScanReportBuilder.format(report));
+  }
+
+  /// Cancels the active explicit scan, including any in-flight discovery.
+  ///
+  /// Bumps the generation token so the in-flight [_connectImpl] either
+  /// bails before runScan (not yet started) or detects the mismatch after
+  /// the scan completes and skips policy. Also stops the scanner and
+  /// cancels any existing selection session.
+  ///
+  /// Safe to call when no scan is active — it is a no-op in that case.
+  void cancelActiveScan() {
+    _explicitScanGeneration++;
+    deviceScanner.stopScan();
+    final session = _selectionSession;
+    if (session != null) {
+      _publishStatus(currentStatus.copyWith(
+        pendingAmbiguity: () => null,
+      ));
+      _finishSelectionSession(
+        session,
+        ScanTerminationReason.cancelledByUser,
+      );
+    }
+    _settleAfterScalePhase();
+    _ensureScaleReacquisition();
   }
 
   /// Cancels the active selection session, finalising the scan report

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -558,22 +558,25 @@ class ConnectionManager {
     try {
       await _executeConnect(scaleOnly, policy: policy);
     } finally {
-      // Drain queued explicit scan first so user-requested discovery
-      // is not delayed behind background scale reacquisition.
-      while (_queuedExplicitScan != null) {
-        final drain = _queuedExplicitScan!;
-        _queuedExplicitScan = null;
-        try {
-          await _executeConnect(
-            false,
-            policy: ConnectionAttemptPolicy.explicitScan,
-          );
-          drain.complete();
-        } catch (e, st) {
-          drain.completeError(e, st);
+      // Single priority-aware drain loop: explicit always evaluated
+      // first at each scheduling boundary. An explicit request arriving
+      // during a queued scale-only drain is picked up immediately.
+      while (_queuedExplicitScan != null || _queuedScaleOnly != null) {
+        if (_queuedExplicitScan != null) {
+          final drain = _queuedExplicitScan!;
+          _queuedExplicitScan = null;
+          try {
+            await _executeConnect(
+              false,
+              policy: ConnectionAttemptPolicy.explicitScan,
+            );
+            drain.complete();
+          } catch (e, st) {
+            drain.completeError(e, st);
+          }
+          continue;
         }
-      }
-      while (_queuedScaleOnly != null) {
+
         final drain = _queuedScaleOnly!;
         _queuedScaleOnly = null;
         try {
@@ -1780,6 +1783,8 @@ class ConnectionManager {
     _deferredScaleScan?.cancel();
     _cancelPreferredScaleReconnect();
     await _attachReconnectCoordinator?.dispose();
+    _queuedExplicitScan?.complete();
+    _queuedExplicitScan = null;
     // Awaited (not via _cancelScaleReacquisition) so the watch is
     // deterministically stopped before the controllers it feeds are
     // disposed.

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -80,6 +80,18 @@ class ConnectionStatus {
   }
 }
 
+class _PendingScalePhase {
+  final List<Scale> scales;
+  final String? preferredScaleId;
+  final ScanReportBuilder scanReport;
+
+  const _PendingScalePhase({
+    required this.scales,
+    required this.preferredScaleId,
+    required this.scanReport,
+  });
+}
+
 class ConnectionManager {
   final DeviceScanner deviceScanner;
   final De1Controller de1Controller;
@@ -113,6 +125,7 @@ class ConnectionManager {
   bool _isConnectingMachine = false;
   bool _isConnectingScale = false;
   bool _activeScaleOnlyScan = false;
+  _PendingScalePhase? _pendingScalePhase;
 
   /// End-to-end timeout for a single `connectMachine` / `connectScale`
   /// call. Phase 1 bounded the MMR-read hang at 2s; this is the
@@ -462,7 +475,7 @@ class ConnectionManager {
   void debugNotifyMachineDisconnected(String deviceId) =>
       _disconnectSupervisor.notifyMachineDisconnected(deviceId);
 
-  /// Scan for devices and connect based on preference policy.
+  /// Quick-connect or scan for devices using automatic recovery policy.
   ///
   /// When [scaleOnly] is false (default):
   /// 1. Scans for all devices
@@ -488,7 +501,21 @@ class ConnectionManager {
   /// replay and share the same returned Future. Non-`scaleOnly` calls
   /// during an in-flight connect are still dropped silently
   /// (comms-harden #9).
-  Future<void> connect({bool scaleOnly = false}) async {
+  Future<void> connect({bool scaleOnly = false}) => _runConnect(
+        scaleOnly: scaleOnly,
+        allowQuickConnect: true,
+      );
+
+  /// Complete an explicit scan before connecting missing device slots.
+  Future<void> scanAndConnect() => _runConnect(
+        scaleOnly: false,
+        allowQuickConnect: false,
+      );
+
+  Future<void> _runConnect({
+    required bool scaleOnly,
+    required bool allowQuickConnect,
+  }) async {
     if (_isConnecting) {
       if (scaleOnly) {
         final completer = _queuedScaleOnly ??= Completer<void>();
@@ -497,18 +524,17 @@ class ConnectionManager {
       return;
     }
 
-    // Run the current call, then drain any scale-only requests that
-    // queued up while it was running. The drain runs in a `finally`
-    // so stranded callers get woken up even if the initial call
-    // throws.
     try {
-      await _executeConnect(scaleOnly);
+      await _executeConnect(
+        scaleOnly,
+        allowQuickConnect: allowQuickConnect,
+      );
     } finally {
       while (_queuedScaleOnly != null) {
         final drain = _queuedScaleOnly!;
         _queuedScaleOnly = null;
         try {
-          await _executeConnect(true);
+          await _executeConnect(true, allowQuickConnect: false);
           drain.complete();
         } catch (e, st) {
           drain.completeError(e, st);
@@ -517,15 +543,19 @@ class ConnectionManager {
     }
   }
 
-  /// One connect iteration — sets `_isConnecting` for the duration so
-  /// the concurrency guard in [connect] sees the in-flight state.
-  Future<void> _executeConnect(bool scaleOnly) async {
+  Future<void> _executeConnect(
+    bool scaleOnly, {
+    required bool allowQuickConnect,
+  }) async {
     _isConnecting = true;
     if (scaleOnly) {
       _activeScaleOnlyScan = true;
     }
     try {
-      await _connectImpl(scaleOnly: scaleOnly);
+      await _connectImpl(
+        scaleOnly: scaleOnly,
+        allowQuickConnect: allowQuickConnect,
+      );
     } finally {
       if (scaleOnly) {
         _activeScaleOnlyScan = false;
@@ -559,7 +589,10 @@ class ConnectionManager {
     return null;
   }
 
-  Future<void> _connectImpl({required bool scaleOnly}) async {
+  Future<void> _connectImpl({
+    required bool scaleOnly,
+    required bool allowQuickConnect,
+  }) async {
     // Also disarms the watch: during a full scan EarlyConnectWatcher
     // observes the same deviceStream and owns preferred-scale connects —
     // a live watch would race it. Re-armed at the end-of-connect sites.
@@ -576,13 +609,17 @@ class ConnectionManager {
       _deferredScaleScan?.cancel();
       _deferredScaleScan = null;
       _earlyStopFired = false;
+      _pendingScalePhase = null;
     }
 
     // Quick-connect: try direct connection to the preferred machine from
     // remembered metadata. Scales are excluded — the machine-only critical
     // path publishes ready immediately after adoption, then kicks off
     // background scale discovery.
-    if (!scaleOnly && !_machineConnected && rememberedDevices != null) {
+    if (allowQuickConnect &&
+        !scaleOnly &&
+        !_machineConnected &&
+        rememberedDevices != null) {
       _publishStatus(currentStatus.copyWith(
           phase: ConnectionPhase.connectingMachine));
       final qcMachine = await _tryQuickConnectMachine();
@@ -614,7 +651,7 @@ class ConnectionManager {
     // Previously gated on preferredMachineId != null, which meant
     // auto-discovered machines never stopped the scan early even
     // with both devices found and connected.
-    final earlyStopEnabled = !scaleOnly;
+    final earlyStopEnabled = !scaleOnly && allowQuickConnect;
 
     final scanStartTime = DateTime.now();
 
@@ -628,8 +665,8 @@ class ConnectionManager {
         : null;
 
     final scanRun = await _scanOrchestrator.runScan(
-      preferredMachineId: preferredMachineId,
-      preferredScaleId: preferredScaleId,
+      preferredMachineId: allowQuickConnect ? preferredMachineId : null,
+      preferredScaleId: allowQuickConnect ? preferredScaleId : null,
       earlyStopEnabled: earlyStopEnabled,
       onEarlyAttemptComplete: () => _checkEarlyStop(earlyStopEnabled),
       scanStartTime: scanStartTime,
@@ -677,8 +714,6 @@ class ConnectionManager {
       currentStatus.copyWith(foundMachines: machines, foundScales: scales),
     );
 
-    // If machine is already connected (either from before or
-    // early-connect), skip straight to scale phase.
     if (_machineConnected) {
       _log.fine('Machine connected, proceeding to scale phase');
       await _runScalePhase(
@@ -687,6 +722,7 @@ class ConnectionManager {
         preferredScaleId,
         scanReport,
       );
+      _settleAfterScalePhase();
       _maybeArmDeferredScaleScan();
       _ensureScaleReacquisition();
       _emitScanReport(
@@ -698,26 +734,55 @@ class ConnectionManager {
       return;
     }
 
-    // Post-scan machine policy. Early-connect already handled the
-    // "preferred found during scan" happy path; what arrives here
-    // is everything else.
+    final policyMachines = allowQuickConnect && preferredMachineId != null
+        ? machines
+            .where((machine) => machine.deviceId != preferredMachineId)
+            .toList()
+        : machines;
     final machineAction = resolveMachinePolicy(
-      machines: machines,
+      machines: policyMachines,
       preferredMachineId: preferredMachineId,
     );
     switch (machineAction) {
       case ConnectMachineAction(machine: final m):
         await _connectMachineTracked(m, scanReport);
-        await _runScalePhase(m, scales, preferredScaleId, scanReport);
-        _maybeArmDeferredScaleScan();
-        _ensureScaleReacquisition();
+        final alternatives =
+            machines.where((machine) => machine != m).toList();
+        if (!_machineConnected && alternatives.isNotEmpty) {
+          _pendingScalePhase = _PendingScalePhase(
+            scales: scales,
+            preferredScaleId: preferredScaleId,
+            scanReport: scanReport,
+          );
+          _publishStatus(currentStatus.copyWith(
+            phase: ConnectionPhase.idle,
+            pendingAmbiguity: () => AmbiguityReason.machinePicker,
+          ));
+        } else {
+          await _runScalePhase(
+            _disconnectSupervisor.latestMachine,
+            scales,
+            preferredScaleId,
+            scanReport,
+          );
+          _settleAfterScalePhase();
+          _maybeArmDeferredScaleScan();
+          _ensureScaleReacquisition();
+        }
       case MachinePickerAction():
+        _pendingScalePhase = _PendingScalePhase(
+          scales: scales,
+          preferredScaleId: preferredScaleId,
+          scanReport: scanReport,
+        );
         _publishStatus(currentStatus.copyWith(
           phase: ConnectionPhase.idle,
           pendingAmbiguity: () => AmbiguityReason.machinePicker,
         ));
       case NoMachineAction():
-        _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.idle));
+        await _runScalePhase(null, scales, preferredScaleId, scanReport);
+        _settleAfterScalePhase();
+        _ensureScaleReacquisition();
     }
 
     _emitScanReport(
@@ -881,6 +946,7 @@ class ConnectionManager {
   bool _shouldRetryPreferredScale() {
     return _machineConnected &&
         !_scaleConnected &&
+        currentStatus.pendingAmbiguity != AmbiguityReason.scalePicker &&
         settingsController.preferredScaleId != null &&
         !_scaleReconnectBlockedByPowerMode;
   }
@@ -1069,6 +1135,14 @@ class ConnectionManager {
     _latestMachineState = null;
   }
 
+  void _settleAfterScalePhase() {
+    final phase =
+        _machineConnected ? ConnectionPhase.ready : ConnectionPhase.idle;
+    if (currentStatus.phase != phase) {
+      _publishStatus(currentStatus.copyWith(phase: phase));
+    }
+  }
+
   /// Gate the scale phase on machine type. When the connected machine
   /// is a [BengleInterface], its integrated scale (exposed as a
   /// [BengleVirtualScale]) takes the slot and external-scale discovery
@@ -1136,13 +1210,20 @@ class ConnectionManager {
     );
     switch (action) {
       case ConnectScaleAction(scale: final s):
-        await _connectScaleTracked(s, scanReport);
+        final result = await _connectScaleTracked(s, scanReport);
+        final alternatives = scales.where((scale) => scale != s).toList();
+        if (!result.success && result.error != null && alternatives.isNotEmpty) {
+          _cancelScaleReacquisition();
+          _publishStatus(currentStatus.copyWith(
+            pendingAmbiguity: () => AmbiguityReason.scalePicker,
+          ));
+        }
       case ScalePickerAction():
+        _cancelScaleReacquisition();
         _publishStatus(currentStatus.copyWith(
           pendingAmbiguity: () => AmbiguityReason.scalePicker,
         ));
       case NoScaleAction():
-        // Nothing to do — idle scale phase.
         break;
     }
   }
@@ -1165,20 +1246,35 @@ class ConnectionManager {
       ),
     );
 
+    final pendingScalePhase = _pendingScalePhase;
     try {
       await de1Controller
           .connectToDe1(machine)
           .timeout(_connectTimeout);
       await settingsController.setPreferredMachineId(machine.deviceId);
-      // `_latestDe1` is populated by the de1Controller.de1 stream
-      // listener; by the time connectToDe1 returns, that microtask has
-      // fired so `_machineConnected` (which reads `_latestDe1`) is true.
-      _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.ready));
+      if (pendingScalePhase != null) {
+        _pendingScalePhase = null;
+        await _runScalePhase(
+          machine,
+          pendingScalePhase.scales,
+          pendingScalePhase.preferredScaleId,
+          pendingScalePhase.scanReport,
+        );
+        _settleAfterScalePhase();
+        _ensureScaleReacquisition();
+      } else if (!_isConnecting) {
+        _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.ready));
+      }
     } catch (e) {
       // Unlike connectScale, this path reverts to `idle` (not a clearing
       // phase), so the _publishStatus/_emit ordering isn't load-bearing —
       // kept consistent with connectScale for readability.
-      _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.idle));
+      _publishStatus(currentStatus.copyWith(
+        phase: ConnectionPhase.idle,
+        pendingAmbiguity: pendingScalePhase == null
+            ? null
+            : () => AmbiguityReason.machinePicker,
+      ));
       final timedOut = e is TimeoutException;
       _emit(_buildConnectError(
         kind: ConnectionErrorKind.machineConnectFailed,
@@ -1240,12 +1336,10 @@ class ConnectionManager {
         return const ConnectionResult.succeeded();
       }
       await settingsController.setPreferredScaleId(scale.deviceId);
-      // `_latestScaleState` is populated by the scaleController
-      // listener; `_scaleConnected` reads from it.
-      // Only emit ready if machine is also connected — scale alone isn't enough
-      if (_machineConnected) {
-        _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.ready));
-      }
+      _publishStatus(currentStatus.copyWith(
+        phase:
+            _machineConnected ? ConnectionPhase.ready : ConnectionPhase.idle,
+      ));
       return const ConnectionResult.succeeded();
     } catch (e) {
       // Scale failure is non-blocking — stay at ready if machine connected, else idle.
@@ -1321,7 +1415,7 @@ class ConnectionManager {
       );
       return;
     }
-    return _connectScaleTracked(scale, scanReport);
+    await _connectScaleTracked(scale, scanReport);
   }
 
   /// Returns true when the external scale's early-connect path should
@@ -1375,7 +1469,7 @@ class ConnectionManager {
 
   /// Connect a scale and record the attempt outcome on the scan
   /// report builder.
-  Future<void> _connectScaleTracked(
+  Future<ConnectionResult> _connectScaleTracked(
     Scale scale,
     ScanReportBuilder scanReport,
   ) async {
@@ -1385,6 +1479,7 @@ class ConnectionManager {
     // than assuming success (a swallowed failure used to log "— connected").
     final result = await connectScale(scale);
     scanReport.recordResult(scale.deviceId, result);
+    return result;
   }
 
   /// Build a [ScanReport] from [scanReport] and publish it on the

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -1244,12 +1244,16 @@ class ConnectionManager {
   Future<void> selectMachine(De1Interface machine) async {
     final session = _selectionSession;
     if (session == null ||
-        currentStatus.pendingAmbiguity != AmbiguityReason.machinePicker ||
-        !session.acceptsMachine(machine)) {
+        currentStatus.pendingAmbiguity != AmbiguityReason.machinePicker) {
       _log.fine('Ignoring stale machine selection ${machine.deviceId}');
       return;
     }
-    await connectMachine(machine);
+    final resolved = session.resolveMachine(machine.deviceId);
+    if (resolved == null) {
+      _log.fine('Ignoring stale machine selection ${machine.deviceId}');
+      return;
+    }
+    await connectMachine(resolved);
   }
 
   Future<void> connectMachine(De1Interface machine) async {
@@ -1300,35 +1304,55 @@ class ConnectionManager {
         machine.deviceId,
         ConnectionResult.failed(e.toString()),
       );
-      // Unlike connectScale, this path reverts to `idle` (not a clearing
-      // phase), so the _publishStatus/_emit ordering isn't load-bearing —
-      // kept consistent with connectScale for readability.
-      _publishStatus(
-        currentStatus.copyWith(
+      final machineError = _buildConnectError(
+        kind: ConnectionErrorKind.machineConnectFailed,
+        deviceId: machine.deviceId,
+        deviceName: machine.name,
+        message: e is TimeoutException
+            ? 'Machine ${machine.name} did not respond within '
+                  '${_connectTimeout.inSeconds}s.'
+            : 'Machine ${machine.name} failed to connect.',
+        suggestion: e is TimeoutException
+            ? 'Try again. If the problem persists, power-cycle the machine.'
+            : 'Make sure the DE1 is powered on and in range, then retry.',
+        exception: e,
+      );
+
+      if (selectionSession == null || !selectionSession.isActive) {
+        _publishStatus(currentStatus.copyWith(
           phase: ConnectionPhase.idle,
-          pendingAmbiguity:
-              selectionSession == null || !selectionSession.isActive
-              ? null
-              : () => AmbiguityReason.machinePicker,
-        ),
+          pendingAmbiguity: () => null,
+        ));
+        _emit(machineError);
+        rethrow;
+      }
+
+      final alternatives = selectionSession.machines
+          .where((m) => m.deviceId != machine.deviceId)
+          .toList();
+      if (alternatives.isNotEmpty) {
+        _publishStatus(currentStatus.copyWith(
+          phase: ConnectionPhase.idle,
+          pendingAmbiguity: () => AmbiguityReason.machinePicker,
+        ));
+        _emit(machineError);
+        rethrow;
+      }
+
+      _publishStatus(currentStatus.copyWith(
+        phase: ConnectionPhase.idle,
+        pendingAmbiguity: () => null,
+      ));
+      _emit(machineError);
+      await _runScalePhase(
+        null,
+        selectionSession.scales,
+        selectionSession.preferredScaleId,
+        selectionSession.scanReport,
       );
-      final timedOut = e is TimeoutException;
-      _emit(
-        _buildConnectError(
-          kind: ConnectionErrorKind.machineConnectFailed,
-          deviceId: machine.deviceId,
-          deviceName: machine.name,
-          message: timedOut
-              ? 'Machine ${machine.name} did not respond within '
-                    '${_connectTimeout.inSeconds}s.'
-              : 'Machine ${machine.name} failed to connect.',
-          suggestion: timedOut
-              ? 'Try again. If the problem persists, power-cycle the machine.'
-              : 'Make sure the DE1 is powered on and in range, then retry.',
-          exception: e,
-        ),
-      );
-      rethrow;
+      _settleAfterScalePhase();
+      _ensureScaleReacquisition();
+      _emit(machineError);
     } finally {
       _isConnectingMachine = false;
     }
@@ -1422,16 +1446,27 @@ class ConnectionManager {
   Future<ConnectionResult> selectScale(Scale scale) async {
     final session = _selectionSession;
     if (session == null ||
-        currentStatus.pendingAmbiguity != AmbiguityReason.scalePicker ||
-        !session.acceptsScale(scale)) {
+        currentStatus.pendingAmbiguity != AmbiguityReason.scalePicker) {
       _log.fine('Ignoring stale scale selection ${scale.deviceId}');
       return const ConnectionResult.skipped();
     }
-    session.scanReport.markAttempted(scale.deviceId);
-    final result = await connectScale(scale);
-    session.scanReport.recordResult(scale.deviceId, result);
+    final resolved = session.resolveScale(scale.deviceId);
+    if (resolved == null) {
+      _log.fine('Ignoring stale scale selection ${scale.deviceId}');
+      return const ConnectionResult.skipped();
+    }
+    // Capture the machine error before connectScale publishes a clearing
+    // phase (connectingScale) and the gatekeeper strips it.
+    final machineError = !_machineConnected &&
+            currentStatus.error?.kind == ConnectionErrorKind.machineConnectFailed
+        ? currentStatus.error
+        : null;
+    session.scanReport.markAttempted(resolved.deviceId);
+    final result = await connectScale(resolved);
+    session.scanReport.recordResult(resolved.deviceId, result);
     if (result.success) {
       _completeSelectionSessionIfResolved(session);
+      if (machineError != null) _emit(machineError);
     } else {
       _cancelScaleReacquisition();
       _publishStatus(
@@ -1570,6 +1605,27 @@ class ConnectionManager {
     _selectionSession = null;
     _scanReportSubject.add(report);
     _log.info(ScanReportBuilder.format(report));
+  }
+
+  /// Cancels the active selection session, finalising the scan report
+  /// as cancelled and clearing [pendingAmbiguity]. Safe to call when no
+  /// session is active — it is a no-op in that case.
+  ///
+  /// After cancellation the phase settles from actual connected state
+  /// and scale reacquisition is re-armed so the background watch can
+  /// pick up the preferred scale again.
+  void cancelSelectionSession() {
+    final session = _selectionSession;
+    if (session == null) return;
+    _publishStatus(currentStatus.copyWith(
+      pendingAmbiguity: () => null,
+    ));
+    _finishSelectionSession(
+      session,
+      ScanTerminationReason.cancelledByUser,
+    );
+    _settleAfterScalePhase();
+    _ensureScaleReacquisition();
   }
 
   void _cancelSelectionSession({required bool emitReport}) {

--- a/lib/src/device_discovery_feature/device_discovery_view.dart
+++ b/lib/src/device_discovery_feature/device_discovery_view.dart
@@ -100,7 +100,9 @@ class _DeviceDiscoveryState extends State<DeviceDiscoveryView> {
       });
     });
 
-    // Kick off the connection flow
+    // Kick off the connection flow.
+    // Automatic startup uses `connect()` (remembered-machine quick-connect +
+    // early stop). Explicit user/API scans use `scanAndConnect()` instead.
     widget.connectionManager.connect();
   }
 

--- a/lib/src/device_discovery_feature/device_discovery_view.dart
+++ b/lib/src/device_discovery_feature/device_discovery_view.dart
@@ -87,7 +87,9 @@ class _DeviceDiscoveryState extends State<DeviceDiscoveryView> {
 
       // Navigate when ready (only once — connectMachine and connectScale
       // both emit ready, so guard against double navigation)
-      if (status.phase == ConnectionPhase.ready && !_navigated) {
+      if (status.phase == ConnectionPhase.ready &&
+          status.pendingAmbiguity == null &&
+          !_navigated) {
         _navigated = true;
         _navigateAfterConnection();
         return;
@@ -201,13 +203,14 @@ class _DeviceDiscoveryState extends State<DeviceDiscoveryView> {
 
     // Idle with no machines found
     if (_status.phase == ConnectionPhase.idle &&
-        _status.foundMachines.isEmpty) {
+        _status.foundMachines.isEmpty &&
+        _status.foundScales.isEmpty) {
       return _noDevicesFoundView(context);
     }
 
     // Idle with machines (shouldn't normally happen without ambiguity, but fallback)
     if (_status.phase == ConnectionPhase.idle &&
-        _status.foundMachines.isNotEmpty) {
+        (_status.foundMachines.isNotEmpty || _status.foundScales.isNotEmpty)) {
       return _resultsView(context);
     }
 
@@ -310,7 +313,7 @@ class _DeviceDiscoveryState extends State<DeviceDiscoveryView> {
             if (!isConnecting)
               ShadButton.outline(
                 size: ShadButtonSize.sm,
-                onPressed: () => widget.connectionManager.connect(),
+                onPressed: () => widget.connectionManager.scanAndConnect(),
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   spacing: 4,
@@ -325,7 +328,7 @@ class _DeviceDiscoveryState extends State<DeviceDiscoveryView> {
               onPressed: isConnecting
                   ? null
                   : widget.settingsController.preferredMachineId != null
-                      ? () => widget.connectionManager.connect()
+                      ? () => widget.connectionManager.scanAndConnect()
                       : null,
               child: isConnecting
                   ? Row(
@@ -410,7 +413,7 @@ class _DeviceDiscoveryState extends State<DeviceDiscoveryView> {
                     )
                   else
                     ShadButton(
-                      onPressed: () => widget.connectionManager.connect(),
+                      onPressed: () => widget.connectionManager.scanAndConnect(),
                       child: Row(
                         mainAxisSize: MainAxisSize.min,
                         spacing: 8,
@@ -425,7 +428,7 @@ class _DeviceDiscoveryState extends State<DeviceDiscoveryView> {
                       widget.settingsController.enableSimulatedDevicesForSession(
                         {SimulatedDevicesTypes.machine, SimulatedDevicesTypes.scale},
                       );
-                      widget.connectionManager.connect();
+                      widget.connectionManager.scanAndConnect();
                     },
                     child: Row(
                       mainAxisSize: MainAxisSize.min,

--- a/lib/src/device_discovery_feature/scan_flow_view.dart
+++ b/lib/src/device_discovery_feature/scan_flow_view.dart
@@ -75,7 +75,7 @@ class ScanFlowViewState extends State<ScanFlowView> {
     setState(() {
       _adapterError = null;
     });
-    widget.connectionManager.connect();
+    widget.connectionManager.scanAndConnect();
   }
 
   void _clearAdapterErrorAndTryDemo() {
@@ -85,14 +85,14 @@ class ScanFlowViewState extends State<ScanFlowView> {
     widget.settingsController.enableSimulatedDevicesForSession(
       {SimulatedDevicesTypes.machine, SimulatedDevicesTypes.scale},
     );
-    widget.connectionManager.connect();
+    widget.connectionManager.scanAndConnect();
   }
 
   void _tryDemoModeFromNoDevices() {
     widget.settingsController.enableSimulatedDevicesForSession(
       {SimulatedDevicesTypes.machine, SimulatedDevicesTypes.scale},
     );
-    widget.connectionManager.connect();
+    widget.connectionManager.scanAndConnect();
   }
 
   late StreamSubscription<ConnectionStatus> _statusSubscription;
@@ -127,7 +127,9 @@ class ScanFlowViewState extends State<ScanFlowView> {
         BootTiming.mark('connect_${status.phase.name}');
       }
 
-      if (status.phase == ConnectionPhase.ready && !_hasNavigated) {
+      if (status.phase == ConnectionPhase.ready &&
+          status.pendingAmbiguity == null &&
+          !_hasNavigated) {
         _hasNavigated = true;
         _cancelTooLongTimer();
         BootTiming.mark('scan_ready');
@@ -233,7 +235,7 @@ class ScanFlowViewState extends State<ScanFlowView> {
         // If we're stuck in scanning phase, the scan may have silently finished
         if (_status.phase == ConnectionPhase.scanning) {
           _log.info('Stale scan detected, restarting');
-          widget.connectionManager.connect();
+          widget.connectionManager.scanAndConnect();
         }
         break;
     }
@@ -276,12 +278,13 @@ class ScanFlowViewState extends State<ScanFlowView> {
     }
     // Idle with no machines found
     else if (_status.phase == ConnectionPhase.idle &&
-        _status.foundMachines.isEmpty) {
+        _status.foundMachines.isEmpty &&
+        _status.foundScales.isEmpty) {
       content = _noDevicesFoundView(context);
     }
     // Idle with machines but no ambiguity (fallback)
     else if (_status.phase == ConnectionPhase.idle &&
-        _status.foundMachines.isNotEmpty) {
+        (_status.foundMachines.isNotEmpty || _status.foundScales.isNotEmpty)) {
       content = _devicePickerView(context);
     }
     // Default: scanning view
@@ -490,10 +493,10 @@ class ScanFlowViewState extends State<ScanFlowView> {
               if (!isConnecting)
                 AccessibleButton(
                   label: 'ReScan',
-                  onTap: () => widget.connectionManager.connect(),
+                  onTap: () => widget.connectionManager.scanAndConnect(),
                   child: ShadButton.outline(
                     size: ShadButtonSize.sm,
-                    onPressed: () => widget.connectionManager.connect(),
+                    onPressed: () => widget.connectionManager.scanAndConnect(),
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       spacing: 4,
@@ -513,14 +516,14 @@ class ScanFlowViewState extends State<ScanFlowView> {
                 onTap: isConnecting
                     ? null
                     : widget.settingsController.preferredMachineId != null
-                        ? () => widget.connectionManager.connect()
+                        ? () => widget.connectionManager.scanAndConnect()
                         : null,
                 child: ShadButton(
                   size: ShadButtonSize.sm,
                   onPressed: isConnecting
                       ? null
                       : widget.settingsController.preferredMachineId != null
-                          ? () => widget.connectionManager.connect()
+                          ? () => widget.connectionManager.scanAndConnect()
                           : null,
                   child: isConnecting
                       ? Row(
@@ -578,9 +581,9 @@ class ScanFlowViewState extends State<ScanFlowView> {
           ),
           AccessibleButton(
             label: 'Retry',
-            onTap: () => widget.connectionManager.connect(),
+            onTap: () => widget.connectionManager.scanAndConnect(),
             child: ShadButton(
-              onPressed: () => widget.connectionManager.connect(),
+              onPressed: () => widget.connectionManager.scanAndConnect(),
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 spacing: 8,
@@ -655,9 +658,9 @@ class ScanFlowViewState extends State<ScanFlowView> {
       return Center(
         child: AccessibleButton(
           label: 'Scan Again',
-          onTap: () => widget.connectionManager.connect(),
+          onTap: () => widget.connectionManager.scanAndConnect(),
           child: ShadButton(
-            onPressed: () => widget.connectionManager.connect(),
+            onPressed: () => widget.connectionManager.scanAndConnect(),
             child: const Text('Scan Again'),
           ),
         ),
@@ -667,7 +670,7 @@ class ScanFlowViewState extends State<ScanFlowView> {
     return Center(
       child: ScanResultsSummary(
         report: report,
-        onScanAgain: () => widget.connectionManager.connect(),
+        onScanAgain: () => widget.connectionManager.scanAndConnect(),
         onTryDemoMode: _tryDemoModeFromNoDevices,
         onTroubleshoot: () => showTroubleshootingWizard(
           context: context,
@@ -708,7 +711,7 @@ class ScanFlowViewState extends State<ScanFlowView> {
               title: const Text('Re-start scan'),
               onTap: () {
                 Navigator.pop(context);
-                widget.connectionManager.connect();
+                widget.connectionManager.scanAndConnect();
               },
             ),
             ListTile(

--- a/lib/src/device_discovery_feature/scan_flow_view.dart
+++ b/lib/src/device_discovery_feature/scan_flow_view.dart
@@ -144,7 +144,7 @@ class ScanFlowViewState extends State<ScanFlowView> {
           _directAutoConnected = true;
           _log.info('--direct: auto-connecting to ${_discoveredMachines.first.name}');
           unawaited(widget.connectionManager
-              .connectMachine(_discoveredMachines.first));
+              .selectMachine(_discoveredMachines.first));
           return;
         }
         if (status.pendingAmbiguity == AmbiguityReason.scalePicker &&
@@ -152,7 +152,7 @@ class ScanFlowViewState extends State<ScanFlowView> {
           _directAutoConnected = true;
           _log.info('--direct: auto-connecting to scale ${_discoveredScales.first.name}');
           unawaited(widget.connectionManager
-              .connectScale(_discoveredScales.first));
+              .selectScale(_discoveredScales.first));
           return;
         }
       }

--- a/lib/src/device_discovery_feature/scan_flow_view.dart
+++ b/lib/src/device_discovery_feature/scan_flow_view.dart
@@ -40,6 +40,12 @@ class ScanFlowView extends StatefulWidget {
   /// of showing a picker on ambiguity.
   final bool directConnect;
 
+  /// The initial connection action. When non-null, invoked once from
+  /// [initState] instead of the default [ConnectionManager.connect].
+  /// Launcher pages should pass `connectionManager.scanAndConnect`;
+  /// onboarding uses `connect` (the default when null).
+  final VoidCallback? initialConnectionIntent;
+
   /// Invoked once when the connection phase first reaches `ready`.
   final VoidCallback onConnected;
 
@@ -59,6 +65,7 @@ class ScanFlowView extends StatefulWidget {
     required this.settingsController,
     required this.scanStateGuardian,
     this.directConnect = false,
+    this.initialConnectionIntent,
     required this.onConnected,
     required this.onExit,
     this.exitLabel = 'Dashboard',
@@ -112,6 +119,10 @@ class ScanFlowViewState extends State<ScanFlowView> {
   List<De1Interface> _discoveredMachines = [];
   List<device_scale.Scale> _discoveredScales = [];
 
+  /// Currently selected device ID in the picker UI.
+  String? _selectedMachineId;
+  String? _selectedScaleId;
+
   /// Bluetooth adapter error message, set by ScanStateGuardian events.
   String? _adapterError;
 
@@ -160,6 +171,9 @@ class ScanFlowViewState extends State<ScanFlowView> {
       // Reset the "taking too long" timer when phase changes away from scanning
       if (status.phase != ConnectionPhase.scanning) {
         _cancelTooLongTimer();
+      } else {
+        _selectedMachineId = null;
+        _selectedScaleId = null;
       }
 
       // Start the timer when entering scanning phase
@@ -194,7 +208,12 @@ class ScanFlowViewState extends State<ScanFlowView> {
         widget.scanStateGuardian.events.listen(_onGuardianEvent);
 
     // Kick off the connection flow
-    widget.connectionManager.connect();
+    final intent = widget.initialConnectionIntent;
+    if (intent != null) {
+      intent();
+    } else {
+      widget.connectionManager.connect();
+    }
     _startTooLongTimer();
   }
 
@@ -407,21 +426,69 @@ class ScanFlowViewState extends State<ScanFlowView> {
   Widget _devicePickerView(BuildContext context) {
     final isConnecting = _status.phase == ConnectionPhase.connectingMachine ||
         _status.phase == ConnectionPhase.connectingScale;
-    final connectingDeviceId = isConnecting
-        ? (_status.foundMachines.isNotEmpty
-            ? _status.foundMachines.first.deviceId
-            : null)
-        : null;
 
-    // Check if preferred device is configured but not among found devices
     final preferredMachineId =
         widget.settingsController.preferredMachineId;
+    final preferredScaleId = widget.settingsController.preferredScaleId;
+
+    if (_status.pendingAmbiguity == AmbiguityReason.machinePicker) {
+      final preferredMachineNotFound = preferredMachineId != null &&
+          _status.foundMachines.isNotEmpty &&
+          !_status.foundMachines
+              .any((m) => m.deviceId == preferredMachineId);
+      return _singlePickerView(
+        context: context,
+        label: preferredMachineNotFound
+            ? "Your preferred machine wasn't found, but we discovered these:"
+            : 'Machines',
+        devices: _status.foundMachines,
+        selectedId: _selectedMachineId,
+        onTapped: (id) => setState(() => _selectedMachineId = id),
+        onConnect: () {
+          final id = _selectedMachineId;
+          if (id == null) return;
+          final machine = _status.foundMachines.firstWhere(
+            (m) => m.deviceId == id,
+          );
+          widget.connectionManager.selectMachine(machine);
+        },
+        isConnecting: isConnecting,
+        canConnect: _selectedMachineId != null,
+      );
+    }
+
+    if (_status.pendingAmbiguity == AmbiguityReason.scalePicker) {
+      final preferredScaleNotFound = preferredScaleId != null &&
+          _status.foundScales.isNotEmpty &&
+          !_status.foundScales
+              .any((s) => s.deviceId == preferredScaleId);
+      return _singlePickerView(
+        context: context,
+        label: preferredScaleNotFound
+            ? "Your preferred scale wasn't found, but we discovered these:"
+            : 'Scales',
+        devices: _status.foundScales,
+        selectedId: _selectedScaleId,
+        onTapped: (id) => setState(() => _selectedScaleId = id),
+        onConnect: () {
+          final id = _selectedScaleId;
+          if (id == null) return;
+          final scale = _status.foundScales.firstWhere(
+            (s) => s.deviceId == id,
+          );
+          widget.connectionManager.selectScale(scale);
+        },
+        isConnecting: isConnecting,
+        canConnect: _selectedScaleId != null,
+      );
+    }
+
+    // Fallback: idle with devices but no ambiguity — show combined view.
     final preferredMachineNotFound = preferredMachineId != null &&
         _status.foundMachines.isNotEmpty &&
         !_status.foundMachines
             .any((m) => m.deviceId == preferredMachineId);
 
-    final preferredScaleId = widget.settingsController.preferredScaleId;
     final preferredScaleNotFound = preferredScaleId != null &&
         _status.foundScales.isNotEmpty &&
         !_status.foundScales
@@ -452,7 +519,11 @@ class ScanFlowViewState extends State<ScanFlowView> {
                     deviceType: dev.DeviceType.machine,
                     showHeader: true,
                     headerText: machineHeader,
-                    connectingDeviceId: connectingDeviceId,
+                    connectingDeviceId: isConnecting
+                        ? (_status.foundMachines.isNotEmpty
+                            ? _status.foundMachines.first.deviceId
+                            : null)
+                        : null,
                     errorMessage: _status.error?.message,
                     selectedDeviceId: null,
                     preferredDeviceId:
@@ -507,43 +578,6 @@ class ScanFlowViewState extends State<ScanFlowView> {
                     ),
                   ),
                 ),
-              AccessibleButton(
-                label: isConnecting
-                    ? 'Connecting'
-                    : widget.settingsController.preferredMachineId != null
-                        ? 'Connect'
-                        : 'Select a machine',
-                onTap: isConnecting
-                    ? null
-                    : widget.settingsController.preferredMachineId != null
-                        ? () => widget.connectionManager.scanAndConnect()
-                        : null,
-                child: ShadButton(
-                  size: ShadButtonSize.sm,
-                  onPressed: isConnecting
-                      ? null
-                      : widget.settingsController.preferredMachineId != null
-                          ? () => widget.connectionManager.scanAndConnect()
-                          : null,
-                  child: isConnecting
-                      ? Row(
-                          mainAxisSize: MainAxisSize.min,
-                          spacing: 4,
-                          children: [
-                            const SizedBox(
-                              width: 14,
-                              height: 14,
-                              child:
-                                  CircularProgressIndicator(strokeWidth: 2),
-                            ),
-                            const Text('Connecting...'),
-                          ],
-                        )
-                      : Text(widget.settingsController.preferredMachineId != null
-                          ? 'Connect'
-                          : 'Select a machine'),
-                ),
-              ),
               if (!isConnecting)
                 AccessibleButton(
                   label: widget.exitLabel,
@@ -554,6 +588,109 @@ class ScanFlowViewState extends State<ScanFlowView> {
                     child: Text(widget.exitLabel),
                   ),
                 ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _singlePickerView<T>({
+    required BuildContext context,
+    required String label,
+    required List<T> devices,
+    required String? selectedId,
+    required void Function(String id) onTapped,
+    required VoidCallback onConnect,
+    required bool isConnecting,
+    required bool canConnect,
+  }) {
+    final theme = ShadTheme.of(context);
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 460),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 16,
+          children: [
+            Text(label, style: theme.textTheme.h3),
+            ...devices.map((device) {
+              final id = (device as dynamic).deviceId as String;
+              final name = (device as dynamic).name as String;
+              final isSelected = selectedId == id;
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: ShadCard(
+                  width: double.infinity,
+                  child: InkWell(
+                    onTap: isConnecting ? null : () => onTapped(id),
+                    child: Padding(
+                      padding: const EdgeInsets.all(12),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(name),
+                                Text(id,
+                                    style: theme.textTheme.muted),
+                              ],
+                            ),
+                          ),
+                          if (isSelected)
+                            Icon(LucideIcons.checkCircle,
+                                color: theme.colorScheme.primary),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            }),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              spacing: 8,
+              children: [
+                if (!isConnecting)
+                  ShadButton.outline(
+                    size: ShadButtonSize.sm,
+                    onPressed: () => widget.connectionManager.scanAndConnect(),
+                    child: const Row(
+                      mainAxisSize: MainAxisSize.min,
+                      spacing: 4,
+                      children: [
+                        Icon(LucideIcons.refreshCw, size: 14),
+                        Text('ReScan'),
+                      ],
+                    ),
+                  ),
+                ShadButton(
+                  size: ShadButtonSize.sm,
+                  onPressed: isConnecting || !canConnect ? null : onConnect,
+                  child: isConnecting
+                      ? const Row(
+                          mainAxisSize: MainAxisSize.min,
+                          spacing: 4,
+                          children: [
+                            SizedBox(
+                              width: 14,
+                              height: 14,
+                              child:
+                                  CircularProgressIndicator(strokeWidth: 2),
+                            ),
+                            Text('Connecting...'),
+                          ],
+                        )
+                      : const Text('Connect'),
+                ),
+                if (!isConnecting)
+                  ShadButton.secondary(
+                    size: ShadButtonSize.sm,
+                    onPressed: _skipToDashboard,
+                    child: Text(widget.exitLabel),
+                  ),
               ],
             ),
           ],

--- a/lib/src/device_discovery_feature/scan_flow_view.dart
+++ b/lib/src/device_discovery_feature/scan_flow_view.dart
@@ -273,11 +273,17 @@ class ScanFlowViewState extends State<ScanFlowView> {
   Widget build(BuildContext context) {
     final Widget content;
 
-    // Adapter error takes precedence
+    // Adapter error takes precedence.
     if (_adapterError != null) {
       content = _adapterErrorView(context);
     }
-    // Error state from connection manager
+    // Ambiguity picker — show even when an error coexists, with the error
+    // rendered inline so the user can continue without a new scan.
+    else if (_status.pendingAmbiguity == AmbiguityReason.machinePicker ||
+        _status.pendingAmbiguity == AmbiguityReason.scalePicker) {
+      content = _devicePickerView(context);
+    }
+    // Standalone error (idle with no pending ambiguity).
     else if (_status.error != null && _status.phase == ConnectionPhase.idle) {
       content = _errorView(context);
     }
@@ -289,11 +295,6 @@ class ScanFlowViewState extends State<ScanFlowView> {
     else if (_status.phase == ConnectionPhase.connectingMachine ||
         _status.phase == ConnectionPhase.connectingScale) {
       content = _connectingView(context);
-    }
-    // Ambiguity: machine or scale picker
-    else if (_status.pendingAmbiguity == AmbiguityReason.machinePicker ||
-        _status.pendingAmbiguity == AmbiguityReason.scalePicker) {
-      content = _devicePickerView(context);
     }
     // Idle with no machines found
     else if (_status.phase == ConnectionPhase.idle &&
@@ -454,6 +455,7 @@ class ScanFlowViewState extends State<ScanFlowView> {
         },
         isConnecting: isConnecting,
         canConnect: _selectedMachineId != null,
+        errorMessage: _status.error?.message,
       );
     }
 
@@ -480,6 +482,7 @@ class ScanFlowViewState extends State<ScanFlowView> {
         },
         isConnecting: isConnecting,
         canConnect: _selectedScaleId != null,
+        errorMessage: _status.error?.message,
       );
     }
 
@@ -596,7 +599,7 @@ class ScanFlowViewState extends State<ScanFlowView> {
     );
   }
 
-  Widget _singlePickerView<T>({
+  Widget _singlePickerView<T extends dev.Device>({
     required BuildContext context,
     required String label,
     required List<T> devices,
@@ -605,6 +608,7 @@ class ScanFlowViewState extends State<ScanFlowView> {
     required VoidCallback onConnect,
     required bool isConnecting,
     required bool canConnect,
+    String? errorMessage,
   }) {
     final theme = ShadTheme.of(context);
     return Center(
@@ -615,9 +619,35 @@ class ScanFlowViewState extends State<ScanFlowView> {
           spacing: 16,
           children: [
             Text(label, style: theme.textTheme.h3),
+            if (errorMessage != null)
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.destructive.withValues(alpha: 0.08),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: theme.colorScheme.destructive.withValues(alpha: 0.2),
+                  ),
+                ),
+                child: Row(
+                  spacing: 8,
+                  children: [
+                    Icon(LucideIcons.triangleAlert,
+                        size: 16, color: theme.colorScheme.destructive),
+                    Expanded(
+                      child: Text(
+                        errorMessage,
+                        style: theme.textTheme.small
+                            .copyWith(color: theme.colorScheme.destructive),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             ...devices.map((device) {
-              final id = (device as dynamic).deviceId as String;
-              final name = (device as dynamic).name as String;
+              final id = device.deviceId;
+              final name = device.name;
               final isSelected = selectedId == id;
               return Padding(
                 padding: const EdgeInsets.symmetric(vertical: 4),

--- a/lib/src/launcher/launcher_scan_page.dart
+++ b/lib/src/launcher/launcher_scan_page.dart
@@ -30,8 +30,10 @@ class LauncherScanPage extends StatelessWidget {
       deviceController: deviceController,
       settingsController: settingsController,
       scanStateGuardian: scanStateGuardian,
+      initialConnectionIntent: () => connectionManager.scanAndConnect(),
       onConnected: () => Navigator.of(context).pop(),
       onExit: () {
+        connectionManager.cancelSelectionSession();
         deviceController.stopScan();
         Navigator.of(context).pop();
       },

--- a/lib/src/launcher/launcher_scan_page.dart
+++ b/lib/src/launcher/launcher_scan_page.dart
@@ -23,21 +23,31 @@ class LauncherScanPage extends StatelessWidget {
   final SettingsController settingsController;
   final ScanStateGuardian scanStateGuardian;
 
+  void _cancelAndExit(BuildContext context) {
+    connectionManager.cancelActiveScan();
+    deviceController.stopScan();
+    Navigator.of(context).pop();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return ScanFlowView(
-      connectionManager: connectionManager,
-      deviceController: deviceController,
-      settingsController: settingsController,
-      scanStateGuardian: scanStateGuardian,
-      initialConnectionIntent: () => connectionManager.scanAndConnect(),
-      onConnected: () => Navigator.of(context).pop(),
-      onExit: () {
-        connectionManager.cancelSelectionSession();
-        deviceController.stopScan();
-        Navigator.of(context).pop();
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) {
+        if (!didPop) {
+          _cancelAndExit(context);
+        }
       },
-      exitLabel: 'Cancel',
+      child: ScanFlowView(
+        connectionManager: connectionManager,
+        deviceController: deviceController,
+        settingsController: settingsController,
+        scanStateGuardian: scanStateGuardian,
+        initialConnectionIntent: () => connectionManager.scanAndConnect(),
+        onConnected: () => Navigator.of(context).pop(),
+        onExit: () => _cancelAndExit(context),
+        exitLabel: 'Cancel',
+      ),
     );
   }
 }

--- a/lib/src/services/webserver/devices_handler.dart
+++ b/lib/src/services/webserver/devices_handler.dart
@@ -234,7 +234,7 @@ class DevicesHandler {
       final bool quickScan =
           req.requestedUri.queryParametersAll["quick"]?.firstOrNull == "true";
       final bool connect =
-          req.requestedUri.queryParametersAll["connect"]?.firstOrNull != "false";
+          req.requestedUri.queryParametersAll["connect"]?.firstOrNull == "true";
       log.info("running scan, quick = $quickScan, connect = $connect");
       if (connect) {
         if (quickScan) {
@@ -395,7 +395,7 @@ class DevicesHandler {
 
     switch (command) {
       case 'scan':
-        final connect = data['connect'] as bool? ?? true;
+        final connect = data['connect'] as bool? ?? false;
         final quick = data['quick'] as bool? ?? false;
         _log.fine("ws scan command: connect=$connect, quick=$quick");
         if (connect) {

--- a/lib/src/services/webserver/devices_handler.dart
+++ b/lib/src/services/webserver/devices_handler.dart
@@ -234,14 +234,14 @@ class DevicesHandler {
       final bool quickScan =
           req.requestedUri.queryParametersAll["quick"]?.firstOrNull == "true";
       final bool connect =
-          req.requestedUri.queryParametersAll["connect"]?.firstOrNull == "true";
+          req.requestedUri.queryParametersAll["connect"]?.firstOrNull != "false";
       log.info("running scan, quick = $quickScan, connect = $connect");
       if (connect) {
         if (quickScan) {
-          _connectionManager.connect();
+          _connectionManager.scanAndConnect();
           return [];
         }
-        await _connectionManager.connect();
+        await _connectionManager.scanAndConnect();
       } else {
         if (quickScan) {
           _controller.scanForDevices();
@@ -395,14 +395,14 @@ class DevicesHandler {
 
     switch (command) {
       case 'scan':
-        final connect = data['connect'] as bool? ?? false;
+        final connect = data['connect'] as bool? ?? true;
         final quick = data['quick'] as bool? ?? false;
         _log.fine("ws scan command: connect=$connect, quick=$quick");
         if (connect) {
           if (quick) {
-            _connectionManager.connect();
+            _connectionManager.scanAndConnect();
           } else {
-            _connectionManager.connect().catchError((e) {
+            _connectionManager.scanAndConnect().catchError((e) {
               socket.sink.add(jsonEncode({'error': 'Scan failed: $e'}));
             });
           }

--- a/lib/src/services/webserver/devices_handler.dart
+++ b/lib/src/services/webserver/devices_handler.dart
@@ -461,9 +461,21 @@ class DevicesHandler {
   Future<void> _connectDevice(Device device) async {
     switch (device.type) {
       case DeviceType.machine:
-        await _connectionManager.connectMachine(device as De1Interface);
+        final machine = device as De1Interface;
+        if (_connectionManager.currentStatus.pendingAmbiguity ==
+            AmbiguityReason.machinePicker) {
+          await _connectionManager.selectMachine(machine);
+        } else {
+          await _connectionManager.connectMachine(machine);
+        }
       case DeviceType.scale:
-        await _connectionManager.connectScale(device as Scale);
+        final scale = device as Scale;
+        if (_connectionManager.currentStatus.pendingAmbiguity ==
+            AmbiguityReason.scalePicker) {
+          await _connectionManager.selectScale(scale);
+        } else {
+          await _connectionManager.connectScale(scale);
+        }
       case DeviceType.sensor:
         await (device as Sensor).onConnect();
     }

--- a/lib/src/shared/connection_error_banner.dart
+++ b/lib/src/shared/connection_error_banner.dart
@@ -7,8 +7,9 @@ import 'package:shadcn_ui/shadcn_ui.dart';
 /// [ConnectionManager.status].
 ///
 /// Renders a destructive [ShadAlert] while `status.error != null`. Shows a
-/// Retry button for transient kinds (connect-failed, disconnected) that
-/// dispatches `connectionManager.scanAndConnect()`. Environmental kinds
+/// Retry button for transient kinds. Disconnect recovery dispatches
+/// `connectionManager.connect()`; failed explicit connections dispatch
+/// `connectionManager.scanAndConnect()`. Environmental kinds
 /// (adapterOff, bluetoothPermissionDenied, scanFailed) require user action
 /// outside the app, so only the instruction text is shown — no retry button.
 class ConnectionErrorBanner extends StatelessWidget {
@@ -45,7 +46,7 @@ class ConnectionErrorBanner extends StatelessWidget {
                 Align(
                   alignment: Alignment.centerRight,
                   child: ShadButton.outline(
-                    onPressed: () => connectionManager.scanAndConnect(),
+                    onPressed: () => _retry(err.kind),
                     child: const Text('Retry'),
                   ),
                 ),
@@ -55,6 +56,15 @@ class ConnectionErrorBanner extends StatelessWidget {
         );
       },
     );
+  }
+
+  void _retry(String kind) {
+    if (kind == ConnectionErrorKind.machineDisconnected ||
+        kind == ConnectionErrorKind.scaleDisconnected) {
+      connectionManager.connect();
+    } else {
+      connectionManager.scanAndConnect();
+    }
   }
 
   /// Retry makes sense for transient kinds — the user can re-trigger a scan

--- a/lib/src/shared/connection_error_banner.dart
+++ b/lib/src/shared/connection_error_banner.dart
@@ -8,7 +8,7 @@ import 'package:shadcn_ui/shadcn_ui.dart';
 ///
 /// Renders a destructive [ShadAlert] while `status.error != null`. Shows a
 /// Retry button for transient kinds (connect-failed, disconnected) that
-/// dispatches `connectionManager.connect()`. Environmental kinds
+/// dispatches `connectionManager.scanAndConnect()`. Environmental kinds
 /// (adapterOff, bluetoothPermissionDenied, scanFailed) require user action
 /// outside the app, so only the instruction text is shown — no retry button.
 class ConnectionErrorBanner extends StatelessWidget {
@@ -45,7 +45,7 @@ class ConnectionErrorBanner extends StatelessWidget {
                 Align(
                   alignment: Alignment.centerRight,
                   child: ShadButton.outline(
-                    onPressed: () => connectionManager.connect(),
+                    onPressed: () => connectionManager.scanAndConnect(),
                     child: const Text('Retry'),
                   ),
                 ),

--- a/test/controllers/connection/policy_resolver_test.dart
+++ b/test/controllers/connection/policy_resolver_test.dart
@@ -72,6 +72,16 @@ void main() {
       expect(result, isA<MachinePickerAction>());
     });
 
+    test('preferred set + preferred discovered → connect preferred', () {
+      final preferred = _FakeDe1('pref');
+      final result = resolveMachinePolicy(
+        machines: [preferred, _FakeDe1('other')],
+        preferredMachineId: 'pref',
+      );
+      expect(result, isA<ConnectMachineAction>());
+      expect((result as ConnectMachineAction).machine, same(preferred));
+    });
+
     test('preferred set + no machines → idle', () {
       final result = resolveMachinePolicy(
         machines: const [],

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -218,6 +218,41 @@ void main() {
         await sub.cancel();
       });
 
+      test('already-connected machine is not quick-connected again', () async {
+        await connectionManager.dispose();
+        await settingsController.setPreferredMachineId('pref-de1');
+        mockSettingsService.setRememberedDevices(RememberedDevice.encodeList([
+          const RememberedDevice(
+            id: 'pref-de1',
+            name: 'DE1',
+            type: DeviceType.machine,
+          ),
+        ]));
+        final remembered = RememberedDevicesController(
+          machineConnections: const Stream.empty(),
+          scaleConnections: const Stream.empty(),
+          settings: mockSettingsService,
+        );
+        await remembered.initialize();
+
+        final connectedMachine = _FakeDe1(deviceId: 'pref-de1');
+        mockDe1Controller.de1Subject.add(connectedMachine);
+        mockScanner.quickConnectResult = _FakeDe1(deviceId: 'pref-de1');
+        connectionManager = ConnectionManager(
+          deviceScanner: mockScanner,
+          de1Controller: mockDe1Controller,
+          scaleController: mockScaleController,
+          settingsController: settingsController,
+          rememberedDevices: remembered,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        await connectionManager.connect();
+
+        expect(mockScanner.quickConnectCallCount, 0);
+        remembered.dispose();
+      });
+
       test('no preferred, 0 machines → stays idle', () async {
         await connectionManager.connect();
         await Future.delayed(Duration.zero);

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -2878,6 +2878,134 @@ void main() {
       });
     });
   });
+
+  group('cancelActiveScan', () {
+    late ConnectionManager connectionManager;
+    late MockDeviceScanner mockScanner;
+    late MockDe1Controller mockDe1Controller;
+    late MockScaleController mockScaleController;
+
+    setUp(() async {
+      mockScanner = MockDeviceScanner();
+      mockDe1Controller =
+          MockDe1Controller(controller: DeviceController([]));
+      mockScaleController = MockScaleController();
+      final localSettings = SettingsController(MockSettingsService());
+      await localSettings.loadSettings();
+      connectionManager = ConnectionManager(
+        deviceScanner: mockScanner,
+        de1Controller: mockDe1Controller,
+        scaleController: mockScaleController,
+        settingsController: localSettings,
+      );
+    });
+
+    test('stops the scanner', () {
+      connectionManager.cancelActiveScan();
+      expect(mockScanner.stopScanCallCount, 1);
+    });
+
+    test('clears pending ambiguity when a session is active', () async {
+      mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+      mockScanner.addDevice(_FakeDe1(deviceId: 'm2'));
+      mockScanner.addDevice(TestScale(deviceId: 's1'));
+
+      await connectionManager.connect();
+      await Future<void>.delayed(Duration.zero);
+
+      // Two machines → machinePicker.
+      expect(connectionManager.currentStatus.pendingAmbiguity,
+          AmbiguityReason.machinePicker);
+
+      connectionManager.cancelActiveScan();
+
+      // Ambiguity cleared, phase settled.
+      expect(connectionManager.currentStatus.pendingAmbiguity, isNull);
+      expect(connectionManager.currentStatus.phase, ConnectionPhase.idle);
+    });
+
+    test('emits exactly one cancelled report', () async {
+      mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+      mockScanner.addDevice(_FakeDe1(deviceId: 'm2'));
+      mockScanner.addDevice(TestScale(deviceId: 's1'));
+
+      await connectionManager.connect();
+      await Future<void>.delayed(Duration.zero);
+
+      final reports = <ScanReport>[];
+      final sub = connectionManager.scanReportStream.listen(reports.add);
+
+      connectionManager.cancelActiveScan();
+
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(reports.length, 1);
+      expect(reports.first.scanTerminationReason,
+          ScanTerminationReason.cancelledByUser);
+    });
+
+    test('holds scanner open → cancel → no machine connected', () async {
+      // Arrange: queue a scan that will be held open.
+      final scanCompleter = Completer<void>();
+      mockScanner.queuedScanCompleters.add(scanCompleter);
+      mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+      mockScanner.addDevice(TestScale(deviceId: 's1'));
+
+      // Start the scan.
+      final connectFuture = connectionManager.scanAndConnect();
+      // Let the async machinery spin up to where it awaits the scan completer.
+      await Future<void>.delayed(Duration.zero);
+
+      // Cancel while scan is in-flight.
+      connectionManager.cancelActiveScan();
+      expect(mockScanner.stopScanCallCount, greaterThan(0));
+
+      // Complete the held scan.
+      scanCompleter.complete();
+      await connectFuture;
+
+      // No machine connected — the cancelled scan skipped policy.
+      expect(mockDe1Controller.connectMachineCallCount, 0);
+    });
+
+    test(
+        'holds scanner open → cancel → no picker appears afterward',
+        () async {
+      final scanCompleter = Completer<void>();
+      mockScanner.queuedScanCompleters.add(scanCompleter);
+      mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+      mockScanner.addDevice(_FakeDe1(deviceId: 'm2'));
+      mockScanner.addDevice(TestScale(deviceId: 's1'));
+
+      final connectFuture = connectionManager.scanAndConnect();
+      await Future<void>.delayed(Duration.zero);
+
+      connectionManager.cancelActiveScan();
+      scanCompleter.complete();
+      await connectFuture;
+
+      // No ambiguity — policy never ran.
+      expect(connectionManager.currentStatus.pendingAmbiguity, isNull);
+    });
+
+    test('holds scanner open → cancel → phase is settled', () async {
+      final scanCompleter = Completer<void>();
+      mockScanner.queuedScanCompleters.add(scanCompleter);
+      mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+      mockScanner.addDevice(TestScale(deviceId: 's1'));
+
+      final connectFuture = connectionManager.scanAndConnect();
+      await Future<void>.delayed(Duration.zero);
+
+      connectionManager.cancelActiveScan();
+      scanCompleter.complete();
+      await connectFuture;
+
+      // Phase settled to idle (no machine connected).
+      expect(connectionManager.currentStatus.phase, ConnectionPhase.idle);
+    });
+  });
 }
 
 /// A De1Controller mock that uses a Completer to control when connectToDe1 completes.

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -253,6 +253,56 @@ void main() {
         remembered.dispose();
       });
 
+      test('explicit scan bypasses machine quick-connect', () async {
+        await connectionManager.dispose();
+        await settingsController.setPreferredMachineId('pref-de1');
+        mockSettingsService.setRememberedDevices(RememberedDevice.encodeList([
+          const RememberedDevice(
+            id: 'pref-de1',
+            name: 'DE1',
+            type: DeviceType.machine,
+          ),
+        ]));
+        final remembered = RememberedDevicesController(
+          machineConnections: const Stream.empty(),
+          scaleConnections: const Stream.empty(),
+          settings: mockSettingsService,
+        );
+        await remembered.initialize();
+        mockScanner.quickConnectResult = _FakeDe1(deviceId: 'pref-de1');
+        connectionManager = ConnectionManager(
+          deviceScanner: mockScanner,
+          de1Controller: mockDe1Controller,
+          scaleController: mockScaleController,
+          settingsController: settingsController,
+          rememberedDevices: remembered,
+        );
+
+        await connectionManager.scanAndConnect();
+
+        expect(mockScanner.quickConnectCallCount, 0);
+        expect(mockScanner.scanCallCount, 1);
+        remembered.dispose();
+      });
+
+      test('explicit scan waits for discovery before connecting preferred',
+          () async {
+        await settingsController.setPreferredMachineId('pref-de1');
+        final preferred = _FakeDe1(deviceId: 'pref-de1');
+        mockScanner.addDevice(preferred);
+        mockScanner.scanCompleter = Completer<void>();
+
+        final scan = connectionManager.scanAndConnect();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(mockDe1Controller.connectCalls, isEmpty);
+
+        mockScanner.scanCompleter!.complete();
+        await scan;
+
+        expect(mockDe1Controller.connectCalls, [same(preferred)]);
+      });
+
       test('no preferred, 0 machines → stays idle', () async {
         await connectionManager.connect();
         await Future.delayed(Duration.zero);
@@ -328,6 +378,20 @@ void main() {
         expect(mockDe1Controller.connectCalls, isEmpty);
       });
 
+      test('failed preferred machine emits ambiguity for alternatives',
+          () async {
+        await settingsController.setPreferredMachineId('pref-de1');
+        mockDe1Controller.shouldFailConnect = true;
+        mockScanner.addDevice(_FakeDe1(deviceId: 'pref-de1'));
+        mockScanner.addDevice(_FakeDe1(deviceId: 'alternative-de1'));
+        await Future.delayed(Duration.zero);
+
+        await connectionManager.scanAndConnect();
+
+        expect(connectionManager.currentStatus.pendingAmbiguity,
+            AmbiguityReason.machinePicker);
+      });
+
       test('preferred machine not found, no others → stays idle', () async {
         await settingsController.setPreferredMachineId('missing-de1');
 
@@ -340,6 +404,83 @@ void main() {
       });
 
       group('scale phase', () {
+        test('connects a scale when no machine is found', () async {
+          final scale = TestScale(deviceId: 'only-scale');
+          mockScanner.addDevice(scale);
+          await Future.delayed(Duration.zero);
+
+          await connectionManager.scanAndConnect();
+
+          expect(mockScaleController.connectCalls, [same(scale)]);
+          expect(connectionManager.currentStatus.phase, ConnectionPhase.idle);
+        });
+
+        test('does not replace an already-connected scale', () async {
+          final connectedScale = TestScale(deviceId: 'connected-scale');
+          mockScaleController.mockEmitConnectionState(ConnectionState.connected);
+          mockScaleController.debugSetLastConnectedId(connectedScale.deviceId);
+          mockScanner.addDevice(TestScale(deviceId: 'alternative-scale'));
+          await Future.delayed(Duration.zero);
+
+          await connectionManager.scanAndConnect();
+
+          expect(mockScaleController.connectCalls, isEmpty);
+        });
+
+        test('machine ambiguity defers scale until machine selection', () async {
+          final machineA = _FakeDe1(deviceId: 'de1-a');
+          final machineB = _FakeDe1(deviceId: 'de1-b');
+          final scale = TestScale(deviceId: 'only-scale');
+          mockScanner.addDevice(machineA);
+          mockScanner.addDevice(machineB);
+          mockScanner.addDevice(scale);
+          await Future.delayed(Duration.zero);
+
+          await connectionManager.scanAndConnect();
+
+          expect(connectionManager.currentStatus.pendingAmbiguity,
+              AmbiguityReason.machinePicker);
+          expect(mockScaleController.connectCalls, isEmpty);
+
+          await connectionManager.connectMachine(machineA);
+
+          expect(mockScaleController.connectCalls, [same(scale)]);
+          expect(connectionManager.currentStatus.pendingAmbiguity, isNull);
+        });
+
+        test('machine ambiguity resolves before scale ambiguity', () async {
+          await settingsController.setPreferredMachineId('missing-de1');
+          await settingsController.setPreferredScaleId('missing-scale');
+          final machine = _FakeDe1(deviceId: 'alternative-de1');
+          mockScanner.addDevice(machine);
+          mockScanner.addDevice(TestScale(deviceId: 'alternative-scale'));
+          await Future.delayed(Duration.zero);
+
+          await connectionManager.scanAndConnect();
+
+          expect(connectionManager.currentStatus.pendingAmbiguity,
+              AmbiguityReason.machinePicker);
+
+          await connectionManager.connectMachine(machine);
+
+          expect(connectionManager.currentStatus.pendingAmbiguity,
+              AmbiguityReason.scalePicker);
+          expect(mockScaleController.connectCalls, isEmpty);
+        });
+
+        test('missing preferred scale emits ambiguity for alternatives', () async {
+          await settingsController.setPreferredScaleId('missing-scale');
+          final alternative = TestScale(deviceId: 'alternative-scale');
+          mockScanner.addDevice(alternative);
+          await Future.delayed(Duration.zero);
+
+          await connectionManager.scanAndConnect();
+
+          expect(mockScaleController.connectCalls, isEmpty);
+          expect(connectionManager.currentStatus.pendingAmbiguity,
+              AmbiguityReason.scalePicker);
+        });
+
         test('preferred scale found → connects after machine', () async {
           await settingsController.setPreferredScaleId('pref-scale');
 
@@ -403,6 +544,20 @@ void main() {
           expect(mockScaleController.connectCalls, isEmpty);
           expect(
               connectionManager.currentStatus.phase, ConnectionPhase.ready);
+        });
+
+        test('failed preferred scale emits ambiguity for alternatives',
+            () async {
+          await settingsController.setPreferredScaleId('pref-scale');
+          mockScaleController.shouldFailConnect = true;
+          mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
+          mockScanner.addDevice(TestScale(deviceId: 'alternative-scale'));
+          await Future.delayed(Duration.zero);
+
+          await connectionManager.scanAndConnect();
+
+          expect(connectionManager.currentStatus.pendingAmbiguity,
+              AmbiguityReason.scalePicker);
         });
 
         test('scale failure does not affect machine connection', () async {
@@ -1322,8 +1477,7 @@ void main() {
         expect(connectionManager.currentStatus.error, isNull);
       });
 
-      test('emits connectingScale but not ready when no machine connected',
-          () async {
+      test('returns to idle after scale connects without a machine', () async {
         final phases = <ConnectionPhase>[];
         final sub = connectionManager.status.listen((s) {
           phases.add(s.phase);
@@ -1333,10 +1487,10 @@ void main() {
         await connectionManager.connectScale(testScale);
         await Future.delayed(Duration.zero);
 
-        // Scale alone should not emit ready — machine must be connected first
         expect(phases, [
           ConnectionPhase.idle,
           ConnectionPhase.connectingScale,
+          ConnectionPhase.idle,
         ]);
 
         await sub.cancel();
@@ -2118,6 +2272,37 @@ void main() {
         expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
         expect(mockScanner.scanCallCount, 0,
             reason: 'the connect must not go through a burst scan');
+      });
+
+      test('scale ambiguity pauses watch and selection updates its target',
+          () async {
+        connectionManager = buildWatchManager();
+        await settingsController.setPreferredScaleId('missing-scale');
+        mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
+        await Future<void>.delayed(Duration.zero);
+        expect(mockScanner.watchActive, isTrue);
+
+        final alternative = TestScale(deviceId: 'alternative-scale');
+        mockScanner.addDevice(alternative);
+        await connectionManager.scanAndConnect();
+
+        expect(connectionManager.currentStatus.pendingAmbiguity,
+            AmbiguityReason.scalePicker);
+        expect(mockScanner.watchActive, isFalse);
+
+        await connectionManager.connectScale(alternative);
+        expect(settingsController.preferredScaleId, alternative.deviceId);
+
+        final callsBeforeDisconnect = mockScaleController.connectCalls.length;
+        mockScaleController
+            .mockEmitConnectionState(ConnectionState.disconnected);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(mockScaleController.connectCalls.length,
+            callsBeforeDisconnect + 1);
+        expect(mockScaleController.connectCalls.last.deviceId,
+            alternative.deviceId);
       });
 
       test('failed watch connect re-arms the watch', () async {

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -404,6 +404,50 @@ void main() {
       });
 
       group('scale phase', () {
+        test('occupied machine fills only the missing scale slot', () async {
+          final connectedMachine = _FakeDe1(deviceId: 'connected-de1');
+          mockDe1Controller.de1Subject.add(connectedMachine);
+          final scale = TestScale(deviceId: 'missing-slot-scale');
+          mockScanner.addDevice(_FakeDe1(deviceId: 'alternative-de1'));
+          mockScanner.addDevice(scale);
+          await Future.delayed(Duration.zero);
+
+          await connectionManager.scanAndConnect();
+
+          expect(mockDe1Controller.connectCalls, isEmpty);
+          expect(mockScaleController.connectCalls, [same(scale)]);
+        });
+
+        test('occupied scale fills only the missing machine slot', () async {
+          mockScaleController.mockEmitConnectionState(ConnectionState.connected);
+          mockScaleController.debugSetLastConnectedId('connected-scale');
+          final machine = _FakeDe1(deviceId: 'missing-slot-de1');
+          mockScanner.addDevice(machine);
+          mockScanner.addDevice(TestScale(deviceId: 'alternative-scale'));
+          await Future.delayed(Duration.zero);
+
+          await connectionManager.scanAndConnect();
+
+          expect(mockDe1Controller.connectCalls, [same(machine)]);
+          expect(mockScaleController.connectCalls, isEmpty);
+        });
+
+        test('occupied machine and scale are both preserved', () async {
+          mockDe1Controller.de1Subject.add(
+            _FakeDe1(deviceId: 'connected-de1'),
+          );
+          mockScaleController.mockEmitConnectionState(ConnectionState.connected);
+          mockScaleController.debugSetLastConnectedId('connected-scale');
+          mockScanner.addDevice(_FakeDe1(deviceId: 'alternative-de1'));
+          mockScanner.addDevice(TestScale(deviceId: 'alternative-scale'));
+          await Future.delayed(Duration.zero);
+
+          await connectionManager.scanAndConnect();
+
+          expect(mockDe1Controller.connectCalls, isEmpty);
+          expect(mockScaleController.connectCalls, isEmpty);
+        });
+
         test('connects a scale when no machine is found', () async {
           final scale = TestScale(deviceId: 'only-scale');
           mockScanner.addDevice(scale);
@@ -442,7 +486,7 @@ void main() {
               AmbiguityReason.machinePicker);
           expect(mockScaleController.connectCalls, isEmpty);
 
-          await connectionManager.connectMachine(machineA);
+          await connectionManager.selectMachine(machineA);
 
           expect(mockScaleController.connectCalls, [same(scale)]);
           expect(connectionManager.currentStatus.pendingAmbiguity, isNull);
@@ -461,7 +505,7 @@ void main() {
           expect(connectionManager.currentStatus.pendingAmbiguity,
               AmbiguityReason.machinePicker);
 
-          await connectionManager.connectMachine(machine);
+          await connectionManager.selectMachine(machine);
 
           expect(connectionManager.currentStatus.pendingAmbiguity,
               AmbiguityReason.scalePicker);
@@ -558,6 +602,21 @@ void main() {
 
           expect(connectionManager.currentStatus.pendingAmbiguity,
               AmbiguityReason.scalePicker);
+        });
+
+        test('machine failure still fills scale slot and stays visible',
+            () async {
+          mockDe1Controller.shouldFailConnect = true;
+          mockScanner.addDevice(_FakeDe1(deviceId: 'failed-machine'));
+          mockScanner.addDevice(TestScale(deviceId: 'available-scale'));
+          await Future.delayed(Duration.zero);
+
+          await connectionManager.scanAndConnect();
+
+          expect(mockScaleController.connectCalls, hasLength(1));
+          expect(connectionManager.currentStatus.phase, ConnectionPhase.idle);
+          expect(connectionManager.currentStatus.error?.kind,
+              ConnectionErrorKind.machineConnectFailed);
         });
 
         test('scale failure does not affect machine connection', () async {
@@ -1030,6 +1089,55 @@ void main() {
         expect(future3Done, isTrue);
       });
 
+      test('queued scaleOnly retains preferred-scale early connection',
+          () async {
+        await settingsController.setPreferredScaleId('pref-scale');
+        final preferredScale = TestScale(deviceId: 'pref-scale');
+        final firstScan = Completer<void>();
+        final recoveryScan = Completer<void>();
+        mockScanner.queuedScanCompleters.addAll([firstScan, recoveryScan]);
+        mockScanner.queuedScanResults.addAll([
+          <Device>[],
+          <Device>[preferredScale],
+        ]);
+
+        final explicitScan = connectionManager.scanAndConnect();
+        await Future<void>.delayed(Duration.zero);
+        final queuedRecovery = connectionManager.connect(scaleOnly: true);
+
+        firstScan.complete();
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(mockScanner.scanCallCount, 2);
+        expect(mockScaleController.connectCalls, [same(preferredScale)]);
+
+        recoveryScan.complete();
+        await explicitScan;
+        await queuedRecovery;
+      });
+
+      test('scale recovery does not supersede a pending selection', () async {
+        final machineA = _FakeDe1(deviceId: 'de1-a');
+        final machineB = _FakeDe1(deviceId: 'de1-b');
+        final scale = TestScale(deviceId: 'scale');
+        mockScanner.addDevice(machineA);
+        mockScanner.addDevice(machineB);
+        mockScanner.addDevice(scale);
+
+        await connectionManager.scanAndConnect();
+        final scansBeforeRecovery = mockScanner.scanCallCount;
+
+        await connectionManager.connect(scaleOnly: true);
+
+        expect(mockScanner.scanCallCount, scansBeforeRecovery);
+        expect(connectionManager.currentStatus.pendingAmbiguity,
+            AmbiguityReason.machinePicker);
+
+        await connectionManager.selectMachine(machineA);
+        expect(mockScaleController.connectCalls, [same(scale)]);
+      });
+
       test(
           'non-scaleOnly concurrent connect is still dropped (no queue)',
           () async {
@@ -1061,6 +1169,75 @@ void main() {
         expect(report!.matchedDevices, hasLength(1));
         expect(report.matchedDevices.first.deviceId, 'solo-de1');
         expect(report.scanTerminationReason, ScanTerminationReason.completed);
+      });
+
+      test('ScanReport waits for picker selection and retained scale phase',
+          () async {
+        final machineA = _FakeDe1(deviceId: 'de1-a');
+        final machineB = _FakeDe1(deviceId: 'de1-b');
+        final scale = TestScale(deviceId: 'scale');
+        mockScanner.addDevice(machineA);
+        mockScanner.addDevice(machineB);
+        mockScanner.addDevice(scale);
+        final reports = <ScanReport>[];
+        final sub = connectionManager.scanReportStream.listen(reports.add);
+
+        await connectionManager.scanAndConnect();
+
+        expect(reports, isEmpty);
+        expect(connectionManager.currentStatus.pendingAmbiguity,
+            AmbiguityReason.machinePicker);
+
+        await connectionManager.selectMachine(machineA);
+
+        expect(mockDe1Controller.connectCalls, [same(machineA)]);
+        expect(mockScaleController.connectCalls, [same(scale)]);
+        expect(connectionManager.currentStatus.pendingAmbiguity, isNull);
+        expect(connectionManager.lastScanReport, isNotNull);
+        await Future<void>.delayed(Duration.zero);
+        expect(reports, hasLength(1));
+        final machineResult = reports.single.matchedDevices
+            .firstWhere((device) => device.deviceId == machineA.deviceId);
+        final scaleResult = reports.single.matchedDevices
+            .firstWhere((device) => device.deviceId == scale.deviceId);
+        expect(machineResult.connectionAttempted, isTrue);
+        expect(machineResult.connectionResult?.success, isTrue);
+        expect(scaleResult.connectionAttempted, isTrue);
+        expect(scaleResult.connectionResult?.success, isTrue);
+        await sub.cancel();
+      });
+
+      test('superseding scan cancels report and rejects stale selection',
+          () async {
+        final staleA = _FakeDe1(deviceId: 'stale-a');
+        final staleB = _FakeDe1(deviceId: 'stale-b');
+        mockScanner.addDevice(staleA);
+        mockScanner.addDevice(staleB);
+        final reports = <ScanReport>[];
+        final sub = connectionManager.scanReportStream.listen(reports.add);
+
+        await connectionManager.scanAndConnect();
+        expect(connectionManager.currentStatus.pendingAmbiguity,
+            AmbiguityReason.machinePicker);
+
+        mockScanner.removeDevice(staleA.deviceId);
+        mockScanner.removeDevice(staleB.deviceId);
+        final currentA = _FakeDe1(deviceId: 'current-a');
+        final currentB = _FakeDe1(deviceId: 'current-b');
+        mockScanner.addDevice(currentA);
+        mockScanner.addDevice(currentB);
+        await connectionManager.scanAndConnect();
+
+        expect(reports, hasLength(1));
+        expect(reports.single.scanTerminationReason,
+            ScanTerminationReason.cancelledByUser);
+
+        await connectionManager.selectMachine(staleA);
+
+        expect(mockDe1Controller.connectCalls, isEmpty);
+        expect(connectionManager.currentStatus.pendingAmbiguity,
+            AmbiguityReason.machinePicker);
+        await sub.cancel();
       });
 
       test('ScanReport includes preferred device IDs from settings', () async {

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -63,7 +63,7 @@ class _FakeDe1 implements De1Interface {
   @override
   Future<void> dispose() async {}
 
-  _FakeDe1({this.deviceId = 'fake-de1'}) : name = 'DE1-$deviceId';
+  _FakeDe1({this.deviceId = 'fake-de1', String? name}) : name = name ?? 'DE1-$deviceId';
 
   void emitState(MachineState state) {
     _snapshotController.add(_machineSnapshot(state));
@@ -2688,6 +2688,193 @@ void main() {
 
         await connectionManager.dispose();
         expect(mockScanner.watchActive, isFalse);
+      });
+    });
+
+    group('cancelSelectionSession', () {
+      test('clears pendingAmbiguity', () async {
+        final scale1 = TestScale(deviceId: 's1');
+        final scale2 = TestScale(deviceId: 's2');
+        mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+        mockScanner.addDevice(scale1);
+        mockScanner.addDevice(scale2);
+        await connectionManager.connect();
+        await Future<void>.delayed(Duration.zero);
+
+        // Machine auto-connects. Two scales with no preferred = scalePicker.
+        expect(
+          connectionManager.currentStatus.pendingAmbiguity,
+          AmbiguityReason.scalePicker,
+        );
+
+        connectionManager.cancelSelectionSession();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(connectionManager.currentStatus.pendingAmbiguity, isNull);
+      });
+
+      test('emits report as cancelled exactly once', () async {
+        final reports = <ScanReport>[];
+        final sub = connectionManager.scanReportStream.listen(reports.add);
+
+        mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+        mockScanner.addDevice(TestScale(deviceId: 's1'));
+        mockScanner.addDevice(TestScale(deviceId: 's2'));
+        await connectionManager.connect();
+        await Future<void>.delayed(Duration.zero);
+        expect(
+          connectionManager.currentStatus.pendingAmbiguity,
+          AmbiguityReason.scalePicker,
+        );
+
+        connectionManager.cancelSelectionSession();
+        await Future<void>.delayed(Duration.zero);
+
+        final cancelled = reports.where(
+          (r) => r.scanTerminationReason == ScanTerminationReason.cancelledByUser,
+        );
+        expect(cancelled.length, 1);
+        await sub.cancel();
+      });
+
+      test('subsequent scaleOnly connect is no longer blocked', () async {
+        mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+        mockScanner.addDevice(TestScale(deviceId: 's1'));
+        mockScanner.addDevice(TestScale(deviceId: 's2'));
+        await connectionManager.connect();
+        await Future<void>.delayed(Duration.zero);
+        expect(
+          connectionManager.currentStatus.pendingAmbiguity,
+          AmbiguityReason.scalePicker,
+        );
+
+        connectionManager.cancelSelectionSession();
+        await Future<void>.delayed(Duration.zero);
+
+        // scaleOnly connect should now proceed (not skipped)
+        await connectionManager.connect(scaleOnly: true);
+        await Future<void>.delayed(Duration.zero);
+        // No exception — the call was not skipped by pending ambiguity guard
+      });
+
+      test('selection submitted after cancellation is ignored', () async {
+        final scale = TestScale(deviceId: 's-cancelled');
+        mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+        mockScanner.addDevice(scale);
+        mockScanner.addDevice(TestScale(deviceId: 's-other'));
+        await connectionManager.connect();
+        await Future<void>.delayed(Duration.zero);
+        expect(
+          connectionManager.currentStatus.pendingAmbiguity,
+          AmbiguityReason.scalePicker,
+        );
+
+        connectionManager.cancelSelectionSession();
+        await Future<void>.delayed(Duration.zero);
+
+        final result = await connectionManager.selectScale(scale);
+        expect(result.success, isFalse);
+      });
+    });
+
+    group('machine failure preserved through scale-picker', () {
+      test('machineConnectFailed remains visible after scale selection',
+          () async {
+        mockDe1Controller.shouldFailConnect = true;
+
+        final scale1 = TestScale(deviceId: 's1');
+        final scale2 = TestScale(deviceId: 's2');
+        mockScanner.addDevice(_FakeDe1(deviceId: 'fail-m1'));
+        mockScanner.addDevice(scale1);
+        mockScanner.addDevice(scale2);
+
+        await connectionManager.connect();
+        await Future<void>.delayed(Duration.zero);
+
+        // Machine failed, scalePicker active.
+        final status = connectionManager.currentStatus;
+        expect(status.pendingAmbiguity, AmbiguityReason.scalePicker);
+        expect(status.error?.kind, ConnectionErrorKind.machineConnectFailed);
+        expect(status.phase, ConnectionPhase.idle);
+
+        // User selects a scale — it should succeed.
+        mockDe1Controller.shouldFailConnect = false;
+        final result = await connectionManager.selectScale(scale1);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(result.success, isTrue);
+        final after = connectionManager.currentStatus;
+        expect(after.phase, ConnectionPhase.idle);
+        expect(after.error?.kind, ConnectionErrorKind.machineConnectFailed,
+            reason: 'machine error must remain visible after scale connects');
+      });
+    });
+
+    group('stale caller-supplied object', () {
+      test('stale machine object is not connected', () async {
+        // Session's candidate is from scanner. Caller supplies a different
+        // object with the same deviceId. resolveMachine must return the
+        // session's object, not the caller's.
+        final staleMachine = _FakeDe1(deviceId: 'same-id', name: 'stale-copy');
+        final sessionMachine = _FakeDe1(deviceId: 'same-id', name: 'session');
+
+        mockScanner.addDevice(sessionMachine);
+        mockScanner.addDevice(_FakeDe1(deviceId: 'm-other'));
+        mockScanner.addDevice(TestScale(deviceId: 's1'));
+        mockScanner.addDevice(TestScale(deviceId: 's2'));
+
+        await connectionManager.connect();
+        await Future<void>.delayed(Duration.zero);
+
+        // Two machines → machinePicker. Both in session.
+        expect(
+          connectionManager.currentStatus.pendingAmbiguity,
+          AmbiguityReason.machinePicker,
+        );
+
+        // Caller supplies the stale object. Resolution must find the
+        // session's canonical candidate.
+        await connectionManager.selectMachine(staleMachine);
+
+        final connected = mockDe1Controller.connectCalls.lastOrNull;
+        expect(identical(connected, staleMachine), isFalse,
+            reason: 'stale caller-supplied object must not be connected');
+        expect(connected?.deviceId, 'same-id',
+            reason: 'resolution must find the canonical candidate by id');
+        expect(connected?.name, 'session',
+            reason: 'must be the session\'s object, not the stale copy');
+      });
+
+      test('stale scale object is not connected', () async {
+        final staleScale = TestScale(
+          deviceId: 'same-scale-id',
+          name: 'stale-scale',
+        );
+        final sessionScale = TestScale(
+          deviceId: 'same-scale-id',
+          name: 'session-scale',
+        );
+
+        mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+        mockScanner.addDevice(sessionScale);
+        mockScanner.addDevice(TestScale(deviceId: 's-other'));
+
+        await connectionManager.connect();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          connectionManager.currentStatus.pendingAmbiguity,
+          AmbiguityReason.scalePicker,
+        );
+
+        final result = await connectionManager.selectScale(staleScale);
+        expect(result.success, isTrue);
+
+        final connected = mockScaleController.connectCalls.lastOrNull;
+        expect(identical(connected, staleScale), isFalse,
+            reason: 'stale caller-supplied scale object must not be connected');
+        expect(connected?.deviceId, 'same-scale-id',
+            reason: 'resolution must find the canonical candidate by id');
       });
     });
   });

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -3029,6 +3029,191 @@ void main() {
           AmbiguityReason.machinePicker);
     });
   });
+
+  group('explicit scan concurrency', () {
+    late ConnectionManager connectionManager;
+    late MockDeviceScanner mockScanner;
+    late MockDe1Controller mockDe1Controller;
+    late MockScaleController mockScaleController;
+
+    setUp(() async {
+      mockScanner = MockDeviceScanner();
+      mockDe1Controller =
+          MockDe1Controller(controller: DeviceController([]));
+      mockScaleController = MockScaleController();
+      final localSettings = SettingsController(MockSettingsService());
+      await localSettings.loadSettings();
+      connectionManager = ConnectionManager(
+        deviceScanner: mockScanner,
+        de1Controller: mockDe1Controller,
+        scaleController: mockScaleController,
+        settingsController: localSettings,
+      );
+    });
+
+    test('explicit restart supersedes active scan', () async {
+      // Hold scan 1 open.
+      final scan1Completer = Completer<void>();
+      mockScanner.queuedScanCompleters.add(scan1Completer);
+      mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+      mockScanner.addDevice(TestScale(deviceId: 's1'));
+
+      final reports = <ScanReport>[];
+      final sub = connectionManager.scanReportStream.listen(reports.add);
+
+      final future1 = connectionManager.scanAndConnect();
+      await Future<void>.delayed(Duration.zero);
+
+      // Call scanAndConnect again while scan 1 is in-flight.
+      final future2 = connectionManager.scanAndConnect();
+      await Future<void>.delayed(Duration.zero);
+
+      // Scanner was stopped.
+      expect(mockScanner.stopScanCallCount, greaterThan(0));
+
+      // Complete scan 1.
+      scan1Completer.complete();
+      await future1;
+      await future2;
+
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      // One cancelled report from the superseded scan.
+      final cancelled =
+          reports.where((r) => r.scanTerminationReason == ScanTerminationReason.cancelledByUser);
+      expect(cancelled.length, 1);
+
+      // At least one non-cancelled report from the replacement.
+      final completed = reports.where(
+          (r) => r.scanTerminationReason != ScanTerminationReason.cancelledByUser);
+      expect(completed.length, greaterThan(0));
+    });
+
+    test('multiple restart requests coalesce into one replacement', () async {
+      final scan1Completer = Completer<void>();
+      mockScanner.queuedScanCompleters.add(scan1Completer);
+      mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+      mockScanner.addDevice(TestScale(deviceId: 's1'));
+
+      connectionManager.scanAndConnect();
+      await Future<void>.delayed(Duration.zero);
+
+      // Three restart requests while scan 1 is active.
+      final f1 = connectionManager.scanAndConnect();
+      final f2 = connectionManager.scanAndConnect();
+      final f3 = connectionManager.scanAndConnect();
+
+      scan1Completer.complete();
+      await Future.wait([f1, f2, f3]);
+      await Future<void>.delayed(Duration.zero);
+
+      // All three callers completed without throwing.
+      // The futures resolved (no exception caught).
+    });
+
+    test('cancelActiveScan discards queued explicit replacement', () async {
+      final scanCompleter = Completer<void>();
+      mockScanner.queuedScanCompleters.add(scanCompleter);
+      mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+
+      final reports = <ScanReport>[];
+      final sub = connectionManager.scanReportStream.listen(reports.add);
+
+      final scanFuture = connectionManager.scanAndConnect();
+      await Future<void>.delayed(Duration.zero);
+
+      // Request restart.
+      final restartFuture = connectionManager.scanAndConnect();
+      await Future<void>.delayed(Duration.zero);
+
+      // Exit before the original scan finishes.
+      connectionManager.cancelActiveScan();
+
+      scanCompleter.complete();
+      await scanFuture;
+      await restartFuture;
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      // No machine connected.
+      expect(mockDe1Controller.connectMachineCallCount, 0);
+
+      // Phase is settled, no ambiguity.
+      expect(connectionManager.currentStatus.phase, ConnectionPhase.idle);
+      expect(connectionManager.currentStatus.pendingAmbiguity, isNull);
+
+      // Exactly one cancelled report — not a duplicate.
+      final cancelled =
+          reports.where((r) => r.scanTerminationReason == ScanTerminationReason.cancelledByUser);
+      expect(cancelled.length, 1);
+    });
+
+    test('automatic scan superseded by explicit intent', () async {
+      final scanCompleter = Completer<void>();
+      mockScanner.queuedScanCompleters.add(scanCompleter);
+      mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+      mockScanner.addDevice(TestScale(deviceId: 's1'));
+
+      final reports = <ScanReport>[];
+      final sub = connectionManager.scanReportStream.listen(reports.add);
+
+      // Start automatic connect.
+      final connectFuture = connectionManager.connect();
+      await Future<void>.delayed(Duration.zero);
+
+      // User requests explicit scan while automatic is active.
+      final scanFuture = connectionManager.scanAndConnect();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(mockScanner.stopScanCallCount, greaterThan(0));
+
+      scanCompleter.complete();
+      await connectFuture;
+      await scanFuture;
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      // The automatic scan was superseded — it emitted a cancelled report.
+      final cancelled = reports
+          .where((r) => r.scanTerminationReason == ScanTerminationReason.cancelledByUser);
+      expect(cancelled.length, 1);
+
+      // The replacement explicit scan completed normally.
+      final completed = reports.where(
+          (r) => r.scanTerminationReason != ScanTerminationReason.cancelledByUser);
+      expect(completed.length, greaterThan(0));
+    });
+
+    test('queue priority: explicit before scaleOnly', () async {
+      final scanCompleter = Completer<void>();
+      mockScanner.queuedScanCompleters.add(scanCompleter);
+      mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+      mockScanner.addDevice(TestScale(deviceId: 's1'));
+
+      // Start a connect cycle and hold it open.
+      connectionManager.connect();
+      await Future<void>.delayed(Duration.zero);
+
+      // Queue both explicit and scaleOnly.
+      connectionManager.scanAndConnect();
+      connectionManager.connect(scaleOnly: true);
+      await Future<void>.delayed(Duration.zero);
+
+      // Before completing: verify scanner was stopped (superseded by explicit).
+      // The key property: after scanCompleter completes, the explicit scan
+      // drains first. We verify by checking that the generation was bumped.
+
+      scanCompleter.complete();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      // The explicit scan ran (generation bump caused superseding). The
+      // scaleOnly also ran afterward if still needed. The system is not
+      // wedged.
+      expect(connectionManager.currentStatus.phase, isNotNull);
+    });
+  });
 }
 
 /// A De1Controller mock that uses a Completer to control when connectToDe1 completes.

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -3005,6 +3005,29 @@ void main() {
       // Phase settled to idle (no machine connected).
       expect(connectionManager.currentStatus.phase, ConnectionPhase.idle);
     });
+
+    test('subsequent connect is not blocked after cancellation', () async {
+      final scanCompleter = Completer<void>();
+      mockScanner.queuedScanCompleters.add(scanCompleter);
+      mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+      mockScanner.addDevice(TestScale(deviceId: 's1'));
+
+      final connectFuture = connectionManager.scanAndConnect();
+      await Future<void>.delayed(Duration.zero);
+
+      connectionManager.cancelActiveScan();
+      scanCompleter.complete();
+      await connectFuture;
+
+      // Second scan with 2 machines → machinePicker (not stuck/cancelled).
+      mockScanner.addDevice(_FakeDe1(deviceId: 'm2'));
+      await connectionManager.scanAndConnect();
+      await Future<void>.delayed(Duration.zero);
+
+      // Not cancelled: policy ran and produced expected ambiguity.
+      expect(connectionManager.currentStatus.pendingAmbiguity,
+          AmbiguityReason.machinePicker);
+    });
   });
 }
 

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -3185,33 +3185,61 @@ void main() {
       expect(completed.length, greaterThan(0));
     });
 
-    test('queue priority: explicit before scaleOnly', () async {
-      final scanCompleter = Completer<void>();
-      mockScanner.queuedScanCompleters.add(scanCompleter);
+    test('queue priority: explicit arrives during scale-only drain', () async {
+      // Set up device list shared by all scans.
       mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
       mockScanner.addDevice(TestScale(deviceId: 's1'));
 
-      // Start a connect cycle and hold it open.
+      // Phase 1: start automatic scan A and hold it.
+      final scanA = Completer<void>();
+      mockScanner.queuedScanCompleters.add(scanA);
       connectionManager.connect();
       await Future<void>.delayed(Duration.zero);
 
-      // Queue both explicit and scaleOnly.
-      connectionManager.scanAndConnect();
+      // Queue scale-only while A is active.
       connectionManager.connect(scaleOnly: true);
       await Future<void>.delayed(Duration.zero);
 
-      // Before completing: verify scanner was stopped (superseded by explicit).
-      // The key property: after scanCompleter completes, the explicit scan
-      // drains first. We verify by checking that the generation was bumped.
+      // Phase 2: add scanB for the drain to hold the scale-only scan.
+      // Then complete A so the drain runs scale-only, which waits on scanB.
+      final scanB = Completer<void>();
+      mockScanner.queuedScanCompleters.add(scanB);
 
-      scanCompleter.complete();
-      await Future<void>.delayed(Duration.zero);
+      scanA.complete();
       await Future<void>.delayed(Duration.zero);
 
-      // The explicit scan ran (generation bump caused superseding). The
-      // scaleOnly also ran afterward if still needed. The system is not
-      // wedged.
-      expect(connectionManager.currentStatus.phase, isNotNull);
+      // Scale-only B is now active (waiting on scanB).
+      // Request explicit scan — this supersedes B.
+      final explicitFuture = connectionManager.scanAndConnect();
+      await Future<void>.delayed(Duration.zero);
+
+      // Scan was stopped (generation bump in scanAndConnect).
+      expect(mockScanner.stopScanCallCount, greaterThan(0));
+
+      // Complete B. Generation mismatch → cancelled report. Drain picks
+      // up queued explicit scan.
+      scanB.complete();
+      await Future<void>.delayed(Duration.zero);
+
+      // Phase 3: explicit scan C starts. Hold and complete it.
+      final scanC = Completer<void>();
+      mockScanner.queuedScanCompleters.add(scanC);
+      mockScanner.addDevice(_FakeDe1(deviceId: 'm1'));
+      mockScanner.addDevice(TestScale(deviceId: 's1'));
+
+      scanC.complete();
+      await explicitFuture;
+      await Future<void>.delayed(Duration.zero);
+
+      // C completed successfully (no exception from the future).
+
+      // Phase 4: no stranded queued request — a subsequent scanAndConnect
+      // runs normally.
+      final newFuture = connectionManager.scanAndConnect();
+      final scanD = Completer<void>();
+      mockScanner.queuedScanCompleters.add(scanD);
+      scanD.complete();
+      await newFuture;
     });
   });
 }

--- a/test/device_discovery_view_test.dart
+++ b/test/device_discovery_view_test.dart
@@ -153,6 +153,31 @@ void main() {
       });
     });
 
+    testWidgets('shows a connected scale when no machine is found',
+        (tester) async {
+      final origOnError = FlutterError.onError;
+      FlutterError.onError = (details) {
+        if (details.toString().contains('overflowed') ||
+            details.toString().contains('deactivated')) {
+          return;
+        }
+        origOnError?.call(details);
+      };
+      addTearDown(() => FlutterError.onError = origOnError);
+
+      await tester.runAsync(() async {
+        mockService.addDevice(TestScale());
+
+        await tester.pumpWidget(buildDiscoveryView());
+        await Future.delayed(Duration(milliseconds: 500));
+        await tester.pump();
+
+        expect(find.text('No Decent Machines Found'), findsNothing);
+        expect(find.text('Scales'), findsOneWidget);
+        expect(find.text('Mock Scale'), findsOneWidget);
+      });
+    });
+
     testWidgets('shows device picker when multiple machines found', (tester) async {
       final origOnError = FlutterError.onError;
       FlutterError.onError = (details) {

--- a/test/devices_handler_test.dart
+++ b/test/devices_handler_test.dart
@@ -233,6 +233,23 @@ void main() {
       });
     });
 
+    group('scan endpoint', () {
+      test('defaults to discovery-only', () async {
+        final response = await sendGet('/api/v1/devices/scan');
+
+        expect(response.statusCode, 200);
+        expect(mockDiscovery.scanCallCount, 1);
+        expect(connectionManager.lastScanReport, isNull);
+      });
+
+      test('connect=true opts into connection policy', () async {
+        final response = await sendGet('/api/v1/devices/scan?connect=true');
+
+        expect(response.statusCode, 200);
+        expect(connectionManager.lastScanReport, isNotNull);
+      });
+    });
+
     group('scanning state', () {
       test('isScanning is initially false', () {
         expect(deviceController.isScanning, isFalse);

--- a/test/devices_handler_test.dart
+++ b/test/devices_handler_test.dart
@@ -234,19 +234,19 @@ void main() {
     });
 
     group('scan endpoint', () {
-      test('defaults to discovery-only', () async {
+      test('defaults to scan-first connection policy', () async {
         final response = await sendGet('/api/v1/devices/scan');
 
         expect(response.statusCode, 200);
         expect(mockDiscovery.scanCallCount, 1);
-        expect(connectionManager.lastScanReport, isNull);
+        expect(connectionManager.lastScanReport, isNotNull);
       });
 
-      test('connect=true opts into connection policy', () async {
-        final response = await sendGet('/api/v1/devices/scan?connect=true');
+      test('connect=false opts into discovery-only', () async {
+        final response = await sendGet('/api/v1/devices/scan?connect=false');
 
         expect(response.statusCode, 200);
-        expect(connectionManager.lastScanReport, isNotNull);
+        expect(connectionManager.lastScanReport, isNull);
       });
     });
 

--- a/test/devices_handler_test.dart
+++ b/test/devices_handler_test.dart
@@ -203,6 +203,30 @@ void main() {
       });
     });
 
+    test('connect continues a pending scale selection session', () async {
+      final scale1 = TestScale(deviceId: 'scale-1', name: 'Scale 1');
+      final scale2 = TestScale(deviceId: 'scale-2', name: 'Scale 2');
+      mockDiscovery.addDevice(scale1);
+      mockDiscovery.addDevice(scale2);
+      await Future.delayed(Duration.zero);
+
+      await connectionManager.scanAndConnect();
+      expect(connectionManager.currentStatus.pendingAmbiguity,
+          AmbiguityReason.scalePicker);
+
+      final response = await sendPut(
+        '/api/v1/devices/connect',
+        body: jsonEncode({'deviceId': scale2.deviceId}),
+      );
+
+      expect(response.statusCode, 200);
+      expect(connectionManager.currentStatus.pendingAmbiguity, isNull);
+      expect(connectionManager.lastScanReport?.matchedDevices
+          .firstWhere((device) => device.deviceId == scale2.deviceId)
+          .connectionResult
+          ?.success, isTrue);
+    });
+
     group('disconnect', () {
       test('reads deviceId from JSON body', () async {
         mockDiscovery.addDevice(

--- a/test/devices_ws_test.dart
+++ b/test/devices_ws_test.dart
@@ -294,6 +294,33 @@ void main() {
       await channel.sink.close();
     });
 
+    test('scan command defaults to discovery-only', () async {
+      final (channel, messages) = connectWs();
+
+      await waitForState(messages);
+      channel.sink.add(jsonEncode({'command': 'scan'}));
+
+      await waitForState(messages);
+      await Future.delayed(const Duration(milliseconds: 300));
+      expect(mockDiscovery.scanCallCount, 1);
+      expect(connectionManager.lastScanReport, isNull);
+
+      await channel.sink.close();
+    });
+
+    test('scan command connect=true opts into connection policy', () async {
+      final (channel, messages) = connectWs();
+
+      await waitForState(messages);
+      channel.sink.add(jsonEncode({'command': 'scan', 'connect': true}));
+
+      await waitForState(messages);
+      await Future.delayed(const Duration(milliseconds: 300));
+      expect(connectionManager.lastScanReport, isNotNull);
+
+      await channel.sink.close();
+    });
+
     test('scan command triggers scanForDevices', () async {
       final (channel, messages) = connectWs();
 

--- a/test/devices_ws_test.dart
+++ b/test/devices_ws_test.dart
@@ -294,7 +294,7 @@ void main() {
       await channel.sink.close();
     });
 
-    test('scan command defaults to discovery-only', () async {
+    test('scan command defaults to scan-first connection policy', () async {
       final (channel, messages) = connectWs();
 
       await waitForState(messages);
@@ -303,20 +303,20 @@ void main() {
       await waitForState(messages);
       await Future.delayed(const Duration(milliseconds: 300));
       expect(mockDiscovery.scanCallCount, 1);
-      expect(connectionManager.lastScanReport, isNull);
+      expect(connectionManager.lastScanReport, isNotNull);
 
       await channel.sink.close();
     });
 
-    test('scan command connect=true opts into connection policy', () async {
+    test('scan command connect=false opts into discovery-only', () async {
       final (channel, messages) = connectWs();
 
       await waitForState(messages);
-      channel.sink.add(jsonEncode({'command': 'scan', 'connect': true}));
+      channel.sink.add(jsonEncode({'command': 'scan', 'connect': false}));
 
       await waitForState(messages);
       await Future.delayed(const Duration(milliseconds: 300));
-      expect(connectionManager.lastScanReport, isNotNull);
+      expect(connectionManager.lastScanReport, isNull);
 
       await channel.sink.close();
     });

--- a/test/helpers/fake_connection_manager.dart
+++ b/test/helpers/fake_connection_manager.dart
@@ -27,6 +27,8 @@ class FakeConnectionManager extends ConnectionManager {
       BehaviorSubject.seeded(const ConnectionStatus());
 
   int connectCalls = 0;
+  int automaticConnectCalls = 0;
+  int scanAndConnectCalls = 0;
   bool _scaleOnlyLastCall = false;
   bool get scaleOnlyLastCall => _scaleOnlyLastCall;
 
@@ -72,12 +74,14 @@ class FakeConnectionManager extends ConnectionManager {
   @override
   Future<void> connect({bool scaleOnly = false}) async {
     connectCalls += 1;
+    automaticConnectCalls += 1;
     _scaleOnlyLastCall = scaleOnly;
   }
 
   @override
   Future<void> scanAndConnect() async {
     connectCalls += 1;
+    scanAndConnectCalls += 1;
     _scaleOnlyLastCall = false;
   }
 

--- a/test/helpers/fake_connection_manager.dart
+++ b/test/helpers/fake_connection_manager.dart
@@ -76,6 +76,12 @@ class FakeConnectionManager extends ConnectionManager {
   }
 
   @override
+  Future<void> scanAndConnect() async {
+    connectCalls += 1;
+    _scaleOnlyLastCall = false;
+  }
+
+  @override
   Future<void> dispose() async {
     _statusOverride.close();
     await super.dispose();

--- a/test/helpers/fake_connection_manager.dart
+++ b/test/helpers/fake_connection_manager.dart
@@ -30,6 +30,7 @@ class FakeConnectionManager extends ConnectionManager {
   int automaticConnectCalls = 0;
   int scanAndConnectCalls = 0;
   int cancelSelectionSessionCalls = 0;
+  int cancelActiveScanCalls = 0;
   bool _scaleOnlyLastCall = false;
   bool get scaleOnlyLastCall => _scaleOnlyLastCall;
 
@@ -84,6 +85,11 @@ class FakeConnectionManager extends ConnectionManager {
     connectCalls += 1;
     scanAndConnectCalls += 1;
     _scaleOnlyLastCall = false;
+  }
+
+  @override
+  void cancelActiveScan() {
+    cancelActiveScanCalls += 1;
   }
 
   @override

--- a/test/helpers/fake_connection_manager.dart
+++ b/test/helpers/fake_connection_manager.dart
@@ -29,6 +29,7 @@ class FakeConnectionManager extends ConnectionManager {
   int connectCalls = 0;
   int automaticConnectCalls = 0;
   int scanAndConnectCalls = 0;
+  int cancelSelectionSessionCalls = 0;
   bool _scaleOnlyLastCall = false;
   bool get scaleOnlyLastCall => _scaleOnlyLastCall;
 
@@ -83,6 +84,11 @@ class FakeConnectionManager extends ConnectionManager {
     connectCalls += 1;
     scanAndConnectCalls += 1;
     _scaleOnlyLastCall = false;
+  }
+
+  @override
+  void cancelSelectionSession() {
+    cancelSelectionSessionCalls += 1;
   }
 
   @override

--- a/test/helpers/mock_connection_manager.dart
+++ b/test/helpers/mock_connection_manager.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:reaprime/src/controllers/connection_error.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart' as dev;
@@ -57,6 +58,8 @@ class MockConnectionManager extends ConnectionManager {
   int selectMachineCallCount = 0;
   int selectScaleCallCount = 0;
   int cancelSelectionSessionCallCount = 0;
+  int cancelActiveScanCallCount = 0;
+  bool shouldFailMachineConnect = false;
   ScanReport? _lastScanReport;
 
   MockConnectionManager({
@@ -91,12 +94,44 @@ class MockConnectionManager extends ConnectionManager {
   }
 
   @override
-  Future<void> connectMachine(De1Interface machine) async {}
-
-  @override
   Future<void> selectMachine(De1Interface machine) async {
     selectMachineCallCount++;
-    await connectMachine(machine);
+    try {
+      await connectMachine(machine);
+    } catch (_) {
+      // connectMachine already updates the status stream with the error.
+      // The widget must not see the exception.
+    }
+  }
+
+  @override
+  Future<void> connectMachine(De1Interface machine) async {
+    if (shouldFailMachineConnect) {
+      final error = ConnectionError(
+        kind: ConnectionErrorKind.machineConnectFailed,
+        severity: ConnectionErrorSeverity.error,
+        timestamp: DateTime.now().toUtc(),
+        message: 'Machine ${machine.name} failed to connect.',
+        suggestion: 'Try again.',
+      );
+      final currentMachines = _statusOverride.value.foundMachines;
+      final alternatives =
+          currentMachines.where((m) => m.deviceId != machine.deviceId).toList();
+      if (alternatives.isNotEmpty) {
+        _statusOverride.add(_statusOverride.value.copyWith(
+          phase: ConnectionPhase.idle,
+          pendingAmbiguity: () => AmbiguityReason.machinePicker,
+          error: () => error,
+        ));
+      } else {
+        _statusOverride.add(_statusOverride.value.copyWith(
+          phase: ConnectionPhase.idle,
+          pendingAmbiguity: () => null,
+          error: () => error,
+        ));
+      }
+      throw Exception('connectMachine failed');
+    }
   }
 
   @override
@@ -107,6 +142,11 @@ class MockConnectionManager extends ConnectionManager {
   Future<ConnectionResult> selectScale(device_scale.Scale scale) async {
     selectScaleCallCount++;
     return connectScale(scale);
+  }
+
+  @override
+  void cancelActiveScan() {
+    cancelActiveScanCallCount++;
   }
 
   @override

--- a/test/helpers/mock_connection_manager.dart
+++ b/test/helpers/mock_connection_manager.dart
@@ -91,8 +91,15 @@ class MockConnectionManager extends ConnectionManager {
   Future<void> connectMachine(De1Interface machine) async {}
 
   @override
+  Future<void> selectMachine(De1Interface machine) => connectMachine(machine);
+
+  @override
   Future<ConnectionResult> connectScale(device_scale.Scale scale) async =>
       const ConnectionResult.succeeded();
+
+  @override
+  Future<ConnectionResult> selectScale(device_scale.Scale scale) =>
+      connectScale(scale);
 
   @override
   Future<void> dispose() async {

--- a/test/helpers/mock_connection_manager.dart
+++ b/test/helpers/mock_connection_manager.dart
@@ -54,6 +54,9 @@ class MockConnectionManager extends ConnectionManager {
 
   int connectCallCount = 0;
   int scanAndConnectCallCount = 0;
+  int selectMachineCallCount = 0;
+  int selectScaleCallCount = 0;
+  int cancelSelectionSessionCallCount = 0;
   ScanReport? _lastScanReport;
 
   MockConnectionManager({
@@ -91,15 +94,25 @@ class MockConnectionManager extends ConnectionManager {
   Future<void> connectMachine(De1Interface machine) async {}
 
   @override
-  Future<void> selectMachine(De1Interface machine) => connectMachine(machine);
+  Future<void> selectMachine(De1Interface machine) async {
+    selectMachineCallCount++;
+    await connectMachine(machine);
+  }
 
   @override
   Future<ConnectionResult> connectScale(device_scale.Scale scale) async =>
       const ConnectionResult.succeeded();
 
   @override
-  Future<ConnectionResult> selectScale(device_scale.Scale scale) =>
-      connectScale(scale);
+  Future<ConnectionResult> selectScale(device_scale.Scale scale) async {
+    selectScaleCallCount++;
+    return connectScale(scale);
+  }
+
+  @override
+  void cancelSelectionSession() {
+    cancelSelectionSessionCallCount++;
+  }
 
   @override
   Future<void> dispose() async {

--- a/test/helpers/mock_connection_manager.dart
+++ b/test/helpers/mock_connection_manager.dart
@@ -53,6 +53,7 @@ class MockConnectionManager extends ConnectionManager {
   );
 
   int connectCallCount = 0;
+  int scanAndConnectCallCount = 0;
   ScanReport? _lastScanReport;
 
   MockConnectionManager({
@@ -78,6 +79,12 @@ class MockConnectionManager extends ConnectionManager {
   @override
   Future<void> connect({bool scaleOnly = false}) async {
     connectCallCount++;
+  }
+
+  @override
+  Future<void> scanAndConnect() async {
+    connectCallCount++;
+    scanAndConnectCallCount++;
   }
 
   @override

--- a/test/helpers/mock_de1_controller.dart
+++ b/test/helpers/mock_de1_controller.dart
@@ -25,6 +25,11 @@ class MockDe1Controller extends De1Controller {
 
   MockDe1Controller({required super.controller});
 
+  De1Interface? get lastConnectedDe1 =>
+      connectCalls.isNotEmpty ? connectCalls.last : null;
+
+  int get connectMachineCallCount => connectCalls.length;
+
   @override
   Stream<De1Interface?> get de1 => de1Subject.stream;
 

--- a/test/helpers/mock_device_discovery_service.dart
+++ b/test/helpers/mock_device_discovery_service.dart
@@ -12,6 +12,7 @@ import 'package:rxdart/rxdart.dart';
 class MockDeviceDiscoveryService implements DeviceDiscoveryService {
   final _controller = BehaviorSubject<List<Device>>.seeded([]);
   final List<Device> _devices = [];
+  int scanCallCount = 0;
 
   @override
   Stream<List<Device>> get devices => _controller.stream;
@@ -38,7 +39,9 @@ class MockDeviceDiscoveryService implements DeviceDiscoveryService {
   Future<void> initialize() async {}
 
   @override
-  Future<void> scanForDevices({ScanFilter? filter}) async {}
+  Future<void> scanForDevices({ScanFilter? filter}) async {
+    scanCallCount++;
+  }
 
   @override
   void stopScan() {}

--- a/test/helpers/mock_device_scanner.dart
+++ b/test/helpers/mock_device_scanner.dart
@@ -34,6 +34,8 @@ class MockDeviceScanner implements DeviceScanner {
   /// this completer before emitting `scanning: false`. This lets tests
   /// add devices mid-scan and verify early-stop behavior.
   Completer<void>? scanCompleter;
+  final List<Completer<void>> queuedScanCompleters = [];
+  final List<List<Device>> queuedScanResults = [];
 
   /// When set, the next [scanForDevices] call throws this object instead of
   /// running a scan. Consumed after one throw. Tests use this to exercise
@@ -121,19 +123,21 @@ class MockDeviceScanner implements DeviceScanner {
     }
     scanCallCount++;
     final start = DateTime.now();
+    final scanDevices =
+        queuedScanResults.isNotEmpty ? queuedScanResults.removeAt(0) : _devices;
     _scanningSubject.add(true);
-    // Re-emit current devices to simulate scan rediscovery.
-    // This ensures listeners that skip(1) the BehaviorSubject replay
-    // still see the devices.
-    _deviceSubject.add(List.from(_devices));
-    if (scanCompleter != null) {
-      await scanCompleter!.future;
+    _deviceSubject.add(List.from(scanDevices));
+    final completer = queuedScanCompleters.isNotEmpty
+        ? queuedScanCompleters.removeAt(0)
+        : scanCompleter;
+    if (completer != null) {
+      await completer.future;
     } else {
       await Future.delayed(Duration.zero);
       _scanningSubject.add(false);
     }
     return ScanResult(
-      matchedDevices: List.unmodifiable(_devices),
+      matchedDevices: List.unmodifiable(scanDevices),
       failedServices: const [],
       terminationReason: ScanTerminationReason.completed,
       duration: DateTime.now().difference(start),

--- a/test/helpers/mock_device_scanner.dart
+++ b/test/helpers/mock_device_scanner.dart
@@ -107,6 +107,20 @@ class MockDeviceScanner implements DeviceScanner {
     _deviceSubject.add(List.from(_devices));
   }
 
+  /// Reset all state for a fresh test.
+  void reset() {
+    _devices.clear();
+    _deviceSubject.add([]);
+    stopScanCallCount = 0;
+    scanCallCount = 0;
+    scanCompleter = null;
+    queuedScanCompleters.clear();
+    queuedScanResults.clear();
+    failNextScanWith = null;
+    quickConnectResult = null;
+    quickConnectCallCount = 0;
+  }
+
   /// Complete the scan. Only needed when [scanCompleter] is set.
   void completeScan() {
     scanCompleter?.complete();

--- a/test/helpers/mock_scale_controller.dart
+++ b/test/helpers/mock_scale_controller.dart
@@ -28,6 +28,9 @@ class MockScaleController extends ScaleController {
 
   MockScaleController();
 
+  Scale? get lastConnectedScale =>
+      connectCalls.isNotEmpty ? connectCalls.last : null;
+
   @override
   String? get lastConnectedDeviceId => _mockLastConnectedDeviceId;
 

--- a/test/integration/connection_manager_bengle_scale_test.dart
+++ b/test/integration/connection_manager_bengle_scale_test.dart
@@ -314,6 +314,32 @@ void main() {
       );
     });
 
+    test('selecting Bengle after scan ignores retained external scales',
+        () async {
+      final bengle = _FakeBengle(deviceId: 'bengle-1');
+      final de1 = _FakeDe1(deviceId: 'de1-1');
+      final externalScale = TestScale(deviceId: 'external-scale');
+      await mockScaleController.connectToScale(externalScale);
+      mockScaleController.connectCalls.clear();
+      mockScanner.addDevice(bengle);
+      mockScanner.addDevice(de1);
+      mockScanner.addDevice(externalScale);
+      await Future.delayed(Duration.zero);
+
+      await connectionManager.scanAndConnect();
+      expect(connectionManager.currentStatus.pendingAmbiguity,
+          AmbiguityReason.machinePicker);
+
+      await connectionManager.selectMachine(bengle);
+
+      expect(mockScaleController.connectCalls, hasLength(1));
+      expect(mockScaleController.connectCalls.single.deviceId,
+          startsWith('bengle-internal-'));
+      expect(mockScaleController.connectCalls.any(
+        (scale) => scale.deviceId == externalScale.deviceId,
+      ), isFalse);
+    });
+
     test('non-Bengle machine still runs external scale phase', () async {
       await settingsController.setPreferredMachineId('de1-1');
       await settingsController.setPreferredScaleId('ext-scale');

--- a/test/launcher_scan_page_test.dart
+++ b/test/launcher_scan_page_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/scan_state_guardian.dart';
+import 'package:reaprime/src/launcher/launcher_scan_page.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+import 'helpers/mock_connection_manager.dart';
+import 'helpers/mock_de1_controller.dart';
+import 'helpers/mock_device_discovery_service.dart';
+import 'helpers/mock_device_scanner.dart';
+import 'helpers/mock_scale_controller.dart';
+import 'helpers/mock_settings_service.dart';
+
+void main() {
+  late MockConnectionManager mockCm;
+  late DeviceController deviceController;
+  late SettingsController settingsController;
+  late ScanStateGuardian scanStateGuardian;
+
+  setUp(() async {
+    final scanner = MockDeviceScanner();
+    final de1 = MockDe1Controller(controller: DeviceController([]));
+    final scale = MockScaleController();
+    final settings = SettingsController(MockSettingsService());
+    await settings.loadSettings();
+
+    mockCm = MockConnectionManager(
+      deviceScanner: scanner,
+      de1Controller: de1,
+      scaleController: scale,
+      settingsController: settings,
+    );
+
+    final discovery = MockBleDiscoveryService();
+    deviceController = DeviceController([discovery]);
+    await deviceController.initialize();
+    settingsController = settings;
+    scanStateGuardian = ScanStateGuardian(bleService: discovery);
+  });
+
+  Widget buildPage() {
+    return ShadApp(
+      home: LauncherScanPage(
+        connectionManager: mockCm,
+        deviceController: deviceController,
+        settingsController: settingsController,
+        scanStateGuardian: scanStateGuardian,
+      ),
+    );
+  }
+
+  testWidgets('opens with scanAndConnect, not connect', (tester) async {
+    await tester.pumpWidget(buildPage());
+    await tester.pump();
+
+    expect(mockCm.scanAndConnectCallCount, 1);
+    expect(
+      mockCm.connectCallCount - mockCm.scanAndConnectCallCount,
+      0,
+      reason: 'all connect calls should be scanAndConnect',
+    );
+  });
+
+  testWidgets('cancel calls cancelSelectionSession', (tester) async {
+    // Navigate to the picker state so the Cancel button is visible.
+    mockCm.emitStatus(ConnectionStatus(
+      phase: ConnectionPhase.idle,
+      pendingAmbiguity: AmbiguityReason.machinePicker,
+      foundMachines: [],
+    ));
+
+    await tester.pumpWidget(buildPage());
+    await tester.pump();
+
+    // Find Cancel button.
+    final cancelFinder = find.text('Cancel');
+    expect(cancelFinder, findsOneWidget);
+
+    await tester.tap(cancelFinder);
+    await tester.pump();
+
+    expect(mockCm.cancelSelectionSessionCallCount, 1);
+  });
+}

--- a/test/launcher_scan_page_test.dart
+++ b/test/launcher_scan_page_test.dart
@@ -64,7 +64,7 @@ void main() {
     );
   });
 
-  testWidgets('cancel calls cancelSelectionSession', (tester) async {
+  testWidgets('cancel calls cancelActiveScan', (tester) async {
     // Navigate to the picker state so the Cancel button is visible.
     mockCm.emitStatus(ConnectionStatus(
       phase: ConnectionPhase.idle,
@@ -82,6 +82,6 @@ void main() {
     await tester.tap(cancelFinder);
     await tester.pump();
 
-    expect(mockCm.cancelSelectionSessionCallCount, 1);
+    expect(mockCm.cancelActiveScanCallCount, 1);
   });
 }

--- a/test/onboarding/scan_step_test.dart
+++ b/test/onboarding/scan_step_test.dart
@@ -155,7 +155,7 @@ void main() {
       expect(find.text('Continue to Dashboard'), findsOneWidget);
     });
 
-    testWidgets('Re-start scan calls connectionManager.connect',
+    testWidgets('Re-start scan uses the scan-first connection path',
         (tester) async {
       await tester.pumpWidget(buildSubject());
       await tester.pump();
@@ -166,12 +166,12 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
-      final before = mockConnectionManager.connectCallCount;
+      final before = mockConnectionManager.scanAndConnectCallCount;
       await tester.tap(find.text('Re-start scan'));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
-      expect(mockConnectionManager.connectCallCount, before + 1);
+      expect(mockConnectionManager.scanAndConnectCallCount, before + 1);
     });
 
     testWidgets('Continue to Dashboard calls advance', (tester) async {

--- a/test/scan_flow_view_test.dart
+++ b/test/scan_flow_view_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection_error.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/scan_state_guardian.dart';
@@ -83,7 +84,6 @@ void main() {
 
   group('picker selection', () {
     testWidgets('machine picker calls selectMachine', (tester) async {
-      // Emit machinePicker state with one machine candidate.
       mockCm.emitStatus(ConnectionStatus(
         phase: ConnectionPhase.idle,
         pendingAmbiguity: AmbiguityReason.machinePicker,
@@ -97,14 +97,11 @@ void main() {
       ));
       await tester.pumpAndSettle();
 
-      // Should see the machine name and Connect button.
       expect(find.text('DE1 #1'), findsOneWidget);
 
-      // Tap the machine card to select it.
       await tester.tap(find.text('DE1 #1'));
       await tester.pump();
 
-      // Tap Connect.
       await tester.tap(find.text('Connect'));
       await tester.pump();
 
@@ -142,7 +139,6 @@ void main() {
 
     testWidgets('machine picker transitions to scale picker after selection',
         (tester) async {
-      // Phase 1: machinePicker
       mockCm.emitStatus(ConnectionStatus(
         phase: ConnectionPhase.idle,
         pendingAmbiguity: AmbiguityReason.machinePicker,
@@ -156,7 +152,6 @@ void main() {
       ));
       await tester.pumpAndSettle();
 
-      // Select and connect the machine.
       await tester.tap(find.text('DE1 #1'));
       await tester.pump();
       await tester.tap(find.text('Connect'));
@@ -164,7 +159,6 @@ void main() {
 
       expect(mockCm.selectMachineCallCount, 1);
 
-      // Phase 2: selectMachine emits scalePicker from the retained session.
       mockCm.emitStatus(ConnectionStatus(
         phase: ConnectionPhase.idle,
         pendingAmbiguity: AmbiguityReason.scalePicker,
@@ -175,19 +169,154 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      // Now the scale picker should be visible.
       expect(find.text('Decent Scale'), findsOneWidget);
       expect(find.text('Scales'), findsOneWidget);
 
-      // Select and connect the scale.
       await tester.tap(find.text('Decent Scale'));
       await tester.pump();
       await tester.tap(find.text('Connect'));
       await tester.pump();
 
       expect(mockCm.selectScaleCallCount, 1);
+      expect(mockCm.scanAndConnectCallCount, 1);
+    });
+  });
 
-      // Scan count still hasn't increased.
+  group('error plus picker coexistence', () {
+    testWidgets(
+        'machine connect failure with another candidate shows picker and error',
+        (tester) async {
+      final candidate1 = FakeDe1(deviceId: 'm1', name: 'DE1 #1');
+      final candidate2 = FakeDe1(deviceId: 'm2', name: 'DE1 #2');
+
+      mockCm.emitStatus(ConnectionStatus(
+        phase: ConnectionPhase.idle,
+        pendingAmbiguity: AmbiguityReason.machinePicker,
+        foundMachines: [candidate1, candidate2],
+      ));
+
+      await tester.pumpWidget(buildView(
+        initialConnectionIntent: () => mockCm.scanAndConnect(),
+      ));
+      await tester.pumpAndSettle();
+
+      // Select candidate1, simulate failure.
+      await tester.tap(find.text('DE1 #1'));
+      await tester.pump();
+
+      mockCm.shouldFailMachineConnect = true;
+      await tester.tap(find.text('Connect'));
+      await tester.pumpAndSettle();
+
+      // Picker must still be visible with both candidates.
+      expect(find.text('DE1 #1'), findsOneWidget);
+      expect(find.text('DE1 #2'), findsOneWidget);
+      expect(find.text('Connect'), findsOneWidget);
+
+      // Failure text must be visible.
+      expect(find.text('Machine DE1 #1 failed to connect.'), findsOneWidget);
+
+      // The user can select the alternative without a new scan.
+      await tester.tap(find.text('DE1 #2'));
+      await tester.pump();
+
+      mockCm.shouldFailMachineConnect = false;
+      await tester.tap(find.text('Connect'));
+      await tester.pump();
+
+      expect(mockCm.selectMachineCallCount, 2);
+      expect(mockCm.scanAndConnectCallCount, 1);
+    });
+
+    testWidgets(
+        'selected machine fails with another candidate — picker remains visible',
+        (tester) async {
+      final candidate1 = FakeDe1(deviceId: 'm1', name: 'DE1 #1');
+      final candidate2 = FakeDe1(deviceId: 'm2', name: 'Alt Machine');
+
+      mockCm.emitStatus(ConnectionStatus(
+        phase: ConnectionPhase.idle,
+        pendingAmbiguity: AmbiguityReason.machinePicker,
+        foundMachines: [candidate1, candidate2],
+      ));
+
+      await tester.pumpWidget(buildView(
+        initialConnectionIntent: () => mockCm.scanAndConnect(),
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('DE1 #1'));
+      await tester.pump();
+
+      mockCm.shouldFailMachineConnect = true;
+      await tester.tap(find.text('Connect'));
+      await tester.pumpAndSettle();
+
+      // Both candidates still present in the picker.
+      expect(find.text('DE1 #1'), findsOneWidget);
+      expect(find.text('Alt Machine'), findsOneWidget);
+
+      // Error message visible.
+      expect(find.text('Machine DE1 #1 failed to connect.'), findsOneWidget);
+
+      // No uncaught exception — the widget is still rendering.
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets(
+        'machine fails with no alternatives — scalePicker shows with error',
+        (tester) async {
+      final machine = FakeDe1(deviceId: 'm1', name: 'My DE1');
+
+      mockCm.emitStatus(ConnectionStatus(
+        phase: ConnectionPhase.idle,
+        pendingAmbiguity: AmbiguityReason.machinePicker,
+        foundMachines: [machine],
+      ));
+
+      await tester.pumpWidget(buildView(
+        initialConnectionIntent: () => mockCm.scanAndConnect(),
+      ));
+      await tester.pumpAndSettle();
+
+      mockCm.shouldFailMachineConnect = true;
+      await tester.tap(find.text('My DE1'));
+      await tester.pump();
+      await tester.tap(find.text('Connect'));
+      await tester.pump();
+
+      // Now emit scalePicker from the session with retained scale candidates.
+      mockCm.emitStatus(ConnectionStatus(
+        phase: ConnectionPhase.idle,
+        pendingAmbiguity: AmbiguityReason.scalePicker,
+        foundScales: [
+          TestScale(deviceId: 's1', name: 'My Scale'),
+        ],
+        error: ConnectionError(
+          kind: ConnectionErrorKind.machineConnectFailed,
+          severity: ConnectionErrorSeverity.error,
+          timestamp: DateTime.now().toUtc(),
+          message: 'Machine My DE1 failed to connect.',
+          suggestion: 'Try another machine.',
+        ),
+      ));
+
+      await tester.pumpAndSettle();
+
+      // Scale picker is visible.
+      expect(find.text('My Scale'), findsOneWidget);
+      expect(find.text('Scales'), findsOneWidget);
+
+      // Machine error is visible inline.
+      expect(find.text('Machine My DE1 failed to connect.'), findsOneWidget);
+
+      // Select the scale — call selectScale, not a new scan.
+      await tester.tap(find.text('My Scale'));
+      await tester.pump();
+      await tester.tap(find.text('Connect'));
+      await tester.pump();
+
+      expect(mockCm.selectScaleCallCount, 1);
       expect(mockCm.scanAndConnectCallCount, 1);
     });
   });

--- a/test/scan_flow_view_test.dart
+++ b/test/scan_flow_view_test.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/scan_state_guardian.dart';
+import 'package:reaprime/src/device_discovery_feature/scan_flow_view.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+import 'helpers/mock_connection_manager.dart';
+import 'helpers/mock_de1_controller.dart';
+import 'helpers/mock_device_discovery_service.dart';
+import 'helpers/mock_device_scanner.dart';
+import 'helpers/mock_scale_controller.dart';
+import 'helpers/mock_settings_service.dart';
+import 'helpers/test_scale.dart';
+
+void main() {
+  late MockConnectionManager mockCm;
+  late MockDeviceScanner mockScanner;
+  late DeviceController deviceController;
+  late SettingsController settingsController;
+  late ScanStateGuardian scanStateGuardian;
+
+  setUp(() async {
+    mockScanner = MockDeviceScanner();
+    final de1 = MockDe1Controller(controller: DeviceController([]));
+    final scale = MockScaleController();
+    final settings = SettingsController(MockSettingsService());
+    await settings.loadSettings();
+
+    mockCm = MockConnectionManager(
+      deviceScanner: mockScanner,
+      de1Controller: de1,
+      scaleController: scale,
+      settingsController: settings,
+    );
+
+    final discovery = MockBleDiscoveryService();
+    deviceController = DeviceController([discovery]);
+    await deviceController.initialize();
+    settingsController = settings;
+    scanStateGuardian = ScanStateGuardian(bleService: discovery);
+  });
+
+  Widget buildView({VoidCallback? initialConnectionIntent}) {
+    return ShadApp(
+      home: ScanFlowView(
+        connectionManager: mockCm,
+        deviceController: deviceController,
+        settingsController: settingsController,
+        scanStateGuardian: scanStateGuardian,
+        initialConnectionIntent: initialConnectionIntent,
+        onConnected: () {},
+        onExit: () {},
+      ),
+    );
+  }
+
+  group('initial connection intent', () {
+    testWidgets('uses scanAndConnect when intent is provided', (tester) async {
+      await tester.pumpWidget(buildView(
+        initialConnectionIntent: () => mockCm.scanAndConnect(),
+      ));
+      await tester.pump();
+
+      expect(mockCm.scanAndConnectCallCount, 1);
+      expect(
+        mockCm.connectCallCount - mockCm.scanAndConnectCallCount,
+        0,
+        reason: 'all connect calls should be scanAndConnect',
+      );
+    });
+
+    testWidgets('uses connect when no intent is provided', (tester) async {
+      await tester.pumpWidget(buildView());
+      await tester.pump();
+
+      expect(mockCm.connectCallCount, 1);
+      expect(mockCm.scanAndConnectCallCount, 0);
+    });
+  });
+
+  group('picker selection', () {
+    testWidgets('machine picker calls selectMachine', (tester) async {
+      // Emit machinePicker state with one machine candidate.
+      mockCm.emitStatus(ConnectionStatus(
+        phase: ConnectionPhase.idle,
+        pendingAmbiguity: AmbiguityReason.machinePicker,
+        foundMachines: [
+          FakeDe1(deviceId: 'm1', name: 'DE1 #1'),
+        ],
+      ));
+
+      await tester.pumpWidget(buildView(
+        initialConnectionIntent: () => mockCm.scanAndConnect(),
+      ));
+      await tester.pumpAndSettle();
+
+      // Should see the machine name and Connect button.
+      expect(find.text('DE1 #1'), findsOneWidget);
+
+      // Tap the machine card to select it.
+      await tester.tap(find.text('DE1 #1'));
+      await tester.pump();
+
+      // Tap Connect.
+      await tester.tap(find.text('Connect'));
+      await tester.pump();
+
+      expect(mockCm.selectMachineCallCount, 1);
+      expect(mockCm.scanAndConnectCallCount, 1,
+          reason: 'scan count must not increase for a picker selection');
+    });
+
+    testWidgets('scale picker calls selectScale', (tester) async {
+      mockCm.emitStatus(ConnectionStatus(
+        phase: ConnectionPhase.idle,
+        pendingAmbiguity: AmbiguityReason.scalePicker,
+        foundScales: [
+          TestScale(deviceId: 's1', name: 'Decent Scale'),
+        ],
+      ));
+
+      await tester.pumpWidget(buildView(
+        initialConnectionIntent: () => mockCm.scanAndConnect(),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Decent Scale'), findsOneWidget);
+
+      await tester.tap(find.text('Decent Scale'));
+      await tester.pump();
+
+      await tester.tap(find.text('Connect'));
+      await tester.pump();
+
+      expect(mockCm.selectScaleCallCount, 1);
+      expect(mockCm.scanAndConnectCallCount, 1,
+          reason: 'scan count must not increase for a picker selection');
+    });
+
+    testWidgets('machine picker transitions to scale picker after selection',
+        (tester) async {
+      // Phase 1: machinePicker
+      mockCm.emitStatus(ConnectionStatus(
+        phase: ConnectionPhase.idle,
+        pendingAmbiguity: AmbiguityReason.machinePicker,
+        foundMachines: [
+          FakeDe1(deviceId: 'm1', name: 'DE1 #1'),
+        ],
+      ));
+
+      await tester.pumpWidget(buildView(
+        initialConnectionIntent: () => mockCm.scanAndConnect(),
+      ));
+      await tester.pumpAndSettle();
+
+      // Select and connect the machine.
+      await tester.tap(find.text('DE1 #1'));
+      await tester.pump();
+      await tester.tap(find.text('Connect'));
+      await tester.pump();
+
+      expect(mockCm.selectMachineCallCount, 1);
+
+      // Phase 2: selectMachine emits scalePicker from the retained session.
+      mockCm.emitStatus(ConnectionStatus(
+        phase: ConnectionPhase.idle,
+        pendingAmbiguity: AmbiguityReason.scalePicker,
+        foundScales: [
+          TestScale(deviceId: 's1', name: 'Decent Scale'),
+        ],
+      ));
+
+      await tester.pumpAndSettle();
+
+      // Now the scale picker should be visible.
+      expect(find.text('Decent Scale'), findsOneWidget);
+      expect(find.text('Scales'), findsOneWidget);
+
+      // Select and connect the scale.
+      await tester.tap(find.text('Decent Scale'));
+      await tester.pump();
+      await tester.tap(find.text('Connect'));
+      await tester.pump();
+
+      expect(mockCm.selectScaleCallCount, 1);
+
+      // Scan count still hasn't increased.
+      expect(mockCm.scanAndConnectCallCount, 1);
+    });
+  });
+}

--- a/test/scan_flow_view_test.dart
+++ b/test/scan_flow_view_test.dart
@@ -320,4 +320,27 @@ void main() {
       expect(mockCm.scanAndConnectCallCount, 1);
     });
   });
+
+  group('stale-scan recovery', () {
+    testWidgets('triggers scanAndConnect on stale event', (tester) async {
+      mockCm.emitStatus(const ConnectionStatus(
+        phase: ConnectionPhase.scanning,
+      ));
+
+      await tester.pumpWidget(buildView(
+        initialConnectionIntent: () => mockCm.scanAndConnect(),
+      ));
+      await tester.pump();
+
+      final callsBefore = mockCm.scanAndConnectCallCount;
+
+      // Simulate stale scan via the public onAppResumed test hook.
+      scanStateGuardian.onAppResumed();
+      await tester.pump();
+
+      // scanAndConnect was called again, which triggers the superseding
+      // logic (stop scan + queue replacement) when an active scan exists.
+      expect(mockCm.scanAndConnectCallCount, greaterThan(callsBefore));
+    });
+  });
 }

--- a/test/shared/connection_error_banner_test.dart
+++ b/test/shared/connection_error_banner_test.dart
@@ -69,7 +69,34 @@ void main() {
       await tester.tap(find.text('Retry'));
       await tester.pump();
 
-      expect(cm.connectCalls, 1);
+      expect(cm.scanAndConnectCalls, 1);
+      expect(cm.automaticConnectCalls, 0);
+    });
+
+    testWidgets('disconnect Retry uses automatic recovery policy',
+        (tester) async {
+      final cm = FakeConnectionManager();
+      cm.setError(ConnectionError(
+        kind: ConnectionErrorKind.machineDisconnected,
+        severity: ConnectionErrorSeverity.error,
+        timestamp: DateTime.now().toUtc(),
+        message: 'x',
+      ));
+
+      await tester.pumpWidget(
+        ShadApp(
+          home: Scaffold(
+            body: ConnectionErrorBanner(connectionManager: cm),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('Retry'));
+      await tester.pump();
+
+      expect(cm.automaticConnectCalls, 1);
+      expect(cm.scanAndConnectCalls, 0);
     });
 
     testWidgets(


### PR DESCRIPTION
## Summary

- Problem: skin scans shared startup/recovery quick-connect, which could re-adopt an already-connected DE1 and produce a false disconnect/re-attach.
- Why it matters: explicit scans should discover alternatives and fill only missing machine/scale slots without disturbing working connections.
- What changed: explicit native, REST, and WebSocket scans now complete discovery first, preserve occupied slots, and resolve missing devices machine-first then scale. Startup, recovery, and USB-attach paths retain quick-connect.
- Follow-up hardening: connection intent is modeled explicitly, picker continuation state lives in a bounded selection session, scan reports cover the complete session, stale selections are rejected, and Bengle selection hands an external scale slot to its integrated scale.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [x] REST API / handlers
- [x] WebSocket API
- [ ] Machine state / shot logic
- [x] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [x] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #477

## Root Cause (if bug fix)

- Root cause: explicit scan requests shared the automatic startup/recovery `connect()` path. That path quick-connected before scanning and could adopt a fresh object for an already-connected DE1.
- Missing detection or guardrail: there was no dedicated scan-first intent, no independently occupied/missing slot matrix, and picker continuation state/report ownership were implicit inside `ConnectionManager`.
- Contributing context: preferred-scale watch duty cycle was not the disconnect source. USB attach remains an incomplete hint and still requires remembered-device probing or scan fallback.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [x] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target tests: `test/controllers/connection_manager_test.dart`, `test/controllers/connection/policy_resolver_test.dart`, `test/integration/connection_manager_bengle_scale_test.dart`, `test/devices_handler_test.dart`, `test/devices_ws_test.dart`, `test/device_discovery_view_test.dart`, `test/onboarding/scan_step_test.dart`, `test/shared/connection_error_banner_test.dart`
- Scenario locked in: explicit scan completion before policy; occupied/missing slot matrix; preferred found/missing/ambiguous matrix; machine-first retained scale selection; stale/cancelled sessions; full-session reports; queued scale recovery intent; machine-error preservation through scale continuation; Bengle handoff; retry intent; `connect=false` discovery-only.
- End-to-end recipe: `.agents/skills/decent-app/scenarios/device-scan-connection-policy.md`
- If no new test added, why not: N/A

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [x] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [x] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [x] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A — no docs affected

Archived design: `doc/plans/archive/device-scan-connection-policy/README.md`.

## Security Impact (required)

- New or changed REST endpoints? (`Yes/No`) Yes, behavior of the existing scan endpoint changed.
- New or changed WebSocket topics? (`Yes/No`) Yes, behavior of the existing devices scan command changed; no new topic.
- New or changed network calls? (`Yes/No`) No
- BLE/USB surface changed? (`Yes/No`) No transport surface change
- File system access changed? (`Yes/No`) No
- Plugin sandbox boundary changed? (`Yes/No`) No
- If any `Yes`, explain risk and mitigation: payloads and defaults remain stable. Automatic replacement is narrower, stale picker selections are rejected, and ambiguous alternatives require explicit selection.

## User-Visible Changes

- Requesting a scan no longer disconnects/re-attaches the current DE1.
- Working machine and scale connections remain attached while alternatives are discovered.
- Missing unambiguous devices auto-connect; preferred-device misses produce machine-first, then scale ambiguity.
- A scale can connect without a machine while phase remains `idle`.
- Selecting or reconnecting Bengle hands an attached external scale slot to Bengle's integrated scale.
- Disconnect retries use recovery policy; explicit connection retries scan first.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 2,344 tests passed
- [x] `(cd packages/dye2-plugin && npm run build)` — built successfully
- [x] REST and WebSocket YAML parsed successfully

### Manual verification (if applicable)

- OS / platform tested: macOS desktop
- Simulated devices? (`simulate=1`): Yes, MockDe1 + MockScale
- Real hardware? (DE1/Bengle/scale): No
- What was verified: default and `connect=false` REST/WebSocket scans retained the same connected machine and scale IDs. Blocking default scans completed and emitted final reports without reconnecting either occupied slot.
- Edge cases covered by automated tests: slot matrix; preference matrix; ordered ambiguity; session cancellation/stale selection; scale-only idle; machine-error retention; Bengle external-to-integrated handoff; scale watch pause/re-target; retry intent.
- Outstanding validation: repeat default REST/WebSocket scans against a real DE1 + scale; repeat Bengle handoff with a physical Bengle and external scale.

### Evidence

- [x] Test output
- [x] Log snippets
- [ ] Screenshot / recording (UI changes)
- [x] curl / websocat output

```text
flutter analyze: No issues found
flutter test: 2,344 tests passed
before=["MockDe1","MockScale"]
after_rest_default=["MockDe1","MockScale"]
after_rest_connect_false=["MockDe1","MockScale"]
after_ws_default=["MockDe1","MockScale"]
after_ws_connect_false=["MockDe1","MockScale"]
```

```text
running scan, quick = false, connect = true
Machine connected, proceeding to scale phase
Scale already connected, skipping scale phase
ws scan command: connect=true, quick=false
ws scan command: connect=false, quick=false
```

## Compatibility & Migration

- Backward compatible? (`Yes/No`) Wire-compatible, intentionally not behavior-identical
- Config / env changes needed? (`Yes/No`) No
- Database migration needed? (`Yes/No`) No
- Details: REST and WebSocket shapes are unchanged; omitted `connect` remains `true`, omitted `quick` remains `false`, and `connect=false` remains discovery-only. Blocking explicit scans can now return later because they wait for complete discovery. Occupied-slot, ambiguity, and Bengle handoff behavior intentionally changed as documented.

## Risks & Mitigations

- Risk: explicit scans wait for the discovery window before connecting.
  - Mitigation: only user/API scans use this intent; startup, automatic recovery, and USB attach retain quick-connect and early stop.
- Risk: picker state could outlive its discovery snapshot or race scale recovery.
  - Mitigation: immutable candidate sessions reject stale selections, finalize on completion/cancellation, and block scale recovery while selection is pending.
- Risk: Bengle selection replaces an attached external scale.
  - Mitigation: this is the documented integrated-scale precedence rule and uses the existing scale-controller handoff path.
- Risk: real BLE timing differs from simulated discovery.
  - Mitigation: hardware validation is explicitly outstanding and tracked in #477.





