### PR TITLE
fix(api): align shot annotation compatibility contract

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -1187,7 +1187,10 @@ paths:
       description: |
         Updates an existing shot record. Supports partial updates — only the fields
         included in the request body will be changed, all other fields are preserved
-        from the existing record. Commonly used to add or update shot notes or metadata.
+        from the existing record. Use annotations for all post-shot data. The legacy
+        shotNotes and metadata fields remain in responses for older clients but are
+        deprecated; new clients should use annotations.espressoNotes and
+        annotations.extras.
       tags: [Shots History]
       parameters:
         - in: path
@@ -1204,15 +1207,17 @@ paths:
               $ref: "#/components/schemas/ShotRecord"
             examples:
               updateNotes:
-                summary: Update only shot notes
+                summary: Update only espresso notes
                 value:
-                  shotNotes: "Tasted great, slightly fruity"
-              updateMetadata:
-                summary: Update only metadata
+                  annotations:
+                    espressoNotes: "Tasted great, slightly fruity"
+              updateAnnotations:
+                summary: Update rating and custom annotations
                 value:
-                  metadata:
-                    rating: 4.5
-                    favorite: true
+                  annotations:
+                    enjoyment: 4.5
+                    extras:
+                      favorite: true
       responses:
         "200":
           description: Shot updated successfully
@@ -5446,6 +5451,34 @@ components:
           description: Rinse flow rate
           example: 6.0
 
+    ShotAnnotations:
+      type: object
+      nullable: true
+      description: Post-shot measurements, extraction data, ratings, notes, and custom data.
+      properties:
+        actualDoseWeight:
+          type: number
+          nullable: true
+        actualYield:
+          type: number
+          nullable: true
+        drinkTds:
+          type: number
+          nullable: true
+        drinkEy:
+          type: number
+          nullable: true
+        enjoyment:
+          type: number
+          nullable: true
+        espressoNotes:
+          type: string
+          nullable: true
+        extras:
+          type: object
+          nullable: true
+          additionalProperties: true
+
     ShotRecord:
       type: object
       properties:
@@ -5459,6 +5492,8 @@ components:
             $ref: "#/components/schemas/ShotSnapshot"
         workflow:
           $ref: "#/components/schemas/WorkflowRequest"
+        annotations:
+          $ref: "#/components/schemas/ShotAnnotations"
         stopReason:
           type: string
           nullable: true
@@ -5475,24 +5510,14 @@ components:
         shotNotes:
           type: string
           nullable: true
-          description: Optional notes about the shot (e.g., tasting notes, observations)
+          deprecated: true
+          description: "Legacy compatibility field — use annotations.espressoNotes instead"
         metadata:
           type: object
           nullable: true
           additionalProperties: true
-          description: |
-            Optional flexible metadata dictionary for future extensibility.
-            Can store arbitrary key-value pairs such as:
-            - rating: numerical rating (1-5)
-            - tags: array of strings for categorization
-            - favorite: boolean flag
-            - barista: string name
-            - customFields: any application-specific data
-          example:
-            rating: 4.5
-            tags: ["morning", "sweet"]
-            favorite: true
-            barista: "Alice"
+          deprecated: true
+          description: "Legacy compatibility field — use annotations.extras instead"
 
     ShotRecordSummary:
       type: object
@@ -5507,32 +5532,7 @@ components:
         workflow:
           $ref: "#/components/schemas/WorkflowRequest"
         annotations:
-          type: object
-          nullable: true
-          description: Post-shot annotations (enjoyment, tasting notes, extraction data)
-          properties:
-            actualDoseWeight:
-              type: number
-              nullable: true
-            actualYield:
-              type: number
-              nullable: true
-            drinkTds:
-              type: number
-              nullable: true
-            drinkEy:
-              type: number
-              nullable: true
-            enjoyment:
-              type: number
-              nullable: true
-            espressoNotes:
-              type: string
-              nullable: true
-            extras:
-              type: object
-              nullable: true
-              additionalProperties: true
+          $ref: "#/components/schemas/ShotAnnotations"
         stopReason:
           type: string
           nullable: true

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -1188,9 +1188,12 @@ paths:
         Updates an existing shot record. Supports partial updates — only the fields
         included in the request body will be changed, all other fields are preserved
         from the existing record. Use annotations for all post-shot data. The legacy
