### PR TITLE
chore(ci): streamline builds and publish unsigned iOS IPA

### DIFF
--- a/.github/workflows/develop-builds.yml
+++ b/.github/workflows/develop-builds.yml
@@ -57,13 +57,13 @@ jobs:
         run: |
           echo "${{ secrets.ANDROID_KEYSTORE_B64 }}" | base64 --decode > android/app/debug.keystore
 
-      - name: Cache Flutter & Gradle
+      - name: Cache Gradle
         uses: actions/cache@v5
         with:
-          path: |
-            ~/.pub-cache
-            ~/.gradle
-          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.yaml', '**/pubspec.lock') }}
+          path: ~/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/develop-builds.yml
+++ b/.github/workflows/develop-builds.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: '3.44.2'
+          cache: true
+          pub-cache: true
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -105,6 +107,8 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: '3.44.2'
+          cache: true
+          pub-cache: true
 
       - name: Install FlutterFire CLI
         run: dart pub global activate flutterfire_cli
@@ -238,6 +242,8 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: '3.44.2'
+          cache: true
+          pub-cache: true
 
       - name: Install dependencies
         run: flutter pub get
@@ -284,6 +290,8 @@ jobs:
           # path lets flutter-action git-clone the tagged version instead.
           channel: 'master'
           flutter-version: '3.44.2'
+          cache: true
+          pub-cache: true
 
       - name: Run git safe dir
         run: git config --global --add safe.directory /opt/hostedtoolcache/flutter/${{ steps.flutter-action.outputs.CHANNEL }}-${{ steps.flutter-action.outputs.VERSION }}-${{ steps.flutter-action.outputs.ARCHITECTURE }}
@@ -330,6 +338,8 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: '3.44.2'
+          cache: true
+          pub-cache: true
 
       - name: Install FlutterFire CLI
         run: dart pub global activate flutterfire_cli
@@ -465,6 +475,8 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: '3.44.2'
+          cache: true
+          pub-cache: true
 
       - name: Install nuget
         uses: nuget/setup-nuget@v2

--- a/.github/workflows/develop-builds.yml
+++ b/.github/workflows/develop-builds.yml
@@ -348,14 +348,6 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Cache Flutter & CocoaPods
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.pub-cache
-            ios/Pods
-          key: ${{ runner.os }}-ios-flutter-${{ hashFiles('**/pubspec.yaml', '**/Podfile.lock') }}
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
@@ -367,97 +359,33 @@ jobs:
           npm ci
           npm run build
 
-      - name: Import distribution certificate
-        env:
-          CERTIFICATE_P12: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_P12 }}
-          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}
-        run: |
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
-
-          # Create temporary keychain
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # Decode and import certificate
-          echo "$CERTIFICATE_P12" | base64 --decode > certificate.p12
-          security import certificate.p12 \
-            -k "$KEYCHAIN_PATH" \
-            -P "$CERTIFICATE_PASSWORD" \
-            -T /usr/bin/codesign
-
-          # Allow codesign to access keychain
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # Make this keychain the default
-          security list-keychain -d user -s "$KEYCHAIN_PATH"
-
-          # Clean up
-          rm certificate.p12
-
-      - name: Install provisioning profile
-        env:
-          PROVISIONING_PROFILE: ${{ secrets.IOS_PROVISIONING_PROFILE_B64 }}
-        run: |
-          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
-          echo "$PROVISIONING_PROFILE" | base64 --decode > "$PP_PATH"
-
-          # Extract UUID and install with correct filename
-          PP_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< "$(security cms -D -i "$PP_PATH")")
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp "$PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/${PP_UUID}.mobileprovision
-
-      - name: Switch to manual signing for CI
-        env:
-          PROVISIONING_PROFILE_NAME: ${{ secrets.IOS_PROVISIONING_PROFILE_NAME }}
-        run: |
-          PBXPROJ="ios/Runner.xcodeproj/project.pbxproj"
-          sed -i '' 's/CODE_SIGN_STYLE = Automatic/CODE_SIGN_STYLE = Manual/g' "$PBXPROJ"
-          sed -i '' 's/PROVISIONING_PROFILE_SPECIFIER = ""/PROVISIONING_PROFILE_SPECIFIER = "'"$PROVISIONING_PROFILE_NAME"'"/g' "$PBXPROJ"
-          sed -i '' 's/CODE_SIGN_IDENTITY = "Apple Development"/CODE_SIGN_IDENTITY = "Apple Distribution"/g' "$PBXPROJ"
-
-      - name: Create ExportOptions.plist
-        env:
-          TEAM_ID: ${{ secrets.TEAM_ID }}
-          PROVISIONING_PROFILE_NAME: ${{ secrets.IOS_PROVISIONING_PROFILE_NAME }}
-        run: |
-          cat > ExportOptions.plist <<EOF
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-            <key>method</key>
-            <string>app-store</string>
-            <key>teamID</key>
-            <string>${TEAM_ID}</string>
-            <key>signingStyle</key>
-            <string>manual</string>
-            <key>signingCertificate</key>
-            <string>Apple Distribution</string>
-            <key>provisioningProfiles</key>
-            <dict>
-              <key>net.tadel.reaprime</key>
-              <string>${PROVISIONING_PROFILE_NAME}</string>
-            </dict>
-            <key>uploadSymbols</key>
-            <true/>
-          </dict>
-          </plist>
-          EOF
-
       - name: Build IPA
