### PR TITLE
fix(scale): separate control and display flow smoothing

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -118,3 +118,14 @@ jobs:
 
       - name: Build Linux app (unsigned)
         run: flutter build linux --release
+
+  tools:
+    name: Python tools tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Test weight-flow analysis tool
+        run: python3 tools/analyze_weight_flow_test.py

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3995,12 +3995,52 @@ paths:
                       type: string
                     message:
                       type: string
+  /api/v1/debug/flow-smoothing:
+    get:
+      summary: Get runtime display-flow smoothing (debug builds only)
+      description: |
+        Returns the process-local display-flow smoothing configuration. Available
+        only when the app is built with a non-empty `simulate` Dart define.
+      tags: [Debug]
+      responses:
+        "200":
+          description: Current smoothing configuration
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlowSmoothingConfig"
+        "404":
+          description: Endpoint not available (non-debug build)
+    post:
+      summary: Set runtime display-flow smoothing (debug builds only)
+      description: |
+        Atomically updates and resets the display-flow estimator. Values are
+        process-local and do not affect the Kalman control-flow estimator.
+      tags: [Debug]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FlowSmoothingConfig"
+      responses:
+        "200":
+          description: Updated smoothing configuration
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlowSmoothingConfig"
+        "400":
+          description: Invalid JSON, type, or range
+        "404":
+          description: Endpoint not available (non-debug build)
+
   /api/v1/debug/scale/{command}:
     post:
       summary: Control mock scale (simulate mode only)
       description: |
         Debug endpoints for controlling the simulated scale. Only available
-        when the app is launched with `--dart-define=simulate=1`.
+        when the app is launched with a non-empty `simulate` Dart define.
         Returns 404 on production builds.
       tags: [Debug]
       parameters:
@@ -4295,6 +4335,21 @@ paths:
 
 components:
   schemas:
+    FlowSmoothingConfig:
+      type: object
+      required: [windowMs, movingAverageSamples]
+      properties:
+        windowMs:
+          type: integer
+          minimum: 100
+          maximum: 2000
+          example: 600
+        movingAverageSamples:
+          type: integer
+          minimum: 1
+          maximum: 50
+          example: 10
+
     AppUpdateState:
       type: object
       description: Snapshot of the app-update state machine.

--- a/doc/AI_BUILD_NOTES.md
+++ b/doc/AI_BUILD_NOTES.md
@@ -37,8 +37,20 @@ Simulated devices avoid hardware requirements for smoke testing. Available types
 | `bengle` | `MockBengle` only |
 | `machine,scale` | `MockDe1` + `MockScale` |
 | `sensor` | `MockSensor` only |
+| `0` | None (debug routes on, real hardware) |
 
 Also toggleable from the settings UI after launch.
+
+### `simulate=0` mode
+
+`--dart-define=simulate=0` enables the debug infrastructure (API routes,
+no-Firebase, no-telemetry) while creating zero simulated devices. Use it for
+temporary real-hardware tuning builds where debug endpoints must be reachable.
+
+- Enables debug REST routes (`/api/v1/debug/*`)
+- Creates no simulated devices — all BLE/USB hardware is real
+- Disables Firebase and telemetry
+- Must not be used for production releases
 
 ## Platform Config
 

--- a/doc/AI_DEBUG_NOTES.md
+++ b/doc/AI_DEBUG_NOTES.md
@@ -13,6 +13,7 @@ Read this when debugging BLE errors, diagnosing platform-specific crashes, inves
 - **adb logcat:** `adb logcat | grep -i rea` for live output on Android.
 - **macOS log path:** `~/Library/Containers/net.tadel.reaprime/Data/Documents/log.txt`.
 - **Simulate mode:** Reproduce without hardware using `--dart-define=simulate=1`. Mock devices are deterministic — use them to isolate whether an issue is transport or logic.
+- **`simulate=0` (debug-on-real):** `--dart-define=simulate=0` enables debug routes and disables Firebase/telemetry while keeping real BLE/USB hardware. Use for temporary tuning builds where `/api/v1/debug/*` must be reachable against real devices. Must not be shipped to users.
 - **Stream debugging:** Enable `Logger('ShotState')` for structured shot decisions. `Logger('Ble')` for BLE operations.
 
 ## Common Error Patterns

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -324,18 +324,20 @@ The **proxy** lets clients *use* the account without ever seeing the credentials
 | GET | `/api/v1/webview/logs` | WebView console log forwarding, newest first (`?order=asc` for original chronological order) | `webview_logs_handler.dart` |
 | POST | `/api/v1/derek/answers/stream` | Relay to the Derek RAG assistant: forwards the JSON body verbatim to `derek.decentespresso.com/api/answers/stream` and pipes the SSE response back unbuffered. No auth (public data). Exists so browser skins avoid Derek's failing CORS preflight. | `derek_handler.dart` |
 
-### Debug (simulate mode only)
+### Debug (debug builds only)
 
-Only registered when the app is launched with `--dart-define=simulate=1`. Returns 404 on production builds.
+Only registered when the app is launched with a non-empty `simulate` Dart define. Use `--dart-define=simulate=0` to enable the routes without selecting simulated devices. Returns 404 on production builds.
 
 | Method | Endpoint | Description | Handler |
 |--------|----------|-------------|---------|
 | POST | `/api/v1/debug/update/force` | Force a fake "update available" so the update API/UI can be tested without a real newer release. Optional query: `version` (default `99.0.0`), `downloadUrl` (default = real latest APK, so the download/install path runs end-to-end). | `debug_handler.dart` |
+| GET | `/api/v1/debug/flow-smoothing` | Read process-local display-flow smoothing (`windowMs`, `movingAverageSamples`). | `debug_handler.dart` |
+| POST | `/api/v1/debug/flow-smoothing` | Atomically update and reset display-flow smoothing; accepts integer `windowMs` (100–2000) and `movingAverageSamples` (1–50). | `debug_handler.dart` |
 | POST | `/api/v1/debug/scale/stall` | Pause mock scale weight emission (stays "connected") | `debug_handler.dart` |
 | POST | `/api/v1/debug/scale/resume` | Resume weight emission after stall | `debug_handler.dart` |
 | POST | `/api/v1/debug/scale/disconnect` | Simulate scale disconnect (emits disconnected state, stops data) | `debug_handler.dart` |
 
