### PR TITLE
divide dispensed water by 10 for visualizer compat

### DIFF
--- a/assets/plugins/visualizer.reaplugin/manifest.json
+++ b/assets/plugins/visualizer.reaplugin/manifest.json
@@ -3,7 +3,7 @@
   "author": "Decent Espresso",
   "name": "Visualizer upload",
   "description": "Uploads shots to Visualizer and syncs your edited shot metadata back",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "apiVersion": 1,
   "permissions": [
     "log",

--- a/assets/plugins/visualizer.reaplugin/plugin.js
+++ b/assets/plugins/visualizer.reaplugin/plugin.js
@@ -239,7 +239,7 @@ function createPlugin(host) {
       visualizerShot.temperature.goal.push(machine.targetGroupTemperature);
       visualizerShot.temperature.mix_goal.push(machine.targetMixTemperature);
       visualizerShot.totals.weight.push(scale?.weight ?? 0);
-      visualizerShot.totals.water_dispensed.push(waterDispensed);
+      visualizerShot.totals.water_dispensed.push(waterDispensed / 10);
       visualizerShot.state_change.push(machine.state.substate);
     }
 
@@ -973,7 +973,7 @@ function createPlugin(host) {
   // Return the plugin object
   return {
     id: "visualizer.reaplugin",
-    version: "1.5.0",
+    version: "1.5.1",
 
     onLoad(settings) {
       state.username = settings.Username;


### PR DESCRIPTION
fixes #483 

Visualizer multiplies `water_dispensed` by 10 for historical reasons apparently.