-        shotNotes and metadata fields remain in responses for older clients but are
-        deprecated; new clients should use annotations.espressoNotes and
-        annotations.extras.
+        shotNotes and metadata request fields are deprecated but remain accepted and
+        map to annotations.espressoNotes and annotations.extras. When canonical and
+        legacy forms are both supplied, canonical fields win, including explicit nulls.
+        A null canonical field clears that field; annotations: null clears all post-shot
+        annotations and ignores legacy values in the same request. Legacy aliases in
+        responses mirror the resulting canonical values and never retain cleared data.
       tags: [Shots History]
       parameters:
         - in: path
@@ -5454,7 +5457,9 @@ components:
     ShotAnnotations:
       type: object
       nullable: true
-      description: Post-shot measurements, extraction data, ratings, notes, and custom data.
+      description: |
+        Post-shot measurements, extraction data, ratings, notes, and custom data.
+        On shot updates, null clears the complete annotations object.
       properties:
         actualDoseWeight:
           type: number
@@ -5474,10 +5479,12 @@ components:
         espressoNotes:
           type: string
           nullable: true
+          description: Null clears the note and its legacy shotNotes alias on update.
         extras:
           type: object
           nullable: true
           additionalProperties: true
+          description: Null clears custom data and its legacy metadata alias on update.
 
     ShotRecord:
       type: object
@@ -5511,13 +5518,13 @@ components:
           type: string
           nullable: true
           deprecated: true
-          description: "Legacy compatibility field — use annotations.espressoNotes instead"
+          description: "Deprecated request alias for annotations.espressoNotes; response value mirrors the canonical field"
         metadata:
           type: object
           nullable: true
           additionalProperties: true
           deprecated: true
-          description: "Legacy compatibility field — use annotations.extras instead"
+          description: "Deprecated request alias for annotations.extras; response value mirrors the canonical field"
 
     ShotRecordSummary:
       type: object
@@ -5544,13 +5551,13 @@ components:
           type: string
           nullable: true
           deprecated: true
-          description: "Legacy field — use annotations.espressoNotes instead"
+          description: "Legacy response alias mirroring annotations.espressoNotes"
         metadata:
           type: object
           nullable: true
           additionalProperties: true
           deprecated: true
-          description: "Legacy field — use annotations.extras instead"
+          description: "Legacy response alias mirroring annotations.extras"
 
     ShotSnapshot:
       type: object

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -657,7 +657,7 @@ Returns array of all shot identifiers. Useful for lightweight syncing.
 GET /api/v1/shots/latest
 ```
 
-Returns the most recent shot record (with measurements).
+Returns the most recent shot record without measurements. Use `GET /api/v1/shots/{id}` for the full record.
 
 #### Get Specific Shot
 ```http
@@ -700,8 +700,13 @@ Returns a single shot record by ID, **including full measurements**.
       "coffeeRoaster": "Square Mile"
     }
   },
-  "shotNotes": "Excellent extraction!",
-  "metadata": { "rating": 4.5 }
+  "annotations": {
+    "actualDoseWeight": 18.0,
+    "actualYield": 36.2,
+    "enjoyment": 4.5,
+    "espressoNotes": "Excellent extraction!",
+    "extras": { "tags": ["morning", "sweet"] }
+  }
 }
 ```
 
@@ -711,22 +716,27 @@ PUT /api/v1/shots/{id}
 Content-Type: application/json
 
 {
-  "shotNotes": "Excellent extraction! Bright acidity with chocolate notes.",
-  "metadata": {
-    "rating": 4.5,
-    "tags": ["morning", "sweet"],
-    "favorite": true
+  "annotations": {
+    "enjoyment": 4.5,
+    "espressoNotes": "Excellent extraction! Bright acidity with chocolate notes.",
+    "extras": {
+      "tags": ["morning", "sweet"],
+      "favorite": true
+    }
   }
 }
 ```
 
