### PR TITLE
feat(serial): harvest USB-serial parity and wired discovery fixes

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,6 +9,10 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  exclude:
+    - build/**
+
 # Formatter configuration (Dart 3.7+). `dart format` and CI's
 # `dart format --set-exit-if-changed lib test` use this.
 formatter:

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -85,15 +85,29 @@ Discovery services are responsible for scanning and creating device instances. E
   - `lib/src/services/serial/serial_service.dart` (factory)
 - **Discovery:** Enumerates serial ports, probes for device identification
 
-  DE1-family detection is layered:
-  1. `productName == "DE1"` → `UnifiedDe1`. `productName == "Bengle"` →
-     `Bengle`. Cheapest path.
-  2. VID:PID match against `lib/src/services/serial/usb_ids.dart`.
-     Tables empty until concrete pairs are captured from hardware.
-  3. Fallback: open the port, send `<+M>` and the v13Model MMR-read
-     request, wait for `[M]` (DE1-protocol baseline) plus an `[E]…`
-     reply at addr `0x0080000C`. v13Model `>= 128` → `Bengle`, else
-     `UnifiedDe1`. Encoded via `lib/src/services/serial/mmr_codec.dart`.
+  DE1-family detection uses product names and the normal protocol probe:
+  1. Exact `productName == "DE1"` creates `UnifiedDe1`; exact
+     `productName == "Bengle"` creates `Bengle`.
+  2. Devices admitted by the existing generic serial-name rules are opened and
+     identified through the normal `v13Model` MMR read. Bengle model values
+     create `Bengle`; stock-DE1 values create `UnifiedDe1`.
+
+  USB VID/PID values do not participate in Bengle recognition. Devices whose
+  descriptors match neither a known product name nor the generic serial-name
+  rules are outside the current discovery policy.
+
+  Serial protocol parity rules:
+  - `<F>` (`writeToMMR`) frames are exactly 20 bytes. Short payloads are
+    zero-padded without changing their length byte; oversized payloads fail.
+  - One-shot A/J/R reads use temporary `<+X>` subscriptions correlated by
+    representation and always attempt `<-X>` cleanup.
+  - Persistent reads return only observed wire data or explicit local state
+    recorded after a successful write. They never return seeded zero buffers.
+  - Missing observed data is temporarily unavailable; endpoints without a
+    serial representation are unsupported. These are distinct errors.
+  - Notification liveness uses the existing snapshot watchdog and normal
+    `ConnectionManager` reconnect lifecycle. Serial has no separate keepalive
+    or reconnect loop.
 
 #### 3. SimulatedDeviceService
 - **Platform:** All
@@ -263,7 +277,17 @@ ConnectionManager exposes a `ConnectionStatus` stream driven by the
 The status also tracks:
 - `foundMachines` / `foundScales` — devices discovered during the last scan
 - `pendingAmbiguity` — `machinePicker` or `scalePicker` when the UI needs to show a device selection dialog
+- `intent` — automatic connection, explicit discovery, or scale recovery
+- `activeTargetTransport` — transport of the selected device while connecting
+- `conditions` — transport-scoped discovery conditions and affected device types
 - `error` — error message from the last connection attempt
+
+USB discovery continues while Bluetooth is unavailable. A Bluetooth condition
+is shown as a nonblocking notice when a serial path remains viable, so serial
+scanning, selection, and connection continue normally. It becomes blocking when
+the current operation has only BLE candidates, such as BLE-only machine
+selection or scale recovery. Selected-device connection failures remain visible
+independently of discovery conditions.
 
 #### Phase transitions
 
@@ -504,6 +528,13 @@ Device preferences are stored via `SettingsController`:
 - `preferredMachineId` — auto-set on successful machine connection
 - `preferredScaleId` — auto-set on successful scale connection
 - Configurable in Settings → Device Management
+
+Identity remains per transport. BLE and USB IDs for the same physical machine
+are not aliased. If the BLE ID is preferred while Bluetooth is unavailable, a
+discovered USB identity is offered for selection; selecting it persists that USB
+ID. Later automatic startup and Android USB-attach recovery can quick-connect
+through the remembered USB record, with normal implementation validation and
+scan fallback on failure.
 
 ---
 

--- a/lib/src/controllers/connection/connection_timings.dart
+++ b/lib/src/controllers/connection/connection_timings.dart
@@ -16,6 +16,8 @@ class ConnectionTimings {
   /// stable "scanning" window rather than a zero-duration flicker.
   static const postScanSettleDelay = Duration(milliseconds: 200);
 
+  static const initialShotSettingsTimeout = Duration(seconds: 2);
+
   /// Debounce window for `De1Controller` shot-settings pushes. Coalesces
   /// the flurry of calls that come from consecutive UI adjustments
   /// (`setSteamFlow`, `setHotWaterFlow`, `updateShotSettings`) into one

--- a/lib/src/controllers/connection/scan_orchestrator.dart
+++ b/lib/src/controllers/connection/scan_orchestrator.dart
@@ -6,9 +6,11 @@ import 'package:reaprime/src/controllers/connection/scan_report_builder.dart';
 import 'package:reaprime/src/controllers/connection/status_publisher.dart';
 import 'package:reaprime/src/controllers/connection_error.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart'
-    show ConnectionPhase;
+    show ConnectionPhase, TransportCondition;
 import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_scanner.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/errors.dart';
@@ -170,7 +172,7 @@ class ScanOrchestrator {
     _statusPublisher.publish(
       _statusPublisher.current.copyWith(phase: ConnectionPhase.idle),
     );
-    _statusPublisher.emitError(ConnectionError(
+    final error = ConnectionError(
       kind: kind,
       severity: ConnectionErrorSeverity.error,
       timestamp: DateTime.now().toUtc(),
@@ -181,7 +183,22 @@ class ScanOrchestrator {
           ? 'Grant Bluetooth permission in system settings and retry.'
           : 'Check that Bluetooth is enabled and retry.',
       details: {'exception': e.toString()},
-    ));
+    );
+    _statusPublisher.publish(
+      _statusPublisher.current.copyWith(
+        conditions: [
+          ..._statusPublisher.current.conditions.where(
+            (condition) => condition.transportType != TransportType.ble,
+          ),
+          TransportCondition(
+            transportType: TransportType.ble,
+            affectedDeviceTypes: const {DeviceType.machine, DeviceType.scale},
+            connectionError: error,
+          ),
+        ],
+      ),
+    );
+    _statusPublisher.emitError(error);
   }
 
   void _clearStickyScanError() {
@@ -189,6 +206,16 @@ class ScanOrchestrator {
     if (prevErr != null &&
         (prevErr.kind == ConnectionErrorKind.scanFailed ||
             prevErr.kind == ConnectionErrorKind.bluetoothPermissionDenied)) {
+      _statusPublisher.publish(
+        _statusPublisher.current.copyWith(
+          conditions: _statusPublisher.current.conditions
+              .where((condition) =>
+                  condition.connectionError.kind != ConnectionErrorKind.scanFailed &&
+                  condition.connectionError.kind !=
+                      ConnectionErrorKind.bluetoothPermissionDenied)
+              .toList(),
+        ),
+      );
       _statusPublisher.clearError();
     }
   }

--- a/lib/src/controllers/connection/status_publisher.dart
+++ b/lib/src/controllers/connection/status_publisher.dart
@@ -65,7 +65,13 @@ class StatusPublisher {
       effectiveError = null;
     }
 
-    _subject.add(next.copyWith(error: () => effectiveError));
+    _subject.add(
+      next.copyWith(
+        error: () => effectiveError,
+        activeTargetTransport:
+            next.phase == ConnectionPhase.ready ? () => null : null,
+      ),
+    );
   }
 
   /// Emit [err] on the status stream without changing the current

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -27,6 +27,7 @@ import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_attach_notifier.dart';
 import 'package:reaprime/src/models/device/device_scanner.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/scan_report.dart';
@@ -49,12 +50,29 @@ enum ConnectionPhase {
 
 enum AmbiguityReason { machinePicker, scalePicker }
 
+enum ConnectionIntent { automatic, explicitDiscovery, scaleRecovery }
+
+class TransportCondition {
+  final TransportType transportType;
+  final Set<DeviceType> affectedDeviceTypes;
+  final ConnectionError connectionError;
+
+  const TransportCondition({
+    required this.transportType,
+    required this.affectedDeviceTypes,
+    required this.connectionError,
+  });
+}
+
 class ConnectionStatus {
   final ConnectionPhase phase;
   final List<De1Interface> foundMachines;
   final List<Scale> foundScales;
   final AmbiguityReason? pendingAmbiguity;
   final ConnectionError? error;
+  final ConnectionIntent intent;
+  final TransportType? activeTargetTransport;
+  final List<TransportCondition> conditions;
 
   const ConnectionStatus({
     this.phase = ConnectionPhase.idle,
@@ -62,6 +80,9 @@ class ConnectionStatus {
     this.foundScales = const [],
     this.pendingAmbiguity,
     this.error,
+    this.intent = ConnectionIntent.automatic,
+    this.activeTargetTransport,
+    this.conditions = const [],
   });
 
   ConnectionStatus copyWith({
@@ -70,6 +91,9 @@ class ConnectionStatus {
     List<Scale>? foundScales,
     AmbiguityReason? Function()? pendingAmbiguity,
     ConnectionError? Function()? error,
+    ConnectionIntent? intent,
+    TransportType? Function()? activeTargetTransport,
+    List<TransportCondition>? conditions,
   }) {
     return ConnectionStatus(
       phase: phase ?? this.phase,
@@ -79,6 +103,11 @@ class ConnectionStatus {
           ? pendingAmbiguity()
           : this.pendingAmbiguity,
       error: error != null ? error() : this.error,
+      intent: intent ?? this.intent,
+      activeTargetTransport: activeTargetTransport != null
+          ? activeTargetTransport()
+          : this.activeTargetTransport,
+      conditions: conditions ?? this.conditions,
     );
   }
 }
@@ -342,34 +371,63 @@ class ConnectionManager {
   void _listenForAdapter() {
     _adapterSub = deviceScanner.adapterStateStream.listen((state) {
       if (state == AdapterState.poweredOff) {
-        _emit(
-          ConnectionError(
-            kind: ConnectionErrorKind.adapterOff,
-            severity: ConnectionErrorSeverity.error,
-            timestamp: DateTime.now().toUtc(),
-            message: 'Bluetooth is turned off.',
-            suggestion: 'Turn Bluetooth on to scan for devices.',
-          ),
+        final error = ConnectionError(
+          kind: ConnectionErrorKind.adapterOff,
+          severity: ConnectionErrorSeverity.error,
+          timestamp: DateTime.now().toUtc(),
+          message: 'Bluetooth is turned off.',
+          suggestion: 'Turn Bluetooth on to scan for Bluetooth devices.',
         );
+        _setTransportCondition(error);
+        _emit(error);
       } else if (state == AdapterState.unauthorized) {
-        _emit(
-          ConnectionError(
-            kind: ConnectionErrorKind.bluetoothPermissionDenied,
-            severity: ConnectionErrorSeverity.error,
-            timestamp: DateTime.now().toUtc(),
-            message: 'Bluetooth permission was denied.',
-            suggestion:
-                'Go to Settings > Privacy & Security > Bluetooth and enable '
-                'permission for Decent.app.',
-          ),
+        final error = ConnectionError(
+          kind: ConnectionErrorKind.bluetoothPermissionDenied,
+          severity: ConnectionErrorSeverity.error,
+          timestamp: DateTime.now().toUtc(),
+          message: 'Bluetooth permission was denied.',
+          suggestion:
+              'Go to Settings > Privacy & Security > Bluetooth and enable '
+              'permission for Decent.app.',
         );
+        _setTransportCondition(error);
+        _emit(error);
       } else if (state == AdapterState.poweredOn &&
           (currentStatus.error?.kind == ConnectionErrorKind.adapterOff ||
               currentStatus.error?.kind ==
                   ConnectionErrorKind.bluetoothPermissionDenied)) {
+        _clearTransportCondition(TransportType.ble);
         _clearError();
       }
     });
+  }
+
+  void _setTransportCondition(ConnectionError error) {
+    final condition = TransportCondition(
+      transportType: TransportType.ble,
+      affectedDeviceTypes: const {DeviceType.machine, DeviceType.scale},
+      connectionError: error,
+    );
+    _publishStatus(
+      currentStatus.copyWith(
+        conditions: [
+          ...currentStatus.conditions.where(
+            (existing) => existing.transportType != TransportType.ble,
+          ),
+          condition,
+        ],
+      ),
+    );
+  }
+
+  void _clearTransportCondition(TransportType transportType) {
+    _publishStatus(
+      currentStatus.copyWith(
+        conditions: currentStatus.conditions
+            .where((condition) => condition.transportType != transportType)
+            .toList(),
+      ),
+    );
   }
 
   /// Emit a [ConnectionError] onto the status stream without changing
@@ -597,6 +655,16 @@ class ConnectionManager {
     required ConnectionAttemptPolicy policy,
   }) async {
     _isConnecting = true;
+    _publishStatus(
+      currentStatus.copyWith(
+        intent: identical(policy, ConnectionAttemptPolicy.explicitScan)
+            ? ConnectionIntent.explicitDiscovery
+            : identical(policy, ConnectionAttemptPolicy.scaleRecovery)
+                ? ConnectionIntent.scaleRecovery
+                : ConnectionIntent.automatic,
+        activeTargetTransport: () => null,
+      ),
+    );
     if (scaleOnly) {
       _activeScaleOnlyScan = true;
     }
@@ -1352,6 +1420,7 @@ class ConnectionManager {
     _publishStatus(
       currentStatus.copyWith(
         phase: ConnectionPhase.connectingMachine,
+        activeTargetTransport: () => machine.transportType,
         pendingAmbiguity: () => null,
       ),
     );
@@ -1456,6 +1525,7 @@ class ConnectionManager {
     _publishStatus(
       currentStatus.copyWith(
         phase: ConnectionPhase.connectingScale,
+        activeTargetTransport: () => scale.transportType,
         pendingAmbiguity: () => null,
       ),
     );

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -392,12 +392,14 @@ class ConnectionManager {
         );
         _setTransportCondition(error);
         _emit(error);
-      } else if (state == AdapterState.poweredOn &&
-          (currentStatus.error?.kind == ConnectionErrorKind.adapterOff ||
-              currentStatus.error?.kind ==
-                  ConnectionErrorKind.bluetoothPermissionDenied)) {
+      } else if (state == AdapterState.poweredOn) {
         _clearTransportCondition(TransportType.ble);
-        _clearError();
+
+        if (currentStatus.error?.kind == ConnectionErrorKind.adapterOff ||
+            currentStatus.error?.kind ==
+                ConnectionErrorKind.bluetoothPermissionDenied) {
+          _clearError();
+        }
       }
     });
   }

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -276,12 +276,30 @@ class De1Controller {
     _dataInitialized = true;
 
     try {
-      final settings = await device.shotSettings.first;
-      if (!stillCurrent()) return;
-      _shotSettingsUpdate(settings);
       _subscriptions.add(
         device.shotSettings.listen(_shotSettingsUpdate),
       );
+      try {
+        final settings = await device.shotSettings.first.timeout(
+          ConnectionTimings.initialShotSettingsTimeout,
+        );
+        if (!stillCurrent()) return;
+        _shotSettingsUpdate(settings);
+      } on TimeoutException catch (e, st) {
+        _log.warning(
+          'Initial shot settings unavailable; skipping startup defaults',
+          e,
+          st,
+        );
+        return;
+      } on EndpointUnavailableException catch (e, st) {
+        _log.warning(
+          'Initial shot settings unavailable; skipping startup defaults',
+          e,
+          st,
+        );
+        return;
+      }
 
       try {
         await _setDe1DefaultsFor(device, stillCurrent);

--- a/lib/src/device_discovery_feature/scan_flow_presentation.dart
+++ b/lib/src/device_discovery_feature/scan_flow_presentation.dart
@@ -1,0 +1,47 @@
+import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/models/device/device.dart';
+
+/// How a transport-scoped condition affects the current connection operation.
+enum TransportConditionDisposition { hidden, notice, blocking }
+
+TransportConditionDisposition resolveTransportCondition(
+  ConnectionStatus status,
+  TransportCondition condition,
+) {
+  final deviceType =
+      status.pendingAmbiguity == AmbiguityReason.scalePicker ||
+          status.phase == ConnectionPhase.connectingScale ||
+          status.intent == ConnectionIntent.scaleRecovery
+      ? DeviceType.scale
+      : DeviceType.machine;
+  if (!condition.affectedDeviceTypes.contains(deviceType)) {
+    return TransportConditionDisposition.hidden;
+  }
+
+  final targetTransport = status.activeTargetTransport;
+  if (targetTransport != null) {
+    return targetTransport == condition.transportType
+        ? TransportConditionDisposition.blocking
+        : TransportConditionDisposition.notice;
+  }
+
+  final candidates = deviceType == DeviceType.machine
+      ? status.foundMachines
+      : status.foundScales;
+  if (candidates.isNotEmpty) {
+    return candidates.any(
+          (candidate) => candidate.transportType != condition.transportType,
+        )
+        ? TransportConditionDisposition.notice
+        : TransportConditionDisposition.blocking;
+  }
+
+  if (status.phase == ConnectionPhase.scanning &&
+      status.intent != ConnectionIntent.scaleRecovery) {
+    return TransportConditionDisposition.notice;
+  }
+  if (status.phase == ConnectionPhase.ready) {
+    return TransportConditionDisposition.notice;
+  }
+  return TransportConditionDisposition.blocking;
+}

--- a/lib/src/device_discovery_feature/scan_flow_view.dart
+++ b/lib/src/device_discovery_feature/scan_flow_view.dart
@@ -5,10 +5,12 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:reaprime/src/controllers/connection_error.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/scan_state_guardian.dart';
 import 'package:reaprime/src/device_discovery_feature/device_discovery_view.dart';
+import 'package:reaprime/src/device_discovery_feature/scan_flow_presentation.dart';
 import 'package:reaprime/src/home_feature/widgets/device_selection_widget.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart' as dev;
@@ -78,17 +80,9 @@ class ScanFlowView extends StatefulWidget {
 class ScanFlowViewState extends State<ScanFlowView> {
   void _skipToDashboard() => widget.onExit();
 
-  void _clearAdapterErrorAndRetry() {
-    setState(() {
-      _adapterError = null;
-    });
-    widget.connectionManager.scanAndConnect();
-  }
+  void _retry() => widget.connectionManager.scanAndConnect();
 
-  void _clearAdapterErrorAndTryDemo() {
-    setState(() {
-      _adapterError = null;
-    });
+  void _tryDemoMode() {
     widget.settingsController.enableSimulatedDevicesForSession(
       {SimulatedDevicesTypes.machine, SimulatedDevicesTypes.scale},
     );
@@ -122,9 +116,6 @@ class ScanFlowViewState extends State<ScanFlowView> {
   /// Currently selected device ID in the picker UI.
   String? _selectedMachineId;
   String? _selectedScaleId;
-
-  /// Bluetooth adapter error message, set by ScanStateGuardian events.
-  String? _adapterError;
 
   @override
   void initState() {
@@ -186,10 +177,6 @@ class ScanFlowViewState extends State<ScanFlowView> {
 
       setState(() {
         _status = status;
-        // Clear adapter error when scanning resumes
-        if (status.phase == ConnectionPhase.scanning) {
-          _adapterError = null;
-        }
       });
     });
 
@@ -239,24 +226,10 @@ class ScanFlowViewState extends State<ScanFlowView> {
 
   void _onGuardianEvent(ScanStateEvent event) {
     if (!mounted) return;
-    switch (event) {
-      case ScanStateEvent.adapterTurnedOff:
-        setState(() {
-          _adapterError = 'Bluetooth was turned off';
-        });
-        break;
-      case ScanStateEvent.adapterTurnedOn:
-        setState(() {
-          _adapterError = null;
-        });
-        break;
-      case ScanStateEvent.scanStateStale:
-        // If we're stuck in scanning phase, the scan may have silently finished
-        if (_status.phase == ConnectionPhase.scanning) {
-          _log.info('Stale scan detected, restarting');
-          widget.connectionManager.scanAndConnect();
-        }
-        break;
+    if (event == ScanStateEvent.scanStateStale &&
+        _status.phase == ConnectionPhase.scanning) {
+      _log.info('Stale scan detected, restarting');
+      widget.connectionManager.scanAndConnect();
     }
   }
 
@@ -271,11 +244,16 @@ class ScanFlowViewState extends State<ScanFlowView> {
 
   @override
   Widget build(BuildContext context) {
-    final Widget content;
+    final blockingCondition = _conditionWithDisposition(
+      TransportConditionDisposition.blocking,
+    );
+    final noticeCondition = _conditionWithDisposition(
+      TransportConditionDisposition.notice,
+    );
+    Widget content;
 
-    // Adapter error takes precedence.
-    if (_adapterError != null) {
-      content = _adapterErrorView(context);
+    if (blockingCondition != null) {
+      content = _adapterErrorView(context, blockingCondition.connectionError);
     }
     // Ambiguity picker — show even when an error coexists, with the error
     // rendered inline so the user can continue without a new scan.
@@ -312,7 +290,32 @@ class ScanFlowViewState extends State<ScanFlowView> {
       content = _scanningView(context);
     }
 
+    if (blockingCondition == null && noticeCondition != null) {
+      content = _withTransportNotice(content);
+    }
     return Scaffold(body: content);
+  }
+
+  TransportCondition? _conditionWithDisposition(
+    TransportConditionDisposition disposition,
+  ) {
+    for (final condition in _status.conditions) {
+      if (resolveTransportCondition(_status, condition) == disposition) {
+        return condition;
+      }
+    }
+    return null;
+  }
+
+  String? get _operationErrorMessage {
+    final error = _status.error;
+    if (error == null ||
+        _status.conditions.any(
+          (condition) => condition.connectionError.kind == error.kind,
+        )) {
+      return null;
+    }
+    return error.message;
   }
 
   /// Whether devices have been found but the preferred one hasn't.
@@ -455,7 +458,7 @@ class ScanFlowViewState extends State<ScanFlowView> {
         },
         isConnecting: isConnecting,
         canConnect: _selectedMachineId != null,
-        errorMessage: _status.error?.message,
+        errorMessage: _operationErrorMessage,
       );
     }
 
@@ -482,7 +485,7 @@ class ScanFlowViewState extends State<ScanFlowView> {
         },
         isConnecting: isConnecting,
         canConnect: _selectedScaleId != null,
-        errorMessage: _status.error?.message,
+        errorMessage: _operationErrorMessage,
       );
     }
 
@@ -527,7 +530,7 @@ class ScanFlowViewState extends State<ScanFlowView> {
                             ? _status.foundMachines.first.deviceId
                             : null)
                         : null,
-                    errorMessage: _status.error?.message,
+                    errorMessage: _operationErrorMessage,
                     selectedDeviceId: null,
                     preferredDeviceId:
                         widget.settingsController.preferredMachineId,
@@ -766,7 +769,31 @@ class ScanFlowViewState extends State<ScanFlowView> {
     );
   }
 
-  Widget _adapterErrorView(BuildContext context) {
+  Widget _withTransportNotice(Widget content) {
+    return Column(
+      children: [
+        Expanded(child: content),
+        SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: ShadAlert(
+              icon: const Icon(LucideIcons.bluetoothOff, size: 16),
+              title: const Text('Bluetooth unavailable'),
+              description: const Text(
+                'Bluetooth is unavailable. USB devices remain available.',
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _adapterErrorView(
+    BuildContext context,
+    ConnectionError error,
+  ) {
     final theme = ShadTheme.of(context);
     return Center(
       child: Column(
@@ -779,15 +806,15 @@ class ScanFlowViewState extends State<ScanFlowView> {
           ),
           Text('Bluetooth Unavailable', style: theme.textTheme.h4),
           Text(
-            _adapterError!,
+            error.message,
             style: theme.textTheme.muted,
             textAlign: TextAlign.center,
           ),
           AccessibleButton(
             label: 'Try Again',
-            onTap: _clearAdapterErrorAndRetry,
+            onTap: _retry,
             child: ShadButton(
-              onPressed: _clearAdapterErrorAndRetry,
+              onPressed: _retry,
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 spacing: 8,
@@ -800,9 +827,9 @@ class ScanFlowViewState extends State<ScanFlowView> {
           ),
           AccessibleButton(
             label: 'Try Demo Mode',
-            onTap: _clearAdapterErrorAndTryDemo,
+            onTap: _tryDemoMode,
             child: ShadButton.outline(
-              onPressed: _clearAdapterErrorAndTryDemo,
+              onPressed: _tryDemoMode,
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 spacing: 8,

--- a/lib/src/models/device/impl/de1/unified_de1/serial_response_correlator.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/serial_response_correlator.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+final class SerialResponseCorrelator {
+  final _pending = <String, Completer<ByteData>>{};
+
+  bool get hasPending => _pending.isNotEmpty;
+
+  Future<ByteData> register(String representation, Duration timeout) {
+    if (!RegExp(r'^[A-Z]$').hasMatch(representation)) {
+      throw ArgumentError.value(representation, 'representation');
+    }
+    if (_pending.containsKey(representation)) {
+      throw StateError('A serial $representation request is already pending');
+    }
+
+    final completer = Completer<ByteData>();
+    _pending[representation] = completer;
+    return completer.future.timeout(
+      timeout,
+      onTimeout: () {
+        if (identical(_pending[representation], completer)) {
+          _pending.remove(representation);
+        }
+        throw TimeoutException(
+          'Serial $representation response timed out',
+          timeout,
+        );
+      },
+    );
+  }
+
+  bool complete(String representation, ByteData data) {
+    final completer = _pending.remove(representation);
+    if (completer == null) return false;
+    completer.complete(data);
+    return true;
+  }
+
+  void remove(String representation) {
+    _pending.remove(representation);
+  }
+
+  void fail(String representation, Object error, StackTrace stackTrace) {
+    _pending.remove(representation)?.completeError(error, stackTrace);
+  }
+
+  void failAll(Object error, [StackTrace? stackTrace]) {
+    final pending = _pending.values.toList();
+    _pending.clear();
+    for (final completer in pending) {
+      completer.completeError(error, stackTrace ?? StackTrace.current);
+    }
+  }
+}

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -627,7 +627,7 @@ class UnifiedDe1 implements De1Interface {
     index++;
 
     await _transport.writeWithResponse(Endpoint.shotSettings, data);
-    _transport.shotSettingsSubject.add(ByteData.sublistView(data));
+    _transport.recordLocalShotSettings(ByteData.sublistView(data));
   }
 
   @override

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -26,6 +26,7 @@ class UnifiedDe1Transport {
   StreamSubscription<String>? _transportSubscription;
   StreamSubscription<device.ConnectionState>? _connectionStateSubscription;
   final _serialResponses = SerialResponseCorrelator();
+  bool _cacheCleared = false;
 
   // True while `_handleBleTimeout` is doing a deliberate disconnect→reconnect
   // to recover from a BLE timeout. The disconnect it issues must stay
@@ -43,29 +44,16 @@ class UnifiedDe1Transport {
 
   String get id => _transport.id;
 
-  final BehaviorSubject<ByteData> _stateSubject = BehaviorSubject.seeded(
-    ByteData(4),
-  );
-  final BehaviorSubject<ByteData> _shotSampleSubject = BehaviorSubject.seeded(
-    ByteData(19),
-  );
-  // TODO: change this to expose a different subject if needed
-  final BehaviorSubject<ByteData> shotSettingsSubject = BehaviorSubject.seeded(
-    ByteData(9),
-  );
-  final BehaviorSubject<ByteData> _waterLevelsSubject = BehaviorSubject.seeded(
-    ByteData(4),
-  );
-  final BehaviorSubject<ByteData> _mmrSubject = BehaviorSubject.seeded(
-    ByteData(20),
-  );
-  final BehaviorSubject<ByteData> _fwMapRequestSubject = BehaviorSubject.seeded(
-    ByteData(7),
-  );
+  BehaviorSubject<ByteData> _stateSubject = BehaviorSubject();
+  BehaviorSubject<ByteData> _shotSampleSubject = BehaviorSubject();
+  BehaviorSubject<ByteData> _shotSettingsSubject = BehaviorSubject();
+  BehaviorSubject<ByteData> _waterLevelsSubject = BehaviorSubject();
+  final PublishSubject<ByteData> _mmrSubject = PublishSubject();
+  BehaviorSubject<ByteData> _fwMapRequestSubject = BehaviorSubject();
 
   Stream<ByteData> get state => _stateSubject.asBroadcastStream();
   Stream<ByteData> get shotSample => _shotSampleSubject.asBroadcastStream();
-  Stream<ByteData> get shotSettings => shotSettingsSubject.asBroadcastStream();
+  Stream<ByteData> get shotSettings => _shotSettingsSubject.asBroadcastStream();
   Stream<ByteData> get waterLevels => _waterLevelsSubject.asBroadcastStream();
   Stream<ByteData> get mmr => _mmrSubject.asBroadcastStream();
   Stream<ByteData> get fwMapRequest => _fwMapRequestSubject.asBroadcastStream();
@@ -136,6 +124,7 @@ class UnifiedDe1Transport {
     }
 
     await _transport.connect();
+    _cacheCleared = false;
 
     switch (transportType) {
       case TransportType.ble:
@@ -211,6 +200,7 @@ class UnifiedDe1Transport {
     _connectionStateSubscription = _transport.connectionState.listen((state) {
       if (state == device.ConnectionState.disconnected) {
         _serialResponses.failAll(StateError('Serial transport disconnected'));
+        _resetCachedState();
       }
     });
 
@@ -239,7 +229,7 @@ class UnifiedDe1Transport {
     // Close all BehaviorSubjects so downstream listeners see onDone
     if (!_stateSubject.isClosed) _stateSubject.close();
     if (!_shotSampleSubject.isClosed) _shotSampleSubject.close();
-    if (!shotSettingsSubject.isClosed) shotSettingsSubject.close();
+    if (!_shotSettingsSubject.isClosed) _shotSettingsSubject.close();
     if (!_waterLevelsSubject.isClosed) _waterLevelsSubject.close();
     if (!_mmrSubject.isClosed) _mmrSubject.close();
     if (!_fwMapRequestSubject.isClosed) _fwMapRequestSubject.close();
@@ -293,6 +283,22 @@ class UnifiedDe1Transport {
     }
 
     await _transport.disconnect();
+    _resetCachedState();
+  }
+
+  void _resetCachedState() {
+    if (_cacheCleared) return;
+    _cacheCleared = true;
+    _stateSubject.close();
+    _shotSampleSubject.close();
+    _shotSettingsSubject.close();
+    _waterLevelsSubject.close();
+    _fwMapRequestSubject.close();
+    _stateSubject = BehaviorSubject();
+    _shotSampleSubject = BehaviorSubject();
+    _shotSettingsSubject = BehaviorSubject();
+    _waterLevelsSubject = BehaviorSubject();
+    _fwMapRequestSubject = BehaviorSubject();
   }
 
   // Matches a complete message: [X] prefix + hex payload, terminated by
@@ -446,7 +452,7 @@ class UnifiedDe1Transport {
   }
 
   void _shotSettingsNotification(ByteData d) {
-    shotSettingsSubject.add(d);
+    _shotSettingsSubject.add(d);
   }
 
   void _fwMapNotification(ByteData d) {
@@ -530,36 +536,58 @@ class UnifiedDe1Transport {
       case Endpoint.calibration:
         return _serialOneShotRead(e, timeout);
       case Endpoint.requestedState:
-        return _stateSubject.first;
+        throw UnsupportedError(
+          'Endpoint ${e.name} has no serial response frame',
+        );
       case Endpoint.setTime:
-        throw UnimplementedError();
       case Endpoint.shotDirectory:
-        throw UnimplementedError();
+        throw UnsupportedError(
+          'Endpoint ${e.name} has no serial read path',
+        );
       case Endpoint.readFromMMR:
-        return _mmrSubject.first;
+        throw UnsupportedError(
+          'MMR reads require address correlation',
+        );
       case Endpoint.writeToMMR:
-        throw UnimplementedError();
+        throw UnsupportedError('Endpoint ${e.name} is write-only');
       case Endpoint.shotMapRequest:
-        throw UnimplementedError();
       case Endpoint.deleteShotRange:
-        throw UnimplementedError();
+        throw UnsupportedError(
+          'Endpoint ${e.name} has no serial read path',
+        );
       case Endpoint.fwMapRequest:
-        return _fwMapRequestSubject.first;
+        return _latestSerialFrame(e, _fwMapRequestSubject, timeout);
       case Endpoint.shotSettings:
-        return shotSettingsSubject.first;
+        return _latestSerialFrame(e, _shotSettingsSubject, timeout);
       case Endpoint.deprecatedShotDesc:
-        throw UnimplementedError();
+        throw UnsupportedError(
+          'Endpoint ${e.name} has no serial read path',
+        );
       case Endpoint.shotSample:
-        return _shotSampleSubject.first;
+        return _latestSerialFrame(e, _shotSampleSubject, timeout);
       case Endpoint.stateInfo:
-        return _stateSubject.first;
+        return _latestSerialFrame(e, _stateSubject, timeout);
       case Endpoint.headerWrite:
-        throw UnimplementedError();
       case Endpoint.frameWrite:
-        throw UnimplementedError();
+        throw UnsupportedError('Endpoint ${e.name} is write-only');
       case Endpoint.waterLevels:
-        return _waterLevelsSubject.first;
+        return _latestSerialFrame(e, _waterLevelsSubject, timeout);
     }
+  }
+
+  Future<ByteData> _latestSerialFrame(
+    Endpoint endpoint,
+    Stream<ByteData> frames,
+    Duration timeout,
+  ) {
+    return frames.first.timeout(
+      timeout,
+      onTimeout: () => throw EndpointUnavailableException(endpoint.name, timeout),
+    );
+  }
+
+  void recordLocalShotSettings(ByteData data) {
+    _shotSettingsSubject.add(data);
   }
 
   Future<ByteData> _serialOneShotRead(Endpoint endpoint, Duration timeout) async {

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -687,7 +687,13 @@ class UnifiedDe1Transport {
     if (_transport is! SerialTransport) {
       throw "Invalid transport type, expected Serial";
     }
-    final payload = data
+    if (e == Endpoint.writeToMMR && data.length > 20) {
+      throw ArgumentError.value(data.length, 'data.length', 'must not exceed 20');
+    }
+    final frame = e == Endpoint.writeToMMR && data.length < 20
+        ? (Uint8List(20)..setAll(0, data))
+        : data;
+    final payload = frame
         .map((e) => e.toRadixString(16).padLeft(2, '0'))
         .join('');
     await _transport.writeCommand('<${e.representation!}>$payload');

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -11,6 +11,7 @@ import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/transport/logical_endpoint.dart';
 import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/serial_response_correlator.dart';
 import 'package:rxdart/rxdart.dart';
 
 class UnifiedDe1Transport {
@@ -23,6 +24,8 @@ class UnifiedDe1Transport {
   // before the subscription was wired, or on BLE transports where the
   // serial branch never runs.
   StreamSubscription<String>? _transportSubscription;
+  StreamSubscription<device.ConnectionState>? _connectionStateSubscription;
+  final _serialResponses = SerialResponseCorrelator();
 
   // True while `_handleBleTimeout` is doing a deliberate disconnect→reconnect
   // to recover from a BLE timeout. The disconnect it issues must stay
@@ -195,6 +198,8 @@ class UnifiedDe1Transport {
     if (_transport is! SerialTransport) {
       throw "Wrong transport type";
     }
+    await _transportSubscription?.cancel();
+    await _connectionStateSubscription?.cancel();
     // Start notifications - regular setup
     // await _transport.writeCommand("<-N>");
     // await _transport.writeCommand("<-M>");
@@ -203,6 +208,11 @@ class UnifiedDe1Transport {
     // await _transport.writeCommand("<-E>");
 
     _transportSubscription = _transport.readStream.listen(_processSerialInput);
+    _connectionStateSubscription = _transport.connectionState.listen((state) {
+      if (state == device.ConnectionState.disconnected) {
+        _serialResponses.failAll(StateError('Serial transport disconnected'));
+      }
+    });
 
     await _transport.writeCommand("<+${Endpoint.stateInfo.representation}>");
     await _transport.writeCommand("<+${Endpoint.shotSample.representation}>");
@@ -219,9 +229,12 @@ class UnifiedDe1Transport {
   /// subscription, and disposes the underlying transport. Safe to call
   /// more than once. Re-use after dispose is not supported.
   Future<void> dispose() async {
+    _serialResponses.failAll(StateError('Serial transport disposed'));
     // Cancel serial subscription if active
     await _transportSubscription?.cancel();
     _transportSubscription = null;
+    await _connectionStateSubscription?.cancel();
+    _connectionStateSubscription = null;
 
     // Close all BehaviorSubjects so downstream listeners see onDone
     if (!_stateSubject.isClosed) _stateSubject.close();
@@ -235,6 +248,7 @@ class UnifiedDe1Transport {
   }
 
   Future<void> disconnect() async {
+    _serialResponses.failAll(StateError('Serial transport disconnected'));
     _log.warning(
       'disconnect() called by app code',
       null,
@@ -247,6 +261,8 @@ class UnifiedDe1Transport {
         }
         await _transportSubscription?.cancel();
         _transportSubscription = null;
+        await _connectionStateSubscription?.cancel();
+        _connectionStateSubscription = null;
         // Start notifications - regular setup
         await _transport.writeCommand(
           "<-${Endpoint.stateInfo.representation}>",
@@ -358,21 +374,24 @@ class UnifiedDe1Transport {
     try {
       final Uint8List payload = hexToBytes(input.substring(3));
       final ByteData data = ByteData.sublistView(payload);
-      switch (input.substring(0, 3)) {
-        case "[M]":
+      final representation = input[1];
+      switch (representation) {
+        case "M":
           _shotSampleNotification(data);
-        case "[N]":
+        case "N":
           _stateNotification(data);
-        case "[Q]":
+        case "Q":
           _waterLevelsNotification(data);
-        case "[K]":
+        case "K":
           _shotSettingsNotification(data);
-        case "[E]":
+        case "E":
           _mmrNotification(data);
-        case "[I]":
+        case "I":
           _fwMapNotification(data);
         default:
-          _log.warning("unhandled de1 message: $input");
+          if (!_serialResponses.complete(representation, data)) {
+            _log.warning("unhandled de1 message: $input");
+          }
           break;
       }
     } on FormatException catch (e) {
@@ -467,7 +486,10 @@ class UnifiedDe1Transport {
             throw StateError(
                 'UnifiedDe1Transport.read: endpoint ${endpoint.name} has no serial wire support');
           }
-          return await _serialRead(endpoint);
+          return await _serialRead(
+            endpoint,
+            timeout ?? const Duration(seconds: 4),
+          );
         default:
           throw ("Unknown transport type: $transportType");
       }
@@ -497,14 +519,16 @@ class UnifiedDe1Transport {
     return response;
   }
 
-  Future<ByteData> _serialRead(Endpoint e) async {
+  Future<ByteData> _serialRead(Endpoint e, Duration timeout) async {
     if (transportType != TransportType.serial) {
       throw "Invalid transport type, expected Serial";
     }
 
     switch (e) {
       case Endpoint.versions:
-        throw UnimplementedError();
+      case Endpoint.temperatures:
+      case Endpoint.calibration:
+        return _serialOneShotRead(e, timeout);
       case Endpoint.requestedState:
         return _stateSubject.first;
       case Endpoint.setTime:
@@ -521,8 +545,6 @@ class UnifiedDe1Transport {
         throw UnimplementedError();
       case Endpoint.fwMapRequest:
         return _fwMapRequestSubject.first;
-      case Endpoint.temperatures:
-        throw UnimplementedError();
       case Endpoint.shotSettings:
         return shotSettingsSubject.first;
       case Endpoint.deprecatedShotDesc:
@@ -537,9 +559,41 @@ class UnifiedDe1Transport {
         throw UnimplementedError();
       case Endpoint.waterLevels:
         return _waterLevelsSubject.first;
-      case Endpoint.calibration:
-        // TODO: Handle this case.
-        throw UnimplementedError();
+    }
+  }
+
+  Future<ByteData> _serialOneShotRead(Endpoint endpoint, Duration timeout) async {
+    final representation = endpoint.representation;
+    final response = _serialResponses.register(representation, timeout);
+    Object? failure;
+    try {
+      await (_transport as SerialTransport)
+          .writeCommand('<+$representation>')
+          .timeout(timeout);
+      return await response;
+    } catch (error, stackTrace) {
+      failure = error;
+      _serialResponses.fail(representation, error, stackTrace);
+      try {
+        await response;
+      } catch (_) {}
+      rethrow;
+    } finally {
+      _serialResponses.remove(representation);
+      try {
+        await (_transport as SerialTransport)
+            .writeCommand('<-$representation>')
+            .timeout(timeout);
+      } catch (error, stackTrace) {
+        if (failure == null) {
+          Error.throwWithStackTrace(error, stackTrace);
+        }
+        _log.warning(
+          'Failed to unsubscribe from serial $representation',
+          error,
+          stackTrace,
+        );
+      }
     }
   }
 

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart
@@ -592,12 +592,24 @@ class UnifiedDe1Transport {
 
   Future<ByteData> _serialOneShotRead(Endpoint endpoint, Duration timeout) async {
     final representation = endpoint.representation;
+    final stopwatch = Stopwatch()..start();
+    Duration remainingBudget() {
+      final remaining = timeout - stopwatch.elapsed;
+      if (remaining <= Duration.zero) {
+        throw TimeoutException(
+          'Serial $representation response timed out',
+          timeout,
+        );
+      }
+      return remaining;
+    }
+
     final response = _serialResponses.register(representation, timeout);
     Object? failure;
     try {
       await (_transport as SerialTransport)
           .writeCommand('<+$representation>')
-          .timeout(timeout);
+          .timeout(remainingBudget());
       return await response;
     } catch (error, stackTrace) {
       failure = error;
@@ -608,11 +620,22 @@ class UnifiedDe1Transport {
       rethrow;
     } finally {
       _serialResponses.remove(representation);
+      final cleanup = (_transport as SerialTransport)
+          .writeCommand('<-$representation>');
       try {
-        await (_transport as SerialTransport)
-            .writeCommand('<-$representation>')
-            .timeout(timeout);
+        await cleanup.timeout(remainingBudget());
       } catch (error, stackTrace) {
+        if (error is TimeoutException && stopwatch.elapsed >= timeout) {
+          unawaited(
+            cleanup.catchError((Object cleanupError, StackTrace cleanupStack) {
+              _log.warning(
+                'Failed to unsubscribe from serial $representation',
+                cleanupError,
+                cleanupStack,
+              );
+            }),
+          );
+        }
         if (failure == null) {
           Error.throwWithStackTrace(error, stackTrace);
         }

--- a/lib/src/models/errors.dart
+++ b/lib/src/models/errors.dart
@@ -74,6 +74,17 @@ class DuplicateBleSubscription implements Exception {
 /// register read does not receive a matching notification within the
 /// bounded timeout. Prevents connect attempts from hanging forever on
 /// a dropped BLE notify.
+class EndpointUnavailableException implements Exception {
+  final String endpointName;
+  final Duration timeout;
+
+  const EndpointUnavailableException(this.endpointName, this.timeout);
+
+  @override
+  String toString() =>
+      'EndpointUnavailableException: no $endpointName frame within $timeout';
+}
+
 class MmrTimeoutException implements Exception {
   final String mmrItemName;
   final Duration timeout;

--- a/lib/src/services/serial/serial_reconcile.dart
+++ b/lib/src/services/serial/serial_reconcile.dart
@@ -60,10 +60,14 @@ class SerialReconcilePlan {
     required this.suppressAdd,
     required this.suppressRemove,
     required this.hdsForget,
-  })  : assert(release.intersection(reap).isEmpty,
-            'a released path must not also be reaped'),
-        assert(suppressAdd.intersection(suppressRemove).isEmpty,
-            'suppressAdd and suppressRemove must be disjoint (add wins)');
+  }) : assert(
+         release.intersection(reap).isEmpty,
+         'a released path must not also be reaped',
+       ),
+       assert(
+         suppressAdd.intersection(suppressRemove).isEmpty,
+         'suppressAdd and suppressRemove must be disjoint (add wins)',
+       );
 }
 
 /// Decide the pre-probe reconcile transition.
@@ -148,11 +152,10 @@ Set<String> hdsResuppressionPaths({
   required Set<String> hdsPaths,
   required Set<String> presentPorts,
   required Set<String> trackedPaths,
-}) =>
-    {
-      for (final p in hdsPaths)
-        if (presentPorts.contains(p) && !trackedPaths.contains(p)) p,
-    };
+}) => {
+  for (final p in hdsPaths)
+    if (presentPorts.contains(p) && !trackedPaths.contains(p)) p,
+};
 
 /// Whether the tracked device set changed since the last emission — steady-state
 /// timer reconciles with no change stay silent.
@@ -170,7 +173,11 @@ bool serialPortMatchesCandidate({
 }) {
   if (transport == 'Bluetooth') return false;
   // Known device productNames — always probe regardless of port name.
-  if (productName == 'DE1' || productName == 'Half Decent Scale') return true;
+  if (productName == 'DE1' ||
+      productName == 'Bengle' ||
+      productName == 'Half Decent Scale') {
+    return true;
+  }
   // Unix-style USB serial port names.
   if (name.contains('serial') ||
       name.contains('usbmodem') ||

--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -307,9 +307,7 @@ class SerialServiceAndroid
 
   Future<Device?> _detectDevice(UsbDevice device) async {
     _log.info("device name: ${device.productName}");
-    if (device.productName?.contains('Serial') == false &&
-        !(device.productName == 'DE1') &&
-        !(device.productName == 'Half Decent Scale')) {
+    if (!serialProbeAllowsProductName(device.productName)) {
       return null;
     }
     UsbPort? port;
@@ -350,9 +348,7 @@ class SerialServiceAndroid
         matchUsbDevice(usbDeviceTable, vid: device.vid, pid: device.pid);
     if (usbModel != null) {
       _log.info("short circuit via VID:PID -> $usbModel");
-      return usbModel == UsbDeviceModel.bengle
-          ? Bengle(transport: transport)
-          : UnifiedDe1(transport: transport);
+      return UnifiedDe1(transport: transport);
     }
 
     final List<Uint8List> rawData = [];
@@ -443,13 +439,23 @@ class SerialServiceAndroid
       }
 
       _log.warning("Unknown device on port $device");
-      await transport.disconnect();
+      await _disposeRejectedTransport(transport);
       return null;
     } catch (e, st) {
       _log.warning("Port $device is probably not a device we want", e, st);
-      await transport.disconnect();
+      await _disposeRejectedTransport(transport);
       return null;
     }
+  }
+
+  Future<void> _disposeRejectedTransport(AndroidSerialPort transport) async {
+    try {
+      await transport.disconnect();
+    } catch (e, st) {
+      _log.fine('Rejected transport disconnect failed', e, st);
+    }
+    _transportForDeviceId.remove(transport.id);
+    await transport.dispose();
   }
 
   Future<void> dispose() async {

--- a/lib/src/services/serial/serial_service_desktop.dart
+++ b/lib/src/services/serial/serial_service_desktop.dart
@@ -484,9 +484,7 @@ class SerialServiceDesktop implements DeviceDiscoveryService {
     try { pid = port.productId; } catch (_) {}
     final usbModel = matchUsbDevice(usbDeviceTable, vid: vid, pid: pid);
     if (usbModel != null) {
-      final device = usbModel == UsbDeviceModel.bengle
-          ? Bengle(transport: transport)
-          : UnifiedDe1(transport: transport);
+      final device = UnifiedDe1(transport: transport);
       _portPathToDeviceId[id] = device.deviceId;
       return device;
     }

--- a/lib/src/services/serial/usb_ids.dart
+++ b/lib/src/services/serial/usb_ids.dart
@@ -1,9 +1,8 @@
-/// USB VID:PID dispatch for DE1-family devices.
+/// USB VID:PID dispatch for stock DE1 devices.
 ///
 /// The desktop and Android serial services consult [usbDeviceTable] as a
-/// fast path before falling through to protocol probing. Currently both
-/// tables are empty until concrete pairs are captured from hardware
-/// (procedure documented in `doc/plans/...bengle-mock-and-usb.md`).
+/// fast path before falling through to protocol probing. Bengle recognition
+/// uses its product name or the v13Model protocol probe, never VID:PID.
 ///
 /// Note on DE1: the original DE1 uses a generic USB-serial adapter
 /// (FTDI / similar), so VID:PID matching may false-match on unrelated
@@ -11,7 +10,7 @@
 /// stays in place. Only add a DE1 VID:PID pair here if a specific DE1
 /// model is verified to expose a custom descriptor distinct from the
 /// generic adapter.
-enum UsbDeviceModel { de1, bengle }
+enum UsbDeviceModel { de1 }
 
 /// `(vendorId, productId)` pairs.
 typedef UsbIdPair = (int vid, int pid);
@@ -19,13 +18,9 @@ typedef UsbIdPair = (int vid, int pid);
 /// DE1 USB ID pairs. See doc on [UsbDeviceModel] for caveats.
 const List<UsbIdPair> de1UsbIds = [];
 
-/// Bengle USB ID pairs. Populated once captured from hardware.
-const List<UsbIdPair> bengleUsbIds = [];
-
 /// Default table consulted by serial services.
 const Map<UsbDeviceModel, List<UsbIdPair>> usbDeviceTable = {
   UsbDeviceModel.de1: de1UsbIds,
-  UsbDeviceModel.bengle: bengleUsbIds,
 };
 
 /// Returns the [UsbDeviceModel] for a `(vid, pid)` pair found in [table],

--- a/lib/src/services/serial/utils.dart
+++ b/lib/src/services/serial/utils.dart
@@ -32,6 +32,11 @@ bool isDE1(List<String> data, List<int> bytes) {
   return data.any((e) => e.startsWith("[M]"));
 }
 
+bool serialProbeAllowsProductName(String? productName) {
+  if (productName == null || productName.contains('Serial')) return true;
+  return const {'DE1', 'Bengle', 'Half Decent Scale'}.contains(productName);
+}
+
 /// Non-blocking replacement for the native `sp_drain`, which has no timeout
 /// and blocks the calling isolate forever when a USB-serial device never
 /// transmits the buffered bytes (observed when scan probes a non-Decent

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -2000,6 +2000,39 @@ void main() {
         expect(connectionManager.currentStatus.error?.kind,
             ConnectionErrorKind.scaleConnectFailed);
       });
+
+      test(
+        'adapter recovery clears stale BLE condition without clearing replacement error',
+        () async {
+          mockScanner.mockAdapterState(AdapterState.poweredOff);
+          await Future<void>.delayed(Duration.zero);
+          expect(
+            connectionManager.currentStatus.conditions.any(
+              (condition) => condition.transportType == TransportType.ble,
+            ),
+            isTrue,
+          );
+
+          connectionManager.debugEmitError(
+            kind: ConnectionErrorKind.scaleConnectFailed,
+            severity: ConnectionErrorSeverity.error,
+            message: 'scale failed',
+          );
+          mockScanner.mockAdapterState(AdapterState.poweredOn);
+          await Future<void>.delayed(Duration.zero);
+
+          expect(
+            connectionManager.currentStatus.conditions.any(
+              (condition) => condition.transportType == TransportType.ble,
+            ),
+            isFalse,
+          );
+          expect(
+            connectionManager.currentStatus.error?.kind,
+            ConnectionErrorKind.scaleConnectFailed,
+          );
+        },
+      );
     });
 
     group('scan failures', () {

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -133,6 +133,9 @@ void main() {
       expect(status.foundScales, isEmpty);
       expect(status.pendingAmbiguity, isNull);
       expect(status.error, isNull);
+      expect(status.intent, ConnectionIntent.automatic);
+      expect(status.activeTargetTransport, isNull);
+      expect(status.conditions, isEmpty);
     });
 
     test('copyWith preserves fields not overridden', () {
@@ -1384,21 +1387,21 @@ void main() {
         manager.dispose();
       });
 
-      test('emits connectingMachine then ready phases', () async {
-        final phases = <ConnectionPhase>[];
-        final sub = connectionManager.status.listen((s) {
-          phases.add(s.phase);
-        });
+      test('emits target transport while connecting then clears it', () async {
+        final statuses = <ConnectionStatus>[];
+        final sub = connectionManager.status.listen(statuses.add);
 
         final fakeDe1 = _FakeDe1(deviceId: 'phase-de1');
         await connectionManager.connectMachine(fakeDe1);
         await Future.delayed(Duration.zero);
 
-        expect(phases, [
+        expect(statuses.map((status) => status.phase), [
           ConnectionPhase.idle,
           ConnectionPhase.connectingMachine,
           ConnectionPhase.ready,
         ]);
+        expect(statuses[1].activeTargetTransport, TransportType.unknown);
+        expect(statuses.last.activeTargetTransport, isNull);
 
         await sub.cancel();
       });
@@ -1961,14 +1964,19 @@ void main() {
     });
 
     group('adapter state', () {
-      test('adapter off emits adapterOff error', () async {
+      test('adapter off emits a BLE-scoped condition', () async {
         mockScanner.mockAdapterState(AdapterState.poweredOff);
         await Future<void>.delayed(Duration.zero);
+
         expect(connectionManager.currentStatus.error?.kind,
             ConnectionErrorKind.adapterOff);
+        expect(connectionManager.currentStatus.conditions.single.transportType,
+            TransportType.ble);
+        expect(connectionManager.currentStatus.conditions.single.affectedDeviceTypes,
+            {DeviceType.machine, DeviceType.scale});
       });
 
-      test('adapter on clears adapterOff', () async {
+      test('adapter on clears the BLE-scoped condition', () async {
         mockScanner.mockAdapterState(AdapterState.poweredOff);
         await Future<void>.delayed(Duration.zero);
         expect(connectionManager.currentStatus.error?.kind,
@@ -1977,6 +1985,7 @@ void main() {
         mockScanner.mockAdapterState(AdapterState.poweredOn);
         await Future<void>.delayed(Duration.zero);
         expect(connectionManager.currentStatus.error, isNull);
+        expect(connectionManager.currentStatus.conditions, isEmpty);
       });
 
       test('adapter on does NOT clear an unrelated transient error',

--- a/test/controllers/connection_manager_usb_attach_test.dart
+++ b/test/controllers/connection_manager_usb_attach_test.dart
@@ -5,6 +5,7 @@ import 'package:reaprime/src/controllers/connection_manager.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/remembered_devices_controller.dart';
+import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_attach_notifier.dart';
@@ -41,7 +42,7 @@ class _FakeDe1 implements De1Interface {
   final _snapshots = StreamController<MachineSnapshot>.broadcast();
 
   @override
-  final String deviceId = 'pref-de1';
+  final String deviceId;
 
   @override
   String get name => 'DE1';
@@ -54,6 +55,8 @@ class _FakeDe1 implements De1Interface {
 
   @override
   TransportType get transportType => TransportType.serial;
+
+  _FakeDe1({this.deviceId = 'pref-de1'});
 
   @override
   Stream<ConnectionState> get connectionState =>
@@ -115,6 +118,26 @@ void main() {
     await manager.dispose();
     scanner.dispose();
     discovery.dispose();
+  });
+
+  test('BLE preference stays distinct until the USB machine is selected',
+      () async {
+    await settings.setPreferredMachineId('ble-machine-id');
+    final usbMachine = _FakeDe1(deviceId: 'usb-machine-id');
+    scanner.addDevice(usbMachine);
+    scanner.mockAdapterState(AdapterState.poweredOff);
+
+    await manager.scanAndConnect();
+
+    expect(manager.currentStatus.pendingAmbiguity,
+        AmbiguityReason.machinePicker);
+    expect(manager.currentStatus.foundMachines.single.deviceId,
+        'usb-machine-id');
+    expect(settings.preferredMachineId, 'ble-machine-id');
+
+    await manager.selectMachine(usbMachine);
+
+    expect(settings.preferredMachineId, 'usb-machine-id');
   });
 
   test('attach invokes current connection policy immediately', () async {

--- a/test/controllers/de1_controller_test.dart
+++ b/test/controllers/de1_controller_test.dart
@@ -10,21 +10,20 @@ import '../helpers/mock_device_discovery_service.dart';
 import '../helpers/test_de1.dart';
 
 De1ShotSettings _emptyShotSettings() => De1ShotSettings(
-      steamSetting: 0,
-      targetSteamTemp: 0,
-      targetSteamDuration: 0,
-      targetHotWaterTemp: 0,
-      targetHotWaterVolume: 0,
-      targetHotWaterDuration: 0,
-      targetShotVolume: 0,
-      groupTemp: 0,
-    );
+  steamSetting: 0,
+  targetSteamTemp: 0,
+  targetSteamDuration: 0,
+  targetHotWaterTemp: 0,
+  targetHotWaterVolume: 0,
+  targetHotWaterDuration: 0,
+  targetShotVolume: 0,
+  groupTemp: 0,
+);
 
 void main() {
   group('connectedDe1OrNull accessor', () {
     test('returns null when no machine connected', () async {
-      final deviceController =
-          DeviceController([MockDeviceDiscoveryService()]);
+      final deviceController = DeviceController([MockDeviceDiscoveryService()]);
       await deviceController.initialize();
       final de1Controller = De1Controller(controller: deviceController);
 
@@ -33,8 +32,9 @@ void main() {
 
     test('returns the connected DE1 once connectToDe1 completes', () async {
       await runZonedGuarded(() async {
-        final deviceController =
-            DeviceController([MockDeviceDiscoveryService()]);
+        final deviceController = DeviceController([
+          MockDeviceDiscoveryService(),
+        ]);
         await deviceController.initialize();
         final de1Controller = De1Controller(controller: deviceController);
         final testDe1 = TestDe1();
@@ -52,8 +52,9 @@ void main() {
 
     test('returns null again after disconnect', () async {
       await runZonedGuarded(() async {
-        final deviceController =
-            DeviceController([MockDeviceDiscoveryService()]);
+        final deviceController = DeviceController([
+          MockDeviceDiscoveryService(),
+        ]);
         await deviceController.initialize();
         final de1Controller = De1Controller(controller: deviceController);
         final testDe1 = TestDe1();
@@ -73,6 +74,34 @@ void main() {
     });
   });
 
+  group('initial shot settings', () {
+    test(
+      'missing initial settings do not block initialization',
+      () async {
+        final deviceController = DeviceController([
+          MockDeviceDiscoveryService(),
+        ]);
+        await deviceController.initialize();
+        final de1Controller = De1Controller(controller: deviceController);
+        final testDe1 = TestDe1();
+
+        await de1Controller.connectToDe1(testDe1);
+
+        expect(
+          await de1Controller.initSettled
+              .firstWhere((generation) => generation != null)
+              .timeout(const Duration(seconds: 3)),
+          isNotNull,
+        );
+        expect(de1Controller.connectedDe1OrNull, same(testDe1));
+
+        testDe1.dispose();
+        de1Controller.dispose();
+      },
+      timeout: const Timeout(Duration(seconds: 5)),
+    );
+  });
+
   group('shot-settings debounce race (comms-harden #5)', () {
     test(
       'disconnect during debounce does not leak an unhandled async error',
@@ -81,8 +110,9 @@ void main() {
 
         await runZonedGuarded(
           () async {
-            final deviceController =
-                DeviceController([MockDeviceDiscoveryService()]);
+            final deviceController = DeviceController([
+              MockDeviceDiscoveryService(),
+            ]);
             await deviceController.initialize();
             final de1Controller = De1Controller(controller: deviceController);
             final testDe1 = TestDe1();
@@ -109,8 +139,7 @@ void main() {
             // Wait past the 100ms debounce window. With the generation
             // fix, the timer body should find a stale generation (or
             // null _de1) and bail without touching connectedDe1().
-            await Future<void>.delayed(
-                const Duration(milliseconds: 200));
+            await Future<void>.delayed(const Duration(milliseconds: 200));
 
             testDe1.dispose();
           },

--- a/test/device_discovery_feature/scan_flow_presentation_test.dart
+++ b/test/device_discovery_feature/scan_flow_presentation_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection_error.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/device_discovery_feature/scan_flow_presentation.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
+
+import '../helpers/mock_connection_manager.dart';
+
+void main() {
+  final bluetoothOff = TransportCondition(
+    transportType: TransportType.ble,
+    affectedDeviceTypes: const {DeviceType.machine, DeviceType.scale},
+    connectionError: ConnectionError(
+      kind: ConnectionErrorKind.adapterOff,
+      severity: ConnectionErrorSeverity.error,
+      timestamp: DateTime.utc(2025),
+      message: 'Bluetooth is turned off.',
+    ),
+  );
+  final permissionDenied = TransportCondition(
+    transportType: TransportType.ble,
+    affectedDeviceTypes: const {DeviceType.machine, DeviceType.scale},
+    connectionError: ConnectionError(
+      kind: ConnectionErrorKind.bluetoothPermissionDenied,
+      severity: ConnectionErrorSeverity.error,
+      timestamp: DateTime.utc(2025),
+      message: 'Bluetooth permission was denied.',
+    ),
+  );
+  final serialMachine = FakeDe1(
+    deviceId: 'usb-machine',
+    transportType: TransportType.serial,
+  );
+  final bleMachine = FakeDe1(
+    deviceId: 'ble-machine',
+    transportType: TransportType.ble,
+  );
+
+  final cases =
+      <
+        ({
+          String name,
+          ConnectionStatus status,
+          TransportConditionDisposition expected,
+        })
+      >[
+        (
+          name: 'BLE off while serial scan is active',
+          status: ConnectionStatus(
+            phase: ConnectionPhase.scanning,
+            conditions: [bluetoothOff],
+          ),
+          expected: TransportConditionDisposition.notice,
+        ),
+        (
+          name: 'BLE off after a serial machine is discovered',
+          status: ConnectionStatus(
+            phase: ConnectionPhase.scanning,
+            foundMachines: [serialMachine],
+            conditions: [bluetoothOff],
+          ),
+          expected: TransportConditionDisposition.notice,
+        ),
+        (
+          name: 'BLE off with serial machine picker',
+          status: ConnectionStatus(
+            pendingAmbiguity: AmbiguityReason.machinePicker,
+            foundMachines: [serialMachine],
+            conditions: [bluetoothOff],
+          ),
+          expected: TransportConditionDisposition.notice,
+        ),
+        (
+          name: 'BLE off with only BLE machines',
+          status: ConnectionStatus(
+            pendingAmbiguity: AmbiguityReason.machinePicker,
+            foundMachines: [bleMachine],
+            conditions: [bluetoothOff],
+          ),
+          expected: TransportConditionDisposition.blocking,
+        ),
+        (
+          name: 'BLE off with mixed machine transports',
+          status: ConnectionStatus(
+            pendingAmbiguity: AmbiguityReason.machinePicker,
+            foundMachines: [bleMachine, serialMachine],
+            conditions: [bluetoothOff],
+          ),
+          expected: TransportConditionDisposition.notice,
+        ),
+        (
+          name: 'BLE off while serial machine connects',
+          status: ConnectionStatus(
+            phase: ConnectionPhase.connectingMachine,
+            activeTargetTransport: TransportType.serial,
+            conditions: [bluetoothOff],
+          ),
+          expected: TransportConditionDisposition.notice,
+        ),
+        (
+          name: 'BLE off after a serial machine is ready',
+          status: ConnectionStatus(
+            phase: ConnectionPhase.ready,
+            conditions: [bluetoothOff],
+          ),
+          expected: TransportConditionDisposition.notice,
+        ),
+        (
+          name: 'BLE permission denied with serial candidate',
+          status: ConnectionStatus(
+            pendingAmbiguity: AmbiguityReason.machinePicker,
+            foundMachines: [serialMachine],
+            conditions: [permissionDenied],
+          ),
+          expected: TransportConditionDisposition.notice,
+        ),
+        (
+          name: 'BLE-only scale recovery is blocked',
+          status: ConnectionStatus(
+            phase: ConnectionPhase.scanning,
+            intent: ConnectionIntent.scaleRecovery,
+            conditions: [bluetoothOff],
+          ),
+          expected: TransportConditionDisposition.blocking,
+        ),
+        (
+          name: 'serial connection failure keeps Bluetooth partial',
+          status: ConnectionStatus(
+            activeTargetTransport: TransportType.serial,
+            error: ConnectionError(
+              kind: ConnectionErrorKind.machineConnectFailed,
+              severity: ConnectionErrorSeverity.error,
+              timestamp: DateTime.utc(2025),
+              message: 'USB machine failed to connect.',
+            ),
+            conditions: [bluetoothOff],
+          ),
+          expected: TransportConditionDisposition.notice,
+        ),
+      ];
+
+  for (final testCase in cases) {
+    test(testCase.name, () {
+      expect(
+        resolveTransportCondition(
+          testCase.status,
+          testCase.status.conditions.single,
+        ),
+        testCase.expected,
+      );
+    });
+  }
+}

--- a/test/helpers/mock_connection_manager.dart
+++ b/test/helpers/mock_connection_manager.dart
@@ -26,14 +26,17 @@ class FakeDe1 implements De1Interface {
   DeviceImplementation get implementation => DeviceImplementation.unifiedDe1;
 
   @override
-  TransportType get transportType => TransportType.unknown;
+  final TransportType transportType;
 
   @override
   Stream<dev.ConnectionState> get connectionState =>
       Stream.value(dev.ConnectionState.connected);
 
-  FakeDe1({this.deviceId = 'fake-de1', String? name})
-      : name = name ?? 'DE1-$deviceId';
+  FakeDe1({
+    this.deviceId = 'fake-de1',
+    String? name,
+    this.transportType = TransportType.unknown,
+  }) : name = name ?? 'DE1-$deviceId';
 
   @override
   Stream<MachineSnapshot> get currentSnapshot => const Stream.empty();

--- a/test/onboarding/scan_step_test.dart
+++ b/test/onboarding/scan_step_test.dart
@@ -5,6 +5,8 @@ import 'package:reaprime/src/controllers/connection_manager.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/scan_state_guardian.dart';
 import 'package:reaprime/src/models/adapter_state.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/scan_report.dart';
 import 'package:reaprime/src/onboarding_feature/onboarding_controller.dart';
 import 'package:reaprime/src/onboarding_feature/steps/scan_step.dart';
@@ -354,45 +356,49 @@ void main() {
     });
   });
 
-  group('ScanStateGuardian integration', () {
-    testWidgets('shows adapter error when BLE adapter turns off',
+  group('connection status authority', () {
+    testWidgets('guardian adapter events do not create independent errors',
         (tester) async {
-      // Set initial state to poweredOn before building widget,
-      // so the guardian sees the transition to poweredOff.
       mockBleService.setAdapterState(AdapterState.poweredOn);
-      // Allow guardian subscription to process
       await tester.runAsync(() => Future.delayed(Duration.zero));
-
       await tester.pumpWidget(buildSubject());
       await tester.pump();
 
-      // Turn off adapter — ScanStateGuardian will emit adapterTurnedOff
       mockBleService.setAdapterState(AdapterState.poweredOff);
-      // Allow stream events to propagate
       await tester.runAsync(() => Future.delayed(Duration.zero));
       await tester.pump();
 
-      expect(find.text('Bluetooth Unavailable'), findsOneWidget);
-      expect(find.text('Bluetooth was turned off'), findsOneWidget);
+      expect(find.text('Bluetooth Unavailable'), findsNothing);
     });
 
-    testWidgets('clears adapter error when BLE adapter turns back on',
+    testWidgets('connection status shows and clears the adapter condition',
         (tester) async {
-      mockBleService.setAdapterState(AdapterState.poweredOn);
-      await tester.runAsync(() => Future.delayed(Duration.zero));
-
       await tester.pumpWidget(buildSubject());
       await tester.pump();
+      final error = ConnectionError(
+        kind: ConnectionErrorKind.adapterOff,
+        severity: ConnectionErrorSeverity.error,
+        timestamp: DateTime.utc(2025),
+        message: 'Bluetooth is turned off.',
+      );
 
-      // Turn off
-      mockBleService.setAdapterState(AdapterState.poweredOff);
-      await tester.runAsync(() => Future.delayed(Duration.zero));
+      mockConnectionManager.emitStatus(ConnectionStatus(
+        error: error,
+        conditions: [
+          TransportCondition(
+            transportType: TransportType.ble,
+            affectedDeviceTypes: const {
+              DeviceType.machine,
+              DeviceType.scale,
+            },
+            connectionError: error,
+          ),
+        ],
+      ));
       await tester.pump();
       expect(find.text('Bluetooth Unavailable'), findsOneWidget);
 
-      // Turn back on
-      mockBleService.setAdapterState(AdapterState.poweredOn);
-      await tester.runAsync(() => Future.delayed(Duration.zero));
+      mockConnectionManager.emitStatus(const ConnectionStatus());
       await tester.pump();
       expect(find.text('Bluetooth Unavailable'), findsNothing);
     });

--- a/test/scan_flow_view_test.dart
+++ b/test/scan_flow_view_test.dart
@@ -5,6 +5,8 @@ import 'package:reaprime/src/controllers/connection_manager.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/scan_state_guardian.dart';
 import 'package:reaprime/src/device_discovery_feature/scan_flow_view.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
@@ -318,6 +320,105 @@ void main() {
 
       expect(mockCm.selectScaleCallCount, 1);
       expect(mockCm.scanAndConnectCallCount, 1);
+    });
+  });
+
+  group('wired discovery without Bluetooth', () {
+    TransportCondition bluetoothOffCondition() {
+      return TransportCondition(
+        transportType: TransportType.ble,
+        affectedDeviceTypes: const {DeviceType.machine, DeviceType.scale},
+        connectionError: ConnectionError(
+          kind: ConnectionErrorKind.adapterOff,
+          severity: ConnectionErrorSeverity.error,
+          timestamp: DateTime.utc(2025),
+          message: 'Bluetooth is turned off.',
+        ),
+      );
+    }
+
+    testWidgets('serial picker remains interactive with a Bluetooth notice',
+        (tester) async {
+      final serialMachine = FakeDe1(
+        deviceId: 'usb-machine',
+        name: 'USB Machine',
+        transportType: TransportType.serial,
+      );
+      final condition = bluetoothOffCondition();
+      mockCm.emitStatus(ConnectionStatus(
+        pendingAmbiguity: AmbiguityReason.machinePicker,
+        foundMachines: [serialMachine],
+        error: condition.connectionError,
+        conditions: [condition],
+      ));
+
+      await tester.pumpWidget(buildView(
+        initialConnectionIntent: () => mockCm.scanAndConnect(),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('USB Machine'), findsOneWidget);
+      expect(
+        find.text('Bluetooth is unavailable. USB devices remain available.'),
+        findsOneWidget,
+      );
+      await tester.tap(find.text('USB Machine'));
+      await tester.pump();
+      await tester.tap(find.text('Connect'));
+      await tester.pump();
+      expect(mockCm.selectMachineCallCount, 1);
+    });
+
+    testWidgets('serial connection failure stays visible above the notice',
+        (tester) async {
+      final condition = bluetoothOffCondition();
+      mockCm.emitStatus(ConnectionStatus(
+        activeTargetTransport: TransportType.serial,
+        error: ConnectionError(
+          kind: ConnectionErrorKind.machineConnectFailed,
+          severity: ConnectionErrorSeverity.error,
+          timestamp: DateTime.utc(2025),
+          message: 'USB machine failed to connect.',
+        ),
+        conditions: [condition],
+      ));
+
+      await tester.pumpWidget(buildView(
+        initialConnectionIntent: () => mockCm.scanAndConnect(),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Connection Error'), findsOneWidget);
+      expect(find.text('USB machine failed to connect.'), findsOneWidget);
+      expect(
+        find.text('Bluetooth is unavailable. USB devices remain available.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('BLE-only picker shows the blocking Bluetooth error',
+        (tester) async {
+      final condition = bluetoothOffCondition();
+      mockCm.emitStatus(ConnectionStatus(
+        pendingAmbiguity: AmbiguityReason.machinePicker,
+        foundMachines: [
+          FakeDe1(
+            deviceId: 'ble-machine',
+            name: 'BLE Machine',
+            transportType: TransportType.ble,
+          ),
+        ],
+        error: condition.connectionError,
+        conditions: [condition],
+      ));
+
+      await tester.pumpWidget(buildView(
+        initialConnectionIntent: () => mockCm.scanAndConnect(),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Bluetooth Unavailable'), findsOneWidget);
+      expect(find.text('BLE Machine'), findsNothing);
     });
   });
 

--- a/test/services/serial/usb_ids_test.dart
+++ b/test/services/serial/usb_ids_test.dart
@@ -4,17 +4,14 @@ import 'package:reaprime/src/services/serial/usb_ids.dart';
 void main() {
   group('matchUsbDevice', () {
     const a = (0x1234, 0x5678);
-    const b = (0xABCD, 0x0001);
-
     test('returns the model for a matching pair', () {
       const table = {
         UsbDeviceModel.de1: [a],
-        UsbDeviceModel.bengle: [b],
       };
-      expect(matchUsbDevice(table, vid: a.$1, pid: a.$2),
-          equals(UsbDeviceModel.de1));
-      expect(matchUsbDevice(table, vid: b.$1, pid: b.$2),
-          equals(UsbDeviceModel.bengle));
+      expect(
+        matchUsbDevice(table, vid: a.$1, pid: a.$2),
+        equals(UsbDeviceModel.de1),
+      );
     });
 
     test('returns null for an unknown pair', () {
@@ -38,8 +35,10 @@ void main() {
       const table = {
         UsbDeviceModel.de1: [a, c],
       };
-      expect(matchUsbDevice(table, vid: c.$1, pid: c.$2),
-          equals(UsbDeviceModel.de1));
+      expect(
+        matchUsbDevice(table, vid: c.$1, pid: c.$2),
+        equals(UsbDeviceModel.de1),
+      );
     });
   });
 

--- a/test/unit/models/device/impl/de1/unified_de1/serial_parity_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/serial_parity_test.dart
@@ -3,9 +3,12 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
+import 'package:reaprime/src/models/errors.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../../../../../../helpers/fake_ble_transport.dart';
@@ -115,6 +118,114 @@ void main() {
     await bleTransport.write(Endpoint.writeToMMR, Uint8List.fromList([1]));
 
     expect(ble.writes.single.data, [1]);
+  });
+
+  group('locally known shot settings', () {
+    final settings = De1ShotSettings(
+      steamSetting: 1,
+      targetSteamTemp: 140,
+      targetSteamDuration: 30,
+      targetHotWaterTemp: 80,
+      targetHotWaterVolume: 200,
+      targetHotWaterDuration: 20,
+      targetShotVolume: 40,
+      groupTemp: 90.5,
+    );
+
+    test('successful writes record local state', () async {
+      final localSerial = _RecordingSerialTransport();
+      final machine = UnifiedDe1(transport: localSerial);
+      addTearDown(machine.dispose);
+
+      await machine.updateShotSettings(settings);
+
+      expect(await machine.shotSettings.first, settings);
+    });
+
+    test('failed writes record no local state', () async {
+      final localSerial = _RecordingSerialTransport();
+      final machine = UnifiedDe1(transport: localSerial);
+      addTearDown(machine.dispose);
+      localSerial.onWrite = (_) => throw StateError('write failed');
+
+      await expectLater(machine.updateShotSettings(settings), throwsStateError);
+      await expectLater(
+        machine.shotSettings.first.timeout(const Duration(milliseconds: 10)),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
+  });
+
+  group('persistent serial reads', () {
+    setUp(() async {
+      await transport.connect();
+      serial.writes.clear();
+    });
+
+    test('missing frames report typed unavailability', () async {
+      for (final endpoint in [
+        Endpoint.stateInfo,
+        Endpoint.shotSample,
+        Endpoint.waterLevels,
+        Endpoint.shotSettings,
+        Endpoint.fwMapRequest,
+      ]) {
+        await expectLater(
+          transport.read(endpoint, timeout: Duration.zero),
+          throwsA(isA<EndpointUnavailableException>()),
+        );
+      }
+    });
+
+    test('latest genuine frame is replayed', () async {
+      serial.input.add('[N]0102\n');
+
+      final result = await transport.read(
+        Endpoint.stateInfo,
+        timeout: const Duration(milliseconds: 100),
+      );
+
+      expect(result.buffer.asUint8List(), [1, 2]);
+    });
+
+    test(
+      'MMR and requested-state reads are not aliases of cached state',
+      () async {
+        serial.input.add('[E]0102\n[N]0304\n');
+
+        await expectLater(
+          transport.read(Endpoint.readFromMMR),
+          throwsA(isA<UnsupportedError>()),
+        );
+        await expectLater(
+          transport.read(Endpoint.requestedState),
+          throwsA(isA<UnsupportedError>()),
+        );
+      },
+    );
+
+    test('write-only endpoint reads are unsupported', () async {
+      await expectLater(
+        transport.read(Endpoint.writeToMMR),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+
+    test('disconnect clears cached persistent frames', () async {
+      serial.input.add('[N]0102\n');
+      expect(
+        (await transport.read(Endpoint.stateInfo)).buffer.asUint8List(),
+        [1, 2],
+      );
+
+      await transport.disconnect();
+      await transport.connect();
+
+      await expectLater(
+        transport.read(Endpoint.stateInfo, timeout: Duration.zero),
+        throwsA(isA<EndpointUnavailableException>()),
+      );
+    });
   });
 
   group('one-shot serial reads', () {

--- a/test/unit/models/device/impl/de1/unified_de1/serial_parity_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/serial_parity_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -13,7 +14,14 @@ class _RecordingSerialTransport extends SerialTransport {
   final _connectionState = BehaviorSubject<ConnectionState>.seeded(
     ConnectionState.connected,
   );
+  final input = StreamController<String>.broadcast(sync: true);
   final writes = <String>[];
+  void Function(String command)? onWrite;
+  String? failCommand;
+
+  void emitDisconnected() {
+    _connectionState.add(ConnectionState.disconnected);
+  }
 
   @override
   String get id => 'serial-test';
@@ -25,7 +33,7 @@ class _RecordingSerialTransport extends SerialTransport {
   Stream<ConnectionState> get connectionState => _connectionState.stream;
 
   @override
-  Stream<String> get readStream => const Stream.empty();
+  Stream<String> get readStream => input.stream;
 
   @override
   Stream<Uint8List> get rawStream => const Stream.empty();
@@ -37,10 +45,17 @@ class _RecordingSerialTransport extends SerialTransport {
   Future<void> disconnect() async {}
 
   @override
-  Future<void> dispose() => _connectionState.close();
+  Future<void> dispose() async {
+    if (!input.isClosed) await input.close();
+    if (!_connectionState.isClosed) await _connectionState.close();
+  }
 
   @override
-  Future<void> writeCommand(String command) async => writes.add(command);
+  Future<void> writeCommand(String command) async {
+    writes.add(command);
+    onWrite?.call(command);
+    if (command == failCommand) throw StateError('write failed');
+  }
 
   @override
   Future<void> writeHexCommand(Uint8List command) async {}
@@ -100,5 +115,187 @@ void main() {
     await bleTransport.write(Endpoint.writeToMMR, Uint8List.fromList([1]));
 
     expect(ble.writes.single.data, [1]);
+  });
+
+  group('one-shot serial reads', () {
+    setUp(() async {
+      await transport.connect();
+      serial.writes.clear();
+    });
+
+    for (final endpoint in [
+      Endpoint.versions,
+      Endpoint.temperatures,
+      Endpoint.calibration,
+    ]) {
+      test(
+        '${endpoint.representation} captures an immediate response',
+        () async {
+          serial.onWrite = (command) {
+            if (command == '<+${endpoint.representation}>') {
+              serial.input.add('[${endpoint.representation}]0102\n');
+            }
+          };
+
+          final result = await transport.read(
+            endpoint,
+            timeout: const Duration(milliseconds: 100),
+          );
+
+          expect(result.buffer.asUint8List(), [1, 2]);
+          expect(serial.writes, [
+            '<+${endpoint.representation}>',
+            '<-${endpoint.representation}>',
+          ]);
+        },
+      );
+    }
+
+    test('different representations can be pending concurrently', () async {
+      final a = transport.read(
+        Endpoint.versions,
+        timeout: const Duration(milliseconds: 100),
+      );
+      final j = transport.read(
+        Endpoint.temperatures,
+        timeout: const Duration(milliseconds: 100),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      serial.input.add('[J]02\n[A]01\n');
+
+      expect((await a).buffer.asUint8List(), [1]);
+      expect((await j).buffer.asUint8List(), [2]);
+    });
+
+    test('duplicate representation is rejected', () async {
+      final first = transport.read(
+        Endpoint.versions,
+        timeout: const Duration(milliseconds: 100),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      await expectLater(
+        transport.read(
+          Endpoint.versions,
+          timeout: const Duration(milliseconds: 100),
+        ),
+        throwsStateError,
+      );
+      serial.input.add('[A]01\n');
+      await first;
+    });
+
+    test('write failure clears the waiter and still unsubscribes', () async {
+      serial.failCommand = '<+A>';
+
+      await expectLater(
+        transport.read(
+          Endpoint.versions,
+          timeout: const Duration(milliseconds: 100),
+        ),
+        throwsStateError,
+      );
+
+      serial.failCommand = null;
+      serial.onWrite = (command) {
+        if (command == '<+A>') serial.input.add('[A]01\n');
+      };
+      expect(
+        (await transport.read(
+          Endpoint.versions,
+          timeout: const Duration(milliseconds: 100),
+        )).buffer.asUint8List(),
+        [1],
+      );
+      expect(serial.writes.where((command) => command == '<-A>').length, 2);
+    });
+
+    test('timeout clears the waiter and ignores a late response', () async {
+      await expectLater(
+        transport.read(Endpoint.versions, timeout: Duration.zero),
+        throwsA(isA<TimeoutException>()),
+      );
+      serial.input.add('[A]09\n');
+      serial.onWrite = (command) {
+        if (command == '<+A>') serial.input.add('[A]01\n');
+      };
+
+      final result = await transport.read(
+        Endpoint.versions,
+        timeout: const Duration(milliseconds: 100),
+      );
+
+      expect(result.buffer.asUint8List(), [1]);
+    });
+
+    test('malformed responses do not complete a request', () async {
+      final result = transport.read(
+        Endpoint.versions,
+        timeout: const Duration(milliseconds: 100),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      serial.input.add('[A]0\n[A]01\n');
+
+      expect((await result).buffer.asUint8List(), [1]);
+    });
+
+    test('transport disconnect fails pending requests immediately', () async {
+      final result = transport.read(
+        Endpoint.versions,
+        timeout: const Duration(seconds: 1),
+      );
+      await Future<void>.delayed(Duration.zero);
+      final expectation = expectLater(result, throwsStateError);
+
+      serial.emitDisconnected();
+
+      await expectation;
+    });
+
+    test('disconnect fails pending requests immediately', () async {
+      final result = transport.read(
+        Endpoint.versions,
+        timeout: const Duration(seconds: 1),
+      );
+      await Future<void>.delayed(Duration.zero);
+      final expectation = expectLater(result, throwsStateError);
+
+      await transport.disconnect();
+
+      await expectation;
+    });
+
+    test('dispose fails pending requests immediately', () async {
+      final result = transport.read(
+        Endpoint.versions,
+        timeout: const Duration(seconds: 1),
+      );
+      await Future<void>.delayed(Duration.zero);
+      final expectation = expectLater(result, throwsStateError);
+
+      await transport.dispose();
+
+      await expectation;
+    });
+
+    test(
+      'unsubscribe failure is surfaced after a successful response',
+      () async {
+        serial.failCommand = '<-A>';
+        serial.onWrite = (command) {
+          if (command == '<+A>') serial.input.add('[A]01\n');
+        };
+
+        await expectLater(
+          transport.read(
+            Endpoint.versions,
+            timeout: const Duration(milliseconds: 100),
+          ),
+          throwsStateError,
+        );
+      },
+    );
   });
 }

--- a/test/unit/models/device/impl/de1/unified_de1/serial_parity_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/serial_parity_test.dart
@@ -1,0 +1,104 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1_transport.dart';
+import 'package:reaprime/src/models/device/transport/serial_port.dart';
+import 'package:rxdart/rxdart.dart';
+
+import '../../../../../../helpers/fake_ble_transport.dart';
+
+class _RecordingSerialTransport extends SerialTransport {
+  final _connectionState = BehaviorSubject<ConnectionState>.seeded(
+    ConnectionState.connected,
+  );
+  final writes = <String>[];
+
+  @override
+  String get id => 'serial-test';
+
+  @override
+  String get name => 'Serial test';
+
+  @override
+  Stream<ConnectionState> get connectionState => _connectionState.stream;
+
+  @override
+  Stream<String> get readStream => const Stream.empty();
+
+  @override
+  Stream<Uint8List> get rawStream => const Stream.empty();
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void> dispose() => _connectionState.close();
+
+  @override
+  Future<void> writeCommand(String command) async => writes.add(command);
+
+  @override
+  Future<void> writeHexCommand(Uint8List command) async {}
+}
+
+void main() {
+  late _RecordingSerialTransport serial;
+  late UnifiedDe1Transport transport;
+
+  setUp(() {
+    serial = _RecordingSerialTransport();
+    transport = UnifiedDe1Transport(transport: serial);
+  });
+
+  tearDown(() => transport.dispose());
+
+  test('serial writeToMMR frames are exactly 20 bytes', () async {
+    for (final length in [1, 19, 20]) {
+      final input = Uint8List.fromList(List.generate(length, (i) => i + 1));
+      final original = Uint8List.fromList(input);
+
+      await transport.write(Endpoint.writeToMMR, input);
+
+      final payload = serial.writes.removeAt(0).substring(3);
+      expect(payload.length, 40);
+      expect(
+        payload.substring(0, length * 2),
+        original.map((byte) => byte.toRadixString(16).padLeft(2, '0')).join(),
+      );
+      expect(
+        payload.substring(length * 2),
+        List.filled((20 - length) * 2, '0').join(),
+      );
+      expect(input, original);
+    }
+  });
+
+  test('serial writeToMMR rejects frames longer than 20 bytes', () async {
+    await expectLater(
+      transport.write(Endpoint.writeToMMR, Uint8List(21)),
+      throwsArgumentError,
+    );
+    expect(serial.writes, isEmpty);
+  });
+
+  test('serial non-writeToMMR frames remain unchanged', () async {
+    await transport.write(Endpoint.headerWrite, Uint8List.fromList([1]));
+
+    expect(serial.writes, ['<O>01']);
+  });
+
+  test('BLE writeToMMR frames remain unchanged', () async {
+    final ble = FakeBleTransport();
+    final bleTransport = UnifiedDe1Transport(transport: ble);
+    addTearDown(bleTransport.dispose);
+
+    await bleTransport.write(Endpoint.writeToMMR, Uint8List.fromList([1]));
+
+    expect(ble.writes.single.data, [1]);
+  });
+}

--- a/test/unit/models/device/impl/de1/unified_de1/serial_parity_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/serial_parity_test.dart
@@ -19,8 +19,12 @@ class _RecordingSerialTransport extends SerialTransport {
   );
   final input = StreamController<String>.broadcast(sync: true);
   final writes = <String>[];
+  final blockedCommands = <String, Completer<void>>{};
   void Function(String command)? onWrite;
   String? failCommand;
+
+  Completer<void> blockCommand(String command) =>
+      blockedCommands[command] = Completer<void>();
 
   void emitDisconnected() {
     _connectionState.add(ConnectionState.disconnected);
@@ -58,6 +62,7 @@ class _RecordingSerialTransport extends SerialTransport {
     writes.add(command);
     onWrite?.call(command);
     if (command == failCommand) throw StateError('write failed');
+    await blockedCommands[command]?.future;
   }
 
   @override
@@ -338,6 +343,25 @@ void main() {
       );
 
       expect(result.buffer.asUint8List(), [1]);
+    });
+
+    test('read timeout is not extended by a fresh unsubscribe timeout',
+        () async {
+      const timeout = Duration(milliseconds: 300);
+      final unsubscribe = serial.blockCommand('<-A>');
+      final stopwatch = Stopwatch()..start();
+
+      try {
+        await expectLater(
+          transport.read(Endpoint.versions, timeout: timeout),
+          throwsA(isA<TimeoutException>()),
+        );
+        stopwatch.stop();
+
+        expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 500)));
+      } finally {
+        if (!unsubscribe.isCompleted) unsubscribe.complete();
+      }
     });
 
     test('malformed responses do not complete a request', () async {

--- a/test/unit/models/device/impl/de1/unified_de1/serial_response_correlator_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/serial_response_correlator_test.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/serial_response_correlator.dart';
+
+void main() {
+  test('correlates different representations independently', () async {
+    final correlator = SerialResponseCorrelator();
+    final a = correlator.register('A', const Duration(seconds: 1));
+    final j = correlator.register('J', const Duration(seconds: 1));
+
+    expect(correlator.complete('J', ByteData(2)), isTrue);
+    expect(correlator.complete('A', ByteData(1)), isTrue);
+
+    expect((await a).lengthInBytes, 1);
+    expect((await j).lengthInBytes, 2);
+  });
+
+  test('rejects a second pending request for the same representation', () {
+    final correlator = SerialResponseCorrelator();
+    correlator.register('A', const Duration(seconds: 1));
+
+    expect(
+      () => correlator.register('A', const Duration(seconds: 1)),
+      throwsStateError,
+    );
+  });
+
+  test('timeout removes the waiter and late responses are ignored', () async {
+    final correlator = SerialResponseCorrelator();
+
+    await expectLater(
+      correlator.register('A', Duration.zero),
+      throwsA(isA<TimeoutException>()),
+    );
+
+    expect(correlator.complete('A', ByteData(1)), isFalse);
+    final next = correlator.register('A', const Duration(seconds: 1));
+    correlator.complete('A', ByteData(2));
+    expect((await next).lengthInBytes, 2);
+  });
+
+  test('failAll fails and removes every waiter', () async {
+    final correlator = SerialResponseCorrelator();
+    final a = correlator.register('A', const Duration(seconds: 1));
+    final j = correlator.register('J', const Duration(seconds: 1));
+
+    correlator.failAll(StateError('disconnected'));
+
+    await expectLater(a, throwsStateError);
+    await expectLater(j, throwsStateError);
+    expect(correlator.hasPending, isFalse);
+  });
+}

--- a/test/unit/models/unified_de1_transport_dispose_test.dart
+++ b/test/unit/models/unified_de1_transport_dispose_test.dart
@@ -62,9 +62,8 @@ void main() {
     // Underlying transport should have been disposed
     expect(fake.disposeCalled, isTrue);
 
-    // After dispose, subjects are closed. A closed BehaviorSubject
-    // stream emits its last value then done, so drain and verify
-    // completion (not the value itself, which is a seeded zero buffer).
+    // After dispose, subjects are closed and complete without emitting
+    // placeholder values.
     for (final stream in [
       transport.state,
       transport.shotSample,
@@ -74,10 +73,7 @@ void main() {
       transport.fwMapRequest,
     ]) {
       final events = await stream.toList();
-      // Each subject was seeded with a ByteData buffer at construction.
-      // After close, toList() returns the buffered value and then
-      // completes — we just verify it completed (no timeout / hang).
-      expect(events.isNotEmpty, isTrue);
+      expect(events, isEmpty);
     }
   });
 

--- a/test/unit/services/serial/serial_probe_name_gate_test.dart
+++ b/test/unit/services/serial/serial_probe_name_gate_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/serial/utils.dart';
+
+void main() {
+  test('admits supported serial product names', () {
+    for (final name in [
+      'Bengle',
+      'DE1',
+      'Half Decent Scale',
+      'USB Serial Device',
+    ]) {
+      expect(serialProbeAllowsProductName(name), isTrue, reason: name);
+    }
+  });
+
+  test('preserves case sensitivity and rejects unrelated names', () {
+    for (final name in ['bengle', 'de1', 'USB serial Device', 'Keyboard']) {
+      expect(serialProbeAllowsProductName(name), isFalse, reason: name);
+    }
+  });
+
+  test('preserves existing null-name admission', () {
+    expect(serialProbeAllowsProductName(null), isTrue);
+  });
+}

--- a/test/unit/services/serial_reconcile_test.dart
+++ b/test/unit/services/serial_reconcile_test.dart
@@ -7,9 +7,12 @@ TrackedPortSnapshot _port(
   bool hds = false,
   bool present = true,
   ConnectionState state = ConnectionState.connected,
-}) =>
-    TrackedPortSnapshot(
-        path: path, isHdsSerial: hds, present: present, state: state);
+}) => TrackedPortSnapshot(
+  path: path,
+  isHdsSerial: hds,
+  present: present,
+  state: state,
+);
 
 void main() {
   group('planSerialReconcile — liveness gate', () {
@@ -17,14 +20,13 @@ void main() {
       required bool explicit,
       required int tick,
       int everyN = 3,
-    }) =>
-        planSerialReconcile(
-          explicitScan: explicit,
-          livenessTick: tick,
-          livenessEveryN: everyN,
-          tracked: const [],
-          hdsPaths: const {},
-        );
+    }) => planSerialReconcile(
+      explicitScan: explicit,
+      livenessTick: tick,
+      livenessEveryN: everyN,
+      tracked: const [],
+      hdsPaths: const {},
+    );
 
     test('an explicit scan is always a liveness pass', () {
       expect(plan(explicit: true, tick: 1).livenessPass, isTrue);
@@ -40,20 +42,23 @@ void main() {
   });
 
   group('planSerialReconcile — liveness releases', () {
-    test('releases a discovered (not-connected) HDS, keeps a connected one', () {
-      final p = planSerialReconcile(
-        explicitScan: true, // liveness pass
-        livenessTick: 1,
-        livenessEveryN: 3,
-        tracked: [
-          _port('/off', hds: true, state: ConnectionState.discovered),
-          _port('/live', hds: true, state: ConnectionState.connected),
-        ],
-        hdsPaths: {'/off', '/live'},
-      );
-      expect(p.release, {'/off'});
-      expect(p.reap, isEmpty, reason: 'a released path is not also reaped');
-    });
+    test(
+      'releases a discovered (not-connected) HDS, keeps a connected one',
+      () {
+        final p = planSerialReconcile(
+          explicitScan: true, // liveness pass
+          livenessTick: 1,
+          livenessEveryN: 3,
+          tracked: [
+            _port('/off', hds: true, state: ConnectionState.discovered),
+            _port('/live', hds: true, state: ConnectionState.connected),
+          ],
+          hdsPaths: {'/off', '/live'},
+        );
+        expect(p.release, {'/off'});
+        expect(p.reap, isEmpty, reason: 'a released path is not also reaped');
+      },
+    );
 
     test('does NOT release a CONNECTING HDS (would dispose mid-connect)', () {
       final p = planSerialReconcile(
@@ -81,17 +86,22 @@ void main() {
       expect(p.release, isEmpty);
     });
 
-    test('does not release a non-HDS device (it is reaped if disconnected)', () {
-      final p = planSerialReconcile(
-        explicitScan: true,
-        livenessTick: 1,
-        livenessEveryN: 3,
-        tracked: [_port('/de1', hds: false, state: ConnectionState.disconnected)],
-        hdsPaths: const {},
-      );
-      expect(p.release, isEmpty);
-      expect(p.reap, {'/de1'});
-    });
+    test(
+      'does not release a non-HDS device (it is reaped if disconnected)',
+      () {
+        final p = planSerialReconcile(
+          explicitScan: true,
+          livenessTick: 1,
+          livenessEveryN: 3,
+          tracked: [
+            _port('/de1', hds: false, state: ConnectionState.disconnected),
+          ],
+          hdsPaths: const {},
+        );
+        expect(p.release, isEmpty);
+        expect(p.reap, {'/de1'});
+      },
+    );
   });
 
   group('planSerialReconcile — reap + suppression', () {
@@ -112,7 +122,9 @@ void main() {
         explicitScan: false,
         livenessTick: 1,
         livenessEveryN: 3,
-        tracked: [_port('/s', present: true, state: ConnectionState.disconnected)],
+        tracked: [
+          _port('/s', present: true, state: ConnectionState.disconnected),
+        ],
         hdsPaths: const {},
       );
       expect(p.reap, {'/s'});
@@ -126,7 +138,14 @@ void main() {
         explicitScan: false,
         livenessTick: 1,
         livenessEveryN: 3,
-        tracked: [_port('/gone', hds: true, present: false, state: ConnectionState.connected)],
+        tracked: [
+          _port(
+            '/gone',
+            hds: true,
+            present: false,
+            state: ConnectionState.connected,
+          ),
+        ],
         hdsPaths: {'/gone'},
       );
       expect(p.reap, {'/gone'});
@@ -135,8 +154,7 @@ void main() {
       expect(p.hdsForget, {'/gone'});
     });
 
-    test(
-        'a liveness pass lifts HDS suppression, but a same-pass present '
+    test('a liveness pass lifts HDS suppression, but a same-pass present '
         'self-disconnected HDS nets to suppressed (add wins)', () {
       final p = planSerialReconcile(
         explicitScan: true, // liveness pass
@@ -146,7 +164,12 @@ void main() {
           // present + disconnected HDS → released first (not connected), so it
           // won't reach the reap branch. Use a NON-HDS present self-disconnect
           // that is also (artificially) in hdsPaths to exercise the net.
-          _port('/x', hds: false, present: true, state: ConnectionState.disconnected),
+          _port(
+            '/x',
+            hds: false,
+            present: true,
+            state: ConnectionState.disconnected,
+          ),
         ],
         hdsPaths: {'/x', '/other'},
       );
@@ -195,37 +218,65 @@ void main() {
   group('serialPortMatchesCandidate', () {
     test('rejects Bluetooth transport', () {
       expect(
-          serialPortMatchesCandidate(
-              name: 'cu.usbmodem1', transport: 'Bluetooth'),
-          isFalse);
+        serialPortMatchesCandidate(
+          name: 'cu.usbmodem1',
+          transport: 'Bluetooth',
+        ),
+        isFalse,
+      );
     });
     test('accepts known productNames', () {
       expect(
+        serialPortMatchesCandidate(
+          name: 'COM5',
+          transport: 'USB',
+          productName: 'DE1',
+        ),
+        isTrue,
+      );
+      for (final productName in ['Bengle', 'Half Decent Scale']) {
+        expect(
           serialPortMatchesCandidate(
-              name: 'COM5', transport: 'USB', productName: 'DE1'),
-          isTrue);
-      expect(
-          serialPortMatchesCandidate(
-              name: 'whatever',
-              transport: 'Unknown',
-              productName: 'Half Decent Scale'),
-          isTrue);
+            name: 'whatever',
+            transport: 'Unknown',
+            productName: productName,
+          ),
+          isTrue,
+        );
+      }
     });
     test('accepts unix usb-serial port names', () {
-      for (final n in ['cu.usbmodem1', 'ttyACM0', 'ttyUSB0', 'cu.wchusbserial']) {
-        expect(serialPortMatchesCandidate(name: n, transport: 'USB'), isTrue,
-            reason: n);
+      for (final n in [
+        'cu.usbmodem1',
+        'ttyACM0',
+        'ttyUSB0',
+        'cu.wchusbserial',
+      ]) {
+        expect(
+          serialPortMatchesCandidate(name: n, transport: 'USB'),
+          isTrue,
+          reason: n,
+        );
       }
     });
     test('accepts a USB COM port, rejects a non-USB COM port', () {
-      expect(serialPortMatchesCandidate(name: 'COM3', transport: 'USB'), isTrue);
       expect(
-          serialPortMatchesCandidate(name: 'COM3', transport: 'Native'), isFalse);
+        serialPortMatchesCandidate(name: 'COM3', transport: 'USB'),
+        isTrue,
+      );
+      expect(
+        serialPortMatchesCandidate(name: 'COM3', transport: 'Native'),
+        isFalse,
+      );
     });
     test('rejects an unrelated port', () {
       expect(
-          serialPortMatchesCandidate(name: 'cu.Bluetooth-Incoming', transport: 'Native'),
-          isFalse);
+        serialPortMatchesCandidate(
+          name: 'cu.Bluetooth-Incoming',
+          transport: 'Native',
+        ),
+        isFalse,
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

- Problem: USB-serial DE1-family connections lacked exact firmware framing, honest read semantics, generic one-shot response correlation, and reliable Bengle/name handling; Bluetooth errors could also replace a viable wired connection flow.
- Why it matters: users need wired discovery and connection to remain usable when Bluetooth is unavailable, without synthetic endpoint data or malformed final firmware chunks.
- What changed: added exact 20-byte serial `<F>` framing, generic A/J/R one-shot correlation, observed-data-only reads, exact Bengle product-name admission plus `v13Model` classification, transport-scoped connection conditions, wired-safe scan presentation, and per-transport preference coverage.
- What did NOT change (scope boundary): no PID/VID Bengle recognition, BLE/USB identity aliasing, live transport transfer, machine replacement, serial keepalive, or serial-specific reconnect lifecycle. This independently reimplements selected behavior researched in #460 on current `main`.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [x] UI / Flutter widgets
- [ ] Storage / Drift database
- [x] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Related #460

## Root Cause (if bug fix)

- Root cause: serial transport behavior had accumulated BLE-shaped assumptions (variable `<F>` frames, seeded endpoint state, endpoint-specific response paths), while scan presentation treated Bluetooth availability as a global gate.
- Missing detection or guardrail: byte-level framing tests, typed unavailable-state coverage, representation-keyed correlation tests, and transport-aware presentation tests were absent.
- Contributing context (if known): discovery services already run independently, but that transport scope was not carried through connection status to the scan UI.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `serial_parity_test.dart`, `serial_response_correlator_test.dart`, `serial_probe_name_gate_test.dart`, `connection_manager_test.dart`, `scan_flow_presentation_test.dart`, `scan_flow_view_test.dart`, and `connection_manager_usb_attach_test.dart`.
- Scenario the test should lock in: exact serial framing and correlation; no invented endpoint state; Bengle recognition without USB IDs; Bluetooth conditions remain nonblocking for viable serial candidates but blocking for BLE-only flows; BLE and USB preferred IDs remain distinct.
- If no new test added, why not: N/A — focused tests were added.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [x] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A — no docs affected

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `Yes`
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`
- If any `Yes`, explain risk and mitigation: serial framing, reads, and USB discovery admission changed. Bounds checks reject oversized frames; reads are correlated or typed unavailable/unsupported; Bengle admission remains exact-name or protocol-probe based and deliberately excludes PID/VID shortcuts.

## User-Visible Changes

- USB discovery and serial machine selection remain usable when Bluetooth is off.
- Bluetooth problems appear as a nonblocking notice when a wired path exists, while BLE-only blockers remain explicit.
- Exact `Bengle` USB product names are recognized.
- BLE and USB identities remain separate; selecting USB makes that USB ID preferred for later quick-connects.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass (2447 tests)
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds

### Manual verification (if applicable)

- OS / platform tested: macOS
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `Yes` (user-reported wired test)
- What you personally verified and how: user disabled Bluetooth on macOS and confirmed the wired discovery/connection flow remained usable.
- Edge cases checked: short/exact/oversized `<F>` frames; concurrent/duplicate/late one-shot responses; disconnect cleanup; absent endpoint data; exact/case-sensitive product names; serial and BLE-only picker behavior; preferred-ID replacement and USB attach fallback.
- What you did **not** verify: firmware upload on hardware, Android USB attach timing, Bengle hardware classification, and A/J/R hardware captures.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`
- If any `No` or `Yes`, explain exact steps: no migration or operator action required.

## Risks & Mitigations

- Risk: serial firmware and USB descriptors vary across hardware revisions.
  - Mitigation: recognition remains restricted to existing name admission plus authoritative `v13Model` probing; unsupported devices are disposed and rejected cleanly.
- Risk: Bluetooth conditions could obscure a selected-device failure.
  - Mitigation: the pure presentation resolver and widget regression tests preserve actual serial connection failures separately from partial Bluetooth notices.
