### PR TITLE
fix(bengle): salvage model guards, MMR corrections, schema, and experimental MTU

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -5050,7 +5050,7 @@ components:
           type: array
           items:
             type: string
-            enum: [machine, scale, sensor]
+            enum: [machine, scale, sensor, bengle]
           nullable: true
         themeMode:
           description: App theme mode
@@ -5140,7 +5140,7 @@ components:
           type: array
           items:
             type: string
-            enum: [machine, scale, sensor]
+            enum: [machine, scale, sensor, bengle]
         themeMode:
           description: App theme mode
           type: string

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -259,7 +259,8 @@ void main(List<String> args) async {
   // (Windows, macOS, iOS, Android, and Linux as of Phase 3) runs on the single
   // universal_ble stack. Linux uses universal_ble's pure-Dart BlueZ backend.
   // See doc/plans/flutter-blue-plus-to-universal-ble-migration.md.
-  bleDiscoveryService = UniversalBleDiscoveryService();
+  final universalBleDiscoveryService = UniversalBleDiscoveryService();
+  bleDiscoveryService = universalBleDiscoveryService;
   if (!cliArgs.serial) {
     services.add(bleDiscoveryService);
   } else {
@@ -544,6 +545,8 @@ void main(List<String> args) async {
     };
   });
   await settingsController.loadSettings();
+  universalBleDiscoveryService.requestLargeMtuNonAndroid = settingsController
+      .isFeatureFlagEnabled(FeatureFlag.largeBleMtuNonAndroid);
 
   // CLI overrides — apply after loadSettings so they overwrite any persisted
   // values and persist themselves.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -65,7 +65,6 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:window_manager/window_manager.dart';
 
 import 'package:reaprime/src/controllers/scan_state_guardian.dart';
-import 'package:reaprime/src/services/ble/ble_discovery_service.dart';
 
 import 'src/app.dart';
 import 'src/launcher/launcher_view.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -252,15 +252,7 @@ void main(List<String> args) async {
 
   final List<DeviceDiscoveryService> services = [];
 
-  // Every platform always has exactly one BLE service.
-  final BleDiscoveryService bleDiscoveryService;
-
-  // flutter_blue_plus → universal_ble migration complete: every platform
-  // (Windows, macOS, iOS, Android, and Linux as of Phase 3) runs on the single
-  // universal_ble stack. Linux uses universal_ble's pure-Dart BlueZ backend.
-  // See doc/plans/flutter-blue-plus-to-universal-ble-migration.md.
-  final universalBleDiscoveryService = UniversalBleDiscoveryService();
-  bleDiscoveryService = universalBleDiscoveryService;
+  final bleDiscoveryService = UniversalBleDiscoveryService();
   if (!cliArgs.serial) {
     services.add(bleDiscoveryService);
   } else {
@@ -545,8 +537,8 @@ void main(List<String> args) async {
     };
   });
   await settingsController.loadSettings();
-  universalBleDiscoveryService.requestLargeMtuNonAndroid = settingsController
-      .isFeatureFlagEnabled(FeatureFlag.largeBleMtuNonAndroid);
+  bleDiscoveryService.requestLargeMtuNonAndroid = () =>
+      settingsController.isFeatureFlagEnabled(.largeBleMtuNonAndroid);
 
   // CLI overrides — apply after loadSettings so they overwrite any persisted
   // values and persist themselves.

--- a/lib/src/models/device/impl/bengle/bengle.dart
+++ b/lib/src/models/device/impl/bengle/bengle.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/foundation.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
@@ -112,7 +110,7 @@ class Bengle extends UnifiedDe1
   Future<void> onConnect() async {
     await super.onConnect();
     if (!isBengleModelValue(connectedModelValue)) {
-      unawaited(dispose());
+      await dispose();
       throw DeviceIdentityMismatchException(
         expected: 'Bengle',
         actualModelValue: connectedModelValue,

--- a/lib/src/models/device/impl/bengle/bengle.dart
+++ b/lib/src/models/device/impl/bengle/bengle.dart
@@ -2,8 +2,10 @@ import 'package:flutter/foundation.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle_mmr.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/errors.dart';
 import 'package:rxdart/rxdart.dart';
 
 class Bengle extends UnifiedDe1
@@ -53,8 +55,9 @@ class Bengle extends UnifiedDe1
   // another MMR slot).
   final BehaviorSubject<double> _stopAtTempTarget =
       BehaviorSubject<double>.seeded(0.0);
-  final BehaviorSubject<bool> _probeAttached =
-      BehaviorSubject<bool>.seeded(false);
+  final BehaviorSubject<bool> _probeAttached = BehaviorSubject<bool>.seeded(
+    false,
+  );
   final PublishSubject<double> _probeTemperature = PublishSubject<double>();
   int _stopAtTempStubWarningsEmitted = 0;
 
@@ -76,7 +79,8 @@ class Bengle extends UnifiedDe1
     final addr = BengleSteamMmr.stopAtTemperatureTarget;
     if (addr.address == 0x00000000) {
       _logStopAtTempStubOnce(
-          'setStopAtTemperatureTarget($clamped) ignored. Awaiting FW.');
+        'setStopAtTemperatureTarget($clamped) ignored. Awaiting FW.',
+      );
       return;
     }
     await writeMmrScaled(addr, clamped);
@@ -107,6 +111,12 @@ class Bengle extends UnifiedDe1
   @override
   Future<void> onConnect() async {
     await super.onConnect();
+    if (!isBengleModelValue(connectedModelValue)) {
+      throw DeviceIdentityMismatchException(
+        expected: 'Bengle',
+        actualModelValue: connectedModelValue,
+      );
+    }
     await initIntegratedScale();
     await initLedStrip();
   }

--- a/lib/src/models/device/impl/bengle/bengle.dart
+++ b/lib/src/models/device/impl/bengle/bengle.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
@@ -106,12 +108,11 @@ class Bengle extends UnifiedDe1
     }
   }
 