-        run: ./flutter_with_commit.sh build ipa --release --dart-define=APP_STORE=true --export-options-plist=ExportOptions.plist
+        run: ./flutter_with_commit.sh build ipa --release --dart-define=APP_STORE=true --no-codesign
         env:
           FEEDBACK_TOKEN: ${{ secrets.FEEDBACK_TOKEN }}
 
-      - name: Upload iOS IPA
+      - name: Package unsigned IPA
+        run: |
+          APP_PATH="build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app"
+          OUTPUT_PATH="$GITHUB_WORKSPACE/decent-ios-unsigned.ipa"
+          PACKAGE_DIR="$RUNNER_TEMP/unsigned-ipa"
+
+          test -d "$APP_PATH"
+
+          rm -rf "$PACKAGE_DIR"
+          mkdir -p "$PACKAGE_DIR/Payload"
+          cp -R "$APP_PATH" "$PACKAGE_DIR/Payload/Runner.app"
+
+          cd "$PACKAGE_DIR"
+          zip -qry "$OUTPUT_PATH" Payload
+
+      - name: Upload unsigned IPA
         uses: actions/upload-artifact@v7
         with:
-          name: ios-ipa
-          path: build/ios/ipa/*.ipa
+          name: ios-ipa-unsigned
+          path: decent-ios-unsigned.ipa
+          if-no-files-found: error
 
-      # TestFlight upload is only done in release builds (release.yml)
 
   build-windows:
     if: github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'windows'

--- a/.github/workflows/develop-builds.yml
+++ b/.github/workflows/develop-builds.yml
@@ -284,6 +284,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-dev
 
       - name: Set up Flutter
+        id: flutter-action
         uses: subosito/flutter-action@v2
         with:
           # Flutter publishes no prebuilt arm64 Linux SDK; the master channel

--- a/.github/workflows/develop-builds.yml
+++ b/.github/workflows/develop-builds.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set build identifier
+        id: build-id
+        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -84,11 +88,15 @@ jobs:
         env:
           FEEDBACK_TOKEN: ${{ secrets.FEEDBACK_TOKEN }}
 
+      - name: Package Android APK
+        run: cp build/app/outputs/flutter-apk/app-release.apk decent-android-develop-${{ steps.build-id.outputs.short_sha }}.apk
+
       - name: Upload Android APK
         uses: actions/upload-artifact@v7
         with:
-          name: android-apk
-          path: build/app/outputs/flutter-apk/app-release.apk
+          name: decent-android-develop
+          path: decent-android-develop-${{ steps.build-id.outputs.short_sha }}.apk
+          if-no-files-found: error
 
   build-macos:
     if: github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'macos'
@@ -98,6 +106,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: Set build identifier
+        id: build-id
+        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Install automake and libtool
         run: brew install automake libtool
@@ -217,13 +229,14 @@ jobs:
       - name: Create development ZIP
         run: |
           cd build/macos/Build/Products/Release
-          ditto -c -k --keepParent Decent.app ../../../../../decent-macos-develop.zip
+          ditto -c -k --keepParent Decent.app ../../../../../decent-macos-develop-${{ steps.build-id.outputs.short_sha }}.zip
 
       - name: Upload macOS app
         uses: actions/upload-artifact@v7
         with:
-          name: macos-app
-          path: decent-macos-develop.zip
+          name: decent-macos-develop
+          path: decent-macos-develop-${{ steps.build-id.outputs.short_sha }}.zip
+          if-no-files-found: error
 
   build-linux:
     if: github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'linux'
@@ -233,6 +246,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: Set build identifier
+        id: build-id
+        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Install Linux dependencies
         run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-dev
@@ -264,11 +281,17 @@ jobs:
         env:
           FEEDBACK_TOKEN: ${{ secrets.FEEDBACK_TOKEN }}
 
+      - name: Create Linux archive
+        run: |
+          cd build/linux/x64/release
+          tar -czf ../../../../decent-linux-x64-develop-${{ steps.build-id.outputs.short_sha }}.tar.gz bundle
+
       - name: Upload Linux app
         uses: actions/upload-artifact@v7
         with:
-          name: linux-app
-          path: build/linux/x64/release/bundle
+          name: decent-linux-x64-develop
+          path: decent-linux-x64-develop-${{ steps.build-id.outputs.short_sha }}.tar.gz
+          if-no-files-found: error
 
   build-raspberrypi:
     name: Build for Raspberry Pi (ARM64 / Pi 4+)
@@ -282,6 +305,10 @@ jobs:
 
       - name: Install Linux dependencies
         run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-dev
+
+      - name: Set build identifier
+        id: build-id
+        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Flutter
         id: flutter-action
@@ -316,11 +343,17 @@ jobs:
         env:
           FEEDBACK_TOKEN: ${{ secrets.FEEDBACK_TOKEN }}
 
+      - name: Create Raspberry Pi archive
+        run: |
+          cd build/linux/arm64/release
+          tar -czf ../../../../decent-linux-arm64-develop-${{ steps.build-id.outputs.short_sha }}.tar.gz bundle
+
       - name: Upload Raspberry Pi build (ARM64)
         uses: actions/upload-artifact@v7
         with:
-          name: raspberrypi-linux-arm64-app
-          path: build/linux/arm64/release/bundle
+          name: decent-linux-arm64-develop
+          path: decent-linux-arm64-develop-${{ steps.build-id.outputs.short_sha }}.tar.gz
+          if-no-files-found: error
 
   build-ios:
     if: github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'ios'
@@ -330,6 +363,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: Set build identifier
+        id: build-id
+        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Select latest Xcode
         run: xcodes select 26.3
@@ -367,7 +404,7 @@ jobs:
       - name: Package unsigned IPA
         run: |
           APP_PATH="build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app"
-          OUTPUT_PATH="$GITHUB_WORKSPACE/decent-ios-unsigned.ipa"
+          OUTPUT_PATH="$GITHUB_WORKSPACE/decent-ios-unsigned-develop-${{ steps.build-id.outputs.short_sha }}.ipa"
           PACKAGE_DIR="$RUNNER_TEMP/unsigned-ipa"
 
           test -d "$APP_PATH"
@@ -382,8 +419,8 @@ jobs:
       - name: Upload unsigned IPA
         uses: actions/upload-artifact@v7
         with:
-          name: ios-ipa-unsigned
-          path: decent-ios-unsigned.ipa
+          name: decent-ios-unsigned-develop
+          path: decent-ios-unsigned-develop-${{ steps.build-id.outputs.short_sha }}.ipa
           if-no-files-found: error
 
 
@@ -398,6 +435,11 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: Set build identifier
+        id: build-id
+        shell: bash
+        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -432,11 +474,16 @@ jobs:
         env:
           FEEDBACK_TOKEN: ${{ secrets.FEEDBACK_TOKEN }}
 
+      - name: Create Windows archive
+        shell: pwsh
+        run: Compress-Archive -Path build/windows/x64/runner/Release/* -DestinationPath decent-windows-x64-develop-${{ steps.build-id.outputs.short_sha }}.zip
+
       - name: Upload Windows app
         uses: actions/upload-artifact@v7
         with:
-          name: windows-app
-          path: build/windows/x64/runner/Release
+          name: decent-windows-x64-develop
+          path: decent-windows-x64-develop-${{ steps.build-id.outputs.short_sha }}.zip
+          if-no-files-found: error
 
 
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           channel: stable
           cache: true
+          pub-cache: true
 
       - name: Dart format check
         run: dart format --output=none --set-exit-if-changed lib test
@@ -43,6 +44,7 @@ jobs:
         with:
           channel: stable
           cache: true
+          pub-cache: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -112,6 +114,7 @@ jobs:
         with:
           channel: stable
           cache: true
+          pub-cache: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,8 @@ jobs:
         run: |
           # Extract version from tag (v1.2.3 -> 1.2.3)
           VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Rename APK with version
         run: |
@@ -213,7 +213,7 @@ jobs:
         id: version
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create release ZIP
         run: |
@@ -267,7 +267,7 @@ jobs:
         id: version
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create Linux archive
         run: |
@@ -329,7 +329,7 @@ jobs:
         id: version
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create Raspberry Pi archive
         run: |
@@ -391,7 +391,7 @@ jobs:
         shell: bash
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create Windows archive
         shell: pwsh
@@ -446,6 +446,37 @@ jobs:
           npm ci
           npm run build
 
+      - name: Build IPA
+        run: ./flutter_with_commit.sh build ipa --release --dart-define=APP_STORE=true --no-codesign
+        env:
+          FEEDBACK_TOKEN: ${{ secrets.FEEDBACK_TOKEN }}
+
+      - name: Get version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Package unsigned IPA
+        run: |
+          APP_PATH="build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app"
+          OUTPUT_PATH="$GITHUB_WORKSPACE/decent-ios-unsigned-${{ steps.version.outputs.version }}.ipa"
+          PACKAGE_DIR="$RUNNER_TEMP/unsigned-ipa"
+
+          test -d "$APP_PATH"
+
+          rm -rf "$PACKAGE_DIR"
+          mkdir -p "$PACKAGE_DIR/Payload"
+          cp -R "$APP_PATH" "$PACKAGE_DIR/Payload/Runner.app"
+
+          cd "$PACKAGE_DIR"
+          zip -qry "$OUTPUT_PATH" Payload
+
+      - name: Upload unsigned IPA
+        uses: actions/upload-artifact@v7
+        with:
+          name: ios-ipa-unsigned
+          path: decent-ios-unsigned-${{ steps.version.outputs.version }}.ipa
+          if-no-files-found: error
+
       - name: Import distribution certificate
         env:
           CERTIFICATE_P12: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_P12 }}
@@ -485,16 +516,7 @@ jobs:
           # Extract UUID and install with correct filename
           PP_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< "$(security cms -D -i "$PP_PATH")")
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp "$PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/${PP_UUID}.mobileprovision
-
-      - name: Switch to manual signing for CI
-        env:
-          PROVISIONING_PROFILE_NAME: ${{ secrets.IOS_PROVISIONING_PROFILE_NAME }}
-        run: |
-          PBXPROJ="ios/Runner.xcodeproj/project.pbxproj"
-          sed -i '' 's/CODE_SIGN_STYLE = Automatic/CODE_SIGN_STYLE = Manual/g' "$PBXPROJ"
-          sed -i '' 's/PROVISIONING_PROFILE_SPECIFIER = ""/PROVISIONING_PROFILE_SPECIFIER = "'"$PROVISIONING_PROFILE_NAME"'"/g' "$PBXPROJ"
-          sed -i '' 's/CODE_SIGN_IDENTITY = "Apple Development"/CODE_SIGN_IDENTITY = "Apple Distribution"/g' "$PBXPROJ"
+          cp "$PP_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles/${PP_UUID}.mobileprovision"
 
       - name: Create ExportOptions.plist
         env:
@@ -507,7 +529,7 @@ jobs:
           <plist version="1.0">
           <dict>
             <key>method</key>
-            <string>app-store</string>
+            <string>app-store-connect</string>
             <key>teamID</key>
             <string>${TEAM_ID}</string>
             <key>signingStyle</key>
@@ -525,10 +547,13 @@ jobs:
           </plist>
           EOF
 
-      - name: Build IPA
-        run: ./flutter_with_commit.sh build ipa --release --dart-define=APP_STORE=true --export-options-plist=ExportOptions.plist
-        env:
-          FEEDBACK_TOKEN: ${{ secrets.FEEDBACK_TOKEN }}
+      - name: Export signed IPA
+        run: |
+          rm -rf build/ios/ipa
+          xcodebuild -exportArchive \
+            -archivePath build/ios/archive/Runner.xcarchive \
+            -exportPath build/ios/ipa \
+            -exportOptionsPlist ExportOptions.plist
 
       - name: Upload dSYMs to Firebase Crashlytics
         run: |
@@ -576,7 +601,7 @@ jobs:
         run: |
           # Write the API key to the expected location
           mkdir -p ~/.private_keys
-          echo "$API_KEY_P8" | base64 --decode > ~/.private_keys/AuthKey_${API_KEY_ID}.p8
+          echo "$API_KEY_P8" | base64 --decode > "$HOME/.private_keys/AuthKey_${API_KEY_ID}.p8"
 
           # Find the built IPA
           IPA_PATH=$(find build/ios/ipa -name "*.ipa" | head -1)
@@ -601,11 +626,11 @@ jobs:
             --apiIssuer "$API_ISSUER_ID"
 
           # Clean up API key
-          rm -f ~/.private_keys/AuthKey_${API_KEY_ID}.p8
+          rm -f "$HOME/.private_keys/AuthKey_${API_KEY_ID}.p8"
 
   create-release:
     name: Create GitHub Release
-    needs: [build-android, build-macos, build-linux, build-raspberrypi, build-windows]
+    needs: [build-android, build-macos, build-linux, build-raspberrypi, build-windows, build-ios]
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -617,8 +642,8 @@ jobs:
         id: version
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Download all artifacts
         uses: actions/download-artifact@v8
@@ -637,6 +662,7 @@ jobs:
             release-artifacts/linux-app/*
             release-artifacts/raspberrypi-linux-arm64-app/*
             release-artifacts/windows-app/*
+            release-artifacts/ios-ipa-unsigned/*
           tag_name: ${{ steps.version.outputs.tag }}
           name: Decent ${{ steps.version.outputs.version }}
           draft: false
@@ -652,6 +678,7 @@ jobs:
             - **Linux x64**: `decent-linux-x64-${{ steps.version.outputs.version }}.tar.gz`
             - **Linux ARM64 (Raspberry Pi)**: `decent-linux-arm64-${{ steps.version.outputs.version }}.tar.gz`
             - **Windows x64**: `decent-windows-x64-${{ steps.version.outputs.version }}.zip`
+            - **iOS (unsigned)**: `decent-ios-unsigned-${{ steps.version.outputs.version }}.ipa`
             
             ### Installation
             
@@ -665,7 +692,7 @@ jobs:
             
             > **Windows users**: Decent requires the [Microsoft Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-supported-redistributable-version) to be installed. If the app doesn't start, please download and install the latest Visual C++ Redistributable from Microsoft.
 
-            **iOS**: Available via TestFlight. Check the project's TestFlight page for access.
+            **iOS**: Use TestFlight for the signed build, or download the unsigned IPA above for self-signing and sideloading. The unsigned IPA cannot be installed directly.
             
             ### What's Changed
             <!-- GitHub will auto-generate release notes here -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,6 +293,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libsecret-1-dev
 
       - name: Set up Flutter
+        id: flutter-action
         uses: subosito/flutter-action@v2
         with:
           # Flutter publishes no prebuilt arm64 Linux SDK; the master channel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,13 @@ jobs:
         run: |
           echo "${{ secrets.ANDROID_KEYSTORE_B64 }}" | base64 --decode > android/app/debug.keystore
 
-      - name: Cache Flutter & Gradle
+      - name: Cache Gradle
         uses: actions/cache@v5
         with:
-          path: |
-            ~/.pub-cache
-            ~/.gradle
-          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.yaml') }}
+          path: ~/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,14 +435,6 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Cache Flutter & CocoaPods
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.pub-cache
-            ios/Pods
-          key: ${{ runner.os }}-ios-flutter-${{ hashFiles('**/pubspec.yaml', '**/Podfile.lock') }}
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: '3.44.2'
+          cache: true
+          pub-cache: true
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -98,6 +100,8 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: '3.44.2'
+          cache: true
+          pub-cache: true
 
       - name: Install dependencies
         run: |
