### PR TITLE
fix(ble): liveness probe recovers a silently dead scale-watch scan

### DIFF
--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -127,6 +127,20 @@ cancellation.
 
 **Fix (PR #246):** `shouldWriteChargerMode()` in `charging_logic.dart`: write-on-change, re-assert "off" every 5min while discharging, skip otherwise. Reset last-applied on disconnect.
 
+## Footgun #4: Watch Scan Silent Death (fork SafeScanner)
+
+**Symptom:** background scale watch armed (`Background device watch started` in the log) but the preferred scale never auto-connects; a manual scan connects it immediately. No error anywhere.
+
+**Root cause (two mechanisms in the universal_ble fork's Android code):**
+1. `SafeScanner`'s scan-frequency throttle (>5 starts/30s) silently swallows a start: the Dart call returns success while the real start is deferred via `handler.postDelayed`, and any `stopScan` in between cancels the deferral (`removeCallbacksAndMessages(null)`). Scan churn (bursts + watch pause/resume around machine reconnects) is the trigger.
+2. `onScanFailed` is logged Kotlin-side and never surfaced to Dart, so a scan Android kills post-start is invisible.
+
+**Fix:** `UniversalBleDiscoveryService` probes `UniversalBle.isScanning()` every 90s while the watch scan is believed running (`_armWatchLiveness`). Dead scan → teardown + restart through `_restartWatchOrReportFailure`, so a failing restart reports on `deviceWatchFailures` and `ScaleWatch` activates the legacy backoff. Probe errors fail open — an unprovable probe must not churn the session; ownership is re-checked after the await (a burst may have taken the session).
+
+**Coverage limit:** `isScanning()` reflects SafeScanner's *host-side bookkeeping*, not adapter truth. Mechanism 1 is caught (bookkeeping never went true). Mechanism 2 is NOT (bookkeeping stays true after `onScanFailed`) — bounded by the 25-min refresh until the fork updates SafeScanner state in `onScanFailed` / emits a scan-state event (candidate fork follow-up).
+
+**Field triage:** `ScaleWatch` logs sightings at INFO. `Background device watch started` with no `Preferred scale … sighted` → scan/screen problem (this footgun, or unfiltered-scan screen-off suspension). `sighted` with no connect → connect-path problem.
+
 ## Gone-Device Error Handling
 
 `UniversalBleTransport._handleGattError()` catches `UniversalBleException` with gone-device codes:

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -418,6 +418,17 @@ Watch lifecycle details:
   session) and resume it when they finish; the watch self-restarts
   every 25 minutes to dodge Android's 30-minute opportunistic-scan
   downgrade, and survives adapter off/on cycles.
+- While its scan is believed running, the watch probes
+  `UniversalBle.isScanning()` every 90 seconds (a host-side bookkeeping
+  check, no radio use). A dead scan is torn down and restarted through
+  the same failure path as refresh/resume, so a restart that also fails
+  reports watch-unavailable and hands off to the legacy backoff
+  fallback. Probe errors fail open (treated as alive) so an unprovable
+  probe never churns the session. Coverage limit: the probe catches
+  starts the fork's `SafeScanner` throttle silently swallowed, but a
+  native `onScanFailed` after a successful start does not update the
+  host-side bookkeeping, so that flavor stays bounded by the 25-minute
+  refresh — see `doc/AI_BLE_NOTES.md` ("Watch Scan Silent Death").
 - `De1StateManager` skips its post-wake scale-only burst when the watch
   covers reacquisition (watch supported + preferred scale set); the
   burst remains for the no-preferred-scale discovery/picker case.

--- a/doc/plans/archive/background-scale-watch/background-scale-watch.md
+++ b/doc/plans/archive/background-scale-watch/background-scale-watch.md
@@ -72,6 +72,13 @@ commit chain is now authoritative for *what* changed. What follows is the
   unfiltered in balanced mode; the duty cycle was always the real win. A
   future improvement could persist the ADVERTISED name at discovery time and
   restore plugin-side prefix filtering to cut platform-channel traffic.
+- **Liveness probe added after field testing (2026-07-17).** The design
+  assumed a started scan stays started until stopped, but the fork can lose
+  the native scan with nothing reaching Dart (SafeScanner throttle swallows
+  starts; `onScanFailed` is dropped) — observed as "watch armed, scale never
+  auto-connects". The service now probes `UniversalBle.isScanning()` every
+  90s and restarts a dead scan through the failure/fallback path. See
+  `doc/AI_BLE_NOTES.md` footgun #4 for mechanics and coverage limits.
 - **Legacy loop retained, not removed.** The 5s→60s backoff-burst loop is the
   active path on non-Android platforms and the runtime fallback when
   `startScaleWatch` throws (`onWatchUnavailable`).

--- a/lib/src/controllers/connection/scale_watch.dart
+++ b/lib/src/controllers/connection/scale_watch.dart
@@ -157,9 +157,6 @@ class ScaleWatch {
   Future<void> _onSighting(Scale scale, int gen) async {
     _connecting = true;
     try {
-      // INFO deliberately: one line per reconnect, and the key field
-      // breadcrumb for diagnosing "scale did not auto-connect" reports
-      // (armed-but-no-sighting vs sighted-but-connect-failed).
       _log.info(
         'Preferred scale ${scale.deviceId} sighted; '
         'stopping watch and connecting',

--- a/lib/src/controllers/connection/scale_watch.dart
+++ b/lib/src/controllers/connection/scale_watch.dart
@@ -157,7 +157,10 @@ class ScaleWatch {
   Future<void> _onSighting(Scale scale, int gen) async {
     _connecting = true;
     try {
-      _log.fine(
+      // INFO deliberately: one line per reconnect, and the key field
+      // breadcrumb for diagnosing "scale did not auto-connect" reports
+      // (armed-but-no-sighting vs sighted-but-connect-failed).
+      _log.info(
         'Preferred scale ${scale.deviceId} sighted; '
         'stopping watch and connecting',
       );

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -95,13 +95,9 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
   /// the watch scan before that kicks in.
   static const _watchRefreshInterval = Duration(minutes: 25);
 
-  /// Liveness probe cadence. The native scan can die without anything
-  /// reaching Dart: the fork drops `onScanFailed` (logs only), and its
-  /// SafeScanner throttle can swallow a start entirely (returns success,
-  /// defers the real start, and a later stopScan cancels the deferral).
-  /// `UniversalBle.isScanning()` is a cheap host-side check — no radio
-  /// use — so probe often enough that a dead watch recovers in ~1 probe
-  /// interval instead of waiting for the 25-min refresh.
+  /// Dead-scan probe cadence. The native scan can die without any event
+  /// reaching Dart; see doc/AI_BLE_NOTES.md ("Watch Scan Silent Death")
+  /// for the fork mechanics and the probe's coverage limits.
   static const _watchLivenessInterval = Duration(seconds: 90);
   Timer? _watchLivenessTimer;
 
@@ -301,11 +297,11 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
       try {
         alive = await UniversalBle.isScanning();
       } catch (e, st) {
-        // A failed probe proves nothing — don't churn the scan over it.
+        // Fail open: an unprovable probe must not churn the session.
         log.fine('Watch liveness probe failed', e, st);
         alive = true;
       }
-      // Re-check: a burst/stop may have taken over during the await.
+      // A burst/stop may have taken ownership during the await.
       if (!_watchScanActive || _isScanning) return;
       if (alive) {
         _armWatchLiveness();

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -95,6 +95,16 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
   /// the watch scan before that kicks in.
   static const _watchRefreshInterval = Duration(minutes: 25);
 
+  /// Liveness probe cadence. The native scan can die without anything
+  /// reaching Dart: the fork drops `onScanFailed` (logs only), and its
+  /// SafeScanner throttle can swallow a start entirely (returns success,
+  /// defers the real start, and a later stopScan cancels the deferral).
+  /// `UniversalBle.isScanning()` is a cheap host-side check — no radio
+  /// use — so probe often enough that a dead watch recovers in ~1 probe
+  /// interval instead of waiting for the 25-min refresh.
+  static const _watchLivenessInterval = Duration(seconds: 90);
+  Timer? _watchLivenessTimer;
+
   final StreamController<void> _watchFailureController =
       StreamController.broadcast();
 
@@ -157,6 +167,8 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
   }) async {
     _watchRefreshTimer?.cancel();
     _watchRefreshTimer = null;
+    _watchLivenessTimer?.cancel();
+    _watchLivenessTimer = null;
     _cancelWatchScanSub();
     _watchScanActive = false;
     if (stopOsScan) {
@@ -276,7 +288,35 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     }
     _watchScanActive = true;
     _armWatchRefresh();
+    _armWatchLiveness();
     log.info('Background device watch started (prefix: $namePrefix)');
+  }
+
+  void _armWatchLiveness() {
+    _watchLivenessTimer?.cancel();
+    _watchLivenessTimer = Timer(_watchLivenessInterval, () async {
+      _watchLivenessTimer = null;
+      if (!_watchScanActive || _isScanning) return;
+      bool alive;
+      try {
+        alive = await UniversalBle.isScanning();
+      } catch (e, st) {
+        // A failed probe proves nothing — don't churn the scan over it.
+        log.fine('Watch liveness probe failed', e, st);
+        alive = true;
+      }
+      // Re-check: a burst/stop may have taken over during the await.
+      if (!_watchScanActive || _isScanning) return;
+      if (alive) {
+        _armWatchLiveness();
+        return;
+      }
+      log.warning(
+        'Watch scan died silently (isScanning=false); restarting',
+      );
+      await _deactivateWatchScan(stopOsScan: false, context: 'liveness');
+      await _restartWatchOrReportFailure('liveness restart');
+    });
   }
 
   void _armWatchRefresh() {

--- a/test/services/universal_ble_discovery_service_test.dart
+++ b/test/services/universal_ble_discovery_service_test.dart
@@ -62,15 +62,22 @@ class _FakeBlePlatform extends UniversalBlePlatform {
       await hold.future;
     }
     startScanCalls.add((filter: scanFilter, config: platformConfig));
+    nativeScanning = true;
   }
 
   @override
   Future<void> stopScan() async {
     stopScanCalls++;
+    nativeScanning = false;
   }
 
+  /// Mirrors the native scanner state (set by startScan/stopScan).
+  /// Tests flip it to false directly to simulate a silent scan death
+  /// (Android killing the scan without any callback reaching Dart).
+  bool nativeScanning = false;
+
   @override
-  Future<bool> isScanning() async => false;
+  Future<bool> isScanning() async => nativeScanning;
 
   @override
   Future<void> connect(
@@ -546,6 +553,57 @@ void main() {
               'a refresh that cannot restart the scan leaves the '
               'watch dead — it must be reported, not swallowed',
         );
+      });
+    });
+
+    test(
+        'the liveness probe restarts a silently dead native scan', () {
+      // The fork's SafeScanner can swallow a start (scan-frequency
+      // throttling returns success without scanning, and a later stop
+      // cancels the pending auto-start) and onScanFailed never reaches
+      // Dart — so the watch must verify the native scan actually exists.
+      fakeAsync((async) {
+        final zoned = UniversalBleDiscoveryService(
+          watchSupportGate: () => true,
+        );
+        zoned.initialize();
+        async.flushMicrotasks();
+        zoned.startDeviceWatch(_watchFilter);
+        async.flushMicrotasks();
+        expect(platform.startScanCalls, hasLength(1));
+
+        platform.nativeScanning = false; // silent death
+        async.elapse(const Duration(minutes: 2));
+        async.flushMicrotasks();
+
+        expect(platform.startScanCalls.length, greaterThanOrEqualTo(2),
+            reason: 'the probe must notice the dead scan and restart it '
+                'instead of waiting for the 25-min refresh');
+        expect(lastStart().filter?.withNamePrefix, ['Decent Scale']);
+
+        zoned.stopDeviceWatch();
+        async.flushMicrotasks();
+      });
+    });
+
+    test('a live scan passes the liveness probe untouched', () {
+      fakeAsync((async) {
+        final zoned = UniversalBleDiscoveryService(
+          watchSupportGate: () => true,
+        );
+        zoned.initialize();
+        async.flushMicrotasks();
+        zoned.startDeviceWatch(_watchFilter);
+        async.flushMicrotasks();
+
+        async.elapse(const Duration(minutes: 10));
+        async.flushMicrotasks();
+
+        expect(platform.startScanCalls, hasLength(1),
+            reason: 'probes on a healthy scan must not churn the session');
+
+        zoned.stopDeviceWatch();
+        async.flushMicrotasks();
       });
     });
 

--- a/test/services/universal_ble_discovery_service_test.dart
+++ b/test/services/universal_ble_discovery_service_test.dart
@@ -201,6 +201,12 @@ void main() {
     await service.initialize();
   });
 
+  tearDown(() async {
+    // Stop any active watch so its refresh/liveness timers cannot fire
+    // in a later test against that test's replaced UniversalBle fake.
+    await service.stopDeviceWatch();
+  });
+
   ({ScanFilter? filter, PlatformConfig? config}) lastStart() =>
       platform.startScanCalls.last;
 
@@ -553,6 +559,9 @@ void main() {
               'a refresh that cannot restart the scan leaves the '
               'watch dead — it must be reported, not swallowed',
         );
+
+        zoned.stopDeviceWatch();
+        async.flushMicrotasks();
       });
     });
 