-Supports partial updates via deep merge — only include the fields you want to change. Commonly used to add tasting notes or metadata after the fact.
+Supports partial updates via deep merge — only include the fields you want to change. Use `annotations` for post-shot data:
+- `actualDoseWeight`: Actual coffee dose in grams
+- `actualYield`: Actual beverage yield in grams
+- `drinkTds`: Measured total dissolved solids percentage
+- `drinkEy`: Calculated extraction yield percentage
+- `enjoyment`: Numeric rating
+- `espressoNotes`: Tasting notes and observations
+- `extras`: Flexible dictionary for tags, flags, plugin data, or other custom fields
 
-**Metadata Field**: The `metadata` object is a flexible dictionary that can store any custom data:
-- `rating`: Numerical rating (e.g., 1-5)
-- `tags`: Array of strings for categorization
-- `favorite`: Boolean flag
-- Any custom fields your application needs
+`shotNotes` and `metadata` are deprecated compatibility fields for older clients. New integrations should read and update `annotations.espressoNotes` and `annotations.extras` instead.
 
 **Response:** Returns the updated shot record.
 

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -736,7 +736,9 @@ Supports partial updates via deep merge — only include the fields you want to 
 - `espressoNotes`: Tasting notes and observations
 - `extras`: Flexible dictionary for tags, flags, plugin data, or other custom fields
 
-`shotNotes` and `metadata` are deprecated compatibility fields for older clients. New integrations should read and update `annotations.espressoNotes` and `annotations.extras` instead.
+`shotNotes` and `metadata` are deprecated compatibility fields for older clients, but remain accepted in PUT requests and map to `annotations.espressoNotes` and `annotations.extras`. If a request supplies both forms, the canonical annotation field wins, including when it is explicitly `null`. Setting either canonical field or its legacy alias to `null` clears that value. Setting `annotations` itself to `null` clears all post-shot annotations and ignores legacy values in the same request.
+
+In responses, `shotNotes` and `metadata` mirror their canonical annotation values. Cleared canonical values never leave stale legacy aliases. New integrations should read and update `annotations` directly.
 
 **Response:** Returns the updated shot record.
 

--- a/lib/src/models/data/shot_record.dart
+++ b/lib/src/models/data/shot_record.dart
@@ -32,8 +32,8 @@ class ShotRecord {
     this.stopReason,
     String? shotNotes,
     Map<String, dynamic>? metadata,
-  })  : _shotNotes = shotNotes ?? annotations?.espressoNotes,
-        _metadata = metadata ?? annotations?.extras;
+  }) : _shotNotes = annotations?.espressoNotes ?? shotNotes,
+       _metadata = annotations?.extras ?? metadata;
 
   /// Synthesized from annotations when available, otherwise from legacy field.
   @Deprecated('Use annotations?.espressoNotes instead')

--- a/lib/src/models/data/shot_record.dart
+++ b/lib/src/models/data/shot_record.dart
@@ -32,8 +32,8 @@ class ShotRecord {
     this.stopReason,
     String? shotNotes,
     Map<String, dynamic>? metadata,
-  }) : _shotNotes = annotations?.espressoNotes ?? shotNotes,
-       _metadata = annotations?.extras ?? metadata;
+  }) : _shotNotes = annotations != null ? annotations.espressoNotes : shotNotes,
+       _metadata = annotations != null ? annotations.extras : metadata;
 
   /// Synthesized from annotations when available, otherwise from legacy field.
   @Deprecated('Use annotations?.espressoNotes instead')