@@ -237,6 +241,8 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: '3.44.2'
+          cache: true
+          pub-cache: true
 
       - name: Install dependencies
         run: flutter pub get
@@ -293,6 +299,8 @@ jobs:
           # path lets flutter-action git-clone the tagged version instead.
           channel: 'master'
           flutter-version: '3.44.2'
+          cache: true
+          pub-cache: true
 
       - name: Run git safe dir
         run: git config --global --add safe.directory /opt/hostedtoolcache/flutter/${{ steps.flutter-action.outputs.CHANNEL }}-${{ steps.flutter-action.outputs.VERSION }}-${{ steps.flutter-action.outputs.ARCHITECTURE }}
@@ -349,6 +357,8 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: '3.44.2'
+          cache: true
+          pub-cache: true
 
       - name: Install nuget
         uses: nuget/setup-nuget@v2
@@ -409,6 +419,8 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: '3.44.2'
+          cache: true
+          pub-cache: true
 
       # Swift Package Manager (Flutter >=3.44 default) is enabled: the iOS
       # project commits the SPM integration and Package.resolved. Firebase

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -78,6 +78,21 @@ After the release is created, you can edit it to:
 - **`.github/workflows/release.yml`**: Builds and publishes releases on tag push
 - **`.github/workflows/develop-builds.yml`**: Development builds on main branch
 
