### PR TITLE
fix(webui): persist GitHub branch skin metadata

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3047,7 +3047,7 @@ paths:
   /api/v1/webui/skins/install/github-branch:
     post:
       summary: Install skin from GitHub branch
-      description: Downloads and installs a WebUI skin from a GitHub branch archive
+      description: Downloads and installs a WebUI skin from a GitHub branch archive, persisting the branch source for future update checks
       tags: [WebUI]
       requestBody:
         required: true
@@ -5788,7 +5788,7 @@ components:
         sourceUrl:
           type: string
           nullable: true
-          description: Source URL or identifier (e.g., 'github_release:owner/repo@v1.0.0')
+          description: Source URL or identifier (e.g., 'github_release:owner/repo@v1.0.0' or 'github_branch:owner/repo@main')
         lastModified:
           type: string
           nullable: true

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -217,7 +217,7 @@ Settings fields include: `gatewayMode`, `themeMode`, `logLevel`, `weightFlowMult
 | GET | `/api/v1/webui/skins/default` | Get default skin | |
 | PUT | `/api/v1/webui/skins/default` | Set default skin (`{skinId}`) | |
 | POST | `/api/v1/webui/skins/install/github-release` | Install from GitHub release | |
-| POST | `/api/v1/webui/skins/install/github-branch` | Install from GitHub branch | |
+| POST | `/api/v1/webui/skins/install/github-branch` | Install from GitHub branch and persist its source for update checks | |
 | POST | `/api/v1/webui/skins/install/url` | Install from ZIP URL | |
 | DELETE | `/api/v1/webui/skins/:id` | Remove installed skin | |
 | POST | `/api/v1/webui/skins/update` | Check all skins for updates from remote sources | |

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -3384,7 +3384,7 @@ Decent.app tracks skin metadata in `.rea_metadata.json`:
 {
   "my-nextjs-skin": {
     "skinId": "my-nextjs-skin",
-    "sourceUrl": "https://github.com/username/repo/archive/refs/heads/dist.zip",
+    "sourceUrl": "github_branch:username/repo@dist",
     "etag": "\"abc123def456\"",
     "lastModified": "Wed, 01 Feb 2026 12:00:00 GMT",
     "commitHash": "branch:dist",
@@ -3398,7 +3398,7 @@ Decent.app tracks skin metadata in `.rea_metadata.json`:
 - Remote skins are checked for updates when `downloadRemoteSkins()` is called
 - Uses HTTP `ETag` and `Last-Modified` headers for efficient version checking
 - Only downloads if remote version differs from installed version
-- Updates are automatic for remote bundled skins
+- Updates are automatic for remote bundled skins and user-installed GitHub branch skins
 
 ---
 

--- a/lib/src/webui_support/webui_storage.dart
+++ b/lib/src/webui_support/webui_storage.dart
@@ -360,8 +360,13 @@ class WebUIStorage {
     final branchName = parts.length > 2 ? parts[2] : branch;
     
     final url = 'https://github.com/$owner/$repoName/archive/refs/heads/$branchName.zip';
-    
-    await installFromUrl(url);
+    final sourceIdentifier = 'github_branch:$owner/$repoName@$branchName';
+
+    await _installFromUrlAsRemoteBundled(
+      url,
+      markAsRemoteBundled: false,
+      sourceIdentifier: sourceIdentifier,
+    );
   }
 
   /// Install a WebUI skin from a GitHub Release
@@ -506,6 +511,8 @@ class WebUIStorage {
   /// to keep all skins up to date. Each skin update is independent — one failure
   /// does not prevent others from updating.
   Future<void> updateAllSkins() async {
+    if (_appStoreMode) return;
+
     _log.info('Starting update check for all skins');
 
     // 1. Update remote-bundled skins
@@ -536,6 +543,19 @@ class WebUIStorage {
 
           _log.info('Updating user-installed skin "$skinId" from GitHub release: $repo');
           await _installFromGitHubRelease(repo, null, false);
+        } else if (sourceUrl.startsWith('github_branch:')) {
+          final withoutPrefix = sourceUrl.substring('github_branch:'.length);
+          final atIndex = withoutPrefix.indexOf('@');
+          final repo =
+              atIndex >= 0 ? withoutPrefix.substring(0, atIndex) : withoutPrefix;
+          final branch =
+              atIndex >= 0 ? withoutPrefix.substring(atIndex + 1) : 'main';
+
+          _log.info(
+            'Updating user-installed skin "$skinId" from GitHub branch: '
+            '$repo@$branch',
+          );
+          await installFromGitHub(repo, branch: branch);
         } else if (sourceUrl.startsWith('http')) {
           _log.info('Updating user-installed skin "$skinId" from URL: $sourceUrl');
           await _installFromUrlAsRemoteBundled(sourceUrl, markAsRemoteBundled: false);
@@ -547,6 +567,7 @@ class WebUIStorage {
       }
     }
 
+    await _scanInstalledSkins();
     _log.info('Finished update check for all skins');
   }
 
@@ -681,16 +702,21 @@ class WebUIStorage {
 
   /// Internal method to install from URL and mark as remote bundled
   /// Includes version checking via HTTP headers (ETag, Last-Modified)
-  Future<void> _installFromUrlAsRemoteBundled(String url, {bool markAsRemoteBundled = true}) async {
+  Future<void> _installFromUrlAsRemoteBundled(
+    String url, {
+    bool markAsRemoteBundled = true,
+    String? sourceIdentifier,
+  }) async {
     try {
       // First, do a HEAD request to check version without downloading
       final headResponse = await http.head(Uri.parse(url));
       final etag = headResponse.headers['etag'];
       final lastModified = headResponse.headers['last-modified'];
+      final trackedSource = sourceIdentifier ?? url;
       
       // Try to find existing skin with this source URL
       final existingMetadata = _skinMetadata.values.firstWhere(
-        (meta) => meta.sourceUrl == url,
+        (meta) => meta.sourceUrl == trackedSource,
         orElse: () => WebUIReaMetadata(
           skinId: '',
           installedAt: DateTime.now(),
@@ -761,7 +787,7 @@ class WebUIStorage {
       // Store REA metadata
       _skinMetadata[installedSkinId] = WebUIReaMetadata(
         skinId: installedSkinId,
-        sourceUrl: url,
+        sourceUrl: trackedSource,
         etag: etag,
         lastModified: lastModified,
         commitHash: commitHash,

--- a/test/webui_storage_install_test.dart
+++ b/test/webui_storage_install_test.dart
@@ -1,7 +1,11 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:archive/archive.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/webui_support/webui_storage.dart';
 
@@ -21,11 +25,21 @@ void main() {
 
       final settingsController = SettingsController(MockSettingsService());
       await settingsController.loadSettings();
-      storage = WebUIStorage(settingsController, appStoreMode: true);
+      storage = WebUIStorage(settingsController, appStoreMode: false);
       storage.debugInitWithWebUIDir(webUIDir);
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        const MethodChannel('plugins.flutter.io/path_provider'),
+        (_) async => tmpRoot.path,
+      );
     });
 
     tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        const MethodChannel('plugins.flutter.io/path_provider'),
+        null,
+      );
       if (tmpRoot.existsSync()) tmpRoot.deleteSync(recursive: true);
     });
 
@@ -50,6 +64,64 @@ void main() {
           as Map<String, dynamic>;
       return json['version'] as String;
     }
+
+    List<int> makeGitHubArchive() {
+      final archive = Archive()
+        ..addFile(ArchiveFile.string(
+          'passione-dist/skin-manifest.json',
+          jsonEncode({
+            'id': 'passione-dist',
+            'name': 'Passione',
+            'version': '1.0.0',
+          }),
+        ))
+        ..addFile(ArchiveFile.string(
+          'passione-dist/index.html',
+          '<html></html>',
+        ));
+      return ZipEncoder().encode(archive);
+    }
+
+    test('GitHub branch install persists source metadata', () async {
+      final archive = makeGitHubArchive();
+      var branchHeadRequests = 0;
+
+      await http.runWithClient(
+        () async {
+          await storage.installFromGitHub('tadelv/passione', branch: 'dist');
+          await storage.updateAllSkins();
+        },
+        () => MockClient((request) async {
+          if (request.url.toString() !=
+              'https://github.com/tadelv/passione/archive/refs/heads/dist.zip') {
+            return http.Response('', 404);
+          }
+          if (request.method == 'HEAD') {
+            branchHeadRequests++;
+            return http.Response('', 200, headers: {'etag': 'branch-etag'});
+          }
+          return http.Response.bytes(archive, 200);
+        }),
+      );
+
+      expect(branchHeadRequests, 2);
+      final metadata = storage.getSkin('passione-dist')?.reaMetadata;
+      expect(metadata, isNotNull);
+      expect(
+        metadata!.sourceUrl,
+        'github_branch:tadelv/passione@dist',
+      );
+      expect(metadata.lastChecked, isNotNull);
+      expect(metadata.lastChecked, isNot(metadata.installedAt));
+
+      final persisted = jsonDecode(
+        File('${webUIDir.path}/.rea_metadata.json').readAsStringSync(),
+      ) as Map<String, dynamic>;
+      expect(
+        persisted['passione-dist']['sourceUrl'],
+        'github_branch:tadelv/passione@dist',
+      );
+    });
 
     test('overwriteIfExists:false leaves an existing skin untouched', () async {
       // Newer copy installed first (e.g. from a GitHub release).

--- a/test/webui_storage_install_test.dart
+++ b/test/webui_storage_install_test.dart
@@ -85,11 +85,23 @@ void main() {
     test('GitHub branch install persists source metadata', () async {
       final archive = makeGitHubArchive();
       var branchHeadRequests = 0;
+      var branchGetRequests = 0;
+      late DateTime before;
+      late DateTime after;
 
       await http.runWithClient(
         () async {
           await storage.installFromGitHub('tadelv/passione', branch: 'dist');
+          before = storage
+              .getSkin('passione-dist')!
+              .reaMetadata!
+              .lastChecked!;
+
           await storage.updateAllSkins();
+          after = storage
+              .getSkin('passione-dist')!
+              .reaMetadata!
+              .lastChecked!;
         },
         () => MockClient((request) async {
           if (request.url.toString() !=
@@ -100,19 +112,20 @@ void main() {
             branchHeadRequests++;
             return http.Response('', 200, headers: {'etag': 'branch-etag'});
           }
+          branchGetRequests++;
           return http.Response.bytes(archive, 200);
         }),
       );
 
       expect(branchHeadRequests, 2);
-      final metadata = storage.getSkin('passione-dist')?.reaMetadata;
-      expect(metadata, isNotNull);
+      expect(branchGetRequests, 1);
+      expect(after.isAfter(before), isTrue);
+
+      final metadata = storage.getSkin('passione-dist')!.reaMetadata!;
       expect(
-        metadata!.sourceUrl,
+        metadata.sourceUrl,
         'github_branch:tadelv/passione@dist',
       );
-      expect(metadata.lastChecked, isNotNull);
-      expect(metadata.lastChecked, isNot(metadata.installedAt));
 
       final persisted = jsonDecode(
         File('${webUIDir.path}/.rea_metadata.json').readAsStringSync(),
@@ -120,6 +133,10 @@ void main() {
       expect(
         persisted['passione-dist']['sourceUrl'],
         'github_branch:tadelv/passione@dist',
+      );
+      expect(
+        DateTime.parse(persisted['passione-dist']['lastChecked']),
+        after,
       );
     });
 


### PR DESCRIPTION
## Summary

- Problem: GitHub branch skin installs downloaded successfully but did not persist `reaMetadata`.
- Why it matters: without a tracked source, `/api/v1/webui/skins/update` skipped the skin and it became stale.
- What changed: branch installs now persist `github_branch:<owner>/<repo>@<branch>`, update checks dispatch that source back through the branch installer, and cached skin metadata refreshes after checks.
- What did NOT change: endpoint paths, request/response shapes, release installs, and direct URL installs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [x] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [x] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #415
- Related: None

## Root Cause (if bug fix)

- Root cause: `installFromGitHub()` delegated to the untracked direct-URL installer, which never populated `_skinMetadata`.
- Missing detection or guardrail: handler coverage only verified delegation to storage; there was no storage-level branch-install round-trip test.
- Contributing context: update checks also refreshed `_skinMetadata` without rebuilding cached `WebUISkin` values, leaving API-visible `lastChecked` stale after an ETag match.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [x] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/webui_storage_install_test.dart`
- Scenario the test should lock in: install a mocked GitHub branch archive, run an update check, and verify persisted/API-visible metadata contains the stable branch source and refreshed `lastChecked`.
- If no new test added, why not: N/A; regression coverage added.

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [x] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed) — N/A
- [x] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed) — N/A
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed) — N/A
- [ ] N/A — no docs affected

