### PR TITLE
chore(ble): bump universal_ble to 2.2.1

### DIFF
--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -157,9 +157,9 @@ Dart `Future.timeout()` does not cancel the native BLE Future. When a queued ope
 `UniversalBleTransport._onOperationTimeout()` must never immediately clear this barrier. Recovery follows one of two safe paths:
 
 1. Poll payload-free queue diagnostics. Once `activeOperations == 0`, clear the faulted generation with `clearQueueWithError(... operationCancelled)`; the next command creates a clean generation.
-2. If the native operation is still unresolved after the 2-second grace period, call unqueued `disconnect()`, then clear with `deviceDisconnected` and let the normal disconnect/reconnect cascade replace the physical connection.
+2. If the native operation is still unresolved after the 2-second grace period, request an unqueued `disconnect()`. Keep the queue faulted unless the native disconnect event confirms teardown; `UniversalBle.disconnect()` swallows timeout/failure, so its returned Future is not confirmation. The native event clears with `deviceDisconnected` and starts the normal reconnect cascade.
 
-A queue can produce only one wrapper timeout per faulted generation; followers are cancelled rather than dispatched. Therefore the old "three consecutive operation timeouts" policy is invalid under 2.2.1. The bounded unresolved-operation grace period is now the dead-link policy. Recovery tasks carry the transport connection generation so late completion from an old connection cannot clear a replacement queue.
+A queue can produce only one wrapper timeout per faulted generation; followers are cancelled rather than dispatched. Therefore the old "three consecutive operation timeouts" policy is invalid under 2.2.1. The bounded unresolved-operation grace period is now the dead-link policy. Recovery tasks and asynchronous OS probes carry the transport connection generation so late completion from an old connection cannot clear a replacement queue or emit stale state.
 
 `operationCancelled` means local queue recovery, never physical disconnect. It is benign Crashlytics noise. `deviceDisconnected` remains reserved for a confirmed or forced physical disconnect. The legacy `Exception('Queue Cancelled')` string sentinel is not part of the 2.2.1 path.
 
@@ -188,7 +188,7 @@ Three reusable idioms from the comms-harden effort:
 | Duplicate state messages | Listener stacking. Check `CharSubscriptions` is cancel-before-replace. |
 | Scale write exceptions escaping to framework | Scale write path missing `DeviceNotConnectedException` catch. Add at `_writeCommand` / `_safeWrite`. |
 | BLE scan overlaps | `ScanStateGuardian` — check adapter state tracking. |