+### Development Artifacts
+
+Development builds use stable GitHub Actions artifact names, while the packaged filename includes the seven-character commit SHA:
+
+| Platform | Actions artifact | Downloaded file |
+| --- | --- | --- |
+| Android | `decent-android-develop` | `decent-android-develop-<short-sha>.apk` |
+| macOS | `decent-macos-develop` | `decent-macos-develop-<short-sha>.zip` |
+| Linux x64 | `decent-linux-x64-develop` | `decent-linux-x64-develop-<short-sha>.tar.gz` |
+| Linux ARM64 | `decent-linux-arm64-develop` | `decent-linux-arm64-develop-<short-sha>.tar.gz` |
+| Windows x64 | `decent-windows-x64-develop` | `decent-windows-x64-develop-<short-sha>.zip` |
+| iOS unsigned | `decent-ios-unsigned-develop` | `decent-ios-unsigned-develop-<short-sha>.ipa` |
+
+Tagged release artifact naming remains unchanged. Development workflow artifacts are retained build outputs, not GitHub Releases or prereleases by themselves.
+
 ## Testing Before Release
 
 ```bash

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -5,9 +5,9 @@ This document describes how to create releases for Decent.app.
 ## Creating a Release
 
 Decent.app uses git tags to trigger automatic releases. When you push a tag, GitHub Actions will:
-1. Build the Android APK
-2. Create a GitHub release
-3. Attach the APK to the release
+1. Build all supported platforms
+2. Export the iOS archive for TestFlight
+3. Create a GitHub release with the desktop, Android, Raspberry Pi, and unsigned iOS artifacts
 4. Auto-generate release notes
 
 ### Step 1: Tag Your Release
@@ -35,8 +35,8 @@ git push origin v1.0.0-alpha.1
 ### Step 3: Verify the Release
 
 1. Go to https://github.com/tadelv/reaprime/releases
-2. Your new release should appear with the APK attached
-3. Download and test the APK
+2. Your new release should appear with all platform artifacts attached
+3. Download and test the relevant artifacts
 
 ## Version Numbering
 
@@ -123,8 +123,11 @@ Then upload via Xcode Organizer (Window → Organizer → Distribute App → Tes
 ### CI/CD
 
 The `build-ios` job in `.github/workflows/release.yml`:
-1. Builds the IPA with manual signing (Apple Distribution certificate + App Store provisioning profile)
-2. Uploads to TestFlight via App Store Connect API
+1. Builds one unsigned Xcode archive and packages an unsigned IPA for the GitHub Release
+2. Exports that archive with the Apple Distribution certificate and App Store provisioning profile
+3. Uploads the signed IPA to TestFlight via the App Store Connect API
+
+The unsigned IPA is intended for self-signing and sideloading; it cannot be installed directly.
 
 Required secrets: `APPLE_DISTRIBUTION_CERTIFICATE_P12`, `APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD`, `IOS_PROVISIONING_PROFILE_B64`, `IOS_PROVISIONING_PROFILE_NAME`, `APP_STORE_CONNECT_API_KEY_ID`, `APP_STORE_CONNECT_API_ISSUER_ID`, `APP_STORE_CONNECT_API_KEY_P8`, `TEAM_ID`.
 


### PR DESCRIPTION
## Summary

- Problem: CI repeatedly downloaded Flutter and the release workflow built iOS separately for unsigned distribution and TestFlight signing.
- Why it matters: redundant setup/build work slows CI, GitHub releases lacked an iOS artifact for self-signing, and development artifacts had inconsistent names and archive layouts.
- What changed: streamlined Flutter/Gradle caching; packages development builds under stable Actions artifact names with SHA-bearing filenames; packages an unsigned IPA from one archive; exports that same archive for TestFlight; and documents both artifact contracts.
- What did NOT change (scope boundary): application runtime behavior, APIs, signing credentials, and App Store Connect authentication.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [x] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes: N/A
- Related: N/A

## Root Cause (if bug fix)

N/A

## Regression Test Plan (if bug fix or refactor)

N/A

## Documentation Obligations (required)

- [x] API spec unchanged: no REST/WebSocket changes
- [x] API docs unchanged: no endpoint changes
- [x] Plugin docs unchanged: no plugin event/API changes
- [x] Skin docs unchanged: no skin behavior changes
- [x] Profile docs unchanged: no profile changes
- [x] Device docs unchanged: no device-flow changes
- [x] Release documentation updated: `doc/RELEASE.md`

## Security Impact (required)

- New or changed REST endpoints? No
- New or changed WebSocket topics? No
- New or changed network calls? No
- BLE/USB surface changed? No
- File system access changed? No application file-system access changed
- Plugin sandbox boundary changed? No
- If any `Yes`, explain risk and mitigation: N/A

## User-Visible Changes

GitHub releases now include `decent-ios-unsigned-<version>.ipa` for users who want to self-sign and sideload it. Development workflow artifacts use stable `decent-<platform>-develop` Actions names and downloadable filenames containing the seven-character commit SHA. Signed iOS builds remain available through TestFlight.

## Verification

### Local gates (run before pushing)

- [x] `dart format --output=none --set-exit-if-changed lib test` — clean
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 2,511 tests passed
- [ ] `(cd packages/dye2-plugin && npm run build)` — N/A, plugin untouched
- [x] `actionlint .github/workflows/*.yml` — clean

### Manual verification (if applicable)

- OS / platform tested: macOS, iOS archive/package path
- Simulated devices? (`simulate=1`): No
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: built the unsigned `.xcarchive`; packaged and unzipped the unsigned IPA; confirmed ZIP integrity, absence of an embedded provisioning profile, and expected `codesign` rejection; confirmed the source archive remained unsigned after export testing; synthetically exercised Android, macOS, Linux x64/ARM64, and iOS development packaging and inspected every producer/upload path.
- Edge cases checked: all development uploads fail on missing files; Linux archives retain `bundle/`; macOS retains `Decent.app/`; iOS retains `Payload/Runner.app/`; Windows packages `Release/*` without an extra `Release/` directory.
- What you did **not** verify: a complete signed export, TestFlight upload, or Windows packaging on a Windows runner. Local `xcodebuild -exportArchive` reached signing but the local private key was unavailable non-interactively (`errSecInternalComponent`); CI imports and unlocks its signing key explicitly.

### Evidence

- [x] Test output: `All tests passed!` (2,511 tests)
- [x] Log snippets: `actionlint` clean; `flutter analyze` reported no issues; local archive/IPA integrity and synthetic development packaging checks passed
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? Yes
- Config / env changes needed? No
- Database migration needed? No
- Existing Apple signing and App Store Connect secrets continue to be used.

## Risks & Mitigations

- Risk: the signed archive export depends on CI-only Apple credentials and cannot be completed locally.
  - Mitigation: the workflow imports the distribution identity into an unlocked temporary keychain, installs the provisioning profile, validates the signed IPA with App Store Connect, and gates release publication on the iOS job.
- Risk: Windows archive layout was not executed locally because PowerShell was unavailable.
  - Mitigation: development builds use the same `Compress-Archive -Path Release/*` layout as the tagged release workflow; verify the archive in the next Windows CI run.