## Security Impact (required)

- New or changed REST endpoints? (`Yes/No`) Yes — behavior of an existing install endpoint changed.
- New or changed WebSocket topics? (`Yes/No`) No
- New or changed network calls? (`Yes/No`) Yes — branch installs now perform the existing tracked installer's HEAD check before downloading the same requested GitHub archive.
- BLE/USB surface changed? (`Yes/No`) No
- File system access changed? (`Yes/No`) Yes — the existing `.rea_metadata.json` registry is now written for branch installs.
- Plugin sandbox boundary changed? (`Yes/No`) No
- If any `Yes`, explain risk and mitigation: no new destination or user-controlled filesystem path was introduced; requests remain limited to the GitHub archive URL derived by the existing installer, and metadata uses the existing registry writer.

## User-Visible Changes

GitHub branch-installed skins now expose populated `reaMetadata` and participate in manual/background skin update checks.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass (2462)
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds

### Manual verification (if applicable)

- OS / platform tested: macOS
- Simulated devices? (`simulate=1`): Yes
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: used `scripts/sb-dev.sh`, installed `tadelv/passione@dist` through the REST endpoint, fetched `passione-dist`, ran the update endpoint, and confirmed `lastChecked` advanced.
- Edge cases checked: unchanged ETag metadata-only update, App Store update early return, existing overwrite semantics.
- What you did **not** verify: real hardware and App Store binary execution; neither is involved in skin storage behavior.

### Evidence

- [x] Test output (failing before + passing after)
- [x] Log snippets
- [ ] Screenshot / recording (UI changes)
- [x] curl / websocat output (API changes)

Failing regression before the fix:

```text
Expected: not null
Actual: <null>
WebUIStorage install overwrite semantics GitHub branch install persists source metadata
```

Final gates and smoke:

```text
flutter test: +2462: All tests passed!
flutter analyze: No issues found!
sourceUrl: github_branch:tadelv/passione@dist
lastChecked before: 2026-07-23T10:01:39.949203
lastChecked after:  2026-07-23T10:03:07.218081
```

## Compatibility & Migration

- Backward compatible? (`Yes/No`) Yes
- Config / env changes needed? (`Yes/No`) No
- Database migration needed? (`Yes/No`) No
- If any `No` or `Yes`, explain exact steps: existing branch-installed skins without metadata need one reinstall to acquire source tracking; future installs are tracked automatically.

## Risks & Mitigations

- Risk: malformed persisted `github_branch:` identifiers could be skipped or resolve to the default branch.
  - Mitigation: identifiers are generated internally from the validated installer inputs, and regression coverage verifies parsing and update dispatch.
