### PR TITLE
fix(api): document firmware NDJSON progress event sequence and scope

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -620,11 +620,17 @@ paths:
         stream. Rejects an empty body with 400. Returns 409 if an update is
         already in progress. Returns 503 if no machine is connected.
 
-        Event sequence: `erasing (0.0)` → `uploading (0.xx)` → `done (1.0)`.
-        `error` with `progress: -1.0` may interrupt at any phase.
-        Progress events only cover the MMR write (upload) phase; the erase
-        phase and the CRC verification phase have no progress events.
-        Progress jumps from ~0.99 to 1.0 after verification completes.
+        A successful stream emits `erasing`, zero or more `uploading` events,
+        then `done`. A failed stream emits `erasing`, zero or more `uploading`
+        events, then `error` with `progress: -1.0`.
+
+        Upload progress is emitted in approximately one-percent increments.
+        The final `uploading` value may be close to or equal to `1.0`. Only the
+        subsequent `done` event indicates that CRC verification completed
+        successfully. The erase and CRC verification phases do not emit
+        intermediate percentage updates. The stream emits `erasing` when the
+        operation starts and remains silent during verification until either
+        `done` or `error`.
       tags: [Machine]
       requestBody:
         required: true
@@ -6428,19 +6434,29 @@ components:
         NDJSON event streamed during a firmware update. One event per line.
         The stream stays open while final verification is pending.
 
-        Event sequence:
+        Successful sequence:
 
-        1. `{"status":"erasing","progress":0.0}` — erase started
-        2. `{"status":"uploading","progress":0.45}` — MMR write, ~1% increments
-        3. `{"status":"done","progress":1.0}` — success (after verification)
+        1. `{"status":"erasing","progress":0.0}`
+        2. Zero or more `{"status":"uploading","progress":0.45}` events
+        3. `{"status":"done","progress":1.0}`
 
-        At any point `{"status":"error","progress":-1.0,"error":"..."}` may
-        replace the above. Verification failure/timeout emits `error`, never
+        Failure sequence:
+
+        1. `{"status":"erasing","progress":0.0}`
+        2. Zero or more `{"status":"uploading","progress":0.45}` events
+        3. `{"status":"error","progress":-1.0,"error":"..."}`
+
+        An `error` event may terminate the sequence after any previously
+        emitted events. Verification failure or timeout emits `error`, never
         `done`.
 
-        Progress only covers the MMR write phase (upload). The erase and CRC
-        verification phases emit no progress events. Progress jumps from ~0.99
-        to 1.0 after verification completes.
+        Upload progress is emitted in approximately one-percent increments.
+        The final `uploading` value may be close to or equal to `1.0`. Only the
+        subsequent `done` event indicates that CRC verification completed
+        successfully. The erase and CRC verification phases do not emit
+        intermediate percentage updates. The stream emits `erasing` when the
+        operation starts and remains silent during verification until either
+        `done` or `error`.
       properties:
         status:
           type: string

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -619,6 +619,12 @@ paths:
         Send a raw firmware file to the machine. Returns an NDJSON progress
         stream. Rejects an empty body with 400. Returns 409 if an update is
         already in progress. Returns 503 if no machine is connected.
+
+        Event sequence: `erasing (0.0)` → `uploading (0.xx)` → `done (1.0)`.
+        `error` with `progress: -1.0` may interrupt at any phase.
+        Progress events only cover the MMR write (upload) phase; the erase
+        phase and the CRC verification phase have no progress events.
+        Progress jumps from ~0.99 to 1.0 after verification completes.
       tags: [Machine]
       requestBody:
         required: true
@@ -6419,10 +6425,22 @@ components:
     FirmwareProgressEvent:
       type: object
       description: |
-        NDJSON event streamed during a firmware update. The stream stays open
-        while final verification is pending. `done` is emitted only after the
-        machine reports successful verification. Verification failure/timeout
-        emits `error`, never `done`.
+        NDJSON event streamed during a firmware update. One event per line.
+        The stream stays open while final verification is pending.
+
+        Event sequence:
+
+        1. `{"status":"erasing","progress":0.0}` — erase started
+        2. `{"status":"uploading","progress":0.45}` — MMR write, ~1% increments
+        3. `{"status":"done","progress":1.0}` — success (after verification)
+
+        At any point `{"status":"error","progress":-1.0,"error":"..."}` may
+        replace the above. Verification failure/timeout emits `error`, never
+        `done`.
+
+        Progress only covers the MMR write phase (upload). The erase and CRC
+        verification phases emit no progress events. Progress jumps from ~0.99
+        to 1.0 after verification completes.
       properties:
         status:
           type: string


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

