### PR TITLE
fix(ble): queue reset must not emit a false DE1 disconnect

### DIFF
--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -246,6 +246,10 @@ class UniversalBleTransport implements BLETransport {
     UniversalBleErrorCode.deviceDisconnected,
   };
 
+  // universal_ble 2.2.0 compatibility; replace with typed cancellation in #497.
+  static bool _isLegacyQueueCancellation(Object error) =>
+      error.toString().contains('Queue Cancelled');
+
   Never _handleGattError(UniversalBleException e, String operation, String path) {
     if (_goneDeviceCodes.contains(e.code)) {
       _log.warning('GATT $operation($path) failed — device gone: ${e.code}');
@@ -395,11 +399,8 @@ class UniversalBleTransport implements BLETransport {
     } on UniversalBleException catch (e) {
       _handleGattError(e, 'read', '$serviceUUID/$characteristicUUID');
     } catch (e) {
-      // Same clearQueue rationale as write() — see write() catch block.
-      if (e.toString().contains('Queue Cancelled')) {
+      if (_isLegacyQueueCancellation(e)) {
         _log.fine('read($serviceUUID/$characteristicUUID) cancelled by clearQueue');
-        _connectionStateSubject.add(device.ConnectionState.disconnected);
-        throw const DeviceNotConnectedException.unknown();
       }
       rethrow;
     }
@@ -570,19 +571,10 @@ class UniversalBleTransport implements BLETransport {
     } on UniversalBleException catch (e) {
       _handleGattError(e, 'write', '$serviceUUID/$characteristicUUID');
     } catch (e) {
-      // universal_ble's Queue.dispose() (called from clearQueue in
-      // _handleGattError or _onOperationTimeout) cancels pending items
-      // with Exception('Queue Cancelled') — a plain Exception, not
-      // UniversalBleException, so the on UniversalBleException catch
-      // above misses it. Treat it as a gone-device: the queue was
-      // cleared because the device is gone, so emit disconnected and
-      // throw the domain exception.
-      if (e.toString().contains('Queue Cancelled')) {
+      if (_isLegacyQueueCancellation(e)) {
         _log.fine(
             'write($serviceUUID/$characteristicUUID) cancelled by clearQueue',
         );
-        _connectionStateSubject.add(device.ConnectionState.disconnected);
-        throw const DeviceNotConnectedException.unknown();
       }
       rethrow;
     }

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/device/device.dart' as device;
+import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/services/ble/universal_ble_transport.dart';
 import 'package:universal_ble/universal_ble.dart';
 
@@ -17,6 +18,7 @@ const _writeTimeout = Duration(milliseconds: 50);
 class _FakeBlePlatform extends UniversalBlePlatform {
   BleConnectionState connectionStateResult = BleConnectionState.connected;
   bool hangWrites = false;
+  UniversalBleException? writeError;
   int getConnectionStateCalls = 0;
   final List<String> disconnectCalls = [];
 
@@ -105,6 +107,7 @@ class _FakeBlePlatform extends UniversalBlePlatform {
     Uint8List value,
     BleOutputProperty bleOutputProperty,
   ) async {
+    if (writeError case final error?) throw error;
     if (hangWrites) {
       await Completer<void>().future;
     }
@@ -164,6 +167,7 @@ void main() {
     // Drop any queues left over from a previous test (a hung write keeps
     // its per-device queue slot busy forever otherwise).
     UniversalBle.clearQueue();
+    UniversalBle.queueType = QueueType.perDevice;
     // Unique id per test so per-device queue state can't bleed over.
     deviceId = 'AA:BB:CC:DD:EE:${(deviceCounter++).toString().padLeft(2, '0')}';
     transport = UniversalBleTransport(device: bleDevice(deviceId));
@@ -177,6 +181,8 @@ void main() {
   tearDown(() async {
     await stateSub.cancel();
     await transport.dispose();
+    UniversalBle.clearQueue();
+    UniversalBle.queueType = QueueType.global;
   });
 
   Future<void> timedOutWrite() async {
@@ -266,6 +272,75 @@ void main() {
         isNot(contains(device.ConnectionState.disconnected)),
         reason: 'counter must reset on success — only 2 consecutive '
             'timeouts since',
+      );
+    });
+  });
+
+  group('queue reset error handling', () {
+    test('timeout-cleared pending write does not emit disconnected', () async {
+      platform.hangWrites = true;
+
+      final active = expectLater(
+        transport.write(
+          _serviceUuid,
+          _charUuid,
+          Uint8List.fromList([1]),
+          timeout: _writeTimeout,
+        ),
+        throwsA(isA<TimeoutException>()),
+      );
+      final nextActive = expectLater(
+        transport.write(
+          _serviceUuid,
+          _charUuid,
+          Uint8List.fromList([2]),
+          timeout: const Duration(milliseconds: 100),
+        ),
+        throwsA(isA<TimeoutException>()),
+      );
+      final pending = expectLater(
+        transport.write(
+          _serviceUuid,
+          _charUuid,
+          Uint8List.fromList([3]),
+          timeout: const Duration(seconds: 5),
+        ),
+        throwsA(predicate((e) => e.toString().contains('Queue Cancelled'))),
+      );
+
+      await active;
+      await pending;
+      await nextActive;
+      await pump();
+
+      expect(
+        observedStates,
+        isNot(contains(device.ConnectionState.disconnected)),
+      );
+    });
+
+    test('deviceDisconnected maps and emits disconnected exactly once',
+        () async {
+      platform.writeError = UniversalBleException(
+        code: UniversalBleErrorCode.deviceDisconnected,
+        message: 'simulated native disconnect',
+      );
+
+      await expectLater(
+        transport.write(
+          _serviceUuid,
+          _charUuid,
+          Uint8List.fromList([1]),
+        ),
+        throwsA(isA<DeviceNotConnectedException>()),
+      );
+      await pump();
+
+      expect(
+        observedStates.where(
+          (state) => state == device.ConnectionState.disconnected,
+        ),
+        hasLength(1),
       );
     });
   });
@@ -435,12 +510,4 @@ void main() {
     });
   });
 
-  // When _handleGattError or _onOperationTimeout calls clearQueue,
-  // universal_ble's Queue.dispose() cancels pending items with
-  // Exception('Queue Cancelled') — a plain Exception, not
-  // UniversalBleException. Our write()/read() catch blocks convert this
-  // to DeviceNotConnectedException. Testing this requires driving the
-  // universal_ble queue through a real dispose cycle, which hangs the
-  // test framework on cleanup. The code is defensive and the framework
-  // error handler filter (isBenignFrameworkError) is the safety net.
 }


### PR DESCRIPTION
## Summary

- Problem: timeout recovery clears the per-device BLE queue, whose pending operations fail with legacy `Exception('Queue Cancelled')`; Decent.app treated that local cancellation as a physical disconnect.
- Why it matters: the false disconnect removes the DE1 upstream and releases the display wake lock even when the native BLE link remains alive.
- What changed: legacy queue cancellation is isolated in one compatibility helper and now propagates unchanged without emitting `disconnected`; regressions cover local queue reset and typed `deviceDisconnected` behavior.
- What did NOT change (scope boundary): timeout counters, OS-link probing, three-timeout teardown, native disconnect handling, retry policy, queue diagnostics, and recovery barriers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs

## Linked Issues

- Closes #496
- Related #490, #475, #480

## Root Cause (if bug fix)

- Root cause: `_onOperationTimeout()` called `UniversalBle.clearQueue()`, then the read/write catch paths interpreted the fork's generic `Queue Cancelled` error as proof that the device was gone, emitted `disconnected`, and converted it to `DeviceNotConnectedException`.
- Missing detection or guardrail: queue-reset cancellation and native link loss were conflated despite native disconnects already arriving through the connection-state stream or typed `deviceDisconnected` errors.
- Contributing context (if known): universal_ble 2.2.0 exposes locally cleared pending operations through a legacy string error; #497 tracks migration to typed `operationCancelled` after the fork API update.

Exact pre-fix sequence: an active GATT operation timed out, Decent.app cleared the device queue, a pending operation received `Queue Cancelled`, the transport emitted `disconnected` and mapped it to `DeviceNotConnectedException`, and downstream DE1/display controllers performed real-disconnect teardown.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/universal_ble_transport_recovery_test.dart`
- Scenario the test should lock in: timeout-driven queue clearing preserves the pending cancellation and emits no `disconnected`; a typed `deviceDisconnected` error still maps to `DeviceNotConnectedException` and emits `disconnected` exactly once.
- If no new test added, why not: N/A

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A — no docs affected

## Security Impact (required)

- New or changed REST endpoints? (`No`)
- New or changed WebSocket topics? (`No`)
- New or changed network calls? (`No`)
- BLE/USB surface changed? (`Yes`)
- File system access changed? (`No`)
- Plugin sandbox boundary changed? (`No`)
- If any `Yes`, explain risk and mitigation: BLE error classification changed only for the existing local queue-reset exception. No new BLE commands or data are introduced; typed gone-device errors and the native connection stream retain teardown behavior, covered by regression tests.

## User-Visible Changes

A locally initiated BLE queue reset no longer makes a still-connected DE1 disappear or release the display wake lock by itself.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [ ] `flutter test` — all pass
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds

`flutter test` ran 2,482 tests: 2,478 passed and the same four unrelated `test/webui_support/webui_token_injection_test.dart` tests failed both before and after this change.

### Manual verification (if applicable)

- OS / platform tested: macOS test host
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: deterministic mocked universal_ble queue timeout/reset and typed native-disconnect paths.
- Edge cases checked: healthy OS link after one timeout; OS-confirmed dead link; three consecutive timeouts; genuine typed `deviceDisconnected`; cancellation error preservation.
- What you did **not** verify: overnight behavior or real iOS CoreBluetooth hardware.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

Before the fix, the new queue-reset regression received `DeviceNotConnectedException` instead of `Queue Cancelled`. After the fix, all 14 tests in `test/universal_ble_transport_recovery_test.dart` pass.

## Compatibility & Migration

- Backward compatible? (`Yes`)
- Config / env changes needed? (`No`)
- Database migration needed? (`No`)
- If any `No` or `Yes`, explain exact steps: no migration or configuration changes.

## Risks & Mitigations

- Risk: the compatibility helper still identifies the fork's untyped cancellation by message text.
  - Mitigation: matching is isolated in `_isLegacyQueueCancellation`; #497 removes it after typed fork errors are available. Genuine native disconnect behavior has separate regression coverage.