@@ -70,11 +70,13 @@ class ShotRecord {
   }
 
   factory ShotRecord.fromJson(Map<String, dynamic> json) {
-    // Read annotations from new format, or synthesize from legacy fields
     ShotAnnotations? ann;
-    if (json['annotations'] != null) {
-      ann = ShotAnnotations.fromJson(json['annotations']);
-    } else if (json['shotNotes'] != null || json['metadata'] != null) {
+    if (json.containsKey('annotations')) {
+      final annotations = json['annotations'];
+      if (annotations != null) {
+        ann = ShotAnnotations.fromJson(annotations as Map<String, dynamic>);
+      }
+    } else if (json.containsKey('shotNotes') || json.containsKey('metadata')) {
       ann = ShotAnnotations.fromLegacyJson(json);
     }
 
@@ -88,8 +90,12 @@ class ShotRecord {
       annotations: ann,
       stopReason: json["stopReason"] as String?,
       // Still parse legacy fields for backward compat with old callers
-      shotNotes: json["shotNotes"] as String?,
-      metadata: json["metadata"] as Map<String, dynamic>?,
+      shotNotes: json.containsKey('annotations')
+          ? null
+          : json["shotNotes"] as String?,
+      metadata: json.containsKey('annotations')
+          ? null
+          : json["metadata"] as Map<String, dynamic>?,
     );
   }
 

--- a/lib/src/services/webserver/shots_handler.dart
+++ b/lib/src/services/webserver/shots_handler.dart
@@ -216,7 +216,11 @@ class ShotsHandler {
       }
 
       // Deep merge partial payload onto existing shot data
-      final merged = _deepMerge(existingShot.toJson(), json);
+      final merged = _deepMerge(
+        existingShot.toJson(),
+        _normalizeLegacyAnnotationPatch(json),
+      );
+      _synchronizeLegacyAnnotationAliases(merged);
       merged['id'] = id;
 
       final updatedShot = ShotRecord.fromJson(merged);
@@ -246,6 +250,61 @@ class ShotsHandler {
         return jsonNotFound({"error": "Shot not found"});
       }
       return jsonError({"error": e.toString()});
+    }
+  }
+
+  Map<String, dynamic> _normalizeLegacyAnnotationPatch(
+    Map<String, dynamic> patch,
+  ) {
+    final normalized = Map<String, dynamic>.from(patch);
+
+    if (patch.containsKey('annotations')) {
+      final annotations = patch['annotations'];
+      if (annotations is Map<String, dynamic>) {
+        final normalizedAnnotations = Map<String, dynamic>.from(annotations);
+        if (!annotations.containsKey('espressoNotes') &&
+            patch.containsKey('shotNotes')) {
+          normalizedAnnotations['espressoNotes'] = patch['shotNotes'];
+        }
+        if (!annotations.containsKey('extras') &&
+            patch.containsKey('metadata')) {
+          normalizedAnnotations['extras'] = patch['metadata'];
+        }
+        normalized['annotations'] = normalizedAnnotations;
+      }
+    } else if (patch.containsKey('shotNotes') ||
+        patch.containsKey('metadata')) {
+      normalized['annotations'] = <String, dynamic>{
+        if (patch.containsKey('shotNotes')) 'espressoNotes': patch['shotNotes'],
+        if (patch.containsKey('metadata')) 'extras': patch['metadata'],
+      };
+    }
+
+    normalized.remove('shotNotes');
+    normalized.remove('metadata');
+    return normalized;
+  }
+
+  void _synchronizeLegacyAnnotationAliases(Map<String, dynamic> json) {
+    if (!json.containsKey('annotations')) return;
+
+    final annotations = json['annotations'];
+    if (annotations is Map<String, dynamic>) {
+      final espressoNotes = annotations['espressoNotes'];
+      final extras = annotations['extras'];
+      if (espressoNotes != null) {
+        json['shotNotes'] = espressoNotes;
+      } else {
+        json.remove('shotNotes');
+      }
+      if (extras != null) {
+        json['metadata'] = extras;
+      } else {
+        json.remove('metadata');
+      }
+    } else {
+      json.remove('shotNotes');
+      json.remove('metadata');
     }
   }
 

