### PR TITLE
fix(visualizer): export profile frames as state changes

### DIFF
--- a/assets/plugins/visualizer.reaplugin/manifest.json
+++ b/assets/plugins/visualizer.reaplugin/manifest.json
@@ -3,7 +3,7 @@
   "author": "Decent Espresso",
   "name": "Visualizer upload",
   "description": "Uploads shots to Visualizer and syncs your edited shot metadata back",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "apiVersion": 1,
   "permissions": [
     "log",

--- a/assets/plugins/visualizer.reaplugin/plugin.js
+++ b/assets/plugins/visualizer.reaplugin/plugin.js
@@ -240,7 +240,7 @@ function createPlugin(host) {
       visualizerShot.temperature.mix_goal.push(machine.targetMixTemperature);
       visualizerShot.totals.weight.push(scale?.weight ?? 0);
       visualizerShot.totals.water_dispensed.push(waterDispensed / 10);
-      visualizerShot.state_change.push(machine.state.substate);
+      visualizerShot.state_change.push(machine.profileFrame);
     }
 
     return visualizerShot;
@@ -973,7 +973,7 @@ function createPlugin(host) {
   // Return the plugin object
   return {
     id: "visualizer.reaplugin",
-    version: "1.5.1",
+    version: "1.5.2",
 
     onLoad(settings) {
       state.username = settings.Username;

--- a/test/plugins/visualizer_plugin_test.dart
+++ b/test/plugins/visualizer_plugin_test.dart
@@ -1,0 +1,16 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Visualizer state_change uses profile frame indices', () {
+    final source = File(
+      'assets/plugins/visualizer.reaplugin/plugin.js',
+    ).readAsStringSync();
+
+    expect(
+      source,
+      contains('visualizerShot.state_change.push(machine.profileFrame);'),
+    );
+  });
+}

--- a/test/plugins/visualizer_plugin_test.dart
+++ b/test/plugins/visualizer_plugin_test.dart
@@ -1,16 +1,138 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/services/storage/kv_store_service.dart';
+
+class _FakeKeyValueStore implements KeyValueStoreService {
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> set({
+    String namespace = 'default',
+    required String key,
+    required Object value,
+  }) async {}
+
+  @override
+  Future<bool> delete({
+    String namespace = 'default',
+    required String key,
+  }) async => false;
+
+  @override
+  Future<Object?> get({
+    String namespace = 'default',
+    required String key,
+  }) async => null;
+
+  @override
+  Future<List<String>> keys({String namespace = 'default'}) async => [];
+
+  @override
+  List<String> get namespaces => [];
+
+  @override
+  Future<Map<String, Object>> getAll({String namespace = 'default'}) async =>
+      {};
+}
 
 void main() {
-  test('Visualizer state_change uses profile frame indices', () {
-    final source = File(
-      'assets/plugins/visualizer.reaplugin/plugin.js',
-    ).readAsStringSync();
+  test(
+    'Visualizer upload uses profile frame indices for state_change',
+    () async {
+      final pluginSource = File(
+        'assets/plugins/visualizer.reaplugin/plugin.js',
+      ).readAsStringSync();
+      final manifest = PluginManifest.fromJson(
+        jsonDecode(
+              File(
+                'assets/plugins/visualizer.reaplugin/manifest.json',
+              ).readAsStringSync(),
+            )
+            as Map<String, dynamic>,
+      );
+      final shot = {
+        'id': 'shot-1',
+        'annotations': <String, dynamic>{},
+        'workflow': {
+          'profile': {'target_weight': 36},
+          'context': <String, dynamic>{},
+        },
+        'measurements': [
+          for (var i = 0; i < 4; i++)
+            {
+              'machine': {
+                'timestamp': '2026-01-01T00:00:0${i * 2}Z',
+                'state': {'substate': 'pouring'},
+                'profileFrame': [0, 0, 1, 2][i],
+                'pressure': 9,
+                'targetPressure': 9,
+                'flow': 2,
+                'targetFlow': 2,
+                'mixTemperature': 93,
+                'groupTemperature': 92,
+                'targetGroupTemperature': 93,
+                'targetMixTemperature': 93,
+              },
+              'scale': {'weight': i * 10, 'weightFlow': 2},
+            },
+        ],
+      };
+      final manager = PluginManager(kvStore: _FakeKeyValueStore());
+      final setupResult = manager.js.evaluate('''
+      globalThis.setTimeout = (callback) => { callback(); return 1; };
+      globalThis.clearTimeout = () => {};
+      globalThis.fetch = async (url, init = {}) => {
+        if (url.endsWith('/shots/latest')) {
+          return { ok: true, json: async () => ({ id: 'shot-1' }) };
+        }
+        if (url.endsWith('/shots/shot-1')) {
+          return { ok: true, json: async () => (${jsonEncode(shot)}) };
+        }
+        if (url.endsWith('/shots/upload')) {
+          const body = init.body;
+          const start = body.indexOf('\\r\\n\\r\\n') + 4;
+          const end = body.lastIndexOf('\\r\\n--');
+          globalThis.__visualizerUpload = JSON.parse(body.slice(start, end));
+          return { ok: true, json: async () => ({ id: 'visualizer-1' }) };
+        }
+        throw new Error('Unexpected URL: ' + url);
+      };
+    ''');
+      expect(setupResult.isError, isFalse, reason: setupResult.stringResult);
 
-    expect(
-      source,
-      contains('visualizerShot.state_change.push(machine.profileFrame);'),
-    );
-  });
+      await manager.loadPlugin(
+        id: manifest.id,
+        manifest: manifest,
+        settings: {
+          'Username': 'user',
+          'Password': 'password',
+          'LengthThreshold': 0,
+        },
+        jsCode: pluginSource,
+      );
+      manager.dispatchEvent(manifest.id, 'stateUpdate', {
+        'state': {'state': 'espresso'},
+      });
+      manager.dispatchEvent(manifest.id, 'stateUpdate', {
+        'state': {'state': 'idle'},
+      });
+
+      Map<String, dynamic>? upload;
+      for (var i = 0; i < 20 && upload == null; i++) {
+        manager.js.executePendingJob();
+        final result = manager.js.evaluate(
+          'JSON.stringify(globalThis.__visualizerUpload ?? null)',
+        );
+        upload = jsonDecode(result.stringResult) as Map<String, dynamic>?;
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      expect(upload?['state_change'], [0, 0, 1, 2]);
+    },
+  );
 }


### PR DESCRIPTION
## Summary

- Problem: Visualizer uploads filled `state_change` with machine substates, which remain mostly `preinfusion` or `pouring` throughout a shot.
- Why it matters: Visualizer could not draw vertical profile-step transition bars like the legacy de1app.
- What changed: Export `machine.profileFrame`, bump the bundled Visualizer plugin to v1.5.2, and add regression coverage.
- What did NOT change (scope boundary): No shot recording, API, profile execution, or Visualizer network behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [x] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [x] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs

## Linked Issues

- Closes #485
- Related #

## Root Cause (if bug fix)

- Root cause: The upload conversion used `machine.state.substate`, but Visualizer's legacy-compatible `state_change` samples represent DE1 profile frame indices.
- Missing detection or guardrail: The bundled Visualizer conversion had no regression test for the source field used by `state_change`.
- Contributing context (if known): Espresso substates are intentionally coarse and do not change at every profile step.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/plugins/visualizer_plugin_test.dart`
- Scenario the test should lock in: The bundled plugin exports `machine.profileFrame` into each `state_change` sample.
- If no new test added, why not: N/A

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A — no docs affected

## Security Impact (required)

- New or changed REST endpoints? (`Yes/No`) No
- New or changed WebSocket topics? (`Yes/No`) No
- New or changed network calls? (`Yes/No`) No
- BLE/USB surface changed? (`Yes/No`) No
- File system access changed? (`Yes/No`) No
- Plugin sandbox boundary changed? (`Yes/No`) No
- If any `Yes`, explain risk and mitigation: N/A

## User-Visible Changes

Visualizer shots regain vertical bars at profile-step transitions.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass (2462 tests)
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds

### Manual verification (if applicable)

- OS / platform tested: macOS
- Simulated devices? (`simulate=1`): Yes, MockDe1
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: Started via `scripts/sb-dev.sh`; `/api/v1/plugins` reported `visualizer.reaplugin` v1.5.2 loaded before and after hot reload; plugin evaluation logged no error.
- Edge cases checked: Bundled manifest and runtime version stay aligned; JavaScript syntax check passes.
- What you did **not** verify: A credentialed upload to visualizer.coffee and resulting graph rendering.

### Evidence

- [x] Test output (failing before + passing after)
- [x] Log snippets
- [ ] Screenshot / recording (UI changes)
- [x] curl / websocat output (API changes)

Focused regression failed before the fix because the plugin did not contain the profile-frame export; it passed after the change. Full suite: `00:02:52 +2462: All tests passed!`. Analyzer: `No issues found!`. Simulated smoke returned:

```json
{"id":"visualizer.reaplugin","version":"1.5.2","loaded":true,"autoLoad":true}
```

## Compatibility & Migration

- Backward compatible? (`Yes/No`) Yes
- Config / env changes needed? (`Yes/No`) No
- Database migration needed? (`Yes/No`) No
- If any `No` or `Yes`, explain exact steps: Existing release installs receive the bundled plugin update through the v1.5.2 version bump; no user action is required.

## Risks & Mitigations

- Risk: The final Visualizer rendering was not exercised against the production service.
  - Mitigation: The change restores the same profile-frame semantics used by legacy de1app, is isolated to one upload field, and has focused regression coverage.