### PR DESCRIPTION
## Summary

- Problem: field reports of the preferred scale sometimes never auto-connecting until a manual tap, with the log showing `Background device watch started` and then silence. The watch's native scan can die without anything reaching Dart.
- Why it matters: the background scale watch (#447) is the only auto-reconnect mechanism on Android; when its scan dies silently, scale reacquisition is dead for up to 25 minutes (the opportunistic-downgrade refresh) or until a manual connect.
- What changed: while the watch believes its scan is running, it probes `UniversalBle.isScanning()` every 90s (host-side bookkeeping check — zero radio cost). A dead scan is torn down and restarted through the existing `_restartWatchOrReportFailure` path, so a restart that also fails feeds the legacy-backoff fallback instead of dying silently. Probe errors count as alive — an unprovable probe must not churn the session. `ScaleWatch`'s sighting log moves to INFO so field logs distinguish armed-but-no-sighting from sighted-but-connect-failed.
- What did NOT change (scope boundary): burst scans, watch arming policy, ConnectionManager, and the fork itself are untouched. No file overlap with #476 — complementary (#476 reduces the scan churn that triggers one of the death mechanisms; this detects and recovers when it happens anyway).

## Root cause (in the fork, observed from this repo)

- `SafeScanner`'s scan-frequency throttle (>5 starts/30s) swallows a start entirely: the Dart call returns success while the real start is deferred — and a later `stopScan` cancels the deferral (`handler.removeCallbacksAndMessages(null)`). Busy periods strand `_watchScanActive = true` with no native scan and none coming.
- `onScanFailed` is logged Kotlin-side and never surfaced to Dart.

Coverage note (honest limits): `isScanning()` reflects SafeScanner's host-side bookkeeping, so the probe reliably catches the throttle-swallow case (bookkeeping never went true). A late `onScanFailed` does not clear that bookkeeping today, so that flavor stays bounded by the 25-min refresh until the fork surfaces scan failures — candidate fork follow-up: update SafeScanner state in `onScanFailed` and/or emit a scan-state event.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [x] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs

## Linked Issues

- Related #447 (background scale watch), #476 (scan-session hardening — complementary, no file overlap)

## Root Cause (if bug fix)

- Root cause: see fork mechanisms above — the watch had no way to observe a native scan that stopped existing after a successful-looking start.
- Missing detection or guardrail: no liveness verification between the 25-minute refreshes.
- Contributing context: scan start/stop churn (machine reconnects, bursts, watch pause/resume) is what trips the SafeScanner throttle; #476 reduces that churn.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/services/universal_ble_discovery_service_test.dart` — `resilience` group: "the liveness probe restarts a silently dead native scan", "a live scan passes the liveness probe untouched". The fake platform now mirrors native scanner state (`nativeScanning`), so tests simulate silent death by flipping it without a stop call.
- Scenario the test should lock in: watch active + native scan gone → fresh filtered start within one probe interval; healthy scan → zero session churn across many probe intervals.
- If no new test added, why not: N/A

## Documentation Obligations (required)

- [ ] API spec updated
- [ ] API docs updated
- [ ] Plugin docs updated
- [ ] Skin docs updated
- [ ] Profile docs updated
- [x] Device docs updated
- [ ] N/A — internal watch-lifecycle hardening; DeviceManagement.md's watch section already describes self-healing at this level of detail

## Security Impact (required)

- New or changed REST endpoints? No
- New or changed WebSocket topics? No
- New or changed network calls? No
- BLE/USB surface changed? Yes
- File system access changed? No
- Plugin sandbox boundary changed? No
- If any `Yes`, explain risk and mitigation: adds a 90s host-side `isScanning()` poll while the watch runs (queue command, no radio activity) and a scan restart when it reports dead. Worst case under a persistently failing stack is one restart attempt per 90s, which SafeScanner's own throttle bounds.

## User-Visible Changes

- Android: a preferred scale powered on after the watch's scan silently died now connects within ~90s + discovery time instead of up to 25 minutes / manual tap.
- One new INFO log line per watch-driven reconnect (`Preferred scale … sighted`).

## Compatibility & Migration

- Backward compatible? Yes
- Config / env changes needed? No
- Database migration needed? No

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (re-run after rebase onto merged #476)
- [x] `flutter test` — all pass (2402 passing, 0 failures on the rebased branch; discovery/watch + connection/wake/Bengle suites 185/185)
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds

### Manual verification (if applicable)

- OS / platform tested: unit-tested against the fake platform; tablet soak pending (needs a naturally-occurring silent death or an adb-forced one — the triggering condition is timing-dependent by nature)
- Simulated devices? No (watch is BLE/Android-scoped)
- Real hardware? Field report drove the diagnosis; the fix's on-device validation is the next scale-off/on cycle on the reporter's tablet
- What you did **not** verify: a real SafeScanner throttle event end-to-end on hardware

### Evidence

- [x] Test output — probe test fails RED without the probe (scan stays dead), passes with it
- [x] Log snippets — field log shows `Background device watch started (prefix: null)` with no subsequent sighting despite the scale advertising (manual tap connected it immediately)

## Risks & Mitigations

- Risk: probe restarts churn the scan session on false "dead" readings.
  - Mitigation: probe errors count as alive; restart only on an explicit `isScanning() == false`; state re-checked after the await so bursts/stops that took over are respected.
- Risk: restart loop under a persistently broken stack.
  - Mitigation: every restart routes through `_restartWatchOrReportFailure` — a failing restart reports watch-unavailable and activates the legacy backoff fallback.

