### PR TITLE
fix(plugins): install Android folders through SAF

### DIFF
--- a/lib/src/device_discovery_feature/device_discovery_view.dart
+++ b/lib/src/device_discovery_feature/device_discovery_view.dart
@@ -544,9 +544,6 @@ class _DeviceDiscoveryState extends State<DeviceDiscoveryView> {
       );
 
       if (outputFile != null) {
-        final destination = File(outputFile);
-        await destination.writeAsBytes(bytes);
-
         if (mounted) {
           showShadDialog(
             context: context,

--- a/lib/src/feedback_feature/feedback_view.dart
+++ b/lib/src/feedback_feature/feedback_view.dart
@@ -141,12 +141,6 @@ class _FeedbackDialogState extends State<FeedbackDialog> {
       );
 
       if (result != null && mounted) {
-        // On some platforms saveFile with bytes writes the file,
-        // on others it only returns the path and we need to write.
-        final file = File(result);
-        if (!await file.exists() || await file.length() == 0) {
-          await file.writeAsBytes(bytes);
-        }
         setState(
           () => _validationMessage = 'Report saved to: $result',
         );

--- a/lib/src/settings/plugins_settings_view.dart
+++ b/lib/src/settings/plugins_settings_view.dart
@@ -11,12 +11,45 @@ import 'package:reaprime/src/plugins/plugin_manifest.dart';
 
 // LucideIcons is exported by shadcn_ui
 
+const _maxPluginSafDepth = 32;
+const _maxPluginSafEntries = 10000;
+
+class _PluginSafCopyState {
+  final visitedDirectoryUris = <String>{};
+  int entriesSeen = 0;
+}
+
 Future<void> copyPluginDirectoryFromSaf(
   String sourceUri,
   Directory destination,
+) => _copyPluginDirectoryFromSaf(
+  sourceUri,
+  destination,
+  0,
+  _PluginSafCopyState(),
+);
+
+Future<void> _copyPluginDirectoryFromSaf(
+  String sourceUri,
+  Directory destination,
+  int depth,
+  _PluginSafCopyState state,
 ) async {
+  if (depth > _maxPluginSafDepth) {
+    throw const FormatException('Plugin directory exceeds maximum depth');
+  }
+  if (!state.visitedDirectoryUris.add(sourceUri)) {
+    throw FormatException('Plugin contains repeated directory URI: $sourceUri');
+  }
+
+  final entries = await SafUtil().list(sourceUri);
+  state.entriesSeen += entries.length;
+  if (state.entriesSeen > _maxPluginSafEntries) {
+    throw const FormatException('Plugin contains too many entries');
+  }
+
   await destination.create(recursive: true);
-  for (final entry in await SafUtil().list(sourceUri)) {
+  for (final entry in entries) {
     if (entry.name == '.' ||
         entry.name == '..' ||
         entry.name.contains('/') ||
@@ -25,7 +58,12 @@ Future<void> copyPluginDirectoryFromSaf(
     }
     final destinationPath = '${destination.path}/${entry.name}';
     if (entry.isDir) {
-      await copyPluginDirectoryFromSaf(entry.uri, Directory(destinationPath));
+      await _copyPluginDirectoryFromSaf(
+        entry.uri,
+        Directory(destinationPath),
+        depth + 1,
+        state,
+      );
     } else {
       await SafStream().copyToLocalFile(entry.uri, destinationPath);
     }
@@ -425,8 +463,12 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
         _showSnackBar(context, 'Failed to install plugin: $e', isError: true);
       }
     } finally {
-      if (await tempDir?.exists() ?? false) {
-        await tempDir!.delete(recursive: true);
+      try {
+        if (await tempDir?.exists() ?? false) {
+          await tempDir!.delete(recursive: true);
+        }
+      } catch (e, st) {
+        logger.warning('Failed to clean up plugin staging directory', e, st);
       }
     }
   }

--- a/lib/src/settings/plugins_settings_view.dart
+++ b/lib/src/settings/plugins_settings_view.dart
@@ -2,12 +2,35 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:logging/logging.dart';
+import 'package:saf_stream/saf_stream.dart';
+import 'package:saf_util/saf_util.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
 
 // LucideIcons is exported by shadcn_ui
+
+Future<void> copyPluginDirectoryFromSaf(
+  String sourceUri,
+  Directory destination,
+) async {
+  await destination.create(recursive: true);
+  for (final entry in await SafUtil().list(sourceUri)) {
+    if (entry.name == '.' ||
+        entry.name == '..' ||
+        entry.name.contains('/') ||
+        entry.name.contains(r'\')) {
+      throw FormatException('Invalid plugin entry name: ${entry.name}');
+    }
+    final destinationPath = '${destination.path}/${entry.name}';
+    if (entry.isDir) {
+      await copyPluginDirectoryFromSaf(entry.uri, Directory(destinationPath));
+    } else {
+      await SafStream().copyToLocalFile(entry.uri, destinationPath);
+    }
+  }
+}
 
 // Plugins list and settings
 // Shows a list of all available plugins,
@@ -368,42 +391,42 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
 
   Future<void> _installPlugin(BuildContext context) async {
     final logger = Logger('PluginsSettingsView');
+    Directory? tempDir;
     try {
-      final result = await FilePicker.getDirectoryPath(
-        // type: FileType.custom,
-        // allowedExtensions: ['reaplugin'],
-        // allowMultiple: false,
-      );
-
-      if (result == null) {
-        return;
+      tempDir = await Directory.systemTemp.createTemp();
+      if (Platform.isAndroid) {
+        final selected = await SafUtil().pickDirectory(
+          writePermission: false,
+          persistablePermission: false,
+        );
+        if (selected == null) return;
+        if (!selected.name.endsWith('.reaplugin')) {
+          throw Exception('selection is not a .reaplugin');
+        }
+        await copyPluginDirectoryFromSaf(selected.uri, tempDir);
+      } else {
+        final selected = await FilePicker.getDirectoryPath();
+        if (selected == null) return;
+        if (!selected.endsWith('.reaplugin')) {
+          throw Exception('selection is not a .reaplugin');
+        }
+        await _copyDirectoryRecursively(Directory(selected), tempDir);
       }
-      if (result.endsWith(".reaplugin") == false) {
-        throw Exception("selection is not a .reaplugin");
-      }
-      final tempDir = await Directory.systemTemp.createTemp();
 
-      final srcDir = Directory(result);
-
-      // Recursively copy the plugin directory to temp directory
-      await _copyDirectoryRecursively(srcDir, tempDir);
-
-      // Install the plugin from the temp directory
       await widget.pluginLoaderService.addPlugin(tempDir.path);
 
       if (context.mounted) {
         _showSnackBar(context, 'Plugin installed successfully');
       }
-
-      // Refresh the plugin list
       _refreshPlugins();
-
-      // Clean up temp directory
-      await tempDir.delete(recursive: true);
     } catch (e, st) {
       logger.warning('Failed to install plugin', e, st);
       if (context.mounted) {
         _showSnackBar(context, 'Failed to install plugin: $e', isError: true);
+      }
+    } finally {
+      if (await tempDir?.exists() ?? false) {
+        await tempDir!.delete(recursive: true);
       }
     }
   }

--- a/test/plugin_saf_copy_test.dart
+++ b/test/plugin_saf_copy_test.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/settings/plugins_settings_view.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const safUtil = MethodChannel('saf_util');
+  const safStream = MethodChannel('saf_stream');
+  late Directory destination;
+
+  setUp(() async {
+    destination = await Directory.systemTemp.createTemp('plugin_saf_test');
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(safUtil, (call) async {
+          if (call.method != 'list') return null;
+          final uri = (call.arguments as Map)['uri'];
+          return switch (uri) {
+            'content://plugin' => [
+              {
+                'uri': 'content://manifest',
+                'name': 'manifest.json',
+                'isDir': false,
+              },
+              {
+                'uri': 'content://assets',
+                'name': 'assets',
+                'isDir': true,
+              },
+            ],
+            'content://assets' => [
+              {
+                'uri': 'content://asset',
+                'name': 'page.html',
+                'isDir': false,
+              },
+            ],
+            _ => [],
+          };
+        });
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(safStream, (call) async {
+          if (call.method != 'copyToLocalFile') return null;
+          final arguments = call.arguments as Map;
+          final contents = switch (arguments['src']) {
+            'content://manifest' => '{}',
+            'content://asset' => '<html></html>',
+            _ => throw StateError('Unexpected source URI'),
+          };
+          await File(arguments['dest'] as String).writeAsString(contents);
+          return null;
+        });
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(safUtil, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(safStream, null);
+    await destination.delete(recursive: true);
+  });
+
+  test('copies an Android SAF plugin directory recursively', () async {
+    await copyPluginDirectoryFromSaf('content://plugin', destination);
+
+    expect(
+      await File('${destination.path}/manifest.json').readAsString(),
+      '{}',
+    );
+    expect(
+      await File('${destination.path}/assets/page.html').readAsString(),
+      '<html></html>',
+    );
+  });
+}

--- a/test/plugin_saf_copy_test.dart
+++ b/test/plugin_saf_copy_test.dart
@@ -76,4 +76,82 @@ void main() {
       '<html></html>',
     );
   });
+
+  test('rejects a self-referencing SAF directory', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(safUtil, (call) async {
+          if (call.method != 'list') return null;
+          return [
+            {
+              'uri': 'content://cycle',
+              'name': 'cycle',
+              'isDir': true,
+            },
+          ];
+        });
+
+    await expectLater(
+      copyPluginDirectoryFromSaf('content://cycle', destination),
+      throwsA(
+        isA<FormatException>().having(
+          (error) => error.message,
+          'message',
+          contains('repeated directory'),
+        ),
+      ),
+    );
+  });
+
+  test('rejects excessive SAF directory nesting', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(safUtil, (call) async {
+          if (call.method != 'list') return null;
+          final uri = (call.arguments as Map)['uri'] as String;
+          final depth = int.parse(uri.split('/').last);
+          return [
+            {
+              'uri': 'content://depth/${depth + 1}',
+              'name': 'nested',
+              'isDir': true,
+            },
+          ];
+        });
+
+    await expectLater(
+      copyPluginDirectoryFromSaf('content://depth/0', destination),
+      throwsA(
+        isA<FormatException>().having(
+          (error) => error.message,
+          'message',
+          contains('maximum depth'),
+        ),
+      ),
+    );
+  });
+
+  test('rejects excessive SAF directory entries', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(safUtil, (call) async {
+          if (call.method != 'list') return null;
+          return List.generate(
+            10001,
+            (index) => {
+              'uri': 'content://file/$index',
+              'name': '$index.txt',
+              'isDir': false,
+            },
+          );
+        });
+
+    await expectLater(
+      copyPluginDirectoryFromSaf('content://plugin', destination),
+      throwsA(
+        isA<FormatException>().having(
+          (error) => error.message,
+          'message',
+          contains('too many entries'),
+        ),
+      ),
+    );
+  });
 }


### PR DESCRIPTION
## Summary

- Problem: Android plugin installation reported `manifest.json not found` for valid `.reaplugin` directories.
- Why it matters: scoped storage made the selected directory appear empty unless Decent.app had broad all-files access.
- What changed: Android now selects and recursively stages plugin folders through SAF using the existing `saf_util` and `saf_stream` dependencies. Traversal rejects repeated URIs, depth over 32, and trees over 10,000 entries; staging cleanup is best-effort. Log and feedback exports also trust `FilePicker.saveFile(bytes:)` instead of reopening its Android document path with `dart:io`.
- What did NOT change (scope boundary): desktop directory installation, plugin manifests, runtime behavior, and plugin sandboxing are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [x] Plugins / JS runtime
- [x] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs

## Linked Issues

- Closes #
- Related #

## Root Cause (if bug fix)

- Root cause: `file_picker` returns a direct Android filesystem path after `ACTION_OPEN_DOCUMENT_TREE`, but target-SDK-35 scoped storage prevents `dart:io` from enumerating that path. The staging copy therefore copied zero files and `PluginLoaderService` correctly rejected the empty staging directory.
- Missing detection or guardrail: plugin installation had no Android SAF copy path or regression coverage for content-URI directories, and recursive provider results had no cycle or resource bounds. Cleanup errors could also replace the installation outcome. Two export flows treated `saveFile`'s returned Android document path as a normal writable filesystem path even though supplying `bytes` had already completed the save.
- Contributing context (if known): the app already had SAF dependencies for de1app imports, but plugin installation predated that flow.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/plugin_saf_copy_test.dart`
- Scenario the test should lock in: recursively copy a valid Android SAF plugin tree while rejecting self-references, nesting over 32 levels, and trees over 10,000 entries.
- If no new test added, why not: the SAF copy has a new regression test. The export correction only removes redundant writes after `FilePicker.saveFile(bytes:)`; the package owns and tests the platform document write.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A — no docs affected

## Security Impact (required)

- New or changed REST endpoints? (`Yes/No`) No
- New or changed WebSocket topics? (`Yes/No`) No
- New or changed network calls? (`Yes/No`) No
- BLE/USB surface changed? (`Yes/No`) No
- File system access changed? (`Yes/No`) Yes
- Plugin sandbox boundary changed? (`Yes/No`) No
- If any `Yes`, explain risk and mitigation: Android reads only the user-selected SAF tree with a non-persisted, read-only grant, rejects path-like entry names and repeated directory URIs, limits traversal depth and entry count, stages into app-local temporary storage, and attempts cleanup in `finally` without masking the installation result. This avoids requiring broad all-files access for plugin installation.

## User-Visible Changes

Android users can install valid `.reaplugin` folders without granting Decent.app all-files access. Log and feedback exports no longer report a failure after `file_picker` has successfully saved their bytes.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass (2499 tests)
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds

### Manual verification (if applicable)

- OS / platform tested: Android 12 / API 31, Teclast P85Pro
- Simulated devices? (`simulate=1`): No
- Real hardware? (DE1/Bengle/scale): Yes (DE1 connected; plugin installation itself is hardware-independent)
- What you personally verified and how: installed a development DYE2 folder from `/storage/emulated/0/Tablet dropbox/Apps/dye2.reaplugin`; UI reported success, logs recorded `Plugin installed: dye2.reaplugin`, and `/api/v1/plugins` returned the source manifest's 11 endpoints while `MANAGE_EXTERNAL_STORAGE` remained `default`.
- Edge cases checked: nested SAF directory copying, self-referencing directory URIs, excessive nesting, excessive entry counts, and staging cleanup on completion/error.
- What you did **not** verify: desktop installation manually; its existing direct-path branch is unchanged. Log and feedback exports were not manually retested on Android; their redundant post-save writes were removed to match the already-working export flows in Data Management and Scan Flow.

### Evidence

- [x] Test output (failing before + passing after)
- [x] Log snippets
- [ ] Screenshot / recording (UI changes)
- [x] curl / websocat output (API changes)

Before fix:
```text
Exception: manifest.json not found in plugin directory
```

After fix:
```text
[main] 2026-07-28 12:40:14.890207 INFO PluginLoaderService - Plugin installed: dye2.reaplugin
MANAGE_EXTERNAL_STORAGE: default
```

## Compatibility & Migration

- Backward compatible? (`Yes/No`) Yes
- Config / env changes needed? (`Yes/No`) No
- Database migration needed? (`Yes/No`) No
- If any `No` or `Yes`, explain exact steps: No migration or operator action required.

## Risks & Mitigations

- Risk: SAF providers may expose unexpected entry names.
  - Mitigation: reject dot entries and names containing path separators before constructing staging paths.