-All endpoints return 400 if no scale is connected or the connected scale is not a `MockScale`.
+Mock-scale command endpoints return 400 if no scale is connected or the connected scale is not a `MockScale`.
 
 ---
 

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -579,7 +579,8 @@ Future<void> connectToDe1(De1Interface de1Interface) async {
 **Responsibilities:**
 - Manages scale connection lifecycle (called by ConnectionManager)
 - Processes weight and flow data
-- Calculates smoothed weight flow
+- Calculates low-lag Kalman control flow for weight-based decisions
+- Calculates separately smoothed display flow for snapshots and shot history
 - Exposes weight snapshots and connection state
 
 **Note:** ScaleController does **not** auto-connect. Connection decisions are made by `ConnectionManager`. ScaleController only handles the mechanics of connecting to a specific scale.

--- a/doc/plans/2026-07-22-issue-484-flow-smoothing.md
+++ b/doc/plans/2026-07-22-issue-484-flow-smoothing.md
@@ -1,0 +1,165 @@
+# Design — #484 weight-flow smoothing regression
+
+- **Issue:** [#484](https://github.com/tadelv/reaprime/issues/484)
+- **Related:** [#420](https://github.com/tadelv/reaprime/issues/420) — SAW lead decomposition
+- **Date:** 2026-07-22
+- **Status:** agreed, not implemented
+
+## Problem
+
+The Kalman estimator introduced for #417 now supplies one `weightFlow` value to two consumers with conflicting requirements:
+
+- control decisions need low latency;
+- charts, shot history, WebSocket clients, and Visualizer need visual stability.
+
+The regression reproduces in both shot pairs attached to #484. Mean absolute change between active consecutive stored flow samples is:
+
+| Profile | de1app | Decent.app | Ratio |
+|---|---:|---:|---:|
+| Filter3 | 0.035 g/s | 0.437 g/s | 12.3× |
+| Espresso | 0.060 g/s | 0.219 g/s | 3.7× |
+
+Five recent shots from `192.168.12.57` reproduce the same Decent.app range at 3.7–4.4 Hz: mean `|Δflow|` is 0.37–0.54 g/s.
+
+## Root cause
+
+The Kalman regression test compares Kalman output against `FlowCalculator` alone. The production legacy path was `FlowCalculator(600ms) + MovingAverage(10)`, so the benchmark omitted its second smoothing stage.
+
+On `test/fixtures/shot1_native_trace.csv`:
+
+- current Kalman: 13.1% standard deviation / mean;
+- actual legacy pipeline: 9.9%;
+- actual legacy mean `|Δflow|`: 0.099 g/s.
+
+PR #437 then relaxed Kalman smoothing to address filtered-weight lag. Raw weight now bypasses the Kalman, but the noisier tuning remains visible through `weightFlow`.
+
+The de1app source also separates fast, slow, and SAW flow estimates in `de1plus/device_scale.tcl`; Decent.app currently uses one value for every role.
+
+## Design
+
+### Split control and display flow
+
+Extend `WeightSnapshot` with an internal `controlWeightFlow` value:
+
+- Kalman output becomes `controlWeightFlow`;
+- `FlowCalculator(600ms) + MovingAverage(10)` becomes public `weightFlow`;
+- `controlWeightFlow` defaults to `weightFlow` when omitted;
+- `controlWeightFlow` is excluded from JSON serialization.
+
+This keeps existing shot, REST, WebSocket, skin, plugin, import, and database contracts unchanged.
+
+Use control flow for:
+
+- `ShotSequencer` projected-weight SAW and per-step weight exits;
+- `ShotSequencer._refineStoppingYield` removal, spike, and settle detection;
+- hot-water projected-weight stopping.
+
+Use display flow for:
+
+- shot measurements and history;
+- REST/WebSocket scale snapshots;
+- realtime UI and charts;
+- Visualizer upload;
+- exported/imported shot data.
+
+### Retire the feature flag
+
+Remove `FeatureFlag.kalmanFlow` and its Advanced Settings toggle. Kalman becomes the fixed internal control estimator, while the legacy smoothing pipeline becomes the fixed public display estimator. Retaining the toggle would give it ambiguous semantics and allow unsigned legacy flow back into control decisions.
+
+### Runtime display tuning
+
+Add ephemeral debug routes:
+
+- `GET /api/v1/debug/flow-smoothing`
+- `POST /api/v1/debug/flow-smoothing`
+
+Payload:
+
+```json
+{
+  "windowMs": 600,
+  "movingAverageSamples": 10
+}
+```
+
+The POST route validates positive bounded integers, applies both values atomically, and resets only the display estimator. Values are process-local and never persisted. Kalman parameters are not exposed.
+
+Debug routes remain compile-time gated by the existing `simulate` Dart define. A real-hardware tuning build can use `--dart-define=simulate=0`: the value registers debug routes but selects no simulated device types.
+
+Update `assets/api/rest_v1.yml` with the debug contract in the same change.
+
+### Offline analysis tool
+
+Add a standard-library-only `tools/analyze_weight_flow.py` that:
+
+- accepts a server base URL and one or more shot IDs;
+- fetches each full `/api/v1/shots/{id}` record;
+- reports sample count, median cadence, active-flow mean `|Δflow|`, p95 `|Δflow|`, and second-difference noise;
+- emits CSV and standalone SVG plots.
+
+Persisted shots are sufficient to score and plot display output. They are not suitable for replaying alternate smoothing parameters because machine-driven persistence downsamples the native scale stream.
+
+## Sequencer cadence
+
+Do not change shot sampling cadence in #484.
+
+`ShotSequencer` is intentionally machine-driven and combines each machine snapshot with the latest scale value. Driving it from whichever stream is fastest would repeatedly process stale machine snapshots and complicate state transitions, profile-frame exits, volume integration, and persistence. A fixed 10 Hz timer would manufacture duplicate samples.
+
+A future #420 refactor may split event handling:
+
+- machine stream for lifecycle, profile frames, volume, and persistence;
+- native scale stream for SAW and post-stop decisions.
+
+That change is independent of this display regression.
+
+## Test-first implementation sequence
+
+1. Correct the golden benchmark to include the full legacy pipeline and demonstrate that current public Kalman output exceeds the agreed display threshold.
+2. Add `WeightSnapshot.controlWeightFlow` compatibility tests:
+   - omitted value falls back to `weightFlow`;
+   - JSON output remains unchanged;
+   - imported historical snapshots receive the fallback.
+3. Add `ScaleController` tests proving:
+   - display mean `|Δflow| ≤ 0.12 g/s` on the native fixture;
+   - control flow remains the existing signed Kalman result;
+   - tare resets both estimators;
+   - runtime tuning resets only display smoothing.
+4. Add divergent-value controller tests proving SAW, hot-water stopping, and stopping-yield refinement consume control flow rather than display flow.
+5. Add debug handler tests for GET, valid atomic update, invalid bounds/types, and estimator reset.
+6. Implement the smallest changes that satisfy those tests.
+7. Remove the Kalman feature flag, settings toggle, and obsolete selection branches.
+8. Add the offline analysis tool and test its metric calculation against a small local fixture.
+
+## Verification
+
+### Automated
+
+- Relevant controller, handler, serialization, and tool tests pass.
+- Display flow mean `|Δflow| ≤ 0.12 g/s` on the native fixture.
+- Existing Kalman control-flow golden behavior remains unchanged.
+- `flutter analyze` passes.
+- Full `flutter test` passes.
+
+### Real hardware
+
+1. Build once with debug routes enabled and connect to the real machine and scale.
+2. Use the debug API to tune without rebuilding.
+3. Pull a long allonge shot before and after tuning.
+4. Run `tools/analyze_weight_flow.py` and inspect its SVG plots.
+5. Require at least 75% lower mean `|Δflow|` than the current Decent.app baseline for the comparable active-flow section.
+6. Pull one SAW shot and require final yield within 1 g of target.
+
+Filter3 is not required; an allonge provides the long-running low-flow trace needed to expose chart chatter.
+
+## Non-goals
+
+- Native-rate shot persistence.
+- Fastest-stream or timer-driven `ShotSequencer` sampling.
+- SAW lead decomposition or runtime transport-lag measurement.
+- Public API exposure of control flow.
+- Persistent user-facing smoothing settings.
+- Runtime tuning of Kalman parameters.
+
+## Completion
+
+After implementation and verification, archive this design under `doc/plans/archive/flow-smoothing/` and update the #484 tracking item with measured before/after results.

--- a/doc/plans/archive/flow-smoothing/2026-07-22-issue-484-flow-smoothing.md
+++ b/doc/plans/archive/flow-smoothing/2026-07-22-issue-484-flow-smoothing.md
@@ -168,6 +168,7 @@ Filter3 is not required; an allonge provides the long-running low-flow trace nee
 - `flutter test`: 2461 tests passed.
 - Python analysis-tool test: passed.
 - Simulated REST smoke: GET, valid POST, invalid POST, hot reload, and state retention passed.
-- Real-hardware allonge and SAW validation: pending.
+- Real-hardware allonge steady-tail mean `|Δflow|`: 0.049 g/s versus 0.276 g/s on the preceding comparable shot, an 82% reduction.
+- First real-hardware SAW result: 53.8 g against 52.5 g target (+1.3 g); one more SAW validation shot is required for the ±1 g gate.
 
-Update the #484 tracking item with measured before/after hardware results after validation.
+Update the #484 tracking item after the remaining SAW validation.

--- a/doc/plans/archive/flow-smoothing/2026-07-22-issue-484-flow-smoothing.md
+++ b/doc/plans/archive/flow-smoothing/2026-07-22-issue-484-flow-smoothing.md
@@ -3,7 +3,7 @@
 - **Issue:** [#484](https://github.com/tadelv/reaprime/issues/484)
 - **Related:** [#420](https://github.com/tadelv/reaprime/issues/420) — SAW lead decomposition
 - **Date:** 2026-07-22
-- **Status:** implemented; real-hardware allonge and SAW validation pending
+- **Status:** implemented and validated
 
 ## Problem
 
@@ -169,6 +169,4 @@ Filter3 is not required; an allonge provides the long-running low-flow trace nee
 - Python analysis-tool test: passed.
 - Simulated REST smoke: GET, valid POST, invalid POST, hot reload, and state retention passed.
 - Real-hardware allonge steady-tail mean `|Δflow|`: 0.049 g/s versus 0.276 g/s on the preceding comparable shot, an 82% reduction.
-- First real-hardware SAW result was invalidated: 53.8 g against 52.5 g target (+1.3 g) was pulled with `weightFlowMultiplier: 0.7` instead of the 1.0 baseline. Repeat after restoring the baseline.
-
-Update the #484 tracking item after the remaining SAW validation.
+- SAW calibration results against a 52.5 g target: multiplier 0.7 yielded 53.8 g, multiplier 1.0 yielded 50.7 g, and multiplier 0.83 yielded 53.3 g (+0.8 g), passing the ±1 g gate.

--- a/doc/plans/archive/flow-smoothing/2026-07-22-issue-484-flow-smoothing.md
+++ b/doc/plans/archive/flow-smoothing/2026-07-22-issue-484-flow-smoothing.md
@@ -169,6 +169,6 @@ Filter3 is not required; an allonge provides the long-running low-flow trace nee
 - Python analysis-tool test: passed.
 - Simulated REST smoke: GET, valid POST, invalid POST, hot reload, and state retention passed.
 - Real-hardware allonge steady-tail mean `|Δflow|`: 0.049 g/s versus 0.276 g/s on the preceding comparable shot, an 82% reduction.
-- First real-hardware SAW result: 53.8 g against 52.5 g target (+1.3 g); one more SAW validation shot is required for the ±1 g gate.
+- First real-hardware SAW result was invalidated: 53.8 g against 52.5 g target (+1.3 g) was pulled with `weightFlowMultiplier: 0.7` instead of the 1.0 baseline. Repeat after restoring the baseline.
 
 Update the #484 tracking item after the remaining SAW validation.

--- a/doc/plans/archive/flow-smoothing/2026-07-22-issue-484-flow-smoothing.md
+++ b/doc/plans/archive/flow-smoothing/2026-07-22-issue-484-flow-smoothing.md
@@ -3,7 +3,7 @@
 - **Issue:** [#484](https://github.com/tadelv/reaprime/issues/484)
 - **Related:** [#420](https://github.com/tadelv/reaprime/issues/420) — SAW lead decomposition
 - **Date:** 2026-07-22
-- **Status:** agreed, not implemented
+- **Status:** implemented; real-hardware allonge and SAW validation pending
 
 ## Problem
 
@@ -160,6 +160,14 @@ Filter3 is not required; an allonge provides the long-running low-flow trace nee
 - Persistent user-facing smoothing settings.
 - Runtime tuning of Kalman parameters.
 
-## Completion
+## Implementation verification
 
-After implementation and verification, archive this design under `doc/plans/archive/flow-smoothing/` and update the #484 tracking item with measured before/after results.
+- Native fixture display mean `|Δflow|`: within the 0.12 g/s gate.
+- Existing Kalman control output: unchanged (`0.2597772268251356` mean `|Δflow|` on the fixture).
+- `flutter analyze`: clean.
+- `flutter test`: 2461 tests passed.
+- Python analysis-tool test: passed.
+- Simulated REST smoke: GET, valid POST, invalid POST, hot reload, and state retention passed.
+- Real-hardware allonge and SAW validation: pending.
+
+Update the #484 tracking item with measured before/after hardware results after validation.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -71,7 +71,6 @@ import 'src/launcher/launcher_view.dart';
 import 'src/services/foreground_service.dart';
 import 'src/services/network/multicast_lock_service.dart';
 import 'src/settings/settings_controller.dart';
-import 'src/settings/feature_flags.dart';
 import 'src/settings/settings_service.dart';
 import 'src/services/serial/serial_service.dart';
 
@@ -314,10 +313,7 @@ void main(List<String> args) async {
   deviceController.telemetryService = telemetryService;
   final de1Controller = De1Controller(controller: deviceController)
     ..defaultWorkflow = workflowController.currentWorkflow;
-  final scaleController = ScaleController()
-    ..setKalmanFlowEnabled(
-      settingsController.isFeatureFlagEnabled(FeatureFlag.kalmanFlow),
-    );
+  final scaleController = ScaleController();
   final sensorController = SensorController(controller: deviceController);
 
   // Remembers devices the user connects to (machine + scale), shown as

--- a/lib/src/controllers/hot_water_sequencer.dart
+++ b/lib/src/controllers/hot_water_sequencer.dart
@@ -50,9 +50,9 @@ class HotWaterSequencer {
   final Logger _log = Logger('HotWaterSequencer');
 
   /// Window after a tare during which the scale reading is not yet trustworthy
-  /// (matches [ScaleController.smoothingWindowDuration]).
+  /// (matches [ScaleController.defaultSmoothingWindow]).
   static const Duration _tareSettleWindow =
-      ScaleController.smoothingWindowDuration;
+      ScaleController.defaultSmoothingWindow;
 
   /// A scale frame older than this is considered stale.
   static const Duration _scaleFreshWindow = Duration(seconds: 2);

--- a/lib/src/controllers/hot_water_sequencer.dart
+++ b/lib/src/controllers/hot_water_sequencer.dart
@@ -31,10 +31,10 @@ class HotWaterSequencer {
     required ScaleController scaleController,
     required SettingsController settingsController,
     DateTime Function()? now,
-  })  : _de1 = de1Controller,
-        _scale = scaleController,
-        _settings = settingsController,
-        _now = now ?? DateTime.now {
+  }) : _de1 = de1Controller,
+       _scale = scaleController,
+       _settings = settingsController,
+       _now = now ?? DateTime.now {
     _scaleConnected =
         _scale.currentConnectionState == device.ConnectionState.connected;
     _hotWaterSub = _de1.hotWaterData.listen((hw) => _latestHotWater = hw);
@@ -169,14 +169,16 @@ class HotWaterSequencer {
     final input = HotWaterStopInput(
       machineState: _latestMachineState,
       sinceArmed: _armedAt == null ? Duration.zero : now.difference(_armedAt!),
-      tareSettled: _tareConfirmed &&
+      tareSettled:
+          _tareConfirmed &&
           _tareRequestedAt != null &&
           now.difference(_tareRequestedAt!) >= _tareSettleWindow,
-      freshScale: _scaleConnected &&
+      freshScale:
+          _scaleConnected &&
           _lastWeightAt != null &&
           now.difference(_lastWeightAt!) < _scaleFreshWindow,
       weight: _latestWeight?.weight,
-      weightFlow: _latestWeight?.weightFlow,
+      weightFlow: _latestWeight?.controlWeightFlow,
     );
 
     final decision = nextHotWaterStop(state, input);
@@ -193,7 +195,9 @@ class HotWaterSequencer {
       );
       final machine = _machine;
       if (machine != null) {
-        machine.requestState(MachineState.idle).catchError(
+        machine
+            .requestState(MachineState.idle)
+            .catchError(
               (e) => _log.warning('Failed to stop hot water at weight', e),
             );
       }

--- a/lib/src/controllers/scale_controller.dart
+++ b/lib/src/controllers/scale_controller.dart
@@ -64,7 +64,9 @@ class ScaleController {
         }
       } catch (e) {
         log.warning(
-            'Failed to disconnect previous scale ${previous.deviceId}', e);
+          'Failed to disconnect previous scale ${previous.deviceId}',
+          e,
+        );
       }
     }
     _scaleSnapshot = scale.currentSnapshot.listen(_processSnapshot);
@@ -117,7 +119,10 @@ class ScaleController {
           await previous.disconnect();
         }
       } catch (e) {
-        log.warning('Failed to disconnect previous scale ${previous.deviceId}', e);
+        log.warning(
+          'Failed to disconnect previous scale ${previous.deviceId}',
+          e,
+        );
       }
     }
     _scaleSnapshot = scale.currentSnapshot.listen(_processSnapshot);
@@ -140,7 +145,7 @@ class ScaleController {
     _scaleConnection?.cancel();
     _scale = null;
     _scaleConnection = null;
-    _flowCalculator = FlowCalculator(windowDuration: smoothingWindowDuration);
+    _resetDisplayEstimator();
     _kalmanEstimator = null;
     _lastSnapshotTime = null;
     _flowSettleUntil = null;
@@ -164,10 +169,10 @@ class ScaleController {
 
   Stream<WeightSnapshot> get weightSnapshot => _weightSnapshotController.stream;
 
-  MovingAverage weightFlowAverage = MovingAverage(10);
-
   static const smoothingWindowDuration = Duration(milliseconds: 600);
+  static const movingAverageSamples = 10;
 
+  MovingAverage weightFlowAverage = MovingAverage(movingAverageSamples);
   FlowCalculator _flowCalculator = FlowCalculator(
     windowDuration: smoothingWindowDuration,
   );
@@ -176,23 +181,8 @@ class ScaleController {
   /// window off the scale's own clock rather than the wall clock.
   DateTime? _lastSnapshotTime;
 
-  /// Until this scale-clock time, report `weightFlow` as 0 (legacy path only).
-  /// The Kalman path uses [KalmanFlowEstimator.reset] instead — a principled
-  /// re-init at the weight discontinuity rather than a suppress window.
+  /// Until this scale-clock time, report `weightFlow` as 0.
   DateTime? _flowSettleUntil;
-
-  // -- Feature flag / estimator selection --
-
-  /// When true, the Kalman estimator replaces [FlowCalculator] +
-  /// [MovingAverage]. Controlled by [FeatureFlag.kalmanFlow].
-  bool _kalmanFlowEnabled = false;
-
-  /// Enable or disable the Kalman flow estimator at runtime. Safe to call
-  /// while a scale is connected — the flag takes effect on the next
-  /// snapshot.
-  void setKalmanFlowEnabled(bool enabled) {
-    _kalmanFlowEnabled = enabled;
-  }
 
   KalmanFlowEstimator? _kalmanEstimator;
 
@@ -207,46 +197,41 @@ class ScaleController {
   Future<void> tare() async {
     final scale = connectedScale();
     await scale.tare();
-    if (_kalmanFlowEnabled) {
-      _kalmanEstimator?.reset(0.0);
-    } else {
-      _flowCalculator =
-          FlowCalculator(windowDuration: smoothingWindowDuration);
-      weightFlowAverage = MovingAverage(10);
-      _flowSettleUntil = _lastSnapshotTime?.add(smoothingWindowDuration);
-    }
+    _kalmanEstimator?.reset(0.0);
+    _resetDisplayEstimator();
+    _flowSettleUntil = _lastSnapshotTime?.add(smoothingWindowDuration);
+  }
+
+  void _resetDisplayEstimator() {
+    _flowCalculator = FlowCalculator(windowDuration: smoothingWindowDuration);
+    weightFlowAverage = MovingAverage(movingAverageSamples);
   }
 
   void _processSnapshot(ScaleSnapshot snapshot) {
     _lastSnapshotTime = snapshot.timestamp;
 
-    final double filteredWeight;
-    final double flow;
+    _kalmanEstimator ??= KalmanFlowEstimator(initialWeight: snapshot.weight);
+    final (_, controlFlow) = _kalmanEstimator!.addSample(
+      snapshot.timestamp,
+      snapshot.weight,
+    );
 
-    if (_kalmanFlowEnabled) {
-      _kalmanEstimator ??=
-          KalmanFlowEstimator(initialWeight: snapshot.weight);
-      final (w, f) =
-          _kalmanEstimator!.addSample(snapshot.timestamp, snapshot.weight);
-      filteredWeight = snapshot.weight;
-      flow = f;
-    } else {
-      // Legacy path: endpoint-difference FlowCalculator + MovingAverage.
-      filteredWeight = snapshot.weight;
-      final rawFlow =
-          _flowCalculator.addSample(snapshot.timestamp, snapshot.weight);
-      weightFlowAverage.add(rawFlow);
-
-      final settling = _flowSettleUntil != null &&
-          snapshot.timestamp.isBefore(_flowSettleUntil!);
-      flow = settling ? 0.0 : weightFlowAverage.average;
-    }
+    final rawFlow = _flowCalculator.addSample(
+      snapshot.timestamp,
+      snapshot.weight,
+    );
+    weightFlowAverage.add(rawFlow);
+    final settling =
+        _flowSettleUntil != null &&
+        snapshot.timestamp.isBefore(_flowSettleUntil!);
+    final displayFlow = settling ? 0.0 : weightFlowAverage.average;
 
     _weightSnapshotController.add(
       WeightSnapshot(
         timestamp: snapshot.timestamp,
-        weight: filteredWeight,
-        weightFlow: flow,
+        weight: snapshot.weight,
+        weightFlow: displayFlow,
+        controlWeightFlow: controlFlow,
         battery: snapshot.batteryLevel,
         timerValue: snapshot.timerValue,
       ),
@@ -266,15 +251,17 @@ class WeightSnapshot {
   final DateTime timestamp;
   final double weight;
   final double weightFlow;
+  final double controlWeightFlow;
   final int? battery;
   final Duration? timerValue;
   WeightSnapshot({
     required this.timestamp,
     required this.weight,
     required this.weightFlow,
+    double? controlWeightFlow,
     this.battery,
     this.timerValue,
-  });
+  }) : controlWeightFlow = controlWeightFlow ?? weightFlow;
 
   Map<String, dynamic> toJson() {
     return {

--- a/lib/src/controllers/scale_controller.dart
+++ b/lib/src/controllers/scale_controller.dart
@@ -169,12 +169,22 @@ class ScaleController {
 
   Stream<WeightSnapshot> get weightSnapshot => _weightSnapshotController.stream;
 
-  static const smoothingWindowDuration = Duration(milliseconds: 600);
-  static const movingAverageSamples = 10;
+  static const defaultSmoothingWindow = Duration(milliseconds: 600);
+  static const defaultMovingAverageSamples = 10;
+  static const minSmoothingWindowMs = 100;
+  static const maxSmoothingWindowMs = 2000;
+  static const minMovingAverageSamples = 1;
+  static const maxMovingAverageSamples = 50;
 
-  MovingAverage weightFlowAverage = MovingAverage(movingAverageSamples);
+  Duration _smoothingWindow = defaultSmoothingWindow;
+  int _movingAverageSamples = defaultMovingAverageSamples;
+
+  int get flowSmoothingWindowMs => _smoothingWindow.inMilliseconds;
+  int get flowSmoothingSamples => _movingAverageSamples;
+
+  MovingAverage weightFlowAverage = MovingAverage(defaultMovingAverageSamples);
   FlowCalculator _flowCalculator = FlowCalculator(
-    windowDuration: smoothingWindowDuration,
+    windowDuration: defaultSmoothingWindow,
   );
 
   /// Latest scale-clock timestamp seen. Used to time the post-tare flow-settle
@@ -199,12 +209,39 @@ class ScaleController {
     await scale.tare();
     _kalmanEstimator?.reset(0.0);
     _resetDisplayEstimator();
-    _flowSettleUntil = _lastSnapshotTime?.add(smoothingWindowDuration);
+    _flowSettleUntil = _lastSnapshotTime?.add(_smoothingWindow);
+  }
+
+  void setFlowSmoothing({
+    required int windowMs,
+    required int movingAverageSamples,
+  }) {
+    if (windowMs < minSmoothingWindowMs || windowMs > maxSmoothingWindowMs) {
+      throw RangeError.range(
+        windowMs,
+        minSmoothingWindowMs,
+        maxSmoothingWindowMs,
+        'windowMs',
+      );
+    }
+    if (movingAverageSamples < minMovingAverageSamples ||
+        movingAverageSamples > maxMovingAverageSamples) {
+      throw RangeError.range(
+        movingAverageSamples,
+        minMovingAverageSamples,
+        maxMovingAverageSamples,
+        'movingAverageSamples',
+      );
+    }
+    _smoothingWindow = Duration(milliseconds: windowMs);
+    _movingAverageSamples = movingAverageSamples;
+    _resetDisplayEstimator();
+    _flowSettleUntil = null;
   }
 
   void _resetDisplayEstimator() {
-    _flowCalculator = FlowCalculator(windowDuration: smoothingWindowDuration);
-    weightFlowAverage = MovingAverage(movingAverageSamples);
+    _flowCalculator = FlowCalculator(windowDuration: _smoothingWindow);
+    weightFlowAverage = MovingAverage(_movingAverageSamples);
   }
 
   void _processSnapshot(ScaleSnapshot snapshot) {

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -372,8 +372,7 @@ class ShotSequencer {
       _emitDecision(
         ShotDecisionKind.terminal,
         ShotDecisionReason.error,
-        details:
-            'Machine entered error state (${machine.state.substate.name})',
+        details: 'Machine entered error state (${machine.state.substate.name})',
         data: {'substate': machine.state.substate.name},
       );
       _volumeCountingActive = false;
@@ -467,7 +466,7 @@ class ShotSequencer {
         _trackFrameAdvance(machine.profileFrame);
         if (_bypassSAW == false && scale != null && !_scaleLost) {
           double currentWeight = scale.weight;
-          double weightFlow = scale.weightFlow;
+          double weightFlow = scale.controlWeightFlow;
           double projectedWeight =
               currentWeight + (weightFlow * _weightFlowMultiplier);
 
@@ -539,10 +538,8 @@ class ShotSequencer {
             ShotDecisionKind.stop,
             reason,
             details: switch (reason) {
-              ShotDecisionReason.apiStop =>
-                'Shot stopped via REST API request',
-              ShotDecisionReason.appStop =>
-                'Shot stopped from the app UI',
+              ShotDecisionReason.apiStop => 'Shot stopped via REST API request',
+              ShotDecisionReason.appStop => 'Shot stopped from the app UI',
               _ =>
                 'Machine reported shot end '
                     '(${machine.state.substate.name})',
@@ -724,7 +721,9 @@ class ShotSequencer {
     if (_stoppingYieldLocked) return;
     final weight = scale?.weight;
     if (weight == null || weight <= 0 || !weight.isFinite) return;
-    final flow = scale!.weightFlow.isFinite ? scale.weightFlow : 0.0;
+    final flow = scale!.controlWeightFlow.isFinite
+        ? scale.controlWeightFlow
+        : 0.0;
     final prevFlow = _prevStoppingFlow;
     _prevStoppingFlow = flow;
 
@@ -766,8 +765,3 @@ class ShotSequencer {
 // ShotState, ShotDecision, ShotDecisionKind and ShotDecisionReason moved to
 // lib/src/models/data/shot_state_event.dart (re-exported above) when the
 // decision stream gained wire serialization for /ws/v1/machine/shotState.
-
-
-
-
-

--- a/lib/src/controllers/weight_flow_calculator.dart
+++ b/lib/src/controllers/weight_flow_calculator.dart
@@ -42,7 +42,6 @@ class FlowCalculator {
     if (deltaTimeMs <= 0 || deltaWeight.abs() < deadband) return 0.0;
 
     var flow = (deltaWeight * 1000) / deltaTimeMs;
-    flow = flow.abs(); // optional: only show positive flow
-    return flow.clamp(0.0, maxFlow);
+    return flow.clamp(-maxFlow, maxFlow);
   }
 }

--- a/lib/src/services/telemetry/telemetry_service.dart
+++ b/lib/src/services/telemetry/telemetry_service.dart
@@ -66,7 +66,7 @@ abstract class TelemetryService {
   static TelemetryService create({required LogBuffer logBuffer}) {
     // Check if telemetry should be disabled
     final isDebugMode = kDebugMode;
-    final isSimulateMode = const String.fromEnvironment('simulate') == '1';
+    final isSimulateMode = const bool.hasEnvironment('simulate');
     final isLinuxOrWindows = Platform.isLinux || Platform.isWindows;
 
     if (isDebugMode || isSimulateMode || isLinuxOrWindows) {

--- a/lib/src/services/webserver/debug_handler.dart
+++ b/lib/src/services/webserver/debug_handler.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
 import 'package:reaprime/src/models/device/impl/mock_scale/mock_scale.dart';
@@ -15,8 +17,13 @@ class DebugHandler {
   DebugHandler({
     required ScaleController scaleController,
     UpdateCheckService? updateCheckService,
-  })  : _scaleController = scaleController,
-        _updateCheckService = updateCheckService;
+  }) : _scaleController = scaleController,
+       _updateCheckService = updateCheckService;
+
+  Map<String, int> get _flowSmoothing => {
+    'windowMs': _scaleController.flowSmoothingWindowMs,
+    'movingAverageSamples': _scaleController.flowSmoothingSamples,
+  };
 
   void addRoutes(RouterPlus app) {
     // Force a fake "update available" so the update API/UI can be tested
@@ -33,6 +40,32 @@ class DebugHandler {
       svc.debugForceUpdate(version: version, downloadUrl: downloadUrl);
       _log.info('Forced update available: $version');
       return jsonOk(svc.currentState.toJson());
+    });
+
+    app.get('/api/v1/debug/flow-smoothing', (request) {
+      return jsonOk(_flowSmoothing);
+    });
+
+    app.post('/api/v1/debug/flow-smoothing', (request) async {
+      try {
+        final body = jsonDecode(await request.readAsString());
+        if (body is! Map<String, dynamic> ||
+            body['windowMs'] is! int ||
+            body['movingAverageSamples'] is! int) {
+          return jsonBadRequest({
+            'error': 'Expected integer windowMs and movingAverageSamples',
+          });
+        }
+        _scaleController.setFlowSmoothing(
+          windowMs: body['windowMs'],
+          movingAverageSamples: body['movingAverageSamples'],
+        );
+        return jsonOk(_flowSmoothing);
+      } on FormatException {
+        return jsonBadRequest({'error': 'Invalid JSON'});
+      } on RangeError catch (e) {
+        return jsonBadRequest({'error': e.message});
+      }
     });
 
     app.post('/api/v1/debug/scale/<command>', (request, command) async {

--- a/lib/src/settings/advanced_page.dart
+++ b/lib/src/settings/advanced_page.dart
@@ -87,8 +87,9 @@ class AdvancedPage extends StatelessWidget {
                   vertical: 8,
                 ),
                 child: ShadSwitch(
-                  value: controller
-                      .isFeatureFlagEnabled(FeatureFlag.stepExitArbiter),
+                  value: controller.isFeatureFlagEnabled(
+                    FeatureFlag.stepExitArbiter,
+                  ),
                   onChanged: (v) async {
                     await controller.setFeatureFlag(
                       FeatureFlag.stepExitArbiter,
@@ -110,65 +111,36 @@ class AdvancedPage extends StatelessWidget {
                 ),
               ),
               const SettingsDivider(),
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 8,
+              if (Platform.isIOS || Platform.isMacOS || Platform.isWindows) ...{
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 8,
+                  ),
+                  child: ShadSwitch(
+                    value: controller.isFeatureFlagEnabled(
+                      .largeBleMtuNonAndroid,
+                    ),
+                    onChanged: (v) async {
+                      await controller.setFeatureFlag(
+                        FeatureFlag.largeBleMtuNonAndroid,
+                        v,
+                      );
+                    },
+                    label: const Text('Use MTU value of 517'),
+                  ),
                 ),
-                child: ShadSwitch(
-                  value: controller
-                      .isFeatureFlagEnabled(FeatureFlag.kalmanFlow),
-                  onChanged: (v) async {
-                    await controller.setFeatureFlag(
-                      FeatureFlag.kalmanFlow,
-                      v,
-                    );
-                  },
-                  label: const Text('Kalman Flow Estimator'),
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                  ),
+                  child: Text(
+                    'Will try to negotiate a larger MTU value '
+                    'for Bluetooth connections. ',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
                 ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                ),
-                child: Text(
-                  'Uses a Kalman filter for smoother, signed flow estimates '
-                  'with disturbance rejection. Enabled by default. Disable if '
-                  'you prefer the legacy endpoint-difference flow calculator.',
-                  style: Theme.of(context).textTheme.bodySmall,
-                ),
-              ),
-              const SettingsDivider(),
-              if (Platform.isIOS || Platform.isMacOS || Platform.isWindows) 
-              ...{
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 8,
-                ),
-                child: ShadSwitch(
-                  value: controller
-                      .isFeatureFlagEnabled(.largeBleMtuNonAndroid),
-                  onChanged: (v) async {
-                    await controller.setFeatureFlag(
-                      FeatureFlag.largeBleMtuNonAndroid,
-                      v,
-                    );
-                  },
-                  label: const Text('Use MTU value of 517'),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                ),
-                child: Text(
-                  'Will try to negotiate a larger MTU value '
-                  'for Bluetooth connections. ',
-                  style: Theme.of(context).textTheme.bodySmall,
-                ),
-              ),
-              const SettingsDivider(),
+                const SettingsDivider(),
               },
 
               // Simulated devices

--- a/lib/src/settings/feature_flags.dart
+++ b/lib/src/settings/feature_flags.dart
@@ -10,15 +10,6 @@ enum FeatureFlag {
   /// Default: **true** (opt-out — the fix is the new default behavior).
   stepExitArbiter,
 
-  /// When enabled, replaces the endpoint-difference [FlowCalculator] +
-  /// [MovingAverage] pipeline with a 1-D constant-velocity Kalman filter
-  /// ([KalmanFlowEstimator]) that provides signed, low-lag flow estimates
-  /// with disturbance rejection (issue #417).
-  ///
-  /// Default: **true** (opt-out — 10-shot validation gate passed;
-  /// mean |Δyield| 0.44g ≤ 1g baseline, flow noise 8–13% vs 14.7% old).
-  kalmanFlow,
-
   /// Requests MTU 517 on native platforms other than Android and Linux.
   /// Android already requests it unconditionally; BlueZ owns Linux MTU.
   largeBleMtuNonAndroid,
@@ -28,6 +19,5 @@ enum FeatureFlag {
 /// flags that ship as experimental default to false.
 const Map<FeatureFlag, bool> defaultFeatureFlagValues = {
   FeatureFlag.stepExitArbiter: true,
-  FeatureFlag.kalmanFlow: true,
   FeatureFlag.largeBleMtuNonAndroid: false,
 };

--- a/test/controllers/hot_water_sequencer_test.dart
+++ b/test/controllers/hot_water_sequencer_test.dart
@@ -29,13 +29,17 @@ class _EmptyDiscovery extends DeviceDiscoveryService {
 
 class _StubDe1Controller extends De1Controller {
   _StubDe1Controller({HotWaterData? hotWater})
-      : _de1subj = BehaviorSubject.seeded(null),
-        _hw = BehaviorSubject.seeded(
-          hotWater ??
-              HotWaterData(
-                  targetTemperature: 85, duration: 35, volume: 30, flow: 2.0),
-        ),
-        super(controller: DeviceController([_EmptyDiscovery()]));
+    : _de1subj = BehaviorSubject.seeded(null),
+      _hw = BehaviorSubject.seeded(
+        hotWater ??
+            HotWaterData(
+              targetTemperature: 85,
+              duration: 35,
+              volume: 30,
+              flow: 2.0,
+            ),
+      ),
+      super(controller: DeviceController([_EmptyDiscovery()]));
 
   final BehaviorSubject<De1Interface?> _de1subj;
   final BehaviorSubject<HotWaterData> _hw;
@@ -51,7 +55,7 @@ class _StubDe1Controller extends De1Controller {
 
 class _StubScaleController extends ScaleController {
   _StubScaleController({ConnectionState initial = ConnectionState.connected})
-      : _conn = BehaviorSubject.seeded(initial);
+    : _conn = BehaviorSubject.seeded(initial);
 
   final BehaviorSubject<WeightSnapshot> _weights = BehaviorSubject();
   final BehaviorSubject<ConnectionState> _conn;
@@ -68,12 +72,20 @@ class _StubScaleController extends ScaleController {
     tareCount++;
   }
 
-  void emitWeight(double weight, {double flow = 0, DateTime? at}) {
-    _weights.add(WeightSnapshot(
-      timestamp: at ?? DateTime.now(),
-      weight: weight,
-      weightFlow: flow,
-    ));
+  void emitWeight(
+    double weight, {
+    double flow = 0,
+    double? controlFlow,
+    DateTime? at,
+  }) {
+    _weights.add(
+      WeightSnapshot(
+        timestamp: at ?? DateTime.now(),
+        weight: weight,
+        weightFlow: flow,
+        controlWeightFlow: controlFlow,
+      ),
+    );
   }
 
   void setConnection(ConnectionState s) => _conn.add(s);
@@ -126,8 +138,10 @@ class _TestMachine implements De1Interface {
   dynamic noSuchMethod(Invocation invocation) => null;
 }
 
-MachineSnapshot _snap(MachineState state,
-    {MachineSubstate substate = MachineSubstate.pouring}) {
+MachineSnapshot _snap(
+  MachineState state, {
+  MachineSubstate substate = MachineSubstate.pouring,
+}) {
   return MachineSnapshot(
     timestamp: DateTime.now(),
     state: MachineStateSnapshot(state: state, substate: substate),
@@ -179,19 +193,21 @@ void main() {
   });
 
   group('arming', () {
-    test('tares the scale and arms on entering hotWater when eligible',
-        () async {
-      await build();
-      final m = _TestMachine();
-      de1.emitMachine(m);
-      await settle();
-      m.emit(_snap(MachineState.hotWater));
-      await settle();
+    test(
+      'tares the scale and arms on entering hotWater when eligible',
+      () async {
+        await build();
+        final m = _TestMachine();
+        de1.emitMachine(m);
+        await settle();
+        m.emit(_snap(MachineState.hotWater));
+        await settle();
 
-      expect(scale.tareCount, 1);
-      expect(sequencer.isArmed, isTrue);
-      m.dispose();
-    });
+        expect(scale.tareCount, 1);
+        expect(sequencer.isArmed, isTrue);
+        m.dispose();
+      },
+    );
 
     test('does not arm when the setting is off', () async {
       await settings.setStopHotWaterAtWeight(false);
@@ -234,8 +250,12 @@ void main() {
 
     test('does not arm when the target volume is zero', () async {
       de1 = _StubDe1Controller(
-        hotWater:
-            HotWaterData(targetTemperature: 85, duration: 35, volume: 0, flow: 2),
+        hotWater: HotWaterData(
+          targetTemperature: 85,
+          duration: 35,
+          volume: 0,
+          flow: 2,
+        ),
       );
       await build();
       final m = _TestMachine();
@@ -277,6 +297,18 @@ void main() {
       m.dispose();
     });
 
+    test('projects weight with control flow', () async {
+      await build();
+      final m = await armAndConfirmTare();
+
+      clock = clock.add(const Duration(seconds: 1));
+      scale.emitWeight(29, flow: 0, controlFlow: 4, at: clock);
+      await settle();
+
+      expect(m.requested, contains(MachineState.idle));
+      m.dispose();
+    });
+
     test('does not stop before the tare-settle window elapses', () async {
       await build();
       final m = await armAndConfirmTare();
@@ -290,33 +322,38 @@ void main() {
       m.dispose();
     });
 
-    test('waits for the post-tare zero before stopping (stale pre-tare weight)',
-        () async {
-      // The cup is still on the platter and the physical tare lags: the scale
-      // keeps reporting the pre-tare weight (>= target) past the time window.
-      // The monitor must NOT false-stop until it has seen the weight settle low.
-      await build();
-      final m = _TestMachine();
-      de1.emitMachine(m);
-      await settle();
-      m.emit(_snap(MachineState.hotWater));
-      await settle();
+    test(
+      'waits for the post-tare zero before stopping (stale pre-tare weight)',
+      () async {
+        // The cup is still on the platter and the physical tare lags: the scale
+        // keeps reporting the pre-tare weight (>= target) past the time window.
+        // The monitor must NOT false-stop until it has seen the weight settle low.
+        await build();
+        final m = _TestMachine();
+        de1.emitMachine(m);
+        await settle();
+        m.emit(_snap(MachineState.hotWater));
+        await settle();
 
-      clock = clock.add(const Duration(seconds: 1)); // window elapsed
-      scale.emitWeight(50, flow: 0, at: clock); // stale pre-tare cup weight
-      await settle();
-      expect(m.requested, isEmpty,
-          reason: 'must not stop on an unconfirmed (pre-tare) reading');
+        clock = clock.add(const Duration(seconds: 1)); // window elapsed
+        scale.emitWeight(50, flow: 0, at: clock); // stale pre-tare cup weight
+        await settle();
+        expect(
+          m.requested,
+          isEmpty,
+          reason: 'must not stop on an unconfirmed (pre-tare) reading',
+        );
 
-      // Tare finally lands — scale drops to zero, then water climbs to target.
-      scale.emitWeight(0, flow: 0, at: clock);
-      await settle();
-      clock = clock.add(const Duration(milliseconds: 200));
-      scale.emitWeight(30, flow: 0, at: clock);
-      await settle();
-      expect(m.requested, contains(MachineState.idle));
-      m.dispose();
-    });
+        // Tare finally lands — scale drops to zero, then water climbs to target.
+        scale.emitWeight(0, flow: 0, at: clock);
+        await settle();
+        clock = clock.add(const Duration(milliseconds: 200));
+        scale.emitWeight(30, flow: 0, at: clock);
+        await settle();
+        expect(m.requested, contains(MachineState.idle));
+        m.dispose();
+      },
+    );
 
     test('only requests idle once', () async {
       await build();

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -82,12 +82,17 @@ class _TestScaleController extends ScaleController {
     return testScale;
   }
 
-  void emitWeight(double weight, {double weightFlow = 0.0}) {
+  void emitWeight(
+    double weight, {
+    double weightFlow = 0.0,
+    double? controlWeightFlow,
+  }) {
     _weight.add(
       WeightSnapshot(
         timestamp: DateTime(2026, 1, 15, 8, 0),
         weight: weight,
         weightFlow: weightFlow,
+        controlWeightFlow: controlWeightFlow,
       ),
     );
   }
@@ -381,6 +386,40 @@ void main() {
               'the controller is using stale weight data',
         );
 
+        shotSequencer.dispose();
+      });
+    });
+
+    test('SAW projects weight with control flow', () {
+      fakeAsync((async) {
+        scaleController.emitWeight(0.0);
+        final shotSequencer = ShotSequencer(
+          scaleController: scaleController,
+          de1controller: de1Controller,
+          persistenceController: persistenceController,
+          targetProfile: profile,
+          targetYield: 36.0,
+          bypassSAW: false,
+          blockOnNoScale: false,
+          weightFlowMultiplier: 1.0,
+          volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
+        );
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring(shotSequencer);
+        scaleController.emitWeight(
+          35.0,
+          weightFlow: 0.0,
+          controlWeightFlow: 2.0,
+        );
+        testDe1.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.pouring,
+        );
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(testDe1.requestedStates, contains(MachineState.idle));
         shotSequencer.dispose();
       });
     });
@@ -845,8 +884,7 @@ void main() {
         expect(
           testDe1.requestedStates,
           isNot(contains(MachineState.skipStep)),
-          reason:
-              'Flow near under-2.0 exit → defer to avoid racing firmware.',
+          reason: 'Flow near under-2.0 exit → defer to avoid racing firmware.',
         );
 
         // After max deferral frames (3), fires regardless.
@@ -903,7 +941,11 @@ void main() {
         );
         async.elapse(Duration(milliseconds: 10));
 
-        scaleController.emitWeight(2.0, weightFlow: -20.0);
+        scaleController.emitWeight(
+          2.0,
+          weightFlow: 0.0,
+          controlWeightFlow: -20.0,
+        );
         testDe1.emitStateAndSubstate(
           MachineState.espresso,
           MachineSubstate.pouringDone,
@@ -1763,7 +1805,8 @@ void main() {
         expect(
           decisions.singleWhere((d) => d.kind == ShotDecisionKind.stop).reason,
           ShotDecisionReason.machineEnded,
-          reason: 'an intent recorded long before the shot end must not be '
+          reason:
+              'an intent recorded long before the shot end must not be '
               'attributed to it',
         );
 
@@ -1809,7 +1852,8 @@ void main() {
             (d) => d.reason == ShotDecisionReason.profileAdvance,
           ),
           isEmpty,
-          reason: 'an app-skipped frame must not double-report as a '
+          reason:
+              'an app-skipped frame must not double-report as a '
               'firmware-natural advance',
         );
 
@@ -1890,36 +1934,38 @@ void main() {
       });
     });
 
-    test('machine error mid-shot emits terminal/error and finishes the shot',
-        () {
-      fakeAsync((async) {
-        scaleController.emitWeight(0.0);
-        final sequencer = makeSequencer();
-        final decisions = <ShotDecision>[];
-        final states = <ShotState>[];
-        sequencer.decisions.listen(decisions.add);
-        sequencer.state.listen(states.add);
+    test(
+      'machine error mid-shot emits terminal/error and finishes the shot',
+      () {
+        fakeAsync((async) {
+          scaleController.emitWeight(0.0);
+          final sequencer = makeSequencer();
+          final decisions = <ShotDecision>[];
+          final states = <ShotState>[];
+          sequencer.decisions.listen(decisions.add);
+          sequencer.state.listen(states.add);
 
-        async.elapse(Duration(milliseconds: 10));
-        driveToPouring();
-        async.elapse(Duration(milliseconds: 10));
+          async.elapse(Duration(milliseconds: 10));
+          driveToPouring();
+          async.elapse(Duration(milliseconds: 10));
 
-        testDe1.emitStateAndSubstate(
-          MachineState.error,
-          MachineSubstate.idle,
-        );
-        async.elapse(Duration(milliseconds: 10));
+          testDe1.emitStateAndSubstate(
+            MachineState.error,
+            MachineSubstate.idle,
+          );
+          async.elapse(Duration(milliseconds: 10));
 
-        final terminal = decisions.singleWhere(
-          (d) => d.kind == ShotDecisionKind.terminal,
-        );
-        expect(terminal.reason, ShotDecisionReason.error);
-        expect(sequencer.finalStopReason, ShotDecisionReason.error);
-        expect(states, contains(ShotState.finished));
+          final terminal = decisions.singleWhere(
+            (d) => d.kind == ShotDecisionKind.terminal,
+          );
+          expect(terminal.reason, ShotDecisionReason.error);
+          expect(sequencer.finalStopReason, ShotDecisionReason.error);
+          expect(states, contains(ShotState.finished));
 
-        sequencer.dispose();
-      });
-    });
+          sequencer.dispose();
+        });
+      },
+    );
 
     test('stopping backstop emits finalize/stoppingBackstop and preserves '
         'the stop trigger as final reason', () {
@@ -1961,7 +2007,8 @@ void main() {
         expect(
           sequencer.finalStopReason,
           ShotDecisionReason.targetWeight,
-          reason: 'the backstop closes the settling window; it is not why '
+          reason:
+              'the backstop closes the settling window; it is not why '
               'the shot stopped',
         );
         expect(states, contains(ShotState.finished));
@@ -1998,7 +2045,8 @@ void main() {
         expect(
           states,
           isNot(contains(ShotState.finished)),
-          reason: 'an aborted preheat is torn down by the manager, not '
+          reason:
+              'an aborted preheat is torn down by the manager, not '
               'persisted via the finished path',
         );
 
@@ -2061,7 +2109,8 @@ void main() {
             (d) => d.reason == ShotDecisionReason.profileAdvance,
           ),
           hasLength(1),
-          reason: 'a BLE frame reorder must not re-emit an advance already '
+          reason:
+              'a BLE frame reorder must not re-emit an advance already '
               'reported',
         );
 

--- a/test/services/webserver/debug_handler_test.dart
+++ b/test/services/webserver/debug_handler_test.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/services/webserver/debug_handler.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+void main() {
+  late ScaleController scaleController;
+  late Handler handler;
+
+  setUp(() {
+    scaleController = ScaleController();
+    final app = Router().plus;
+    DebugHandler(scaleController: scaleController).addRoutes(app);
+    handler = app.call;
+  });
+
+  tearDown(() => scaleController.dispose());
+
+  Future<Response> get() async => await handler(
+    Request(
+      'GET',
+      Uri.parse('http://localhost/api/v1/debug/flow-smoothing'),
+    ),
+  );
+
+  Future<Response> post(Object body) async => await handler(
+    Request(
+      'POST',
+      Uri.parse('http://localhost/api/v1/debug/flow-smoothing'),
+      headers: {'content-type': 'application/json'},
+      body: jsonEncode(body),
+    ),
+  );
+
+  test('gets and updates flow smoothing', () async {
+    final initial = await get();
+    expect(initial.statusCode, 200);
+    expect(jsonDecode(await initial.readAsString()), {
+      'windowMs': 600,
+      'movingAverageSamples': 10,
+    });
+
+    final updated = await post({
+      'windowMs': 800,
+      'movingAverageSamples': 6,
+    });
+    expect(updated.statusCode, 200);
+    expect(jsonDecode(await updated.readAsString()), {
+      'windowMs': 800,
+      'movingAverageSamples': 6,
+    });
+  });
+
+  test('rejects invalid updates atomically', () async {
+    for (final body in [
+      {'windowMs': '800', 'movingAverageSamples': 6},
+      {'windowMs': 99, 'movingAverageSamples': 6},
+      {'windowMs': 800, 'movingAverageSamples': 51},
+    ]) {
+      final response = await post(body);
+      expect(response.statusCode, 400);
+    }
+
+    final current = await get();
+    expect(jsonDecode(await current.readAsString()), {
+      'windowMs': 600,
+      'movingAverageSamples': 10,
+    });
+  });
+}

--- a/test/unit/controllers/scale_controller_test.dart
+++ b/test/unit/controllers/scale_controller_test.dart
@@ -243,6 +243,34 @@ void main() {
     controller.dispose();
   });
 
+  test('runtime smoothing update resets only display flow', () async {
+    final controller = ScaleController();
+    final scale = _TrackingScale('A');
+    await controller.connectToScale(scale);
+    final frames = <WeightSnapshot>[];
+    final sub = controller.weightSnapshot.listen(frames.add);
+    final t0 = DateTime.utc(2026, 7, 22);
+
+    for (var i = 0; i < 20; i++) {
+      scale.emitAt(t0.add(Duration(milliseconds: i * 100)), i * 0.5);
+    }
+    await Future.delayed(Duration.zero);
+    expect(frames.last.weightFlow, greaterThan(0));
+    expect(frames.last.controlWeightFlow, greaterThan(0));
+
+    controller.setFlowSmoothing(windowMs: 800, movingAverageSamples: 6);
+    scale.emitAt(t0.add(const Duration(seconds: 2)), 10.0);
+    await Future.delayed(Duration.zero);
+
+    expect(controller.flowSmoothingWindowMs, 800);
+    expect(controller.flowSmoothingSamples, 6);
+    expect(frames.last.weightFlow, 0);
+    expect(frames.last.controlWeightFlow, greaterThan(0));
+
+    await sub.cancel();
+    controller.dispose();
+  });
+
   test('control flow is internal and falls back for historical snapshots', () {
     final timestamp = DateTime.utc(2026, 7, 22);
     final historical = WeightSnapshot.fromJson({

--- a/test/unit/controllers/scale_controller_test.dart
+++ b/test/unit/controllers/scale_controller_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
@@ -15,7 +16,9 @@ class _TrackingScale implements Scale {
   final String deviceId;
   _TrackingScale(this.deviceId);
 
-  final _conn = BehaviorSubject<ConnectionState>.seeded(ConnectionState.discovered);
+  final _conn = BehaviorSubject<ConnectionState>.seeded(
+    ConnectionState.discovered,
+  );
   final _snap = BehaviorSubject<ScaleSnapshot>();
   bool disconnected = false;
 
@@ -55,11 +58,13 @@ class _TrackingScale implements Scale {
   @override
   Future<void> resetTimer() async {}
 
-  void emitAt(DateTime t, double weight) => _snap.add(ScaleSnapshot(
-        timestamp: t,
-        weight: weight,
-        batteryLevel: 50,
-      ));
+  void emitAt(DateTime t, double weight) => _snap.add(
+    ScaleSnapshot(
+      timestamp: t,
+      weight: weight,
+      batteryLevel: 50,
+    ),
+  );
 }
 
 /// A handoff-capable scale (like the BLE Decent Scale) that records whether it
@@ -85,26 +90,31 @@ class _FailingScale extends _TrackingScale {
   @override
   Future<void> onConnect() async => throw StateError('connect failed');
 
-  void emitSnapshot() => _snap.add(ScaleSnapshot(
-        timestamp: DateTime.now(),
-        weight: 1.0,
-        batteryLevel: 100,
-      ));
+  void emitSnapshot() => _snap.add(
+    ScaleSnapshot(
+      timestamp: DateTime.now(),
+      weight: 1.0,
+      batteryLevel: 100,
+    ),
+  );
 }
 
 void main() {
-  test(
-      'a scale whose onConnect throws surfaces as disconnected and leaks no '
+  test('a scale whose onConnect throws surfaces as disconnected and leaks no '
       'snapshot subscription', () async {
     final controller = ScaleController();
     final scale = _FailingScale('W');
 
     await expectLater(
-        controller.connectToScale(scale), throwsA(isA<StateError>()));
+      controller.connectToScale(scale),
+      throwsA(isA<StateError>()),
+    );
 
     // The controller did not retain the scale and reports disconnected.
-    expect(() => controller.connectedScale(),
-        throwsA(isA<DeviceNotConnectedException>()));
+    expect(
+      () => controller.connectedScale(),
+      throwsA(isA<DeviceNotConnectedException>()),
+    );
     expect(controller.currentConnectionState, ConnectionState.disconnected);
 
     // The snapshot subscription opened before onConnect must have been
@@ -113,16 +123,19 @@ void main() {
     final sub = controller.weightSnapshot.listen(frames.add);
     scale.emitSnapshot();
     await Future.delayed(Duration.zero);
-    expect(frames, isEmpty,
-        reason: 'a failed connect must not leave the snapshot subscription '
-            'live');
+    expect(
+      frames,
+      isEmpty,
+      reason:
+          'a failed connect must not leave the snapshot subscription '
+          'live',
+    );
 
     await sub.cancel();
     controller.dispose();
   });
 
-  test(
-      'switching away from a handoff-capable scale releases it WITHOUT '
+  test('switching away from a handoff-capable scale releases it WITHOUT '
       'power-off (uses disconnectForHandoff)', () async {
     final controller = ScaleController();
     final a = _HandoffTrackingScale('A'); // e.g. BLE Decent Scale
@@ -131,33 +144,45 @@ void main() {
     await controller.connectToScale(a);
     await controller.connectToScale(b);
 
-    expect(a.handoffReleased, isTrue,
-        reason: 'a transport switch must use the non-power-off handoff path');
-    expect(a.disconnected, isFalse,
-        reason: 'the destructive disconnect() (power-off) must NOT be used '
-            'when switching the active scale');
+    expect(
+      a.handoffReleased,
+      isTrue,
+      reason: 'a transport switch must use the non-power-off handoff path',
+    );
+    expect(
+      a.disconnected,
+      isFalse,
+      reason:
+          'the destructive disconnect() (power-off) must NOT be used '
+          'when switching the active scale',
+    );
 
     controller.dispose();
   });
 
-  test('connecting a new scale disconnects the previously-connected scale',
-      () async {
-    final controller = ScaleController();
-    final a = _TrackingScale('A');
-    final b = _TrackingScale('B');
+  test(
+    'connecting a new scale disconnects the previously-connected scale',
+    () async {
+      final controller = ScaleController();
+      final a = _TrackingScale('A');
+      final b = _TrackingScale('B');
 
-    await controller.connectToScale(a);
-    expect(controller.connectedScale().deviceId, 'A');
-    expect(a.disconnected, isFalse);
+      await controller.connectToScale(a);
+      expect(controller.connectedScale().deviceId, 'A');
+      expect(a.disconnected, isFalse);
 
-    await controller.connectToScale(b);
-    expect(controller.connectedScale().deviceId, 'B');
-    expect(a.disconnected, isTrue,
-        reason: 'the previous scale must be disconnected (one active scale)');
-    expect(b.disconnected, isFalse);
+      await controller.connectToScale(b);
+      expect(controller.connectedScale().deviceId, 'B');
+      expect(
+        a.disconnected,
+        isTrue,
+        reason: 'the previous scale must be disconnected (one active scale)',
+      );
+      expect(b.disconnected, isFalse);
 
-    controller.dispose();
-  });
+      controller.dispose();
+    },
+  );
 
   test('reconnecting the SAME scale does not disconnect it', () async {
     final controller = ScaleController();
@@ -165,14 +190,81 @@ void main() {
 
     await controller.connectToScale(a);
     await controller.connectToScale(a); // same device id
-    expect(a.disconnected, isFalse,
-        reason: 'same-device reconnect should not toggle disconnect');
+    expect(
+      a.disconnected,
+      isFalse,
+      reason: 'same-device reconnect should not toggle disconnect',
+    );
 
     controller.dispose();
   });
 
-  test(
-      'tare suppresses the flow transient for one smoothing window without '
+  test('public flow stays smooth on the native shot trace', () async {
+    final controller = ScaleController();
+    final scale = _TrackingScale('A');
+    await controller.connectToScale(scale);
+
+    final frames = <WeightSnapshot>[];
+    final sub = controller.weightSnapshot.listen(frames.add);
+    final rows = File(
+      'test/fixtures/shot1_native_trace.csv',
+    ).readAsLinesSync().skip(1);
+    for (final row in rows) {
+      final values = row.split(',');
+      scale.emitAt(
+        DateTime.fromMillisecondsSinceEpoch(int.parse(values[0]), isUtc: true),
+        double.parse(values[1]),
+      );
+    }
+    await Future.delayed(Duration.zero);
+
+    final flows = frames.skip(10).map((frame) => frame.weightFlow).toList();
+    final meanDelta =
+        [
+          for (var i = 1; i < flows.length; i++)
+            (flows[i] - flows[i - 1]).abs(),
+        ].reduce((a, b) => a + b) /
+        (flows.length - 1);
+    expect(meanDelta, lessThanOrEqualTo(0.12));
+
+    final controlFlows = frames
+        .skip(10)
+        .map((frame) => frame.controlWeightFlow)
+        .toList();
+    final controlMeanDelta =
+        [
+          for (var i = 1; i < controlFlows.length; i++)
+            (controlFlows[i] - controlFlows[i - 1]).abs(),
+        ].reduce((a, b) => a + b) /
+        (controlFlows.length - 1);
+    expect(controlMeanDelta, closeTo(0.2597772268251356, 1e-9));
+
+    await sub.cancel();
+    controller.dispose();
+  });
+
+  test('control flow is internal and falls back for historical snapshots', () {
+    final timestamp = DateTime.utc(2026, 7, 22);
+    final historical = WeightSnapshot.fromJson({
+      'timestamp': timestamp.toIso8601String(),
+      'weight': 12.3,
+      'weightFlow': 4.5,
+      'battery': 50,
+      'timerValue': null,
+    });
+    final live = WeightSnapshot(
+      timestamp: timestamp,
+      weight: 12.3,
+      weightFlow: 1.2,
+      controlWeightFlow: 4.5,
+    );
+
+    expect(historical.controlWeightFlow, 4.5);
+    expect(live.controlWeightFlow, 4.5);
+    expect(live.toJson(), isNot(contains('controlWeightFlow')));
+  });
+
+  test('tare suppresses the flow transient for one smoothing window without '
       'touching weight', () async {
     final controller = ScaleController();
     final scale = _TrackingScale('A');
@@ -187,8 +279,11 @@ void main() {
     scale.emitAt(t0, 10.0);
     scale.emitAt(t0.add(const Duration(milliseconds: 100)), 14.0);
     await Future.delayed(Duration.zero);
-    expect(frames.last.weightFlow, greaterThan(0),
-        reason: 'real flow flows before any tare');
+    expect(
+      frames.last.weightFlow,
+      greaterThan(0),
+      reason: 'real flow flows before any tare',
+    );
 
     await controller.tare();
 
@@ -199,21 +294,32 @@ void main() {
     scale.emitAt(t0.add(const Duration(milliseconds: 500)), 0.0);
     await Future.delayed(Duration.zero);
     final settleFrames = frames
-        .where((f) => f.timestamp.isAfter(t0.add(const Duration(milliseconds: 150))))
+        .where(
+          (f) => f.timestamp.isAfter(t0.add(const Duration(milliseconds: 150))),
+        )
         .toList();
     expect(settleFrames, isNotEmpty);
-    expect(settleFrames.every((f) => f.weightFlow == 0), isTrue,
-        reason: 'the post-tare flow transient must be suppressed');
-    expect(frames.last.weight, 0.0,
-        reason: 'weight itself is never suppressed by tare');
+    expect(
+      settleFrames.every((f) => f.weightFlow == 0),
+      isTrue,
+      reason: 'the post-tare flow transient must be suppressed',
+    );
+    expect(
+      frames.last.weight,
+      0.0,
+      reason: 'weight itself is never suppressed by tare',
+    );
 
     // Past the smoothing window, real flow resumes from a clean baseline.
     scale.emitAt(t0.add(const Duration(milliseconds: 800)), 4.0);
     scale.emitAt(t0.add(const Duration(milliseconds: 900)), 8.0);
     await Future.delayed(Duration.zero);
     expect(frames.last.weight, 8.0);
-    expect(frames.last.weightFlow, greaterThan(0),
-        reason: 'real flow resumes once the window has cleared');
+    expect(
+      frames.last.weightFlow,
+      greaterThan(0),
+      reason: 'real flow resumes once the window has cleared',
+    );
 
     await sub.cancel();
     controller.dispose();

--- a/test/unit/util/kalman_flow_estimator_test.dart
+++ b/test/unit/util/kalman_flow_estimator_test.dart
@@ -1,7 +1,7 @@
-import 'dart:math';
-
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/weight_flow_calculator.dart';
 import 'package:reaprime/src/util/kalman_flow_estimator.dart';
+import 'package:reaprime/src/util/moving_average.dart';
 
 void main() {
   group('KalmanFlowEstimator', () {
@@ -78,10 +78,15 @@ void main() {
       for (int i = 1; i <= 20; i++) {
         final elapsed = 0.1 * i;
         estimator.addSample(
-            t0.add(Duration(milliseconds: (100 * i))), 5.0 * elapsed);
+          t0.add(Duration(milliseconds: (100 * i))),
+          5.0 * elapsed,
+        );
       }
-      expect(estimator.flow, greaterThan(1.0),
-          reason: 'flow should build up before reset');
+      expect(
+        estimator.flow,
+        greaterThan(1.0),
+        reason: 'flow should build up before reset',
+      );
 
       estimator.reset(0.0);
 
@@ -96,8 +101,10 @@ void main() {
     });
 
     test('spike rejection: transient spike is attenuated via adaptive R', () {
-      final estimator =
-          KalmanFlowEstimator(initialWeight: 100.0, processNoiseIntensity: 2.0);
+      final estimator = KalmanFlowEstimator(
+        initialWeight: 100.0,
+        processNoiseIntensity: 2.0,
+      );
       final t0 = DateTime(2026, 1, 1, 12, 0, 0);
       const dt = Duration(milliseconds: 100);
 
@@ -121,15 +128,20 @@ void main() {
         100.0 + 5.0 * 32 * 0.1,
       );
 
-      expect((afterFlow - beforeFlow).abs(), lessThan(3.0),
-          reason: 'adaptive R should attenuate spike impact on flow '
-              '(10g spike should not shift flow by more than 3 g/s)');
+      expect(
+        (afterFlow - beforeFlow).abs(),
+        lessThan(3.0),
+        reason:
+            'adaptive R should attenuate spike impact on flow '
+            '(10g spike should not shift flow by more than 3 g/s)',
+      );
     });
 
-    test('step response: weight tracks a level change, flow settles back',
-        () {
-      final estimator =
-          KalmanFlowEstimator(initialWeight: 0.0, processNoiseIntensity: 2.0);
+    test('step response: weight tracks a level change, flow settles back', () {
+      final estimator = KalmanFlowEstimator(
+        initialWeight: 0.0,
+        processNoiseIntensity: 2.0,
+      );
       final t0 = DateTime(2026, 1, 1, 12, 0, 0);
       const dt = Duration(milliseconds: 100);
 
@@ -150,8 +162,11 @@ void main() {
 
       // After 50 samples (5 s) at the new weight, estimate is near target.
       expect(estimator.weight, closeTo(40.0, 5.0));
-      expect(estimator.flow.abs(), lessThan(2.0),
-          reason: 'after settling, flow should return toward zero');
+      expect(
+        estimator.flow.abs(),
+        lessThan(2.0),
+        reason: 'after settling, flow should return toward zero',
+      );
     });
 
     test('variable dt: handles irregular sample intervals', () {
@@ -168,11 +183,16 @@ void main() {
         elapsedMs += ms;
         final weight = rate * elapsedMs / 1000.0;
         estimator.addSample(
-            t0.add(Duration(milliseconds: elapsedMs.round())), weight);
+          t0.add(Duration(milliseconds: elapsedMs.round())),
+          weight,
+        );
       }
 
-      expect(estimator.flow, closeTo(rate, 0.5),
-          reason: 'variable-dt Kalman should track true rate');
+      expect(
+        estimator.flow,
+        closeTo(rate, 0.5),
+        reason: 'variable-dt Kalman should track true rate',
+      );
     });
 
     test('convergence speed: tracks true flow within 5 samples', () {
@@ -195,8 +215,11 @@ void main() {
       // convergence problem was never in the flow estimate — it was the
       // weight estimate that lagged (now fixed by raw-passthrough in
       // ScaleController).
-      expect(estimator.flow, greaterThan(rate * 0.5),
-          reason: 'flow should converge to >50% of true rate within 5 samples');
+      expect(
+        estimator.flow,
+        greaterThan(rate * 0.5),
+        reason: 'flow should converge to >50% of true rate within 5 samples',
+      );
     });
 
     group('golden trace (shot 1, native ~10 Hz)', () {
@@ -288,79 +311,44 @@ void main() {
                 isUtc: true,
               ),
               weight: e.$2,
-            )
+            ),
         ];
       }
 
-      test('flow noise is meaningfully lower than old FlowCalculator', () {
+      test('legacy display pipeline meets the smoothness threshold', () {
         final trace = _loadFixture();
-        final estimator =
-            KalmanFlowEstimator(initialWeight: trace.first.weight);
-
+        final kalman = KalmanFlowEstimator(initialWeight: trace.first.weight);
+        final calculator = FlowCalculator(
+          windowDuration: const Duration(milliseconds: 600),
+        );
+        final average = MovingAverage(10);
         final kalmanFlows = <double>[];
-        for (final s in trace) {
-          final (_, f) = estimator.addSample(s.timestamp, s.weight);
-          kalmanFlows.add(f);
+        final displayFlows = <double>[];
+
+        for (final sample in trace) {
+          final (_, controlFlow) = kalman.addSample(
+            sample.timestamp,
+            sample.weight,
+          );
+          average.add(calculator.addSample(sample.timestamp, sample.weight));
+          kalmanFlows.add(controlFlow);
+          displayFlows.add(average.average);
         }
 
-        // Compute Kalman flow stdev (skip first 10 samples for convergence).
-        final kalmanSettled = kalmanFlows.skip(10).toList();
-        final kalmanStdev = _stdev(kalmanSettled);
-        final kalmanMean = kalmanSettled.reduce((a, b) => a + b) /
-            kalmanSettled.length;
+        final controlDelta = _meanAbsoluteDelta(kalmanFlows.skip(10).toList());
+        final displayDelta = _meanAbsoluteDelta(displayFlows.skip(10).toList());
 
-        // Simulate old FlowCalculator (600ms endpoint-difference, abs).
-        final oldFlows = <double>[];
-        const windowMs = 600;
-        for (int i = 0; i < trace.length; i++) {
-          final tNow = trace[i].timestamp;
-          double? flow;
-          for (int j = i - 1; j >= 0; j--) {
-            final spanMs =
-                tNow.difference(trace[j].timestamp).inMilliseconds;
-            if (spanMs >= windowMs) {
-              final dw = trace[i].weight - trace[j].weight;
-              flow = (dw / spanMs * 1000).abs().clamp(0.0, 8.0);
-              break;
-            }
-          }
-          oldFlows.add(flow ?? 0.0);
-        }
-        final oldSettled =
-            oldFlows.where((f) => f > 0).skip(3).toList(); // skip 0s + warmup
-        final oldStdev = _stdev(oldSettled);
-        final oldMean =
-            oldSettled.reduce((a, b) => a + b) / oldSettled.length;
-
-        // ignore: avoid_print
-        print('Kalman: mean=${kalmanMean.toStringAsFixed(2)} '
-            'stdev=${kalmanStdev.toStringAsFixed(3)} '
-            'stdev/mean=${(kalmanStdev / kalmanMean * 100).toStringAsFixed(1)}%'
-            '  |  Old FC: mean=${oldMean.toStringAsFixed(2)} '
-            'stdev=${oldStdev.toStringAsFixed(3)} '
-            'stdev/mean=${(oldStdev / oldMean * 100).toStringAsFixed(1)}%');
-
-        // Acceptance: Kalman stdev/mean must be below old stdev/mean.
-        final kalmanRatio = kalmanStdev / kalmanMean;
-        final oldRatio = oldStdev / oldMean;
-        expect(kalmanRatio, lessThan(oldRatio),
-            reason: 'Kalman flow noise must be lower than old FlowCalculator');
-
-        // Kalman noise must stay below FlowCalculator's ~15%. The previous
-        // threshold (12%) was achievable only with an over-damped filter
-        // (high R, high P floor) that introduced multi-hundred-ms lag.
-        // The retuned filter trades some smoothness for responsiveness —
-        // 14.5% noise at 7 g/s ≈ ±1 g/s stdev, well within ShotSequencer
-        // operating thresholds.
-        expect(kalmanRatio * 100, lessThan(oldRatio * 100),
-            reason: 'Kalman flow noise must be lower than FlowCalculator');
+        expect(displayDelta, lessThanOrEqualTo(0.12));
+        expect(controlDelta, greaterThan(displayDelta));
       });
 
       test('Kalman flow is natively signed (no abs())', () {
         // Synthetic data: pour then cup removal (negative slope).
         final estimator = KalmanFlowEstimator(initialWeight: 50.0);
-        final t0 = DateTime.fromMillisecondsSinceEpoch(1783576240000,
-            isUtc: true);
+        final t0 = DateTime.fromMillisecondsSinceEpoch(
+          1783576240000,
+          isUtc: true,
+        );
 
         // Pour: 50→55g at 7 g/s for 10 samples.
         for (int i = 0; i <= 10; i++) {
@@ -377,34 +365,47 @@ void main() {
           );
         }
 
-        expect(estimator.flow, lessThan(-0.5),
-            reason: 'signed flow — cup removal should produce negative flow');
+        expect(
+          estimator.flow,
+          lessThan(-0.5),
+          reason: 'signed flow — cup removal should produce negative flow',
+        );
       });
 
       test('no absurd flow spikes on real data', () {
         final trace = _loadFixture();
-        final estimator =
-            KalmanFlowEstimator(initialWeight: trace.first.weight);
+        final estimator = KalmanFlowEstimator(
+          initialWeight: trace.first.weight,
+        );
 
         for (final s in trace) {
           final (_, f) = estimator.addSample(s.timestamp, s.weight);
-          expect(f.abs(), lessThan(15.0),
-              reason: 'flow should never exceed 15 g/s (unphysical)');
+          expect(
+            f.abs(),
+            lessThan(15.0),
+            reason: 'flow should never exceed 15 g/s (unphysical)',
+          );
         }
       });
 
       test('weight estimate tracks raw weight within 2g over the pour', () {
         final trace = _loadFixture();
-        final estimator =
-            KalmanFlowEstimator(initialWeight: trace.first.weight);
+        final estimator = KalmanFlowEstimator(
+          initialWeight: trace.first.weight,
+        );
 
         // Skip first 5 samples (convergence), check the rest.
         for (int i = 0; i < trace.length; i++) {
-          final (w, _) = estimator.addSample(trace[i].timestamp, trace[i].weight);
+          final (w, _) = estimator.addSample(
+            trace[i].timestamp,
+            trace[i].weight,
+          );
           if (i >= 5) {
-            expect((w - trace[i].weight).abs(), lessThan(3.0),
-                reason:
-                    'filtered weight should not drift more than 3g from raw');
+            expect(
+              (w - trace[i].weight).abs(),
+              lessThan(3.0),
+              reason: 'filtered weight should not drift more than 3g from raw',
+            );
           }
         }
       });
@@ -412,12 +413,9 @@ void main() {
   });
 }
 
-/// Population stdev helper.
-double _stdev(List<double> values) {
-  if (values.length < 2) return 0.0;
-  final mean = values.reduce((a, b) => a + b) / values.length;
-  final variance =
-      values.map((v) => (v - mean) * (v - mean)).reduce((a, b) => a + b) /
-          values.length;
-  return sqrt(variance);
+double _meanAbsoluteDelta(List<double> values) {
+  final deltas = [
+    for (var i = 1; i < values.length; i++) (values[i] - values[i - 1]).abs(),
+  ];
+  return deltas.reduce((a, b) => a + b) / deltas.length;
 }

--- a/tools/analyze_weight_flow.py
+++ b/tools/analyze_weight_flow.py
@@ -4,7 +4,9 @@ import argparse
 import csv
 import json
 import math
+import re
 import statistics
+import urllib.parse
 import urllib.request
 from datetime import datetime
 from pathlib import Path
@@ -123,8 +125,18 @@ def write_svg(path, samples, title):
     )
 
 
+SHOT_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def validate_shot_id(shot_id):
+    if not SHOT_ID_RE.match(shot_id) or shot_id in (".", ".."):
+        raise ValueError(f"invalid shot_id: {shot_id!r}")
+    return shot_id
+
+
 def fetch_shot(base_url, shot_id):
-    url = f"{base_url.rstrip('/')}/api/v1/shots/{shot_id}"
+    encoded = urllib.parse.quote(shot_id, safe="")
+    url = f"{base_url.rstrip('/')}/api/v1/shots/{encoded}"
     with urllib.request.urlopen(url, timeout=15) as response:
         return json.load(response)
 
@@ -139,6 +151,7 @@ def main():
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
     for shot_id in args.shot_ids:
+        validate_shot_id(shot_id)
         shot = fetch_shot(args.base_url, shot_id)
         samples = extract_samples(shot)
         result = metrics(samples, args.min_flow)

--- a/tools/analyze_weight_flow.py
+++ b/tools/analyze_weight_flow.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import math
+import statistics
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+
+def parse_timestamp(value):
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def extract_samples(shot):
+    samples = []
+    for measurement in shot.get("measurements", []):
+        scale = measurement.get("scale")
+        if not scale or not isinstance(scale.get("weightFlow"), (int, float)):
+            continue
+        samples.append(
+            {
+                "timestamp": parse_timestamp(scale["timestamp"]),
+                "weight": float(scale["weight"]),
+                "flow": float(scale["weightFlow"]),
+            }
+        )
+    return samples
+
+
+def longest_active_run(samples, minimum_flow=0.1):
+    runs = []
+    current = []
+    for sample in samples:
+        if sample["flow"] > minimum_flow:
+            current.append(sample)
+        elif current:
+            runs.append(current)
+            current = []
+    if current:
+        runs.append(current)
+    return max(runs, key=len, default=[])
+
+
+def metrics(samples, minimum_flow=0.1):
+    intervals = [
+        (right["timestamp"] - left["timestamp"]).total_seconds()
+        for left, right in zip(samples, samples[1:])
+        if right["timestamp"] > left["timestamp"]
+    ]
+    active = longest_active_run(samples, minimum_flow)
+    flows = [sample["flow"] for sample in active]
+    deltas = [abs(right - left) for left, right in zip(flows, flows[1:])]
+    second_deltas = [
+        abs(flows[index] - 2 * flows[index - 1] + flows[index - 2])
+        for index in range(2, len(flows))
+    ]
+    return {
+        "samples": len(samples),
+        "active_samples": len(active),
+        "cadence_hz": 1 / statistics.median(intervals) if intervals else 0.0,
+        "mean_abs_delta": statistics.fmean(deltas) if deltas else 0.0,
+        "p95_abs_delta": sorted(deltas)[math.ceil(len(deltas) * 0.95) - 1]
+        if deltas
+        else 0.0,
+        "mean_abs_second_delta": statistics.fmean(second_deltas)
+        if second_deltas
+        else 0.0,
+    }
+
+
+def write_csv(path, samples):
+    start = samples[0]["timestamp"] if samples else None
+    with path.open("w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["timestamp", "elapsed_seconds", "weight_g", "flow_g_s"])
+        for sample in samples:
+            elapsed = (sample["timestamp"] - start).total_seconds()
+            writer.writerow(
+                [sample["timestamp"].isoformat(), elapsed, sample["weight"], sample["flow"]]
+            )
+
+
+def write_svg(path, samples, title):
+    width, height, margin = 1000, 420, 50
+    if samples:
+        start = samples[0]["timestamp"]
+        xs = [(sample["timestamp"] - start).total_seconds() for sample in samples]
+        ys = [sample["flow"] for sample in samples]
+    else:
+        xs, ys = [0.0], [0.0]
+    x_span = max(xs[-1] - xs[0], 1.0)
+    y_min, y_max = min(ys), max(ys)
+    y_span = max(y_max - y_min, 1.0)
+    points = " ".join(
+        f"{margin + (x - xs[0]) / x_span * (width - 2 * margin):.1f},"
+        f"{height - margin - (y - y_min) / y_span * (height - 2 * margin):.1f}"
+        for x, y in zip(xs, ys)
+    )
+    path.write_text(
+        f'''<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">
+<rect width="100%" height="100%" fill="white"/>
+<text x="{margin}" y="28" font-family="sans-serif" font-size="18">{escape(title)}</text>
+<line x1="{margin}" y1="{height - margin}" x2="{width - margin}" y2="{height - margin}" stroke="#777"/>
+<line x1="{margin}" y1="{margin}" x2="{margin}" y2="{height - margin}" stroke="#777"/>
+<polyline fill="none" stroke="#1976d2" stroke-width="2" points="{points}"/>
+<text x="{width / 2}" y="{height - 12}" text-anchor="middle" font-family="sans-serif">seconds</text>
+<text x="14" y="{height / 2}" transform="rotate(-90 14 {height / 2})" text-anchor="middle" font-family="sans-serif">flow (g/s)</text>
+<text x="{margin}" y="{height - margin + 20}" font-family="sans-serif" font-size="12">0</text>
+<text x="{width - margin}" y="{height - margin + 20}" text-anchor="end" font-family="sans-serif" font-size="12">{x_span:.1f}</text>
+<text x="{margin - 8}" y="{height - margin}" text-anchor="end" font-family="sans-serif" font-size="12">{y_min:.2f}</text>
+<text x="{margin - 8}" y="{margin + 4}" text-anchor="end" font-family="sans-serif" font-size="12">{y_max:.2f}</text>
+</svg>
+'''
+    )
+
+
+def fetch_shot(base_url, shot_id):
+    url = f"{base_url.rstrip('/')}/api/v1/shots/{shot_id}"
+    with urllib.request.urlopen(url, timeout=15) as response:
+        return json.load(response)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("shot_ids", nargs="+")
+    parser.add_argument("--base-url", default="http://192.168.12.57:8080")
+    parser.add_argument("--output-dir", type=Path, default=Path("flow-analysis"))
+    parser.add_argument("--min-flow", type=float, default=0.1)
+    args = parser.parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    for shot_id in args.shot_ids:
+        shot = fetch_shot(args.base_url, shot_id)
+        samples = extract_samples(shot)
+        result = metrics(samples, args.min_flow)
+        write_csv(args.output_dir / f"{shot_id}.csv", samples)
+        write_svg(args.output_dir / f"{shot_id}.svg", samples, shot_id)
+        print(
+            f"{shot_id}: samples={result['samples']} active={result['active_samples']} "
+            f"cadence={result['cadence_hz']:.2f}Hz "
+            f"mean|Δflow|={result['mean_abs_delta']:.3f}g/s "
+            f"p95|Δflow|={result['p95_abs_delta']:.3f}g/s "
+            f"mean|Δ²flow|={result['mean_abs_second_delta']:.3f}g/s"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/analyze_weight_flow.py
+++ b/tools/analyze_weight_flow.py
@@ -58,11 +58,16 @@ def metrics(samples, minimum_flow=0.1):
         abs(flows[index] - 2 * flows[index - 1] + flows[index - 2])
         for index in range(2, len(flows))
     ]
+    tail = flows[-10:]
+    tail_deltas = [abs(right - left) for left, right in zip(tail, tail[1:])]
     return {
         "samples": len(samples),
         "active_samples": len(active),
         "cadence_hz": 1 / statistics.median(intervals) if intervals else 0.0,
         "mean_abs_delta": statistics.fmean(deltas) if deltas else 0.0,
+        "tail_mean_abs_delta": statistics.fmean(tail_deltas)
+        if tail_deltas
+        else 0.0,
         "p95_abs_delta": sorted(deltas)[math.ceil(len(deltas) * 0.95) - 1]
         if deltas
         else 0.0,
@@ -143,6 +148,7 @@ def main():
             f"{shot_id}: samples={result['samples']} active={result['active_samples']} "
             f"cadence={result['cadence_hz']:.2f}Hz "
             f"mean|Δflow|={result['mean_abs_delta']:.3f}g/s "
+            f"tail10={result['tail_mean_abs_delta']:.3f}g/s "
             f"p95|Δflow|={result['p95_abs_delta']:.3f}g/s "
             f"mean|Δ²flow|={result['mean_abs_second_delta']:.3f}g/s"
         )

--- a/tools/analyze_weight_flow_test.py
+++ b/tools/analyze_weight_flow_test.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 import analyze_weight_flow
 
 
-class AnalyzeWeightFlowTest(unittest.TestCase):
+class MetricsTest(unittest.TestCase):
     def test_metrics_use_the_longest_active_run(self):
         start = datetime(2026, 7, 22, tzinfo=timezone.utc)
         flows = [0.0, 1.0, 1.5, 0.0, 2.0, 2.5, 3.5, 3.0]
@@ -28,6 +28,57 @@ class AnalyzeWeightFlowTest(unittest.TestCase):
         self.assertAlmostEqual(result["tail_mean_abs_delta"], 2 / 3)
         self.assertAlmostEqual(result["p95_abs_delta"], 1.0)
         self.assertAlmostEqual(result["mean_abs_second_delta"], 1.0)
+
+    def test_metrics_handles_empty_samples(self):
+        result = analyze_weight_flow.metrics([])
+        self.assertEqual(result["samples"], 0)
+        self.assertEqual(result["active_samples"], 0)
+        self.assertEqual(result["cadence_hz"], 0.0)
+
+    def test_metrics_handles_no_scale_measurements(self):
+        shot = {"measurements": [{"scale": None}, {"no_scale": True}]}
+        samples = analyze_weight_flow.extract_samples(shot)
+        self.assertEqual(samples, [])
+
+    def test_metrics_handles_malformed_scale_record(self):
+        shot = {
+            "measurements": [
+                {"scale": {"timestamp": "2026-01-01T00:00:00Z"}},
+                {"scale": {"timestamp": "2026-01-01T00:00:00Z", "weight": "nope"}},
+                {
+                    "scale": {
+                        "timestamp": "2026-01-01T00:00:00Z",
+                        "weight": 100,
+                        "weightFlow": "slow",
+                    }
+                },
+            ]
+        }
+        samples = analyze_weight_flow.extract_samples(shot)
+        self.assertEqual(samples, [])
+
+
+class ValidationTest(unittest.TestCase):
+    def test_accepts_valid_shot_ids(self):
+        valid = ["abc123", "shot-001", "2026-07-22_esp", "test.v1"]
+        for sid in valid:
+            analyze_weight_flow.validate_shot_id(sid)  # no raise
+
+    def test_rejects_dot_and_dotdot(self):
+        with self.assertRaises(ValueError):
+            analyze_weight_flow.validate_shot_id(".")
+        with self.assertRaises(ValueError):
+            analyze_weight_flow.validate_shot_id("..")
+
+    def test_rejects_path_traversal(self):
+        bad_ids = ["../../tmp/result", "foo/bar", "a\\b"]
+        for sid in bad_ids:
+            with self.assertRaises(ValueError):
+                analyze_weight_flow.validate_shot_id(sid)
+
+    def test_rejects_empty(self):
+        with self.assertRaises(ValueError):
+            analyze_weight_flow.validate_shot_id("")
 
 
 if __name__ == "__main__":

--- a/tools/analyze_weight_flow_test.py
+++ b/tools/analyze_weight_flow_test.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+import analyze_weight_flow
+
+
+class AnalyzeWeightFlowTest(unittest.TestCase):
+    def test_metrics_use_the_longest_active_run(self):
+        start = datetime(2026, 7, 22, tzinfo=timezone.utc)
+        flows = [0.0, 1.0, 1.5, 0.0, 2.0, 2.5, 3.5, 3.0]
+        samples = [
+            {
+                "timestamp": start + timedelta(milliseconds=index * 250),
+                "weight": float(index),
+                "flow": flow,
+            }
+            for index, flow in enumerate(flows)
+        ]
+
+        result = analyze_weight_flow.metrics(samples)
+
+        self.assertEqual(result["samples"], 8)
+        self.assertEqual(result["active_samples"], 4)
+        self.assertAlmostEqual(result["cadence_hz"], 4.0)
+        self.assertAlmostEqual(result["mean_abs_delta"], 2 / 3)
+        self.assertAlmostEqual(result["p95_abs_delta"], 1.0)
+        self.assertAlmostEqual(result["mean_abs_second_delta"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/analyze_weight_flow_test.py
+++ b/tools/analyze_weight_flow_test.py
@@ -25,6 +25,7 @@ class AnalyzeWeightFlowTest(unittest.TestCase):
         self.assertEqual(result["active_samples"], 4)
         self.assertAlmostEqual(result["cadence_hz"], 4.0)
         self.assertAlmostEqual(result["mean_abs_delta"], 2 / 3)
+        self.assertAlmostEqual(result["tail_mean_abs_delta"], 2 / 3)
         self.assertAlmostEqual(result["p95_abs_delta"], 1.0)
         self.assertAlmostEqual(result["mean_abs_second_delta"], 1.0)
 


### PR DESCRIPTION
## Summary

- Problem: Kalman-smoothed public weight flow was 3.7–12.3× noisier than comparable legacy de1app traces.
- Why it matters: noisy charts obscured extraction behavior, while retuning the single signal risked changing stop-at-weight response.
- What changed: Kalman now supplies internal control flow; the legacy `FlowCalculator(600ms) + MovingAverage(10)` pipeline supplies public/recorded display flow. Added debug-only runtime display tuning and an offline shot-analysis tool.
- What did NOT change: raw weight, public `weightFlow` JSON shape, shot sampling cadence, and the Kalman control estimator behavior.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [x] REST API / handlers
- [ ] WebSocket API
- [x] Machine state / shot logic
- [x] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [x] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #484
- Related #420

## Root Cause (if bug fix)

- Root cause: one `weightFlow` signal served conflicting low-lag control and smooth display requirements.
- Missing detection or guardrail: the Kalman regression benchmark compared against `FlowCalculator` alone, omitting the production legacy `MovingAverage(10)` stage.
- Contributing context: raw weight was changed to bypass Kalman lag, but public flow retained the noisier Kalman tuning.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [x] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/unit/controllers/scale_controller_test.dart`, `test/unit/util/kalman_flow_estimator_test.dart`, controller sequencer tests, and `test/services/webserver/debug_handler_test.dart`.
- Scenario the test should lock in: public flow stays below mean `|Δflow| ≤ 0.12 g/s` on the native fixture while signed Kalman control flow and weight decisions remain unchanged.
- If no new test added, why not: N/A.

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [x] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [x] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A — no docs affected

## Security Impact (required)

- New or changed REST endpoints? `Yes`
- New or changed WebSocket topics? `No`
- New or changed network calls? `Yes`
- BLE/USB surface changed? `No`
- File system access changed? `Yes`
- Plugin sandbox boundary changed? `No`
- If any `Yes`, explain risk and mitigation: the tuning endpoint is compile-time gated by the existing non-empty `simulate` define and validates bounded integers. The standalone analysis tool fetches explicitly requested local shot IDs and writes CSV/SVG files only to its requested output directory.

## User-Visible Changes

- Recorded and graphed scale flow uses the smoother legacy display pipeline.
- The experimental Kalman feature toggle is retired; Kalman remains internal for control decisions.
- Debug builds expose ephemeral display smoothing at `/api/v1/debug/flow-smoothing`.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all 2461 tests pass
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds

### Manual verification (if applicable)

- OS / platform tested: macOS simulated app; Android tablet with DE1 and real scale.
- Simulated devices? (`simulate=1`): `Yes`
- Real hardware? (DE1/Bengle/scale): `Yes — DE1 + scale`
- What you personally verified and how: GET/POST/validation/hot-reload for the debug endpoint; analyzed persisted allonge shots; steady-tail mean `|Δflow|` fell from 0.276 to 0.049 g/s (82%); SAW at calibrated multiplier 0.83 landed 53.3 g against 52.5 g target (+0.8 g).
- Edge cases checked: historical JSON fallback, tare reset, invalid/atomic tuning updates, divergent display/control flow for espresso and hot-water stops, cup removal.
- What you did **not** verify: Filter3, Bengle autonomous SAW, other physical scale models, iOS/Windows/Linux hardware.

### Evidence

- [x] Test output (failing before + passing after)
- [x] Log snippets
- [ ] Screenshot / recording (UI changes)
- [x] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`
- If any `No` or `Yes`, explain exact steps: `controlWeightFlow` is internal-only and defaults to public `weightFlow` for historical/imported snapshots; serialized contracts remain unchanged.

## Risks & Mitigations

- Risk: smoothing adds display lag.
  - Mitigation: all weight-based decisions consume the unchanged low-lag Kalman control flow.
- Risk: runtime tuning could use pathological values.
  - Mitigation: debug-only route, bounded validation, atomic update, and process-local settings.