> **Naming:** The display name is **Decent.app**. The repo, package, and bundle ID use legacy `reaprime` / `streamline-bridge` — see the naming table in [`CLAUDE.md`](CLAUDE.md).

- Problem: The OpenAPI firmware progress description incorrectly implied that verification changes progress from approximately `0.99` to `1.0`, that erase emits no event, and that an error replaces prior NDJSON lines.
- Why it matters: Clients must not treat an `uploading` event with `progress: 1.0` as successful CRC verification.
- What changed: Corrected the shared `FirmwareProgressEvent` contract and raw-upload description to document `erasing`, zero or more `uploading` events, and terminal `done` or `error` events. The shared schema covers both raw upload and managed apply because both responses use `FirmwareProgressEvent`.
- What did NOT change (scope boundary): No runtime behavior, endpoint, network, BLE/USB, or test code changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #419
- Related: N/A

## Root Cause (if bug fix)

For bugs: explain why this happened, not just what changed. Otherwise write `N/A`.

- Root cause: N/A — docs/spec correction only.
- Missing detection or guardrail: N/A.
- Contributing context (if known): N/A.

## Regression Test Plan (if bug fix or refactor)

For bugs and refactors: name the smallest reliable test that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [x] Existing coverage already sufficient
- Target test or file: `test/webserver/firmware_handler_test.dart`
- Scenario the test should lock in: Existing tests show `uploading` may report `1.0` before `done`, `done` waits for successful verification, and verification failure or timeout terminates with `error` without `done`.
- If no new test added, why not: Existing focused coverage already establishes the documented runtime behavior; this PR changes documentation only.

## Documentation Obligations (required)

These are **not optional**. Stale specs mislead clients and agents.

- [x] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A — no docs affected

`doc/Api.md` was reviewed and left unchanged because it already accurately documents zero or more `uploading` events, terminal `error`, and `done` only after verification.

## Security Impact (required)

This app runs a local web server (port 8080) and connects to BLE/USB hardware.

- New or changed REST endpoints? (`Yes/No`) No
- New or changed WebSocket topics? (`Yes/No`) No
- New or changed network calls? (`Yes/No`) No
- BLE/USB surface changed? (`Yes/No`) No
- File system access changed? (`Yes/No`) No
- Plugin sandbox boundary changed? (`Yes/No`) No
- If any `Yes`, explain risk and mitigation: N/A; documentation only.

## User-Visible Changes

None. The machine and API runtime behavior are unchanged; only the published API contract is corrected.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no issues found)
- [x] `flutter test` — all 2,463 tests passed
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin built successfully

Additional checks:

- [x] `flutter test test/webserver/firmware_handler_test.dart` — all 11 tests passed
- [x] `git diff --check` — passed
- [x] PyYAML `safe_load` plus OpenAPI version/path/schema assertions — parsed `assets/api/rest_v1.yml` as OpenAPI 3.0.3

### Manual verification (if applicable)

- OS / platform tested: macOS command-line test environment
- Simulated devices? (`simulate=1`): No
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: Inspected `firmware_handler.dart`, `unified_de1.firmware.dart`, and the focused handler tests against the OpenAPI wording; ran the commands listed above.
- Edge cases checked: Pre-verification `uploading` at `1.0`; verification wait; verification failure; verification timeout; failure cardinality allowing no upload callback.
- What you did **not** verify: No live app, curl stream, simulated-device session, or real DE1 firmware update was run because runtime behavior is unchanged and the existing transport-edge tests directly establish the contract.

### Evidence

Attach at least one:

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

Documentation-only correction: there is no meaningful pre-change runtime test failure. Passing focused and full-suite results are listed above.

## Compatibility & Migration

- Backward compatible? (`Yes/No`) Yes
- Config / env changes needed? (`Yes/No`) No
- Database migration needed? (`Yes/No`) No
- If any `No` or `Yes`, explain exact steps: The corrected documentation describes existing behavior; no consumer, configuration, or migration steps are required.

## Risks & Mitigations

- Risk: Clients that previously interpreted `uploading` progress of `1.0` as completion may continue doing so.
  - Mitigation: The schema now explicitly states that only the subsequent `done` event confirms successful CRC verification.