-| `TimeoutException` in `universal_ble/queue.dart` | Queue generation must stay faulted until the native Future settles or the 2-second grace forces disconnect; never clear immediately. May relate to zombie-link (#431) or concurrent BLE write contention (#423). |
+| `TimeoutException` in `universal_ble/queue.dart` | Queue generation must stay faulted until the native Future settles or a native event confirms disconnect; a disconnect request timing out is not confirmation. May relate to zombie-link (#431) or concurrent BLE write contention (#423). |
 | `PlatformException: Location services required` | Android location permissions not granted. Onboarding check or troubleshooting wizard (#125/#126). |
 
 ## Android USB Attach Recovery

--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -146,9 +146,22 @@ cancellation.
 `UniversalBleTransport._handleGattError()` catches `UniversalBleException` with gone-device codes:
 `characteristicNotFound`, `deviceNotFound`, `serviceNotFound`, `connectionTerminated`, `deviceDisconnected`, `unknownError`.
 
-On hit: emits `disconnected`, drains the queue, throws `DeviceNotConnectedException`.
+On hit: emits `disconnected`, drains the queue with typed `deviceDisconnected`, and throws `DeviceNotConnectedException`.
 
 The `isBenignFrameworkError()` filter in `crashlytics_error_filter.dart` suppresses these from `FlutterError.onError` — but scale-level catches at the write helper are defense-in-depth.
+
+## Faulted Queue Recovery
+
+Dart `Future.timeout()` does not cancel the native BLE Future. When a queued operation times out, universal_ble 2.2.1 faults that exact queue generation. The original caller receives `TimeoutException`; pending and newly submitted commands receive typed `operationCancelled` and are not dispatched.
+
+`UniversalBleTransport._onOperationTimeout()` must never immediately clear this barrier. Recovery follows one of two safe paths:
+
+1. Poll payload-free queue diagnostics. Once `activeOperations == 0`, clear the faulted generation with `clearQueueWithError(... operationCancelled)`; the next command creates a clean generation.
+2. If the native operation is still unresolved after the 2-second grace period, call unqueued `disconnect()`, then clear with `deviceDisconnected` and let the normal disconnect/reconnect cascade replace the physical connection.
+
+A queue can produce only one wrapper timeout per faulted generation; followers are cancelled rather than dispatched. Therefore the old "three consecutive operation timeouts" policy is invalid under 2.2.1. The bounded unresolved-operation grace period is now the dead-link policy. Recovery tasks carry the transport connection generation so late completion from an old connection cannot clear a replacement queue.
+
+`operationCancelled` means local queue recovery, never physical disconnect. It is benign Crashlytics noise. `deviceDisconnected` remains reserved for a confirmed or forced physical disconnect. The legacy `Exception('Queue Cancelled')` string sentinel is not part of the 2.2.1 path.
 
 ## BLE Scanning
 
@@ -175,7 +188,7 @@ Three reusable idioms from the comms-harden effort:
 | Duplicate state messages | Listener stacking. Check `CharSubscriptions` is cancel-before-replace. |
 | Scale write exceptions escaping to framework | Scale write path missing `DeviceNotConnectedException` catch. Add at `_writeCommand` / `_safeWrite`. |
 | BLE scan overlaps | `ScanStateGuardian` — check adapter state tracking. |
-| `TimeoutException` in `universal_ble/queue.dart` | May relate to zombie-link (#431) or concurrent BLE write contention (#423). |
+| `TimeoutException` in `universal_ble/queue.dart` | Queue generation must stay faulted until the native Future settles or the 2-second grace forces disconnect; never clear immediately. May relate to zombie-link (#431) or concurrent BLE write contention (#423). |
 | `PlatformException: Location services required` | Android location permissions not granted. Onboarding check or troubleshooting wizard (#125/#126). |
 
 ## Android USB Attach Recovery

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -27,20 +27,21 @@ class UniversalBleTransport implements BLETransport {
   // Android after a DE1 power outage: writes time out forever while the
   // app believes it is connected). Two independent detectors feed
   // [_declareLinkDead]:
-  //  1. GATT operation timeouts trigger an OS-level connection-state probe;
-  //     [_maxConsecutiveOpTimeouts] in a row force a teardown even when the
-  //     OS still claims connected.
+  //  1. GATT operation timeouts fault their queue generation. Recovery waits
+  //     for the unresolved native operation, then clears the queue; if it does
+  //     not settle within a grace period, the link is disconnected instead.
   //  2. Advertisements for our own deviceId while we believe we are
-  //     connected trigger the same probe (throttled) — probe-confirmed
-  //     only, because some peripherals legitimately advertise while
-  //     connected (this transport is shared by scales and sensors).
-  int _consecutiveOpTimeouts = 0;
+  //     connected trigger an OS-level connection-state probe (throttled) —
+  //     probe-confirmed only, because some peripherals legitimately advertise
+  //     while connected (this transport is shared by scales and sensors).
   bool _linkDeadDeclared = false;
+  int _connectionGeneration = 0;
+  int? _recoveringQueueGeneration;
   DateTime? _lastAdvertProbe;
   StreamSubscription<BleDevice>? _advertSub;
 
-  static const int _maxConsecutiveOpTimeouts = 3;
   static const Duration _linkProbeTimeout = Duration(seconds: 2);
+  static const Duration _faultRecoveryPollInterval = Duration(milliseconds: 50);
 
   /// Minimum spacing between advert-triggered OS probes. A disconnected
   /// peripheral advertises ~1/s during a scan; one probe per window is
@@ -68,11 +69,13 @@ class UniversalBleTransport implements BLETransport {
     bool requestLargeMtuNonAndroid = false,
     bool? isAndroidOverride,
     bool? isLinuxOverride,
+    Duration faultRecoveryGrace = const Duration(seconds: 2),
   })  : _device = device,
         _stopScan = stopScan,
         _requestLargeMtuNonAndroid = requestLargeMtuNonAndroid,
         _isAndroidOverride = isAndroidOverride,
-        _isLinuxOverride = isLinuxOverride {
+        _isLinuxOverride = isLinuxOverride,
+        _faultRecoveryGrace = faultRecoveryGrace {
 
     _log = Logger("BLETransport-${device.deviceId}");
   }
@@ -87,6 +90,7 @@ class UniversalBleTransport implements BLETransport {
   final bool _requestLargeMtuNonAndroid;
   final bool? _isAndroidOverride;
   final bool? _isLinuxOverride;
+  final Duration _faultRecoveryGrace;
 
   Future<void> _stopScanViaOwner() =>
       _stopScan?.call() ?? UniversalBle.stopScan();
@@ -104,8 +108,9 @@ class UniversalBleTransport implements BLETransport {
 
   @override
   Future<void> connect() async {
+    _connectionGeneration++;
+    _recoveringQueueGeneration = null;
     _linkDeadDeclared = false;
-    _consecutiveOpTimeouts = 0;
     _lastAdvertProbe = null;
     // Use connectionUpdateStream (from our universal_ble fork) to get
     // native disconnect reason codes (GATT error, HCI status) — the
@@ -246,17 +251,13 @@ class UniversalBleTransport implements BLETransport {
     UniversalBleErrorCode.deviceDisconnected,
   };
 
-  // universal_ble 2.2.0 compatibility; replace with typed cancellation in #497.
-  static bool _isLegacyQueueCancellation(Object error) =>
-      error.toString().contains('Queue Cancelled');
-
   Never _handleGattError(UniversalBleException e, String operation, String path) {
     if (_goneDeviceCodes.contains(e.code)) {
       _log.warning('GATT $operation($path) failed — device gone: ${e.code}');
       _connectionStateSubject.add(device.ConnectionState.disconnected);
       // Drain pending writes — the device is gone, queued writes will
       // only fail with deviceNotFound and flood logs.
-      UniversalBle.clearQueue(_device.deviceId);
+      _clearQueue(UniversalBleErrorCode.deviceDisconnected);
       throw const DeviceNotConnectedException.unknown();
     }
     // GATT-133 (gattError): transient Android BLE stack error. Often
@@ -265,7 +266,7 @@ class UniversalBleTransport implements BLETransport {
     // Do NOT declare the link dead or emit disconnected.
     if (e.code == UniversalBleErrorCode.gattError) {
       _log.warning('GATT $operation($path) failed — GATT error 133 (transient): $e');
-      UniversalBle.clearQueue(_device.deviceId);
+      _clearQueue(UniversalBleErrorCode.operationCancelled);
       throw BleTimeoutException('GATT $operation($path)', e);
     }
     // Also treat unknownError as likely device-gone on Bluetooth-off / macOS
@@ -275,7 +276,7 @@ class UniversalBleTransport implements BLETransport {
         'GATT $operation($path) failed — unknown error (likely BT off): $e',
       );
       _connectionStateSubject.add(device.ConnectionState.disconnected);
-      UniversalBle.clearQueue(_device.deviceId);
+      _clearQueue(UniversalBleErrorCode.deviceDisconnected);
       throw const DeviceNotConnectedException.unknown();
     }
     // All other codes: throw as-is (caller's problem).
@@ -303,6 +304,8 @@ class UniversalBleTransport implements BLETransport {
 
   @override
   Future<void> disconnect() async {
+    _connectionGeneration++;
+    _recoveringQueueGeneration = null;
     _advertSub?.cancel();
     _advertSub = null;
     try {
@@ -388,7 +391,6 @@ class UniversalBleTransport implements BLETransport {
         characteristicUUID,
         timeout: timeout
       );
-      _noteOperationSuccess();
       return value;
     } on TimeoutException {
       // Fail fast (see write() — a read-timeout reconnect mid profile-upload
@@ -398,43 +400,71 @@ class UniversalBleTransport implements BLETransport {
       rethrow;
     } on UniversalBleException catch (e) {
       _handleGattError(e, 'read', '$serviceUUID/$characteristicUUID');
-    } catch (e) {
-      if (_isLegacyQueueCancellation(e)) {
-        _log.fine('read($serviceUUID/$characteristicUUID) cancelled by clearQueue');
-      }
-      rethrow;
     }
   }
 
-  /// universal_ble's internal operation queue throws a bare [TimeoutException]
-  /// (not a [UniversalBleException]) when a GATT op never completes — e.g. the
-  /// DE1 stops servicing ops on a flaky link. Clear the stuck queue entry so it
-  /// doesn't block (and time out) every following operation, then let the plain
-  /// timeout propagate. Do NOT convert it to a [BleTimeoutException]: that would
-  /// trigger a disconnect/reconnect+single-write retry, which corrupts an
-  /// in-flight profile upload (a stateful multi-write sequence).
-  ///
-  /// A timeout is also a zombie-link symptom: verify the link async (never
-  /// blocking the caller). A single timeout with a healthy OS link changes
-  /// nothing; an OS-confirmed drop — or [_maxConsecutiveOpTimeouts] in a
-  /// row — declares the link dead so recovery can start instead of the app
-  /// staying "connected" to a corpse forever.
+  /// universal_ble faults a queue generation when its Dart timeout fires
+  /// because the underlying native Future cannot be cancelled. Keep that
+  /// barrier in place until the native operation settles. If it does not settle
+  /// within the grace period, disconnect the physical link before clearing the
+  /// generation so a replacement connection cannot overlap the old operation.
   void _onOperationTimeout(String operation, String path) {
-    _log.warning('GATT $operation($path) timed out — clearing BLE queue');
-    UniversalBle.clearQueue(_device.deviceId);
-    _consecutiveOpTimeouts++;
-    if (_consecutiveOpTimeouts >= _maxConsecutiveOpTimeouts) {
-      _declareLinkDead(
-        '$_consecutiveOpTimeouts consecutive GATT timeouts',
-        forceOsDisconnect: true,
-      );
-    } else {
-      unawaited(_probeAndDeclareIfDead('GATT $operation timeout'));
+    _log.warning('GATT $operation($path) timed out — BLE queue faulted');
+    final generation = _connectionGeneration;
+    unawaited(_probeAndDeclareIfDead('GATT $operation timeout'));
+    if (_recoveringQueueGeneration == generation) return;
+    _recoveringQueueGeneration = generation;
+    unawaited(_recoverFaultedQueue(generation, 'GATT $operation($path)'));
+  }
+
+  Future<void> _recoverFaultedQueue(int generation, String context) async {
+    final deadline = DateTime.now().add(_faultRecoveryGrace);
+    try {
+      while (generation == _connectionGeneration && !_linkDeadDeclared) {
+        final diagnostics = UniversalBle.getQueueDiagnostics(_device.deviceId);
+        if (diagnostics.state != QueueDiagnosticsState.faulted) return;
+        if (diagnostics.activeOperations == 0) {
+          _clearQueue(UniversalBleErrorCode.operationCancelled);
+          return;
+        }
+        if (!DateTime.now().isBefore(deadline)) {
+          _log.warning(
+            '$context native operation remained unresolved for '
+            '${_faultRecoveryGrace.inMilliseconds}ms — disconnecting',
+          );
+          try {
+            await UniversalBle.disconnect(
+              _device.deviceId,
+              timeout: const Duration(seconds: 5),
+            );
+          } catch (e) {
+            _log.fine('Fault-recovery disconnect failed: $e');
+          }
+          if (generation == _connectionGeneration) {
+            _clearQueue(UniversalBleErrorCode.deviceDisconnected);
+            _declareLinkDead('$context did not settle after queue timeout');
+          }
+          return;
+        }
+        await Future<void>.delayed(_faultRecoveryPollInterval);
+      }
+    } finally {
+      if (_recoveringQueueGeneration == generation) {
+        _recoveringQueueGeneration = null;
+      }
     }
   }
 
-  void _noteOperationSuccess() {
-    _consecutiveOpTimeouts = 0;
+  void _clearQueue(UniversalBleErrorCode code) {
+    UniversalBle.clearQueueWithError(
+      _device.deviceId,
+      error: UniversalBleException(
+        code: code,
+        message: code == UniversalBleErrorCode.operationCancelled
+            ? 'Cancelled after a preceding BLE operation timed out'
+            : 'Cancelled because the BLE device disconnected',
+      ),
+    );
   }
 
   /// Listen for advertisements carrying our own deviceId while we believe
@@ -485,26 +515,17 @@ class UniversalBleTransport implements BLETransport {
 
   /// Emit `disconnected` so the normal recovery cascade runs (device impl →
   /// controller reset → DisconnectSupervisor → machine auto-reconnect).
-  /// Idempotent per connection. [forceOsDisconnect] additionally releases
-  /// the OS-level GATT handle (best-effort) so it can't block the next
-  /// connect — used when the OS still claims the dead link is connected.
-  void _declareLinkDead(String reason, {bool forceOsDisconnect = false}) {
+  /// Idempotent per connection.
+  void _declareLinkDead(String reason) {
     if (_linkDeadDeclared) return;
     _linkDeadDeclared = true;
     _log.warning('Declaring BLE link dead: $reason');
     _advertSub?.cancel();
     _advertSub = null;
-    UniversalBle.clearQueue(_device.deviceId);
-    _connectionStateSubject.add(device.ConnectionState.disconnected);
-    if (forceOsDisconnect) {
-      unawaited(
-        UniversalBle.disconnect(
-          _device.deviceId,
-          timeout: const Duration(seconds: 5),
-        ).catchError((Object e) {
-          _log.fine('Best-effort OS disconnect failed: $e');
-        }),
-      );
+    _clearQueue(UniversalBleErrorCode.deviceDisconnected);
+    if (_connectionStateSubject.valueOrNull !=
+        device.ConnectionState.disconnected) {
+      _connectionStateSubject.add(device.ConnectionState.disconnected);
     }
   }
 
@@ -556,7 +577,6 @@ class UniversalBleTransport implements BLETransport {
         withoutResponse: !withResponse,
         timeout: timeout
       );
-      _noteOperationSuccess();
     } on TimeoutException {
       // Fail fast — do NOT map this to a BleTimeoutException. Doing so routes it
       // into the DE1 transport's reconnect-and-retry-this-one-write recovery,
@@ -570,13 +590,6 @@ class UniversalBleTransport implements BLETransport {
       rethrow;
     } on UniversalBleException catch (e) {
       _handleGattError(e, 'write', '$serviceUUID/$characteristicUUID');
-    } catch (e) {
-      if (_isLegacyQueueCancellation(e)) {
-        _log.fine(
-            'write($serviceUUID/$characteristicUUID) cancelled by clearQueue',
-        );
-      }
-      rethrow;
     }
   }
 
@@ -599,6 +612,8 @@ class UniversalBleTransport implements BLETransport {
 
   @override
   Future<void> dispose() async {
+    _connectionGeneration++;
+    _recoveringQueueGeneration = null;
     _advertSub?.cancel();
     _advertSub = null;
     _connectionStateSubscription?.cancel();

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -70,12 +70,14 @@ class UniversalBleTransport implements BLETransport {
     bool? isAndroidOverride,
     bool? isLinuxOverride,
     Duration faultRecoveryGrace = const Duration(seconds: 2),
+    Duration faultRecoveryDisconnectTimeout = const Duration(seconds: 5),
   })  : _device = device,
         _stopScan = stopScan,
         _requestLargeMtuNonAndroid = requestLargeMtuNonAndroid,
         _isAndroidOverride = isAndroidOverride,
         _isLinuxOverride = isLinuxOverride,
-        _faultRecoveryGrace = faultRecoveryGrace {
+        _faultRecoveryGrace = faultRecoveryGrace,
+        _faultRecoveryDisconnectTimeout = faultRecoveryDisconnectTimeout {
 
     _log = Logger("BLETransport-${device.deviceId}");
   }
@@ -91,6 +93,7 @@ class UniversalBleTransport implements BLETransport {
   final bool? _isAndroidOverride;
   final bool? _isLinuxOverride;
   final Duration _faultRecoveryGrace;
+  final Duration _faultRecoveryDisconnectTimeout;
 
   Future<void> _stopScanViaOwner() =>
       _stopScan?.call() ?? UniversalBle.stopScan();
@@ -411,7 +414,9 @@ class UniversalBleTransport implements BLETransport {
   void _onOperationTimeout(String operation, String path) {
     _log.warning('GATT $operation($path) timed out — BLE queue faulted');
     final generation = _connectionGeneration;
-    unawaited(_probeAndDeclareIfDead('GATT $operation timeout'));
+    unawaited(
+      _probeAndDeclareIfDead('GATT $operation timeout', generation),
+    );
     if (_recoveringQueueGeneration == generation) return;
     _recoveringQueueGeneration = generation;
     unawaited(_recoverFaultedQueue(generation, 'GATT $operation($path)'));
@@ -432,18 +437,10 @@ class UniversalBleTransport implements BLETransport {
             '$context native operation remained unresolved for '
             '${_faultRecoveryGrace.inMilliseconds}ms — disconnecting',
           );
-          try {
-            await UniversalBle.disconnect(
-              _device.deviceId,
-              timeout: const Duration(seconds: 5),
-            );
-          } catch (e) {
-            _log.fine('Fault-recovery disconnect failed: $e');
-          }
-          if (generation == _connectionGeneration) {
-            _clearQueue(UniversalBleErrorCode.deviceDisconnected);
-            _declareLinkDead('$context did not settle after queue timeout');
-          }
+          await UniversalBle.disconnect(
+            _device.deviceId,
+            timeout: _faultRecoveryDisconnectTimeout,
+          );
           return;
         }
         await Future<void>.delayed(_faultRecoveryPollInterval);
@@ -489,13 +486,18 @@ class UniversalBleTransport implements BLETransport {
     _log.warning(
       'Received advertisement while believed connected — probing OS link state',
     );
-    unawaited(_probeAndDeclareIfDead('advertising while believed connected'));
+    unawaited(
+      _probeAndDeclareIfDead(
+        'advertising while believed connected',
+        _connectionGeneration,
+      ),
+    );
   }
 
   /// Ask the OS for the actual connection state. Declares the link dead
   /// only on an explicit disconnected/disconnecting answer — a probe
   /// error is inconclusive and must not tear down a possibly-live link.
-  Future<void> _probeAndDeclareIfDead(String context) async {
+  Future<void> _probeAndDeclareIfDead(String context, int generation) async {
     final BleConnectionState state;
     try {
       state = await UniversalBle.getConnectionState(
@@ -503,10 +505,12 @@ class UniversalBleTransport implements BLETransport {
         timeout: _linkProbeTimeout,
       );
     } catch (e) {
+      if (generation != _connectionGeneration) return;
       _log.fine('Link probe inconclusive ($context): $e');
       return;
     }
-    if (state == BleConnectionState.connected ||
+    if (generation != _connectionGeneration ||
+        state == BleConnectionState.connected ||
         state == BleConnectionState.connecting) {
       return;
     }

--- a/lib/src/services/telemetry/crashlytics_error_filter.dart
+++ b/lib/src/services/telemetry/crashlytics_error_filter.dart
@@ -1,17 +1,17 @@
 import 'package:reaprime/src/models/errors.dart';
 
-/// Error codes from universal_ble that indicate the device is gone and the
-/// error is already handled by [UniversalBleTransport._handleGattError].
+/// Expected universal_ble errors that are already handled by the transport.
 /// When these escape to the framework error handler (e.g., from a
-/// fire-and-forget timer callback or a cancelled queue item), they are
-/// not crash signals — the transport already emitted `disconnected` and
-/// the device impl's disconnect cascade handles cleanup.
-const _goneDeviceBleErrorCodes = <String>{
+/// fire-and-forget timer callback or a cancelled queue item), they are not
+/// crash signals. Gone-device errors trigger disconnect cleanup;
+/// `operationCancelled` is a local queue-recovery result.
+const _benignBleErrorCodes = <String>{
   'characteristicNotFound',
   'deviceNotFound',
   'serviceNotFound',
   'connectionTerminated',
   'deviceDisconnected',
+  'operationCancelled',
   'unknownError',
 };
 
@@ -44,18 +44,13 @@ bool isBenignFrameworkError(Object error) {
   final errorString = error.toString();
   if (errorString.startsWith('UniversalBleException:') ||
       errorString.contains('UniversalBleException:')) {
-    for (final code in _goneDeviceBleErrorCodes) {
+    for (final code in _benignBleErrorCodes) {
       if (errorString.contains('UniversalBleErrorCode.$code') ||
           errorString.contains('Code: $code')) {
         return true;
       }
     }
   }
-
-  // Exception('Queue Cancelled') — thrown by universal_ble's Queue.dispose()
-  // when clearQueue cancels pending items. Not a UniversalBleException, so
-  // _handleGattError can't catch it.
-  if (errorString.contains('Queue Cancelled')) return true;
 
   // PlatformException from bonsoir DNS-SD plugin — ServiceNotRunning means
   // the mDNS daemon isn't available on the platform (iOS/macOS transient

--- a/lib/src/services/telemetry/firebase_crashlytics_telemetry_service.dart
+++ b/lib/src/services/telemetry/firebase_crashlytics_telemetry_service.dart
@@ -39,8 +39,8 @@ class FirebaseCrashlyticsTelemetryService implements TelemetryService {
     }
 
     // TELE-04: Set up global error handlers to route through TelemetryService.
-    // Filter known-benign exceptions (DeviceNotConnectedException, gone-device
-    // UniversalBleException, Queue Cancelled) that escape from fire-and-forget
+    // Filter known-benign exceptions (DeviceNotConnectedException and typed
+    // UniversalBleException disconnect/cancellation errors) from fire-and-forget
     // contexts (Timer callbacks, unawaited Futures). These are handled by upper
     // layers but can reach the framework error handler without being caught —
     // recording them as FATAL creates false crash signals in Crashlytics

--- a/lib/src/services/telemetry/telemetry_forwarder_filter.dart
+++ b/lib/src/services/telemetry/telemetry_forwarder_filter.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/errors.dart';
+import 'package:reaprime/src/services/telemetry/crashlytics_error_filter.dart';
 
 const _webUiStorageLoggerName = 'WebUIStorage';
 const _skinAlreadyExistsPrefix = 'Skin already exists';
@@ -44,6 +45,9 @@ bool shouldForwardToTelemetry(LogRecord record) {
   // bounded MMR-read timeouts — not crash signals.
   if (record.error is DeviceNotConnectedException) return false;
   if (record.error is MmrTimeoutException) return false;
+  if (record.error case final error? when isBenignFrameworkError(error)) {
+    return false;
+  }
 
   if (record.loggerName == _webUiStorageLoggerName &&
       record.message.startsWith(_skinAlreadyExistsPrefix)) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1706,11 +1706,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "2.2.0"
-      resolved-ref: "734012dd4e880e20b7b3d3a97a5c2dc92e631e10"
+      ref: "2.2.1"
+      resolved-ref: "420c771e5944cf75782e00e430ef94fa7f577165"
       url: "https://github.com/tadelv/universal_ble.git"
     source: git
-    version: "2.2.0"
+    version: "2.2.1"
   universal_image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   universal_ble:
     git:
       url: https://github.com/tadelv/universal_ble.git
-      ref: 2.2.0
+      ref: 2.2.1
   shared_preferences: ^2.5.3
   # share_plus HELD at 12.x — 13.x requires win32 ^6, which conflicts with
   # file_picker 11's win32 ^5.9 pin. 13.x is only SDK-floor bumps, no API gain.

--- a/test/services/ble/universal_ble_transport_mtu_test.dart
+++ b/test/services/ble/universal_ble_transport_mtu_test.dart
@@ -51,6 +51,7 @@ class _MtuRecordingBlePlatform extends UniversalBlePlatform {
     String deviceId, {
     Duration? connectionTimeout,
     bool autoConnect = false,
+    ConnectionPlatformConfig? platformConfig,
   }) async {
     updateConnection(deviceId, true);
   }

--- a/test/services/telemetry/crashlytics_error_filter_test.dart
+++ b/test/services/telemetry/crashlytics_error_filter_test.dart
@@ -25,7 +25,7 @@ void main() {
       });
     });
 
-    group('UniversalBleException with gone-device codes', () {
+    group('UniversalBleException with expected BLE codes', () {
       // We match by toString() prefix + error code string because we can't
       // import universal_ble in the telemetry layer (would create a layer
       // dependency). The crash events use both formats:
@@ -74,6 +74,13 @@ void main() {
         expect(isBenignFrameworkError(e), isTrue);
       });
 
+      test('operationCancelled is benign', () {
+        final e = _FakeUniversalBleException(
+          'Code: UniversalBleErrorCode.operationCancelled',
+        );
+        expect(isBenignFrameworkError(e), isTrue);
+      });
+
       test('short format "Code: deviceNotFound" is benign', () {
         final e = _FakeUniversalBleException(
           'Code: deviceNotFound, Message: Unknown deviceId',
@@ -82,11 +89,6 @@ void main() {
       });
     });
 
-    group('Queue Cancelled exception', () {
-      test('Exception("Queue Cancelled") is benign', () {
-        expect(isBenignFrameworkError(Exception('Queue Cancelled')), isTrue);
-      });
-    });
 
     group('non-benign errors (should crash)', () {
       test('StateError is NOT benign', () {

--- a/test/services/telemetry/telemetry_forwarder_filter_test.dart
+++ b/test/services/telemetry/telemetry_forwarder_filter_test.dart
@@ -54,6 +54,19 @@ void main() {
       });
     });
 
+    test('drops SEVERE operationCancelled errors', () {
+      final record = _record(
+        Level.SEVERE,
+        'BLETransport-device',
+        'queued write failed',
+        _FakeUniversalBleException(
+          'Code: UniversalBleErrorCode.operationCancelled',
+        ),
+      );
+
+      expect(shouldForwardToTelemetry(record), isFalse);
+    });
+
     group('drops noise from WebUIStorage', () {
       test('"Skin already exists: ..." is dropped', () {
         final record = _record(
@@ -248,4 +261,13 @@ void main() {
       });
     });
   });
+}
+
+class _FakeUniversalBleException implements Exception {
+  _FakeUniversalBleException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'UniversalBleException: $message';
 }

--- a/test/services/universal_ble_discovery_service_test.dart
+++ b/test/services/universal_ble_discovery_service_test.dart
@@ -84,6 +84,7 @@ class _FakeBlePlatform extends UniversalBlePlatform {
     String deviceId, {
     Duration? connectionTimeout,
     bool autoConnect = false,
+    ConnectionPlatformConfig? platformConfig,
   }) async {}
 
   @override

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -17,6 +17,8 @@ const _writeTimeout = Duration(milliseconds: 50);
 /// `connectionStateResult` is what the OS-level probe reports.
 class _FakeBlePlatform extends UniversalBlePlatform {
   BleConnectionState connectionStateResult = BleConnectionState.connected;
+  Completer<BleConnectionState>? connectionStateBlocker;
+  bool emitDisconnectEvent = true;
   bool hangWrites = false;
   Completer<void>? writeBlocker;
   UniversalBleException? writeError;
@@ -65,7 +67,7 @@ class _FakeBlePlatform extends UniversalBlePlatform {
   @override
   Future<void> disconnect(String deviceId) async {
     disconnectCalls.add(deviceId);
-    updateConnection(deviceId, false);
+    if (emitDisconnectEvent) updateConnection(deviceId, false);
   }
 
   @override
@@ -141,7 +143,7 @@ class _FakeBlePlatform extends UniversalBlePlatform {
   @override
   Future<BleConnectionState> getConnectionState(String deviceId) async {
     getConnectionStateCalls++;
-    return connectionStateResult;
+    return connectionStateBlocker?.future ?? connectionStateResult;
   }
 
   @override
@@ -177,6 +179,7 @@ void main() {
     transport = UniversalBleTransport(
       device: bleDevice(deviceId),
       faultRecoveryGrace: const Duration(milliseconds: 200),
+      faultRecoveryDisconnectTimeout: const Duration(milliseconds: 20),
     );
     observedStates = [];
     stateSub = transport.connectionState.listen(observedStates.add);
@@ -245,6 +248,24 @@ void main() {
       expect(observedStates, contains(device.ConnectionState.disconnected));
       expect(platform.disconnectCalls, contains(deviceId),
           reason: 'forced teardown must release the OS-level handle');
+    });
+
+    test('failed disconnect leaves unresolved queue faulted', () async {
+      platform.hangWrites = true;
+      platform.emitDisconnectEvent = false;
+
+      await timedOutWrite();
+      await pump(300);
+
+      expect(platform.disconnectCalls, contains(deviceId));
+      expect(
+        UniversalBle.getQueueDiagnostics(deviceId).state,
+        QueueDiagnosticsState.faulted,
+      );
+      expect(
+        observedStates,
+        isNot(contains(device.ConnectionState.disconnected)),
+      );
     });
 
     test('late native completion clears the faulted queue without disconnecting',
@@ -425,6 +446,43 @@ void main() {
 
       expect(platform.getConnectionStateCalls, probesBefore,
           reason: 'no probe when we already know we are disconnected');
+    });
+
+    test('probe completing after reconnect cannot tear down new connection',
+        () async {
+      platform.connectionStateBlocker = Completer<BleConnectionState>();
+      platform.updateScanResult(bleDevice(deviceId));
+      await pump(10);
+      expect(platform.getConnectionStateCalls, 1);
+
+      await transport.connect();
+      platform.hangWrites = true;
+      platform.writeBlocker = Completer<void>();
+      final active = transport.write(
+        _serviceUuid,
+        _charUuid,
+        Uint8List.fromList([1]),
+        timeout: const Duration(seconds: 1),
+      );
+      final pending = transport.write(
+        _serviceUuid,
+        _charUuid,
+        Uint8List.fromList([2]),
+        timeout: const Duration(seconds: 1),
+      );
+      await pump(10);
+
+      platform.connectionStateBlocker!.complete(BleConnectionState.disconnected);
+      await pump(10);
+      expect(
+        observedStates.last,
+        device.ConnectionState.connected,
+      );
+
+      platform.hangWrites = false;
+      platform.writeBlocker!.complete();
+      await Future.wait([active, pending]);
+      expect(platform.writeCalls, 2);
     });
 
     test('advert probes are throttled', () async {

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -55,6 +55,7 @@ class _FakeBlePlatform extends UniversalBlePlatform {
     String deviceId, {
     Duration? connectionTimeout,
     bool autoConnect = false,
+    ConnectionPlatformConfig? platformConfig,
   }) async {
     updateConnection(deviceId, true);
   }
@@ -296,7 +297,13 @@ void main() {
           Uint8List.fromList([2]),
           timeout: const Duration(milliseconds: 100),
         ),
-        throwsA(isA<TimeoutException>()),
+        throwsA(
+          isA<UniversalBleException>().having(
+            (e) => e.code,
+            'code',
+            UniversalBleErrorCode.operationCancelled,
+          ),
+        ),
       );
       final pending = expectLater(
         transport.write(
@@ -305,7 +312,13 @@ void main() {
           Uint8List.fromList([3]),
           timeout: const Duration(seconds: 5),
         ),
-        throwsA(predicate((e) => e.toString().contains('Queue Cancelled'))),
+        throwsA(
+          isA<UniversalBleException>().having(
+            (e) => e.code,
+            'code',
+            UniversalBleErrorCode.operationCancelled,
+          ),
+        ),
       );
 
       await active;

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -18,7 +18,9 @@ const _writeTimeout = Duration(milliseconds: 50);
 class _FakeBlePlatform extends UniversalBlePlatform {
   BleConnectionState connectionStateResult = BleConnectionState.connected;
   bool hangWrites = false;
+  Completer<void>? writeBlocker;
   UniversalBleException? writeError;
+  int writeCalls = 0;
   int getConnectionStateCalls = 0;
   final List<String> disconnectCalls = [];
 
@@ -108,9 +110,10 @@ class _FakeBlePlatform extends UniversalBlePlatform {
     Uint8List value,
     BleOutputProperty bleOutputProperty,
   ) async {
+    writeCalls++;
     if (writeError case final error?) throw error;
     if (hangWrites) {
-      await Completer<void>().future;
+      await (writeBlocker ?? Completer<void>()).future;
     }
   }
 
@@ -171,7 +174,10 @@ void main() {
     UniversalBle.queueType = QueueType.perDevice;
     // Unique id per test so per-device queue state can't bleed over.
     deviceId = 'AA:BB:CC:DD:EE:${(deviceCounter++).toString().padLeft(2, '0')}';
-    transport = UniversalBleTransport(device: bleDevice(deviceId));
+    transport = UniversalBleTransport(
+      device: bleDevice(deviceId),
+      faultRecoveryGrace: const Duration(milliseconds: 200),
+    );
     observedStates = [];
     stateSub = transport.connectionState.listen(observedStates.add);
     await transport.connect();
@@ -229,56 +235,71 @@ void main() {
           reason: 'the timeout should have probed the OS link state');
     });
 
-    test(
-        'three consecutive timeouts with OS claiming connected → forced '
-        'teardown', () async {
+    test('unresolved native write past grace period forces teardown', () async {
       platform.hangWrites = true;
       platform.connectionStateResult = BleConnectionState.connected;
 
       await timedOutWrite();
-      await timedOutWrite();
-      expect(observedStates,
-          isNot(contains(device.ConnectionState.disconnected)));
-
-      await timedOutWrite();
-      await pump();
+      await pump(250);
 
       expect(observedStates, contains(device.ConnectionState.disconnected));
       expect(platform.disconnectCalls, contains(deviceId),
           reason: 'forced teardown must release the OS-level handle');
     });
 
-    test('successful write resets the consecutive-timeout counter', () async {
+    test('late native completion clears the faulted queue without disconnecting',
+        () async {
+      platform.hangWrites = true;
+      platform.writeBlocker = Completer<void>();
       platform.connectionStateResult = BleConnectionState.connected;
 
-      platform.hangWrites = true;
       await timedOutWrite();
-      await timedOutWrite();
+      platform.writeBlocker!.complete();
+      await pump(100);
 
       platform.hangWrites = false;
       await transport.write(
         _serviceUuid,
         _charUuid,
-        Uint8List.fromList([1]),
+        Uint8List.fromList([2]),
         timeout: _writeTimeout,
       );
 
-      platform.hangWrites = true;
-      await timedOutWrite();
-      await timedOutWrite();
-      await pump();
-
+      expect(platform.writeCalls, 2);
       expect(
         observedStates,
         isNot(contains(device.ConnectionState.disconnected)),
-        reason: 'counter must reset on success — only 2 consecutive '
-            'timeouts since',
       );
     });
   });
 
   group('queue reset error handling', () {
-    test('timeout-cleared pending write does not emit disconnected', () async {
+    test('post-timeout write is not dispatched while native write is unresolved',
+        () async {
+      platform.hangWrites = true;
+
+      await timedOutWrite();
+      await expectLater(
+        transport.write(
+          _serviceUuid,
+          _charUuid,
+          Uint8List.fromList([2]),
+          timeout: _writeTimeout,
+        ),
+        throwsA(
+          isA<UniversalBleException>().having(
+            (e) => e.code,
+            'code',
+            UniversalBleErrorCode.operationCancelled,
+          ),
+        ),
+      );
+      await pump(100);
+
+      expect(platform.writeCalls, 1);
+    });
+
+    test('faulted queue cancels pending writes without disconnecting', () async {
       platform.hangWrites = true;
 
       final active = expectLater(


### PR DESCRIPTION
## Summary

- Problem: Decent.app was pinned to `universal_ble` 2.2.0 and immediately cleared a timed-out queue, allowing a new command to dispatch while the original native Future remained unresolved.
- Why it matters: Dart `Future.timeout()` does not cancel native BLE work; overlapping GATT operations can cascade into queue failures and false disconnect recovery.
- What changed: bump to 2.2.1, preserve the faulted-generation barrier, recover only after `activeOperations == 0`, or request disconnect after a bounded 2-second grace period while retaining the barrier until a native disconnect event confirms teardown.
- What did NOT change: no operation retries were added; the original timed-out caller still receives `TimeoutException`, and genuine disconnects retain `deviceDisconnected` teardown semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #497
- Related #496
- Related #490
- Related #475
- Related #480
- Related #423
- Fork implementation: https://github.com/tadelv/universal_ble/issues/4
- Fork release PR: https://github.com/tadelv/universal_ble/pull/8

## Root Cause (if bug fix)

- Root cause: `_onOperationTimeout()` immediately called `clearQueue()`. That removed universal_ble 2.2.1's faulted queue generation even though diagnostics still reported an unresolved native operation, so the next command could create a clean generation and dispatch concurrently.
- Missing detection or guardrail: Decent.app did not inspect `QueueDiagnostics.activeOperations` before clearing and still relied on the legacy `Queue Cancelled` string sentinel.
- Contributing context: the old three-consecutive-timeout policy cannot work with a faulted queue because only the first command is dispatched; followers are cancelled instead of timing out.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/universal_ble_transport_recovery_test.dart`, `test/services/telemetry/crashlytics_error_filter_test.dart`
- Scenario the test should lock in: after the first timeout, a newly submitted command receives typed `operationCancelled` and is never dispatched while the original native Future is unresolved; late completion clears safely, while an unresolved operation past grace requests disconnect and remains faulted if no native disconnect event arrives.
- If no new test added, why not: N/A.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A — no user-facing docs affected; BLE rationale and debugging rules updated in `doc/AI_BLE_NOTES.md`

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `Yes`
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`
- If any `Yes`, explain risk and mitigation: queued BLE dispatch and timeout recovery changed. Generation guards prevent late recovery from clearing a replacement connection; tests cover unresolved, late-completing, and forced-disconnect paths.

## User-Visible Changes

Fewer BLE timeout cascades and false recovery sequences: later commands cannot overlap a native operation that outlived its Dart timeout.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean
- [x] `flutter test` — 2495 passed
- [x] `(cd packages/dye2-plugin && npm run build)` — N/A, plugin unchanged

### Manual verification (if applicable)

- OS / platform tested: macOS host, Dart/Flutter VM tests
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: focused BLE recovery, discovery, MTU, and Crashlytics-filter suites; then the full test suite.
- Edge cases checked: post-timeout command is not dispatched; late native completion recovers without disconnect; unresolved native operation requests teardown after grace but remains faulted without confirmation; delayed probes cannot tear down a reconnected generation; native `deviceDisconnected` still emits exactly once; `operationCancelled` is benign telemetry.
- What you did **not** verify: real-device behavior or platform builds.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

The new post-timeout test failed before the transport fix: the second command dispatched and reached its own `TimeoutException`. It now receives `operationCancelled`, and the fake platform records only one native write.

## Compatibility & Migration

- Backward compatible? `Yes` for callers; timeout recovery behavior intentionally becomes stricter.
- Config / env changes needed? `No`
- Database migration needed? `No`
- If any `No` or `Yes`, explain exact steps: dependency resolution moves from fork tag `2.2.0` (`734012d`) to `2.2.1` (`420c771`).

## Risks & Mitigations

- Risk: a native operation may never settle.
  - Mitigation: after a 2-second grace period, recovery requests unqueued disconnect but relies on the native disconnect event to clear; a failed or timed-out request leaves the generation faulted.
- Risk: an old recovery task could clear a replacement connection's queue.
  - Mitigation: recovery is scoped to the transport connection generation and exits after disconnect, dispose, or reconnect.