--- a/test/models/shot_record_test.dart
+++ b/test/models/shot_record_test.dart
@@ -1,27 +1,81 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/shot_annotations.dart';
 import 'package:reaprime/src/models/data/shot_record.dart';
 
 void main() {
-  test('canonical annotations override stale legacy aliases', () {
-    final json =
-        ShotRecord(
-          id: 'shot-1',
-          timestamp: DateTime.utc(2026, 7, 23),
-          measurements: const [],
-          workflow: WorkflowController().currentWorkflow,
-        ).toJson()..addAll({
-          'annotations': {
-            'espressoNotes': 'canonical notes',
-            'extras': {'favorite': true},
-          },
-          'shotNotes': 'stale notes',
-          'metadata': {'favorite': false},
+  test('canonical constructor annotations stay authoritative when null', () {
+    final serialized = ShotRecord(
+      id: 'shot-1',
+      timestamp: DateTime.utc(2026, 7, 23),
+      measurements: const [],
+      workflow: WorkflowController().currentWorkflow,
+      annotations: const ShotAnnotations(),
+      shotNotes: 'legacy notes',
+      metadata: const {'favorite': true},
+    ).toJson();
+
+    expect(serialized['annotations'], isEmpty);
+    expect(serialized.containsKey('shotNotes'), isFalse);
+    expect(serialized.containsKey('metadata'), isFalse);
+  });
+
+  test(
+    'legacy aliases synthesize annotations when canonical key is absent',
+    () {
+      final json = _baseJson()
+        ..addAll({
+          'shotNotes': 'legacy notes',
+          'metadata': {'favorite': true},
         });
+
+      final serialized = ShotRecord.fromJson(json).toJson();
+
+      expect(serialized['annotations'], {
+        'espressoNotes': 'legacy notes',
+        'extras': {'favorite': true},
+      });
+      expect(serialized['shotNotes'], 'legacy notes');
+      expect(serialized['metadata'], {'favorite': true});
+    },
+  );
+
+  test('canonical annotation object ignores conflicting legacy aliases', () {
+    final json = _baseJson()
+      ..addAll({
+        'annotations': {
+          'espressoNotes': 'canonical notes',
+          'extras': {'favorite': true},
+        },
+        'shotNotes': 'stale notes',
+        'metadata': {'favorite': false},
+      });
 
     final serialized = ShotRecord.fromJson(json).toJson();
 
     expect(serialized['shotNotes'], 'canonical notes');
     expect(serialized['metadata'], {'favorite': true});
   });
+
+  test('explicit canonical null does not reconstruct stale aliases', () {
+    final json = _baseJson()
+      ..addAll({
+        'annotations': null,
+        'shotNotes': 'stale notes',
+        'metadata': {'favorite': false},
+      });
+
+    final serialized = ShotRecord.fromJson(json).toJson();
+
+    expect(serialized.containsKey('annotations'), isFalse);
+    expect(serialized.containsKey('shotNotes'), isFalse);
+    expect(serialized.containsKey('metadata'), isFalse);
+  });
 }
+
+Map<String, dynamic> _baseJson() => ShotRecord(
+  id: 'shot-1',
+  timestamp: DateTime.utc(2026, 7, 23),
+  measurements: const [],
+  workflow: WorkflowController().currentWorkflow,
+).toJson();

--- a/test/models/shot_record_test.dart
+++ b/test/models/shot_record_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/shot_record.dart';
+
+void main() {
+  test('canonical annotations override stale legacy aliases', () {
+    final json =
+        ShotRecord(
+          id: 'shot-1',
+          timestamp: DateTime.utc(2026, 7, 23),
+          measurements: const [],
+          workflow: WorkflowController().currentWorkflow,
+        ).toJson()..addAll({
+          'annotations': {
+            'espressoNotes': 'canonical notes',
+            'extras': {'favorite': true},
+          },
+          'shotNotes': 'stale notes',
+          'metadata': {'favorite': false},
+        });
+
+    final serialized = ShotRecord.fromJson(json).toJson();
+
+    expect(serialized['shotNotes'], 'canonical notes');
+    expect(serialized['metadata'], {'favorite': true});
+  });
+}

--- a/test/webserver/shots_handler_test.dart
+++ b/test/webserver/shots_handler_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/persistence_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/models/data/bean.dart';
+import 'package:reaprime/src/models/data/shot_annotations.dart';
 import 'package:reaprime/src/models/data/shot_record.dart';
 import 'package:reaprime/src/models/data/workflow_context.dart';
 import 'package:reaprime/src/services/database/database.dart'
@@ -42,6 +43,43 @@ void main() {
 
   Future<Response> sendGet(String path) async =>
       handler(Request('GET', Uri.parse('http://localhost$path')));
+
+  Future<Response> sendPut(String id, Map<String, dynamic> patch) async =>
+      handler(
+        Request(
+          'PUT',
+          Uri.parse('http://localhost/api/v1/shots/$id'),
+          headers: {'content-type': 'application/json'},
+          body: jsonEncode(patch),
+        ),
+      );
+
+  Future<Map<String, dynamic>> decode(Response response) async =>
+      jsonDecode(await response.readAsString()) as Map<String, dynamic>;
+
+  Future<void> persistAnnotatedShot({String id = 'annotated'}) =>
+      persistence.persistShot(
+        makeShot(
+          id: id,
+          annotations: const ShotAnnotations(
+            espressoNotes: 'old notes',
+            extras: {'favorite': false, 'origin': 'existing'},
+          ),
+        ),
+      );
+
+  Future<(Map<String, dynamic>, Map<String, dynamic>)> putAndGet(
+    String id,
+    Map<String, dynamic> patch,
+  ) async {
+    final putResponse = await sendPut(id, patch);
+    expect(putResponse.statusCode, 200);
+    final putJson = await decode(putResponse);
+
+    final getResponse = await sendGet('/api/v1/shots/$id');
+    expect(getResponse.statusCode, 200);
+    return (putJson, await decode(getResponse));
+  }
 
   group('ShotsHandler', () {
     test('GET /api/v1/shots filters by beanId across all batches', () async {
@@ -121,6 +159,158 @@ void main() {
         expect(body['items'], isEmpty);
       },
     );
+
+    test('legacy shotNotes updates canonical notes and persists', () async {
+      await persistAnnotatedShot();
+
+      final (putJson, getJson) = await putAndGet('annotated', {
+        'shotNotes': 'new legacy notes',
+      });
+
+      for (final json in [putJson, getJson]) {
+        expect(json['annotations']['espressoNotes'], 'new legacy notes');
+        expect(json['shotNotes'], 'new legacy notes');
+      }
+    });
+
+    test('legacy metadata deep-merges canonical extras and persists', () async {
+      await persistAnnotatedShot();
+
+      final (putJson, getJson) = await putAndGet('annotated', {
+        'metadata': {'favorite': true},
+      });
+
+      for (final json in [putJson, getJson]) {
+        expect(json['annotations']['extras'], {
+          'favorite': true,
+          'origin': 'existing',
+        });
+        expect(json['metadata'], json['annotations']['extras']);
+      }
+    });
+
+    test('canonical annotation fields win over legacy aliases', () async {
+      await persistAnnotatedShot();
+
+      final (putJson, getJson) = await putAndGet('annotated', {
+        'annotations': {
+          'espressoNotes': 'canonical',
+          'extras': {'favorite': true},
+        },
+        'shotNotes': 'legacy',
+        'metadata': {'favorite': false, 'legacy': true},
+      });
+
+      for (final json in [putJson, getJson]) {
+        expect(json['annotations']['espressoNotes'], 'canonical');
+        expect(json['shotNotes'], 'canonical');
+        expect(json['annotations']['extras'], {
+          'favorite': true,
+          'origin': 'existing',
+        });
+        expect(json['metadata'], json['annotations']['extras']);
+      }
+    });
+
+    test('canonical null clears notes without changing extras', () async {
+      await persistAnnotatedShot();
+
+      final (putJson, getJson) = await putAndGet('annotated', {
+        'annotations': {'espressoNotes': null},
+      });
+
+      for (final json in [putJson, getJson]) {
+        expect(json['annotations'].containsKey('espressoNotes'), isFalse);
+        expect(json.containsKey('shotNotes'), isFalse);
+        expect(json['annotations']['extras'], {
+          'favorite': false,
+          'origin': 'existing',
+        });
+      }
+    });
+
+    test('canonical null clears extras without changing notes', () async {
+      await persistAnnotatedShot();
+
+      final (putJson, getJson) = await putAndGet('annotated', {
+        'annotations': {'extras': null},
+      });
+
+      for (final json in [putJson, getJson]) {
+        expect(json['annotations'].containsKey('extras'), isFalse);
+        expect(json.containsKey('metadata'), isFalse);
+        expect(json['annotations']['espressoNotes'], 'old notes');
+      }
+    });
+
+    test('annotations null clears all annotations and aliases', () async {
+      await persistAnnotatedShot();
+
+      final (putJson, getJson) = await putAndGet('annotated', {
+        'annotations': null,
+      });
+
+      for (final json in [putJson, getJson]) {
+        expect(json.containsKey('annotations'), isFalse);
+        expect(json.containsKey('shotNotes'), isFalse);
+        expect(json.containsKey('metadata'), isFalse);
+      }
+    });
+
+    test('annotations null wins over conflicting legacy aliases', () async {
+      await persistAnnotatedShot();
+
+      final (putJson, getJson) = await putAndGet('annotated', {
+        'annotations': null,
+        'shotNotes': 'must be ignored',
+        'metadata': {'must': 'be ignored'},
+      });
+
+      for (final json in [putJson, getJson]) {
+        expect(json.containsKey('annotations'), isFalse);
+        expect(json.containsKey('shotNotes'), isFalse);
+        expect(json.containsKey('metadata'), isFalse);
+      }
+    });
+
+    test('legacy nulls clear canonical values and aliases', () async {
+      await persistAnnotatedShot();
+
+      final (notesPut, notesGet) = await putAndGet('annotated', {
+        'shotNotes': null,
+      });
+      for (final json in [notesPut, notesGet]) {
+        expect(json['annotations'].containsKey('espressoNotes'), isFalse);
+        expect(json.containsKey('shotNotes'), isFalse);
+        expect(json['annotations']['extras'], isNotNull);
+      }
+
+      final (metadataPut, metadataGet) = await putAndGet('annotated', {
+        'metadata': null,
+      });
+      for (final json in [metadataPut, metadataGet]) {
+        expect(json['annotations'].containsKey('extras'), isFalse);
+        expect(json.containsKey('metadata'), isFalse);
+      }
+    });
+
+    test('unrelated partial update preserves annotations', () async {
+      await persistAnnotatedShot();
+
+      final (putJson, getJson) = await putAndGet('annotated', {
+        'stopReason': 'apiStop',
+      });
+
+      for (final json in [putJson, getJson]) {
+        expect(json['stopReason'], 'apiStop');
+        expect(json['annotations'], {
+          'espressoNotes': 'old notes',
+          'extras': {'favorite': false, 'origin': 'existing'},
+        });
+        expect(json['shotNotes'], 'old notes');
+        expect(json['metadata'], json['annotations']['extras']);
+      }
+    });
   });
 }
 
@@ -130,6 +320,7 @@ ShotRecord makeShot({
   String? beanBatchId,
   String? coffeeName,
   String? coffeeRoaster,
+  ShotAnnotations? annotations,
 }) {
   final workflow = WorkflowController().currentWorkflow.copyWith(
     context: WorkflowContext(
@@ -143,5 +334,6 @@ ShotRecord makeShot({
     timestamp: timestamp ?? DateTime.utc(2026, 1, 1, 10),
     measurements: const [],
     workflow: workflow,
+    annotations: annotations,
   );
 }


### PR DESCRIPTION
## Summary

- Problem: canonical annotation precedence caused partial legacy `shotNotes` / `metadata` PUTs to be ignored after merging with an existing canonical record, while explicit nulls could leave stale aliases.
- Why it matters: older clients could receive 200 responses without their writes taking effect, and PUT/GET responses could disagree after a clear.
- What changed: normalized legacy PUT fields into canonical annotation patches before deep merge, made model deserialization presence-aware, synchronized response aliases from canonical values, and documented null/conflict behavior.
- What did NOT change (scope boundary): no endpoint, database schema, persistence table, or canonical annotation field was added or removed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [x] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [x] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes: N/A
- Related: Nils's shot API documentation report

## Root Cause (if bug fix)

- Root cause: partial PUTs were deep-merged into a serialized record before parsing. The merged JSON retained old canonical annotation fields, so canonical precedence silently overrode newly supplied legacy aliases. Null-coalescing also treated explicit canonical null like absence.
- Missing detection or guardrail: handler tests did not cover partial legacy writes, explicit null clearing, persistence, or immediate PUT versus subsequent GET consistency.
- Contributing context (if known): compatibility aliases intentionally remain available for older clients.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [x] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/models/shot_record_test.dart`, `test/webserver/shots_handler_test.dart`
- Scenario the test should lock in: legacy-only writes map into canonical annotations; canonical conflicts and explicit nulls win; aliases mirror canonical values in both PUT and persisted GET responses; unrelated fields survive partial updates.
- If no new test added, why not: N/A

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml`
- [x] API docs updated: `doc/Api.md` reviewed; its endpoint summary remains accurate and required no edit
- [ ] Plugin docs updated: `doc/Plugins.md` (no plugin event/API change)
- [x] Skin docs updated: `doc/Skins.md`
- [ ] Profile docs updated: `doc/Profiles.md` (no profile change)
- [ ] Device docs updated: `doc/DeviceManagement.md` (no device-flow change)
- [ ] N/A — no docs affected

## Security Impact (required)

- New or changed REST endpoints? (`Yes/No`): Yes — existing shot PUT compatibility semantics changed
- New or changed WebSocket topics? (`Yes/No`): No
- New or changed network calls? (`Yes/No`): No
- BLE/USB surface changed? (`Yes/No`): No
- File system access changed? (`Yes/No`): No
- Plugin sandbox boundary changed? (`Yes/No`): No
- If any `Yes`, explain risk and mitigation: the existing local PUT endpoint now normalizes deprecated aliases before its existing validation/persistence path. No authorization or trust boundary changed; model and handler regression tests cover precedence and clearing.

## User-Visible Changes

Legacy `shotNotes` and `metadata` PUTs update canonical annotations again. Canonical fields, including explicit nulls and `annotations: null`, win conflicts. PUT and GET responses no longer expose stale compatibility aliases after clearing.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean, no issues
- [x] `flutter test` — 2476 tests passed
- [x] `(cd packages/dye2-plugin && npm run build)` — Vite build passed

### Manual verification (if applicable)

- OS / platform tested: macOS
- Simulated devices? (`simulate=1`): Yes — MockDe1
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: created a simulated persisted shot, exercised legacy note/metadata PUTs, canonical note clearing, and conflicting `annotations: null` via curl, asserted immediate PUT and subsequent GET representations with `jq`, then deleted the test shot.
- Edge cases checked: legacy deep merge, canonical-over-legacy conflicts, canonical field null, legacy null, whole-object null, alias synchronization, unrelated partial updates.
- What you did **not** verify: real hardware; no hardware behavior changed.

### Evidence

- [x] Test output (failing before + passing after)
- [x] Log snippets
- [ ] Screenshot / recording (UI changes)
- [x] curl / websocat output (API changes)

The presence-aware model regressions failed before the implementation and passed afterward. Focused handler tests passed 11/11; the full suite completed with `+2476: All tests passed!`. The curl smoke printed `shot annotation PUT/GET compatibility smoke passed` after all `jq -e` assertions.

## Compatibility & Migration

- Backward compatible? (`Yes/No`): Yes
- Config / env changes needed? (`Yes/No`): No
- Database migration needed? (`Yes/No`): No
- If any `No` or `Yes`, explain exact steps: legacy request aliases remain accepted and legacy response aliases mirror canonical annotations. New clients should use `annotations`; no migration is required.

## Risks & Mitigations

- Risk: clients sending contradictory canonical and legacy values now consistently receive the canonical value, and explicit canonical null clears rather than falling back.
  - Mitigation: this is the documented compatibility contract and is covered at model, handler/persistence, and running-app levels.