-  // --- integrated scale lifecycle ---
-
   @override
   Future<void> onConnect() async {
     await super.onConnect();
     if (!isBengleModelValue(connectedModelValue)) {
+      unawaited(dispose());
       throw DeviceIdentityMismatchException(
         expected: 'Bengle',
         actualModelValue: connectedModelValue,

--- a/lib/src/models/device/impl/de1/de1.models.dart
+++ b/lib/src/models/device/impl/de1/de1.models.dart
@@ -73,7 +73,9 @@ enum De1StateEnum {
   inBootLoader(0x13), // Bootloader is active, firmware has not run
   airPurge(0x14), // Air purge
   schedIdle(0x15), // Scheduled wake-up idle state
-  fwUpgrade(0x16), // FirmwareUp (corrected from 0x22, which was never a wire value)
+  fwUpgrade(
+    0x16,
+  ), // FirmwareUp (corrected from 0x22, which was never a wire value)
   unknown(-1); // Default or unknown state
 
   final int hexValue;
@@ -296,6 +298,8 @@ enum MMRItem implements MmrAddress {
     4,
     MmrValueKind.scaledFloat,
     "Seconds of high steam flow * 100. Valid range 0.0 - 4.0. 0 may result in an overheated heater. Be careful.",
+    readScale: 0.01,
+    writeScale: 100.0,
   ),
   serialN(0x00803830, 4, MmrValueKind.int32, "Current serial number"),
   heaterV(
@@ -397,6 +401,8 @@ enum MMRItem implements MmrAddress {
   String get name => (this as Enum).name;
 }
 
+bool isBengleModelValue(int value) => value >= 128;
+
 enum DecentMachineModel {
   DE1Pro,
   DE1XL,
@@ -415,10 +421,10 @@ enum DecentMachineModel {
         return DecentMachineModel.DE1XXL;
       case 6:
         return DecentMachineModel.DE1XXXL;
-      case 128:
-        return DecentMachineModel.Bengle;
       default:
-        return DecentMachineModel.Unknown;
+        return isBengleModelValue(model)
+            ? DecentMachineModel.Bengle
+            : DecentMachineModel.Unknown;
     }
   }
 }

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -12,7 +12,6 @@ import 'package:reaprime/src/models/device/de1_rawmessage.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/firmware_update_state.dart';
-import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.utils.dart';
 import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
@@ -237,7 +236,7 @@ class UnifiedDe1 implements De1Interface {
 
     final model = _unpackMMRInt(await _mmrRead(MMRItem.v13Model));
     _connectedModelValue = model;
-    if (isBengleModelValue(model) && this is! Bengle) {
+    if (isBengleModelValue(model) && implementation != .bengle) {
       _log.warning(
         'Device model $model indicates Bengle hardware; '
         'continuing in degraded DE1-compatible mode.',

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -215,6 +215,10 @@ class UnifiedDe1 implements De1Interface {
   int _voltage = -1;
   int _refillKit = -1;
   double? _cachedFlowEstimation;
+  int? _connectedModelValue;
+
+  @protected
+  int get connectedModelValue => _connectedModelValue!;
 
   @override
   Future<void> onConnect() async {
@@ -231,10 +235,11 @@ class UnifiedDe1 implements De1Interface {
     }
 
     final model = _unpackMMRInt(await _mmrRead(MMRItem.v13Model));
-    if (model >= 128) {
+    _connectedModelValue = model;
+    if (isBengleModelValue(model)) {
       _log.warning(
-        'Device model $model indicates non-DE1 hardware '
-        '(Bengle or similar). Advertised name may be misleading.',
+        'Device model $model indicates Bengle hardware; '
+        'continuing in degraded DE1-compatible mode.',
       );
     }
     final ghcInfo = _unpackMMRInt(await _mmrRead(MMRItem.ghcInfo));

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -12,6 +12,7 @@ import 'package:reaprime/src/models/device/de1_rawmessage.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/firmware_update_state.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.utils.dart';
 import 'package:reaprime/src/models/device/impl/de1/mmr_address.dart';
@@ -236,7 +237,7 @@ class UnifiedDe1 implements De1Interface {
 
     final model = _unpackMMRInt(await _mmrRead(MMRItem.v13Model));
     _connectedModelValue = model;
-    if (isBengleModelValue(model)) {
+    if (isBengleModelValue(model) && this is! Bengle) {
       _log.warning(
         'Device model $model indicates Bengle hardware; '
         'continuing in degraded DE1-compatible mode.',

--- a/lib/src/models/errors.dart
+++ b/lib/src/models/errors.dart
@@ -5,8 +5,9 @@ class PermissionDeniedException implements Exception {
   const PermissionDeniedException([this.message]);
 
   @override
-  String toString() =>
-      message == null ? 'PermissionDeniedException' : 'PermissionDeniedException: $message';
+  String toString() => message == null
+      ? 'PermissionDeniedException'
+      : 'PermissionDeniedException: $message';
 }
 
 /// Which kind of device produced a [DeviceNotConnectedException].
@@ -31,6 +32,20 @@ class DeviceNotConnectedException implements Exception {
   @override
   String toString() =>
       'DeviceNotConnectedException: ${kind.name} not connected';
+}
+
+class DeviceIdentityMismatchException implements Exception {
+  final String expected;
+  final int actualModelValue;
+
+  const DeviceIdentityMismatchException({
+    required this.expected,
+    required this.actualModelValue,
+  });
+
+  @override
+  String toString() =>
+      'DeviceIdentityMismatchException: expected $expected, got v13Model=$actualModelValue';
 }
 
 /// Recorded as a non-fatal (never thrown) when `UnifiedDe1Transport.connect`
@@ -76,7 +91,8 @@ class MmrTimeoutException implements Exception {
 /// streaming response.
 class FirmwareUpdateInProgressException implements Exception {
   @override
-  String toString() => 'FirmwareUpdateInProgressException: a firmware '
+  String toString() =>
+      'FirmwareUpdateInProgressException: a firmware '
       'update is already in progress';
 }
 
@@ -86,7 +102,8 @@ class FirmwareUpdateCancelledException implements Exception {
   const FirmwareUpdateCancelledException();
 
   @override
-  String toString() => 'FirmwareUpdateCancelledException: firmware update '
+  String toString() =>
+      'FirmwareUpdateCancelledException: firmware update '
       'was cancelled';
 }
 

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -59,13 +59,21 @@ class UniversalBleTransport implements BLETransport {
   static const int _bluezDiscoveryRetries = 3;
   static const Duration _bluezDiscoveryRetryDelay = Duration(seconds: 1);
 
-  bool get _isLinux => Platform.isLinux;
+  bool get _isAndroid => _isAndroidOverride ?? Platform.isAndroid;
+  bool get _isLinux => _isLinuxOverride ?? Platform.isLinux;
 
   UniversalBleTransport({
     required BleDevice device,
     Future<void> Function()? stopScan,
+    bool requestLargeMtuNonAndroid = false,
+    bool? isAndroidOverride,
+    bool? isLinuxOverride,
   })  : _device = device,
-        _stopScan = stopScan {
+        _stopScan = stopScan,
+        _requestLargeMtuNonAndroid = requestLargeMtuNonAndroid,
+        _isAndroidOverride = isAndroidOverride,
+        _isLinuxOverride = isLinuxOverride {
+
     _log = Logger("BLETransport-${device.deviceId}");
   }
 
@@ -76,6 +84,9 @@ class UniversalBleTransport implements BLETransport {
   /// is already stopped. Falls back to a direct platform stop for
   /// transports constructed without a service.
   final Future<void> Function()? _stopScan;
+  final bool _requestLargeMtuNonAndroid;
+  final bool? _isAndroidOverride;
+  final bool? _isLinuxOverride;
 
   Future<void> _stopScanViaOwner() =>
       _stopScan?.call() ?? UniversalBle.stopScan();
@@ -121,7 +132,7 @@ class UniversalBleTransport implements BLETransport {
     // as the BlueZ le-connection-abort-by-local mitigation above; observed
     // 2026-07-15 as repeated 10s connect timeouts to an advertising scale
     // mid-scan). The ConnectionManager retry loop restarts scanning.
-    if (Platform.isAndroid) {
+    if (_isAndroid) {
       try {
         _log.fine("stopping scan before connect");
         await _stopScanViaOwner();
@@ -144,12 +155,10 @@ class UniversalBleTransport implements BLETransport {
     }
     _startAdvertWatch();
 
-    // Android: post-connect settle + MTU bump.
-    // The 200ms settle avoids service-discovery races on tablet SoCs
-    // where the BLE stack finalises GATT setup asynchronously after
-    // connect. MTU 517 reduces GATT round-trips for reads/writes.
-    if (!_isLinux && Platform.isAndroid) {
+    if (_isAndroid) {
       await Future.delayed(_androidPostConnectDelay);
+    }
+    if (!_isLinux && (_isAndroid || _requestLargeMtuNonAndroid)) {
       try {
         await UniversalBle.requestMtu(
           _device.deviceId,

--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -9,6 +9,7 @@ import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_attach_notifier.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale_serial.dart';
 import 'package:reaprime/src/models/device/impl/sensor/debug_port.dart';
@@ -431,7 +432,8 @@ class SerialServiceAndroid
               break;
             }
           }
-          final isBengle = v13Model != null && v13Model >= 128;
+          final isBengle =
+              v13Model != null && isBengleModelValue(v13Model);
           _log.info(
               "Detected: ${isBengle ? 'Bengle' : 'DE1'} (v13Model=$v13Model)");
           return isBengle

--- a/lib/src/services/serial/serial_service_desktop.dart
+++ b/lib/src/services/serial/serial_service_desktop.dart
@@ -8,6 +8,7 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale_serial.dart';
 import 'package:reaprime/src/models/device/impl/sensor/debug_port.dart';
@@ -598,7 +599,8 @@ class SerialServiceDesktop implements DeviceDiscoveryService {
             }
           }
 
-          final isBengle = v13Model != null && v13Model >= 128;
+          final isBengle =
+              v13Model != null && isBengleModelValue(v13Model);
           _log.info(
               "Detected: ${isBengle ? 'Bengle' : 'DE1'} (v13Model=$v13Model)");
           final device = isBengle

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -12,6 +12,7 @@ import 'package:reaprime/src/services/device_factory.dart';
 import 'package:reaprime/src/services/device_matcher.dart';
 import 'package:reaprime/src/models/device/device_watch.dart';
 import 'package:reaprime/src/models/device/watch_filter.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:universal_ble/universal_ble.dart';
 import '../models/device/device.dart';
@@ -19,20 +20,49 @@ import '../models/device/machine.dart';
 import '../models/device/impl/de1/de1.models.dart';
 import 'package:logging/logging.dart' as logging;
 
+typedef BleTransportFactory = BLETransport Function({
+  required BleDevice device,
+  required Future<void> Function() stopScan,
+  required bool requestLargeMtuNonAndroid,
+});
+
 class UniversalBleDiscoveryService extends BleDiscoveryService
     implements DeviceWatchCapable {
-  /// [watchSupportGate] gates [supportsDeviceWatch]. Defaults to
-  /// Android-only: the background watch relies on `AndroidScanMode`
-  /// duty cycles; CoreBluetooth has no equivalent knob and a
-  /// continuous scan there is battery-hostile. Injectable so host
-  /// tests (where `Platform.isAndroid` is false) can exercise the
-  /// watch path.
-  UniversalBleDiscoveryService({bool Function()? watchSupportGate, bool Function()? requestLargeMtuNonAndroid})
-    : _watchSupportGate = watchSupportGate ?? (() => Platform.isAndroid),
-    requestLargeMtuNonAndroid = requestLargeMtuNonAndroid ?? (() => false);
+    UniversalBleDiscoveryService({
+    bool Function()? watchSupportGate,
+    bool Function()? requestLargeMtuNonAndroid,
+    BleTransportFactory? transportFactory,
+  }) : _watchSupportGate =
+           watchSupportGate ?? (() => Platform.isAndroid),
+       requestLargeMtuNonAndroid =
+           requestLargeMtuNonAndroid ?? (() => false),
+       _transportFactory =
+           transportFactory ?? _defaultTransportFactory;
+
+  static BLETransport _defaultTransportFactory({
+    required BleDevice device,
+    required Future<void> Function() stopScan,
+    required bool requestLargeMtuNonAndroid,
+  }) {
+    return UniversalBleTransport(
+      device: device,
+      stopScan: stopScan,
+      requestLargeMtuNonAndroid: requestLargeMtuNonAndroid,
+    );
+  }
 
   final bool Function() _watchSupportGate;
+  final BleTransportFactory _transportFactory;
+
   bool Function() requestLargeMtuNonAndroid;
+
+  BLETransport _createTransport(BleDevice device) {
+    return _transportFactory(
+      device: device,
+      stopScan: _stopScanForConnect,
+      requestLargeMtuNonAndroid: requestLargeMtuNonAndroid(),
+    );
+  }
 
   @override
   bool get supportsDeviceWatch => _watchSupportGate();
@@ -534,11 +564,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
       if (_devices.containsKey(device.deviceId.toString())) return;
 
       final matchedDevice = await DeviceMatcher.match(
-        transport: UniversalBleTransport(
-          device: device,
-          stopScan: _stopScanForConnect,
-          requestLargeMtuNonAndroid: requestLargeMtuNonAndroid(),
-        ),
+        transport: _createTransport(device),
         advertisedName: name,
       );
 
@@ -582,11 +608,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
       bleDevice = BleDevice(deviceId: deviceId, name: remembered.name);
     }
 
-    final transport = UniversalBleTransport(
-      device: bleDevice,
-      stopScan: _stopScanForConnect,
-      requestLargeMtuNonAndroid: requestLargeMtuNonAndroid(),
-    );
+    final transport = _createTransport(bleDevice);
     final device = DeviceFactory.createBle(impl, transport);
     if (device == null) {
       log.warning('Quick-connect: DeviceFactory returned null for $impl');

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -31,6 +31,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
       : _watchSupportGate = watchSupportGate ?? (() => Platform.isAndroid);
 
   final bool Function() _watchSupportGate;
+  bool requestLargeMtuNonAndroid = false;
 
   @override
   bool get supportsDeviceWatch => _watchSupportGate();
@@ -362,7 +363,9 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     });
 
     if (initialState != AvailabilityState.poweredOn) {
-      log.warning("Bluetooth not supported on this platform, state: ${initialState.name}");
+      log.warning(
+        "Bluetooth not supported on this platform, state: ${initialState.name}",
+      );
     }
   }
 
@@ -533,6 +536,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
         transport: UniversalBleTransport(
           device: device,
           stopScan: _stopScanForConnect,
+          requestLargeMtuNonAndroid: requestLargeMtuNonAndroid,
         ),
         advertisedName: name,
       );
@@ -580,6 +584,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     final transport = UniversalBleTransport(
       device: bleDevice,
       stopScan: _stopScanForConnect,
+      requestLargeMtuNonAndroid: requestLargeMtuNonAndroid,
     );
     final device = DeviceFactory.createBle(impl, transport);
     if (device == null) {
@@ -598,8 +603,12 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
             'Quick-connect: identity mismatch for $deviceId '
             '(expected ${impl.name}, got model=$model)',
           );
-          try { await device.disconnect(); } catch (_) {}
-          try { await transport.dispose(); } catch (_) {}
+          try {
+            await device.disconnect();
+          } catch (_) {}
+          try {
+            await transport.dispose();
+          } catch (_) {}
           return null;
         }
       }

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -27,11 +27,12 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
   /// continuous scan there is battery-hostile. Injectable so host
   /// tests (where `Platform.isAndroid` is false) can exercise the
   /// watch path.
-  UniversalBleDiscoveryService({bool Function()? watchSupportGate})
-      : _watchSupportGate = watchSupportGate ?? (() => Platform.isAndroid);
+  UniversalBleDiscoveryService({bool Function()? watchSupportGate, bool Function()? requestLargeMtuNonAndroid})
+    : _watchSupportGate = watchSupportGate ?? (() => Platform.isAndroid),
+    requestLargeMtuNonAndroid = requestLargeMtuNonAndroid ?? (() => false);
 
   final bool Function() _watchSupportGate;
-  bool requestLargeMtuNonAndroid = false;
+  bool Function() requestLargeMtuNonAndroid;
 
   @override
   bool get supportsDeviceWatch => _watchSupportGate();
@@ -536,7 +537,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
         transport: UniversalBleTransport(
           device: device,
           stopScan: _stopScanForConnect,
-          requestLargeMtuNonAndroid: requestLargeMtuNonAndroid,
+          requestLargeMtuNonAndroid: requestLargeMtuNonAndroid(),
         ),
         advertisedName: name,
       );
@@ -584,7 +585,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     final transport = UniversalBleTransport(
       device: bleDevice,
       stopScan: _stopScanForConnect,
-      requestLargeMtuNonAndroid: requestLargeMtuNonAndroid,
+      requestLargeMtuNonAndroid: requestLargeMtuNonAndroid(),
     );
     final device = DeviceFactory.createBle(impl, transport);
     if (device == null) {
@@ -603,13 +604,15 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
             'Quick-connect: identity mismatch for $deviceId '
             '(expected ${impl.name}, got model=$model)',
           );
-          try {
-            await device.disconnect();
-          } catch (_) {}
-          try {
-            await transport.dispose();
-          } catch (_) {}
-          return null;
+          if (expectedBengle && !actualBengle) {
+            try {
+              await device.disconnect();
+            } catch (_) {}
+            try {
+              await transport.dispose();
+            } catch (_) {}
+            return null;
+          }
         }
       }
       _devices[deviceId] = device;

--- a/lib/src/settings/advanced_page.dart
+++ b/lib/src/settings/advanced_page.dart
@@ -139,6 +139,37 @@ class AdvancedPage extends StatelessWidget {
                 ),
               ),
               const SettingsDivider(),
+              if (Platform.isIOS || Platform.isMacOS || Platform.isWindows) 
+              ...{
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
+                child: ShadSwitch(
+                  value: controller
+                      .isFeatureFlagEnabled(.largeBleMtuNonAndroid),
+                  onChanged: (v) async {
+                    await controller.setFeatureFlag(
+                      FeatureFlag.largeBleMtuNonAndroid,
+                      v,
+                    );
+                  },
+                  label: const Text('Use MTU value of 517'),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                ),
+                child: Text(
+                  'Will try to negotiate a larger MTU value '
+                  'for Bluetooth connections. ',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ),
+              const SettingsDivider(),
+              },
 
               // Simulated devices
               Padding(

--- a/lib/src/settings/feature_flags.dart
+++ b/lib/src/settings/feature_flags.dart
@@ -18,6 +18,10 @@ enum FeatureFlag {
   /// Default: **true** (opt-out — 10-shot validation gate passed;
   /// mean |Δyield| 0.44g ≤ 1g baseline, flow noise 8–13% vs 14.7% old).
   kalmanFlow,
+
+  /// Requests MTU 517 on native platforms other than Android and Linux.
+  /// Android already requests it unconditionally; BlueZ owns Linux MTU.
+  largeBleMtuNonAndroid,
 }
 
 /// Default values for each flag. Flags that ship as "on" default to true;
@@ -25,4 +29,5 @@ enum FeatureFlag {
 const Map<FeatureFlag, bool> defaultFeatureFlagValues = {
   FeatureFlag.stepExitArbiter: true,
   FeatureFlag.kalmanFlow: true,
+  FeatureFlag.largeBleMtuNonAndroid: false,
 };

--- a/test/rest_simulated_bengle_schema_test.dart
+++ b/test/rest_simulated_bengle_schema_test.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('REST request and response schemas accept simulated Bengle', () async {
+    final spec = await File('assets/api/rest_v1.yml').readAsString();
+    expect(
+      RegExp(
+        r'enum: \[machine, scale, sensor, bengle\]',
+      ).allMatches(spec).length,
+      2,
+    );
+  });
+}

--- a/test/services/ble/universal_ble_transport_mtu_test.dart
+++ b/test/services/ble/universal_ble_transport_mtu_test.dart
@@ -1,0 +1,191 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/ble/universal_ble_transport.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+class _MtuRecordingBlePlatform extends UniversalBlePlatform {
+  /// Recorded (deviceId, expectedMtu) pairs from [requestMtu].
+  final List<(String, int)> mtuRequests = [];
+
+  /// When true, [requestMtu] throws — simulating a stack that rejects the
+  /// negotiation.
+  bool throwOnRequestMtu = false;
+
+  @override
+  Future<int> requestMtu(String deviceId, int expectedMtu) async {
+    mtuRequests.add((deviceId, expectedMtu));
+    if (throwOnRequestMtu) {
+      throw UniversalBleException(
+        code: UniversalBleErrorCode.failed,
+        message: 'simulated MTU negotiation failure',
+      );
+    }
+    return expectedMtu;
+  }
+
+  @override
+  Future<AvailabilityState> getBluetoothAvailabilityState() async =>
+      AvailabilityState.poweredOn;
+
+  @override
+  Future<bool> enableBluetooth() async => true;
+
+  @override
+  Future<bool> disableBluetooth() async => false;
+
+  @override
+  Future<void> startScan({
+    ScanFilter? scanFilter,
+    PlatformConfig? platformConfig,
+  }) async {}
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  Future<bool> isScanning() async => false;
+
+  @override
+  Future<void> connect(
+    String deviceId, {
+    Duration? connectionTimeout,
+    bool autoConnect = false,
+  }) async {
+    updateConnection(deviceId, true);
+  }
+
+  @override
+  Future<void> disconnect(String deviceId) async {
+    updateConnection(deviceId, false);
+  }
+
+  @override
+  Future<List<BleService>> discoverServices(
+    String deviceId,
+    bool withDescriptors,
+  ) async => [];
+
+  @override
+  Future<void> setNotifiable(
+    String deviceId,
+    String service,
+    String characteristic,
+    BleInputProperty bleInputProperty,
+  ) async {}
+
+  @override
+  Future<Uint8List> readValue(
+    String deviceId,
+    String service,
+    String characteristic, {
+    Duration? timeout,
+  }) async => Uint8List(0);
+
+  @override
+  Future<void> writeValue(
+    String deviceId,
+    String service,
+    String characteristic,
+    Uint8List value,
+    BleOutputProperty bleOutputProperty,
+  ) async {}
+
+  @override
+  Future<int> readRssi(String deviceId) async => -50;
+
+  @override
+  Future<void> requestConnectionPriority(
+    String deviceId,
+    BleConnectionPriority priority,
+  ) async {}
+
+  @override
+  Future<bool> isPaired(String deviceId) async => false;
+
+  @override
+  Future<bool> pair(String deviceId) async => true;
+
+  @override
+  Future<void> unpair(String deviceId) async {}
+
+  @override
+  Future<BleConnectionState> getConnectionState(String deviceId) async =>
+      BleConnectionState.connected;
+
+  @override
+  Future<List<BleDevice>> getSystemDevices(
+    List<String>? withServices,
+  ) async => [];
+}
+
+void main() {
+  late _MtuRecordingBlePlatform platform;
+  var deviceCounter = 0;
+  late String deviceId;
+
+  setUp(() {
+    platform = _MtuRecordingBlePlatform();
+    UniversalBle.setInstance(platform);
+    UniversalBle.clearQueue();
+    // Unique id per test so per-device queue state can't bleed over.
+    deviceId = 'AA:BB:CC:DD:FF:${(deviceCounter++).toString().padLeft(2, '0')}';
+  });
+
+  UniversalBleTransport transport({
+    required bool android,
+    required bool linux,
+    bool flag = false,
+  }) => UniversalBleTransport(
+    device: BleDevice(deviceId: deviceId, name: 'Bengle'),
+    isAndroidOverride: android,
+    isLinuxOverride: linux,
+    requestLargeMtuNonAndroid: flag,
+  );
+
+  test('Android requests 517 once with the flag off or on', () async {
+    for (final flag in [false, true]) {
+      final value = transport(android: true, linux: false, flag: flag);
+      await value.connect();
+      await value.dispose();
+    }
+
+    expect(platform.mtuRequests, [(deviceId, 517), (deviceId, 517)]);
+  });
+
+  test('Linux never requests an MTU', () async {
+    final value = transport(android: false, linux: true, flag: true);
+    await value.connect();
+    expect(platform.mtuRequests, isEmpty);
+    await value.dispose();
+  });
+
+  test('other native platforms request only when the flag is on', () async {
+    var value = transport(android: false, linux: false);
+    await value.connect();
+    await value.dispose();
+    expect(platform.mtuRequests, isEmpty);
+
+    value = transport(android: false, linux: false, flag: true);
+    await value.connect();
+    expect(platform.mtuRequests, [(deviceId, 517)]);
+    await value.dispose();
+  });
+
+  test('failed negotiation does not fail connect', () async {
+    platform.throwOnRequestMtu = true;
+    final value = transport(android: false, linux: false, flag: true);
+    await value.connect();
+    expect(platform.mtuRequests, [(deviceId, 517)]);
+    await value.dispose();
+  });
+
+  test('reconnect requests once per physical connection', () async {
+    final value = transport(android: false, linux: false, flag: true);
+    await value.connect();
+    await value.disconnect();
+    await value.connect();
+    expect(platform.mtuRequests, [(deviceId, 517), (deviceId, 517)]);
+    await value.dispose();
+  });
+}

--- a/test/services/universal_ble_discovery_service_test.dart
+++ b/test/services/universal_ble_discovery_service_test.dart
@@ -3,15 +3,29 @@ import 'dart:typed_data';
 
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart' as domain;
 import 'package:reaprime/src/models/device/watch_filter.dart';
 import 'package:reaprime/src/services/universal_ble_discovery_service.dart';
 import 'package:universal_ble/universal_ble.dart';
 
+import 'package:reaprime/src/models/device/device_implementation.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/remembered_device.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:reaprime/src/settings/feature_flags.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+
+import '../helpers/fake_ble_transport.dart';
+import '../helpers/mock_settings_service.dart';
+
 /// Fake platform backend for universal_ble. The abstract base class
 /// already carries the stream plumbing (`updateScanResult`,
 /// `updateAvailability`); this fake records scan start/stop calls.
 class _FakeBlePlatform extends UniversalBlePlatform {
+  final List<BleDevice> systemDevices = [];
+
   final List<({ScanFilter? filter, PlatformConfig? config})> startScanCalls =
       [];
   int stopScanCalls = 0;
@@ -72,8 +86,7 @@ class _FakeBlePlatform extends UniversalBlePlatform {
   Future<List<BleService>> discoverServices(
     String deviceId,
     bool withDescriptors,
-  ) async =>
-      [];
+  ) async => [];
 
   @override
   Future<void> setNotifiable(
@@ -89,8 +102,7 @@ class _FakeBlePlatform extends UniversalBlePlatform {
     String service,
     String characteristic, {
     Duration? timeout,
-  }) async =>
-      Uint8List(0);
+  }) async => Uint8List(0);
 
   @override
   Future<void> writeValue(
@@ -129,8 +141,32 @@ class _FakeBlePlatform extends UniversalBlePlatform {
   @override
   Future<List<BleDevice>> getSystemDevices(
     List<String>? withServices,
-  ) async =>
-      [];
+  ) async {
+    return List<BleDevice>.unmodifiable(systemDevices);
+  }
+}
+
+class _TrackingFakeBleTransport extends FakeBleTransport {
+  int disconnectCalls = 0;
+  int disposeCalls = 0;
+  bool _disposed = false;
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCalls++;
+    if (!_disposed) {
+      await super.disconnect();
+    }
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposeCalls++;
+    if (_disposed) return;
+
+    _disposed = true;
+    await super.dispose();
+  }
 }
 
 const _watchFilter = DeviceWatchFilter(namePrefix: 'Decent Scale');
@@ -138,6 +174,12 @@ const _watchFilter = DeviceWatchFilter(namePrefix: 'Decent Scale');
 void main() {
   late _FakeBlePlatform platform;
   late UniversalBleDiscoveryService service;
+
+  _TrackingFakeBleTransport transportForModel(int model) {
+    return _TrackingFakeBleTransport()
+      ..queueOnConnectResponses(v13Model: model)
+      ..queueMmrResponseInt(MMRItem.calFlowEst, 100);
+  }
 
   Future<void> pump([int n = 3]) async {
     for (var i = 0; i < n; i++) {
@@ -217,8 +259,11 @@ void main() {
       final burst = service.scanForDevices();
       await pump();
       // Watch paused (one stopScan), burst started with lowLatency.
-      expect(platform.stopScanCalls, 1,
-          reason: 'the watch scan must be stopped before the burst starts');
+      expect(
+        platform.stopScanCalls,
+        1,
+        reason: 'the watch scan must be stopped before the burst starts',
+      );
       expect(platform.startScanCalls, hasLength(2));
       expect(
         lastStart().filter?.withNamePrefix,
@@ -230,45 +275,57 @@ void main() {
       await burst;
       await pump();
 
-      expect(platform.startScanCalls, hasLength(3),
-          reason: 'the watch must resume after the burst');
+      expect(
+        platform.startScanCalls,
+        hasLength(3),
+        reason: 'the watch must resume after the burst',
+      );
       expect(lastStart().filter?.withNamePrefix, ['Decent Scale']);
       expect(lastStart().config?.android?.scanMode, AndroidScanMode.balanced);
     });
 
-    test('startDeviceWatch during a burst defers until the burst ends',
-        () async {
-      final burst = service.scanForDevices();
-      await pump();
-      expect(platform.startScanCalls, hasLength(1)); // the burst itself
+    test(
+      'startDeviceWatch during a burst defers until the burst ends',
+      () async {
+        final burst = service.scanForDevices();
+        await pump();
+        expect(platform.startScanCalls, hasLength(1)); // the burst itself
 
+        await service.startDeviceWatch(_watchFilter);
+        expect(
+          platform.startScanCalls,
+          hasLength(1),
+          reason: 'watch start must not fight the in-flight burst',
+        );
+
+        service.stopScan();
+        await burst;
+        await pump();
+
+        expect(
+          platform.startScanCalls,
+          hasLength(2),
+          reason: 'the requested watch starts once the burst is done',
+        );
+        expect(lastStart().filter?.withNamePrefix, ['Decent Scale']);
+      },
+    );
+
+    test('external stopScan() with only the watch active is a no-op', () async {
       await service.startDeviceWatch(_watchFilter);
-      expect(platform.startScanCalls, hasLength(1),
-          reason: 'watch start must not fight the in-flight burst');
-
-      service.stopScan();
-      await burst;
-      await pump();
-
-      expect(platform.startScanCalls, hasLength(2),
-          reason: 'the requested watch starts once the burst is done');
-      expect(lastStart().filter?.withNamePrefix, ['Decent Scale']);
-    });
-
-    test('external stopScan() with only the watch active is a no-op',
-        () async {
-      await service.startDeviceWatch(_watchFilter);
       service.stopScan();
       await pump();
 
-      expect(platform.stopScanCalls, 0,
-          reason: 'stopScan means "stop burst" — it must not kill the watch');
+      expect(
+        platform.stopScanCalls,
+        0,
+        reason: 'stopScan means "stop burst" — it must not kill the watch',
+      );
     });
   });
 
   group('start-window races', () {
-    test(
-        'stopDeviceWatch during an in-flight start waits for it and '
+    test('stopDeviceWatch during an in-flight start waits for it and '
         'undoes the scan', () async {
       // stopDeviceWatch serializes against the in-flight start (it must
       // not act while session ownership is undecided), so the test
@@ -280,8 +337,11 @@ void main() {
       await pump();
       final stop = service.stopDeviceWatch();
       await pump();
-      expect(platform.stopScanCalls, 0,
-          reason: 'stop must wait for the start to settle first');
+      expect(
+        platform.stopScanCalls,
+        0,
+        reason: 'stop must wait for the start to settle first',
+      );
 
       hold.complete();
       await start;
@@ -289,54 +349,75 @@ void main() {
       await pump();
 
       expect(platform.startScanCalls, hasLength(1));
-      expect(platform.stopScanCalls, 1,
-          reason: 'the scan the raced start opened must be undone — '
-              'otherwise it runs orphaned forever');
+      expect(
+        platform.stopScanCalls,
+        1,
+        reason:
+            'the scan the raced start opened must be undone — '
+            'otherwise it runs orphaned forever',
+      );
     });
 
     test(
-        'a burst racing the watch start is serialized: the burst scan '
-        'starts only after the watch start settles and owns the session',
-        () async {
-      final hold = Completer<void>();
-      platform.holdNextStartScan = hold;
+      'a burst racing the watch start is serialized: the burst scan '
+      'starts only after the watch start settles and owns the session',
+      () async {
+        final hold = Completer<void>();
+        platform.holdNextStartScan = hold;
 
-      final start = service.startDeviceWatch(_watchFilter);
-      await pump();
-      final burst = service.scanForDevices();
-      await pump();
+        final start = service.startDeviceWatch(_watchFilter);
+        await pump();
+        final burst = service.scanForDevices();
+        await pump();
 
-      expect(platform.startScanCalls, isEmpty,
-          reason: 'the burst must wait for the in-flight watch start — '
+        expect(
+          platform.startScanCalls,
+          isEmpty,
+          reason:
+              'the burst must wait for the in-flight watch start — '
               'issuing its startScan concurrently leaves session '
-              'ownership undefined');
+              'ownership undefined',
+        );
 
-      hold.complete();
-      await start;
-      await pump();
+        hold.complete();
+        await start;
+        await pump();
 
-      // Ownership order: the watch start settles first, then the burst's
-      // startScan runs — the burst's unfiltered scan is the live native
-      // session for the whole burst.
-      final prefixes = platform.startScanCalls
-          .map((c) => c.filter?.withNamePrefix ?? const <String>[])
-          .toList();
-      expect(prefixes.first, ['Decent Scale'],
-          reason: 'the raced watch start settles before the burst starts');
-      expect(prefixes[1], isEmpty,
-          reason: 'the burst scan follows and owns the session');
+        // Ownership order: the watch start settles first, then the burst's
+        // startScan runs — the burst's unfiltered scan is the live native
+        // session for the whole burst.
+        final prefixes = platform.startScanCalls
+            .map((c) => c.filter?.withNamePrefix ?? const <String>[])
+            .toList();
+        expect(
+          prefixes.first,
+          ['Decent Scale'],
+          reason: 'the raced watch start settles before the burst starts',
+        );
+        expect(
+          prefixes[1],
+          isEmpty,
+          reason: 'the burst scan follows and owns the session',
+        );
 
-      service.stopScan(); // end the burst
-      await burst;
-      await pump();
+        service.stopScan(); // end the burst
+        await burst;
+        await pump();
 
-      expect(platform.startScanCalls, hasLength(3),
-          reason: 'the watch must resume after the burst');
-      expect(lastStart().filter?.withNamePrefix, ['Decent Scale'],
-          reason: 'the burst finally-block must resume a real watch scan, '
-              'not skip it because the raced start claimed to be active');
-    });
-
+        expect(
+          platform.startScanCalls,
+          hasLength(3),
+          reason: 'the watch must resume after the burst',
+        );
+        expect(
+          lastStart().filter?.withNamePrefix,
+          ['Decent Scale'],
+          reason:
+              'the burst finally-block must resume a real watch scan, '
+              'not skip it because the raced start claimed to be active',
+        );
+      },
+    );
   });
 
   group('resilience', () {
@@ -354,21 +435,28 @@ void main() {
       await start;
       await pump();
 
-      expect(platform.startScanCalls, hasLength(1),
-          reason: 'the raced start alone — nothing may claim active while '
-              'the adapter is off');
+      expect(
+        platform.startScanCalls,
+        hasLength(1),
+        reason:
+            'the raced start alone — nothing may claim active while '
+            'the adapter is off',
+      );
 
       platform.updateAvailability(AvailabilityState.poweredOn);
       await pump();
 
-      expect(platform.startScanCalls, hasLength(2),
-          reason: 'a still-requested watch must restart on power-on; a '
-              'stale active claim from the raced start would block this');
+      expect(
+        platform.startScanCalls,
+        hasLength(2),
+        reason:
+            'a still-requested watch must restart on power-on; a '
+            'stale active claim from the raced start would block this',
+      );
       expect(lastStart().filter?.withNamePrefix, ['Decent Scale']);
     });
 
-    test(
-        'adapter off AND on completing within the start window discards '
+    test('adapter off AND on completing within the start window discards '
         'the raced start and starts a fresh scan', () async {
       // The off/on transition may have killed the native scan the raced
       // start opened; its completion must never claim active. The
@@ -388,10 +476,14 @@ void main() {
       await start;
       await pump(6);
 
-      expect(platform.startScanCalls, hasLength(2),
-          reason: 'the raced start is discarded and a fresh start must '
-              'own the session — claiming active over a possibly-dead '
-              'native scan leaves the watch permanently silent');
+      expect(
+        platform.startScanCalls,
+        hasLength(2),
+        reason:
+            'the raced start is discarded and a fresh start must '
+            'own the session — claiming active over a possibly-dead '
+            'native scan leaves the watch permanently silent',
+      );
       expect(lastStart().filter?.withNamePrefix, ['Decent Scale']);
     });
 
@@ -407,18 +499,26 @@ void main() {
       await burst;
       await pump();
 
-      expect(failures, hasLength(1),
-          reason: 'a dead watch must be reported so ScaleWatch can fall '
-              'back to the legacy loop instead of staying silently armed');
+      expect(
+        failures,
+        hasLength(1),
+        reason:
+            'a dead watch must be reported so ScaleWatch can fall '
+            'back to the legacy loop instead of staying silently armed',
+      );
 
       // The request is cleared: adapter recovery must not resurrect it.
       platform.updateAvailability(AvailabilityState.poweredOff);
       await pump();
       platform.updateAvailability(AvailabilityState.poweredOn);
       await pump();
-      expect(platform.startScanCalls, hasLength(2),
-          reason: 'watch start + burst only — no resurrection after a '
-              'reported failure');
+      expect(
+        platform.startScanCalls,
+        hasLength(2),
+        reason:
+            'watch start + burst only — no resurrection after a '
+            'reported failure',
+      );
       await sub.cancel();
     });
 
@@ -439,9 +539,13 @@ void main() {
         async.elapse(const Duration(minutes: 26));
         async.flushMicrotasks();
 
-        expect(failures, hasLength(1),
-            reason: 'a refresh that cannot restart the scan leaves the '
-                'watch dead — it must be reported, not swallowed');
+        expect(
+          failures,
+          hasLength(1),
+          reason:
+              'a refresh that cannot restart the scan leaves the '
+              'watch dead — it must be reported, not swallowed',
+        );
       });
     });
 
@@ -454,9 +558,13 @@ void main() {
       platform.updateAvailability(AvailabilityState.poweredOn);
       await pump();
 
-      expect(platform.startScanCalls, hasLength(2),
-          reason: 'a still-requested watch must restart when the adapter '
-              'comes back');
+      expect(
+        platform.startScanCalls,
+        hasLength(2),
+        reason:
+            'a still-requested watch must restart when the adapter '
+            'comes back',
+      );
       expect(lastStart().filter?.withNamePrefix, ['Decent Scale']);
     });
 
@@ -476,15 +584,210 @@ void main() {
         async.elapse(const Duration(minutes: 26));
         async.flushMicrotasks();
 
-        expect(platform.stopScanCalls, greaterThanOrEqualTo(1),
-            reason: 'refresh must stop the aging scan');
-        expect(platform.startScanCalls.length, greaterThanOrEqualTo(2),
-            reason: 'and start a fresh one');
+        expect(
+          platform.stopScanCalls,
+          greaterThanOrEqualTo(1),
+          reason: 'refresh must stop the aging scan',
+        );
+        expect(
+          platform.startScanCalls.length,
+          greaterThanOrEqualTo(2),
+          reason: 'and start a fresh one',
+        );
         expect(lastStart().filter?.withNamePrefix, ['Decent Scale']);
 
         zoned.stopDeviceWatch();
         async.flushMicrotasks();
       });
     });
+  });
+
+  group('quick-connect identity policy', () {
+    test(
+      'remembered UnifiedDe1 accepts Bengle wire model in degraded mode',
+      () async {
+        const deviceId = 'AA:BB:CC:DD:EE:01';
+
+        platform.systemDevices.add(
+          BleDevice(deviceId: deviceId, name: 'DE1'),
+        );
+
+        final transport = transportForModel(129);
+        final sut = UniversalBleDiscoveryService(
+          transportFactory:
+              ({
+                required device,
+                required stopScan,
+                required requestLargeMtuNonAndroid,
+              }) {
+                return transport;
+              },
+        );
+        await sut.initialize();
+
+        const remembered = RememberedDevice(
+          id: deviceId,
+          name: 'DE1',
+          type: domain.DeviceType.machine,
+          implementation: DeviceImplementation.unifiedDe1,
+          transportType: TransportType.ble,
+        );
+
+        final result = await sut.tryQuickConnect(remembered);
+
+        expect(result, isNotNull);
+        expect(
+          result!.implementation,
+          DeviceImplementation.unifiedDe1,
+          reason: 'quick-connect must trust the remembered implementation',
+        );
+        expect(
+          (result as Machine).machineInfo.model,
+          DecentMachineModel.Bengle.name,
+          reason: 'the wire model is still preserved for diagnostics',
+        );
+        expect(
+          transport.disconnectCalls,
+          0,
+          reason: 'the safe mismatch direction must remain connected',
+        );
+        expect(transport.disposeCalls, 0);
+
+        await (result as De1Interface).dispose();
+      },
+    );
+
+    test(
+      'remembered Bengle rejects stock DE1 and falls back to discovery',
+      () async {
+        const deviceId = 'AA:BB:CC:DD:EE:02';
+
+        platform.systemDevices.add(
+          BleDevice(deviceId: deviceId, name: 'Bengle'),
+        );
+
+        final transport = transportForModel(3);
+        final sut = UniversalBleDiscoveryService(
+          transportFactory:
+              ({
+                required device,
+                required stopScan,
+                required requestLargeMtuNonAndroid,
+              }) {
+                return transport;
+              },
+        );
+        await sut.initialize();
+
+        final emissions = <List<domain.Device>>[];
+        final subscription = sut.devices.listen(emissions.add);
+        addTearDown(subscription.cancel);
+
+        const remembered = RememberedDevice(
+          id: deviceId,
+          name: 'Bengle',
+          type: domain.DeviceType.machine,
+          implementation: DeviceImplementation.bengle,
+          transportType: TransportType.ble,
+        );
+
+        final result = await sut.tryQuickConnect(remembered);
+        await pump();
+
+        expect(
+          result,
+          isNull,
+          reason: 'a stock DE1 must not be adopted as Bengle',
+        );
+        expect(
+          emissions.expand((devices) => devices),
+          isEmpty,
+          reason: 'the rejected device must never enter the registry',
+        );
+        expect(
+          transport.disconnectCalls,
+          greaterThanOrEqualTo(1),
+        );
+        expect(
+          transport.disposeCalls,
+          greaterThanOrEqualTo(1),
+        );
+      },
+    );
+  });
+
+  group('large MTU feature-flag wiring', () {
+    test(
+      'new transports read the current SettingsController flag value',
+      () async {
+        final settingsController = SettingsController(
+          MockSettingsService(),
+        );
+        await settingsController.loadSettings();
+
+        final capturedValues = <bool>[];
+        final transports = <FakeBleTransport>[];
+
+        final sut = UniversalBleDiscoveryService(
+          watchSupportGate: () => true,
+          requestLargeMtuNonAndroid: () =>
+              settingsController.isFeatureFlagEnabled(
+                FeatureFlag.largeBleMtuNonAndroid,
+              ),
+          transportFactory:
+              ({
+                required device,
+                required stopScan,
+                required requestLargeMtuNonAndroid,
+              }) {
+                capturedValues.add(requestLargeMtuNonAndroid);
+
+                final transport = FakeBleTransport();
+                transports.add(transport);
+                return transport;
+              },
+        );
+
+        addTearDown(() async {
+          for (final transport in transports) {
+            await transport.dispose();
+          }
+        });
+
+        await sut.initialize();
+        await sut.startDeviceWatch(const DeviceWatchFilter());
+
+        platform.updateScanResult(
+          BleDevice(
+            deviceId: 'AA:BB:CC:DD:EE:10',
+            name: 'DE1',
+          ),
+        );
+        await pump();
+
+        await settingsController.setFeatureFlag(
+          FeatureFlag.largeBleMtuNonAndroid,
+          true,
+        );
+
+        platform.updateScanResult(
+          BleDevice(
+            deviceId: 'AA:BB:CC:DD:EE:11',
+            name: 'DE1',
+          ),
+        );
+        await pump();
+
+        expect(
+          capturedValues,
+          [false, true],
+          reason:
+              'the callback must be evaluated when each transport is created, '
+              'not snapshotted during service construction',
+        );
+
+        await sut.stopDeviceWatch();
+      },
+    );
   });
 }

--- a/test/unit/models/device/impl/bengle/bengle_firmware_prelude_test.dart
+++ b/test/unit/models/device/impl/bengle/bengle_firmware_prelude_test.dart
@@ -33,7 +33,7 @@ void main() {
         () async {
       final transport = FakeBleTransport();
       addTearDown(transport.dispose);
-      transport.queueOnConnectResponses();
+      transport.queueOnConnectResponses(v13Model: 128);
 
       final bengle = Bengle(transport: transport);
       await bengle.onConnect();

--- a/test/unit/models/device/impl/de1/bengle_model_validation_test.dart
+++ b/test/unit/models/device/impl/de1/bengle_model_validation_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+import 'package:reaprime/src/models/errors.dart';
+
+import '../../../../../helpers/fake_ble_transport.dart';
+
+void main() {
+  test('maps the Bengle model family without changing DE1 mappings', () {
+    expect(isBengleModelValue(127), isFalse);
+    for (final value in [128, 129, 255]) {
+      expect(isBengleModelValue(value), isTrue);
+      expect(DecentMachineModel.fromInt(value), DecentMachineModel.Bengle);
+    }
+    expect(DecentMachineModel.fromInt(3), DecentMachineModel.DE1Pro);
+    expect(DecentMachineModel.fromInt(4), DecentMachineModel.DE1XL);
+    expect(DecentMachineModel.fromInt(5), DecentMachineModel.DE1XXL);
+    expect(DecentMachineModel.fromInt(6), DecentMachineModel.DE1XXXL);
+    expect(DecentMachineModel.fromInt(127), DecentMachineModel.Unknown);
+  });
+
+  test('UnifiedDe1 warns but connects to a Bengle model', () async {
+    final transport = FakeBleTransport()
+      ..queueOnConnectResponses(v13Model: 129);
+    final records = <LogRecord>[];
+    final subscription = Logger.root.onRecord.listen(records.add);
+    final de1 = UnifiedDe1(transport: transport);
+
+    await de1.onConnect();
+
+    expect(de1.machineInfo.model, DecentMachineModel.Bengle.name);
+    expect(
+      records.any(
+        (record) => record.message.toString().contains(
+          'continuing in degraded DE1-compatible mode',
+        ),
+      ),
+      isTrue,
+    );
+    await subscription.cancel();
+    await transport.dispose();
+  });
+
+  test(
+    'Bengle rejects a stock DE1 model before capability initialization',
+    () async {
+      final transport = FakeBleTransport()
+        ..queueOnConnectResponses(v13Model: 3);
+      final bengle = Bengle(transport: transport);
+
+      await expectLater(
+        bengle.onConnect(),
+        throwsA(
+          isA<DeviceIdentityMismatchException>().having(
+            (e) => e.actualModelValue,
+            'actualModelValue',
+            3,
+          ),
+        ),
+      );
+      await transport.dispose();
+    },
+  );
+
+  test('Bengle initializes normally for the Bengle model family', () async {
+    final transport = FakeBleTransport()
+      ..queueOnConnectResponses(v13Model: 129);
+    final bengle = Bengle(transport: transport);
+
+    await bengle.onConnect();
+
+    expect(bengle.machineInfo.model, DecentMachineModel.Bengle.name);
+    await transport.dispose();
+  });
+}

--- a/test/unit/models/device/impl/de1/unified_de1/integrated_scale_capability_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/integrated_scale_capability_test.dart
@@ -21,7 +21,7 @@ void main() {
       logSub = Logger.root.onRecord.listen(logRecords.add);
       transport = FakeBleTransport();
       bengle = Bengle(transport: transport);
-      transport.queueOnConnectResponses();
+      transport.queueOnConnectResponses(v13Model: 128);
       await bengle.onConnect();
     });
 
@@ -86,7 +86,7 @@ void main() {
       // subject; otherwise a fresh listener would observe `done`
       // immediately and the capability would be dead until the device
       // is re-instantiated.
-      transport.queueOnConnectResponses();
+      transport.queueOnConnectResponses(v13Model: 128);
       await bengle.onConnect();
 
       // Listening to weightSnapshot after the second onConnect should

--- a/test/unit/models/device/impl/de1/unified_de1/led_strip_capability_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/led_strip_capability_test.dart
@@ -21,7 +21,7 @@ void main() {
       logSub = Logger.root.onRecord.listen(logRecords.add);
       transport = FakeBleTransport();
       bengle = Bengle(transport: transport);
-      transport.queueOnConnectResponses();
+      transport.queueOnConnectResponses(v13Model: 128);
       await bengle.onConnect();
     });
 
@@ -100,7 +100,7 @@ void main() {
         emitsInOrder([isA<LedStripState>(), emitsDone]),
       );
 
-      transport.queueOnConnectResponses();
+      transport.queueOnConnectResponses(v13Model: 128);
       await bengle.onConnect();
 
       var streamCompletedWithoutValue = false;

--- a/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
@@ -207,6 +207,22 @@ void main() {
       expect(result, closeTo(25.0, 1e-9));
     });
 
+    test('SteamStartSecs uses hundredths of a second on the wire', () async {
+      expect(MMRItem.steamStartSecs.address, 0x0080382C);
+      expect(MMRItem.steamStartSecs.length, 4);
+
+      transport.queueMmrResponseInt(MMRItem.steamStartSecs, 150);
+      expect(await de1.capReadScaled(MMRItem.steamStartSecs), 1.5);
+
+      transport.writes.clear();
+      await de1.capWriteScaled(MMRItem.steamStartSecs, 1.5);
+      final frame = transport.writes.firstWhere(
+        (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
+      );
+      final payload = ByteData.sublistView(frame.data, 4, 8);
+      expect(payload.getInt32(0, Endian.little), 150);
+    });
+
     test('writeMmrScaled clamps to min/max and writes scaled int', () async {
       const addr = _CapabilityAddr(
         address: 0x00804000,


### PR DESCRIPTION
## Summary

- Problem: #459 mixed useful protocol/schema corrections with a rejected post-connect machine-class resolver.
- Why it matters: Bengle identity boundaries, SteamStartSecs wire scaling, simulated-device schema, and optional large-MTU support can land independently.
- What changed: centralized the `v13Model >= 128` predicate, guarded Bengle capability initialization, corrected SteamStartSecs ×100 scaling, documented simulated Bengle, and added default-off non-Android MTU 517 negotiation.
- What did NOT change: no resolver, machine replacement, transport transfer/detach, second `onConnect()`, generic scaled-write rounding, or provisional firmware contract.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [x] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #
- Related #459

## Root Cause (if bug fix)

- Root cause: Bengle model-family detection was duplicated and `DecentMachineModel.fromInt()` recognized only exact model 128; SteamStartSecs retained default 1:1 scaling despite firmware using hundredths of a second.
- Missing detection or guardrail: Bengle capability initialization did not verify the model read by the base implementation.
- Contributing context (if known): #459 combined these independent fixes with a rejected resolver architecture.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/unit/models/device/impl/de1/bengle_model_validation_test.dart`, `test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart`, `test/services/ble/universal_ble_transport_mtu_test.dart`, `test/rest_simulated_bengle_schema_test.dart`.
- Scenario the test should lock in: model-family boundaries and mismatch behavior, exact ×100 MMR bytes, both schema enums, and MTU platform/flag/failure/reconnect policy.
- If no new test added, why not: N/A.

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A — API spec changed; no prose docs affected because runtime already supported simulated Bengle and name-selected discovery remains unchanged.

## Security Impact (required)

- New or changed REST endpoints? No
- New or changed WebSocket topics? No
- New or changed network calls? No
- BLE/USB surface changed? Yes
- File system access changed? No
- Plugin sandbox boundary changed? No
- If any `Yes`, explain risk and mitigation: MTU 517 may be requested on non-Android/non-Linux native BLE stacks only when the persisted experimental flag is enabled; it defaults off, Linux is excluded, and rejection is nonfatal. Android behavior is unchanged.

## User-Visible Changes

None by default. Enabling `largeBleMtuNonAndroid` opts Apple/other native BLE connections into an MTU 517 request.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — `flutter analyze lib test --no-pub` clean; plain repository-wide analyze is polluted by generated Firebase SPM sources under `build/`
- [x] `flutter test` — 2397 tests passed
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds

### Manual verification (if applicable)

- OS / platform tested: macOS host unit tests only
- Simulated devices? (`simulate=1`): No
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: fake UniversalBle platform tests for Android, Linux, and other-native policy; queued MMR transport tests for DE1/Bengle identity and exact wire encoding.
- Edge cases checked: 127/128/129/larger models, mismatched Bengle identity, failed MTU request, reconnect request count.
- What you did **not** verify: iOS/macOS hardware negotiation, negotiated MTU logs, or the 28-byte Bengle sample on real hardware. The flag remains default-off.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? Yes
- Config / env changes needed? No
- Database migration needed? No
- If any `No` or `Yes`, explain exact steps: no migration; the new feature flag defaults to false.

## Risks & Mitigations

- Risk: non-Android MTU behavior is not validated on real Apple hardware.
  - Mitigation: default-off feature flag, nonfatal negotiation failure, and explicit Linux exclusion.
