### PR TITLE
feat(settings): add stable and beta update channels

### DIFF
--- a/doc/plans/archive/update-channel-picker/design.md
+++ b/doc/plans/archive/update-channel-picker/design.md
@@ -1,0 +1,26 @@
+# Issue #82 — Update channel picker
+
+## Decisions
+
+- Expose Stable and Beta channels only.
+- Stable accepts final GitHub releases.
+- Beta accepts final releases and every GitHub prerelease.
+- Default to Stable and persist the choice in SharedPreferences.
+- Re-check immediately after a channel change.
+- Hide the picker on iOS.
+- Defer Development/Nightly until nightly releases exist.
+
+## Acceptance criteria
+
+- Stable users are offered only newer final releases.
+- Beta users are offered the highest newer final or prerelease version.
+- Semantic version precedence detects prerelease-to-prerelease and prerelease-to-final upgrades.
+- The selected channel survives settings reloads and drives manual and periodic checks.
+- Settings > Updates shows the selected channel and allows changing it outside iOS.
+- Changing channel triggers an update check.
+
+## Verification
+
+1. Add failing tests at the `AndroidUpdater.checkForUpdate`, `UpdateCheckService.checkForUpdate`, and `SettingsController` interfaces.
+2. Implement the smallest persistence, filtering, comparison, and picker changes.
+3. Run `dart format lib test`, focused tests, `flutter analyze`, and full `flutter test`.

--- a/lib/src/services/android_updater.dart
+++ b/lib/src/services/android_updater.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:reaprime/src/services/apk_installer.dart';
 
 /// Represents an available update from GitHub releases
@@ -44,36 +45,7 @@ class UpdateInfo {
 }
 
 /// Update channel configuration
-enum UpdateChannel {
-  stable,
-  beta,
-  development;
-
-  /// Returns true if this channel should include prereleases
-  bool get includePrereleases {
-    switch (this) {
-      case UpdateChannel.stable:
-        return false;
-      case UpdateChannel.beta:
-      case UpdateChannel.development:
-        return true;
-    }
-  }
-
-  /// Returns true if a release matches this channel based on tag naming
-  bool matchesRelease(String tagName, bool isPrerelease) {
-    switch (this) {
-      case UpdateChannel.stable:
-        return !isPrerelease &&
-            !tagName.contains('beta') &&
-            !tagName.contains('dev');
-      case UpdateChannel.beta:
-        return isPrerelease || tagName.contains('beta');
-      case UpdateChannel.development:
-        return true; // Development channel accepts all releases
-    }
-  }
-}
+enum UpdateChannel { stable, beta }
 
 /// Service for checking and installing app updates from GitHub releases
 class AndroidUpdater {
@@ -100,7 +72,7 @@ class AndroidUpdater {
   /// Check if an update is available for the given current version
   ///
   /// [currentVersion] - The current app version (e.g., "1.2.3")
-  /// [channel] - The update channel to check (stable, beta, development)
+  /// [channel] - The update channel to check (stable or beta)
   ///
   /// Returns [UpdateInfo] if an update is available, null otherwise
   Future<UpdateInfo?> checkForUpdate(
@@ -126,21 +98,30 @@ class AndroidUpdater {
         return null;
       }
 
-      // Filter releases by channel
-      final matchingReleases = releases.where((release) {
-        final tagName = release['tag_name'] as String;
-        final isPrerelease = release['prerelease'] as bool;
-        return channel.matchesRelease(tagName, isPrerelease);
-      }).toList();
+      final matchingReleases =
+          releases
+              .where(
+                (release) =>
+                    channel == UpdateChannel.beta ||
+                    !((release as Map<String, dynamic>)['prerelease'] as bool),
+              )
+              .map(
+                (release) => UpdateInfo.fromGitHubRelease(
+                  release as Map<String, dynamic>,
+                ),
+              )
+              .toList()
+            ..sort(
+              (a, b) =>
+                  Version.parse(b.version).compareTo(Version.parse(a.version)),
+            );
 
       if (matchingReleases.isEmpty) {
         _log.info('No releases found for $channel channel');
         return null;
       }
 
-      // Get the latest matching release
-      final latestRelease = matchingReleases.first;
-      final updateInfo = UpdateInfo.fromGitHubRelease(latestRelease);
+      final updateInfo = matchingReleases.first;
 
       // Compare versions
       if (_isNewerVersion(updateInfo.version, currentVersion)) {
@@ -239,45 +220,16 @@ class AndroidUpdater {
     }
   }
 
-  /// Compare two semantic version strings
-  ///
-  /// Returns true if [newVersion] is newer than [currentVersion]
   bool _isNewerVersion(String newVersion, String currentVersion) {
-    // Handle dev versions
-    if (currentVersion == '0.0.0-dev') {
-      return true;
-    }
-
     try {
-      final newParts = _parseVersion(newVersion);
-      final currentParts = _parseVersion(currentVersion);
-
-      for (int i = 0; i < 3; i++) {
-        if (newParts[i] > currentParts[i]) {
-          return true;
-        } else if (newParts[i] < currentParts[i]) {
-          return false;
-        }
-      }
-
-      return false; // Versions are equal
+      return Version.parse(
+            newVersion,
+          ).compareTo(Version.parse(currentVersion)) >
+          0;
     } catch (e) {
       _log.warning('Error comparing versions: $e');
       return false;
     }
-  }
-
-  /// Parse a semantic version string into [major, minor, patch]
-  List<int> _parseVersion(String version) {
-    // Remove any suffix like -beta, -dev
-    final cleanVersion = version.split('-').first;
-    final parts = cleanVersion.split('.');
-
-    if (parts.length != 3) {
-      throw FormatException('Invalid version format: $version');
-    }
-
-    return parts.map((p) => int.parse(p)).toList();
   }
 
   void dispose() {

--- a/lib/src/services/android_updater.dart
+++ b/lib/src/services/android_updater.dart
@@ -100,16 +100,8 @@ class AndroidUpdater {
 
       final matchingReleases =
           releases
-              .where(
-                (release) =>
-                    channel == UpdateChannel.beta ||
-                    !((release as Map<String, dynamic>)['prerelease'] as bool),
-              )
-              .map(
-                (release) => UpdateInfo.fromGitHubRelease(
-                  release as Map<String, dynamic>,
-                ),
-              )
+              .map((release) => _parseRelease(release, channel))
+              .whereType<UpdateInfo>()
               .toList()
             ..sort(
               (a, b) =>
@@ -217,6 +209,20 @@ class AndroidUpdater {
     } catch (e, stackTrace) {
       _log.severe('Error installing update', e, stackTrace);
       rethrow;
+    }
+  }
+
+  UpdateInfo? _parseRelease(Object? release, UpdateChannel channel) {
+    try {
+      final json = release as Map<String, dynamic>;
+      final isPrerelease = json['prerelease'] as bool;
+      if (channel == UpdateChannel.stable && isPrerelease) return null;
+      final update = UpdateInfo.fromGitHubRelease(json);
+      Version.parse(update.version);
+      return update;
+    } catch (e) {
+      _log.warning('Skipping unsupported GitHub release: $e');
+      return null;
     }
   }
 

--- a/lib/src/services/update_check_service.dart
+++ b/lib/src/services/update_check_service.dart
@@ -199,7 +199,7 @@ class UpdateCheckService {
 
       final updateInfo = await _updater.checkForUpdate(
         BuildInfo.version,
-        channel: UpdateChannel.stable,
+        channel: await _settingsService.updateChannel(),
       );
 
       await _settingsService.setLastUpdateCheckTime(DateTime.now());

--- a/lib/src/settings/settings_controller.dart
+++ b/lib/src/settings/settings_controller.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
+import 'package:reaprime/src/services/android_updater.dart';
 import 'package:reaprime/src/settings/charging_mode.dart';
 import 'package:reaprime/src/settings/feature_flags.dart';
 import 'package:reaprime/src/settings/gateway_mode.dart';
@@ -53,6 +54,8 @@ class SettingsController with ChangeNotifier {
 
   bool _automaticUpdateCheck = true;
 
+  UpdateChannel _updateChannel = UpdateChannel.stable;
+
   bool _telemetryConsent = false;
 
   bool _telemetryPromptShown = false;
@@ -95,6 +98,7 @@ class SettingsController with ChangeNotifier {
   String? get preferredScaleId => _preferredScaleId;
   String get defaultSkinId => _defaultSkinId;
   bool get automaticUpdateCheck => _automaticUpdateCheck;
+  UpdateChannel get updateChannel => _updateChannel;
   bool get telemetryConsent => _telemetryConsent;
   bool get telemetryPromptShown => _telemetryPromptShown;
   bool get telemetryConsentDialogShown => _telemetryConsentDialogShown;
@@ -137,6 +141,7 @@ class SettingsController with ChangeNotifier {
     _preferredScaleId = await _settingsService.preferredScaleId();
     _defaultSkinId = await _settingsService.defaultSkinId();
     _automaticUpdateCheck = await _settingsService.automaticUpdateCheck();
+    _updateChannel = await _settingsService.updateChannel();
     _telemetryConsent = await _settingsService.telemetryConsent();
     _telemetryPromptShown = await _settingsService.telemetryPromptShown();
     _telemetryConsentDialogShown = await _settingsService
@@ -358,6 +363,13 @@ class SettingsController with ChangeNotifier {
     }
     _automaticUpdateCheck = value;
     await _settingsService.setAutomaticUpdateCheck(value);
+    notifyListeners();
+  }
+
+  Future<void> setUpdateChannel(UpdateChannel channel) async {
+    if (channel == _updateChannel) return;
+    _updateChannel = channel;
+    await _settingsService.setUpdateChannel(channel);
     notifyListeners();
   }
 

--- a/lib/src/settings/settings_service.dart
+++ b/lib/src/settings/settings_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_js/quickjs/ffi.dart';
+import 'package:reaprime/src/services/android_updater.dart';
 import 'package:reaprime/src/settings/charging_mode.dart';
 import 'package:reaprime/src/settings/feature_flags.dart';
 import 'package:reaprime/src/settings/gateway_mode.dart';
@@ -41,6 +42,8 @@ abstract class SettingsService {
   Future<void> setDefaultSkinId(String skinId);
   Future<bool> automaticUpdateCheck();
   Future<void> setAutomaticUpdateCheck(bool value);
+  Future<UpdateChannel> updateChannel();
+  Future<void> setUpdateChannel(UpdateChannel channel);
   Future<DateTime?> lastUpdateCheckTime();
   Future<void> setLastUpdateCheckTime(DateTime time);
   Future<bool> telemetryConsent();
@@ -283,6 +286,20 @@ class SharedPreferencesSettingsService extends SettingsService {
   }
 
   @override
+  Future<UpdateChannel> updateChannel() async {
+    final stored = await prefs.getString(SettingsKeys.updateChannel.name);
+    return UpdateChannel.values.firstWhere(
+      (channel) => channel.name == stored,
+      orElse: () => UpdateChannel.stable,
+    );
+  }
+
+  @override
+  Future<void> setUpdateChannel(UpdateChannel channel) async {
+    await prefs.setString(SettingsKeys.updateChannel.name, channel.name);
+  }
+
+  @override
   Future<DateTime?> lastUpdateCheckTime() async {
     final timestamp = await prefs.getInt(SettingsKeys.lastUpdateCheckTime.name);
     return timestamp != null
@@ -521,6 +538,7 @@ enum SettingsKeys {
   preferredScaleId,
   defaultSkinId,
   automaticUpdateCheck,
+  updateChannel,
   lastUpdateCheckTime,
   telemetryConsent,
   telemetryPromptShown,

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -73,6 +73,15 @@ class SettingsView extends StatelessWidget {
 
               // MARK: Updates
               const SettingsSectionHeader('Updates'),
+              if (!Platform.isIOS) ...[
+                SettingsTile(
+                  icon: Icons.science_outlined,
+                  label: 'Update channel',
+                  trailing: Text(_updateChannelLabel(controller.updateChannel)),
+                  onTap: () => _showUpdateChannelPicker(context),
+                ),
+                const SettingsDivider(),
+              ],
               Padding(
                 padding: const EdgeInsets.symmetric(
                   horizontal: 16,
@@ -170,6 +179,15 @@ class SettingsView extends StatelessWidget {
     }
   }
 
+  static String _updateChannelLabel(UpdateChannel channel) {
+    switch (channel) {
+      case UpdateChannel.stable:
+        return 'Stable';
+      case UpdateChannel.beta:
+        return 'Beta';
+    }
+  }
+
   String _chargingModeLabel(ChargingMode mode) {
     switch (mode) {
       case ChargingMode.disabled:
@@ -240,6 +258,52 @@ class SettingsView extends StatelessWidget {
         );
       },
     );
+  }
+
+  void _showUpdateChannelPicker(BuildContext context) {
+    showShadDialog(
+      context: context,
+      builder: (dialogContext) {
+        return ShadDialog(
+          title: const Text('Update channel'),
+          child: Material(
+            type: MaterialType.transparency,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ListTile(
+                  title: const Text('Stable'),
+                  subtitle: const Text('Final releases only'),
+                  trailing: controller.updateChannel == UpdateChannel.stable
+                      ? const Icon(Icons.check)
+                      : null,
+                  onTap: () =>
+                      _selectUpdateChannel(dialogContext, UpdateChannel.stable),
+                ),
+                ListTile(
+                  title: const Text('Beta'),
+                  subtitle: const Text('Final and prerelease builds'),
+                  trailing: controller.updateChannel == UpdateChannel.beta
+                      ? const Icon(Icons.check)
+                      : null,
+                  onTap: () =>
+                      _selectUpdateChannel(dialogContext, UpdateChannel.beta),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _selectUpdateChannel(
+    BuildContext dialogContext,
+    UpdateChannel channel,
+  ) async {
+    await controller.setUpdateChannel(channel);
+    if (dialogContext.mounted) Navigator.of(dialogContext).pop();
+    await updateCheckService?.requestCheck();
   }
 
   void _showAboutSection(BuildContext context) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1242,7 +1242,7 @@ packages:
     source: hosted
     version: "3.6.0"
   pub_semver:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pub_semver
       sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -114,6 +114,7 @@ dependencies:
   # every platform: NsdManager (Android), Bonjour (Apple), Avahi (Linux),
   # dns_sd (Windows) — so no app-managed MulticastLock is needed on Android.
   bonsoir: ^7.1.1
+  pub_semver: ^2.2.0
   # path: ../flutter_libserialport
   # git:
   #   url: https://github.com/tadelv/flutter_libserialport.git

--- a/test/android_updater_download_test.dart
+++ b/test/android_updater_download_test.dart
@@ -8,15 +8,20 @@ import 'package:reaprime/src/services/android_updater.dart';
 
 void main() {
   group('AndroidUpdater.checkForUpdate', () {
-    Map<String, Object> release(String version, {required bool prerelease}) => {
-      'tag_name': 'v$version',
+    Map<String, Object> release(
+      String version, {
+      required bool prerelease,
+      bool includeApk = true,
+    }) => {
+      'tag_name': version.startsWith('nightly-') ? version : 'v$version',
       'prerelease': prerelease,
       'body': '',
       'assets': [
-        {
-          'name': 'decent-android-$version.apk',
-          'browser_download_url': 'https://example.com/$version.apk',
-        },
+        if (includeApk)
+          {
+            'name': 'decent-android-$version.apk',
+            'browser_download_url': 'https://example.com/$version.apk',
+          },
       ],
     };
 
@@ -70,6 +75,51 @@ void main() {
       );
 
       expect(update?.version, '0.7.16-beta.1');
+    });
+
+    test('skips a release without an APK', () async {
+      final updater = updaterFor([
+        release('0.8.0', prerelease: false, includeApk: false),
+        release('0.7.15', prerelease: false),
+      ]);
+
+      final update = await updater.checkForUpdate('0.7.14');
+
+      expect(update?.version, '0.7.15');
+    });
+
+    test('skips a release with a non-semver tag', () async {
+      final updater = updaterFor([
+        release('nightly-2026-07-30', prerelease: true),
+        release('0.7.15-beta.1', prerelease: true),
+      ]);
+
+      final update = await updater.checkForUpdate(
+        '0.7.14',
+        channel: UpdateChannel.beta,
+      );
+
+      expect(update?.version, '0.7.15-beta.1');
+    });
+
+    test('all invalid releases do not affect a later valid check', () async {
+      var callCount = 0;
+      final updater = AndroidUpdater(
+        owner: 'tadelv',
+        repo: 'reaprime',
+        httpClient: MockClient((_) async {
+          final releases = callCount++ == 0
+              ? [
+                  release('0.8.0', prerelease: false, includeApk: false),
+                  release('nightly-2026-07-30', prerelease: true),
+                ]
+              : [release('0.7.15', prerelease: false)];
+          return http.Response(jsonEncode(releases), 200);
+        }),
+      );
+
+      expect(await updater.checkForUpdate('0.7.14'), isNull);
+      expect((await updater.checkForUpdate('0.7.14'))?.version, '0.7.15');
     });
   });
 

--- a/test/android_updater_download_test.dart
+++ b/test/android_updater_download_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -6,6 +7,72 @@ import 'package:http/testing.dart';
 import 'package:reaprime/src/services/android_updater.dart';
 
 void main() {
+  group('AndroidUpdater.checkForUpdate', () {
+    Map<String, Object> release(String version, {required bool prerelease}) => {
+      'tag_name': 'v$version',
+      'prerelease': prerelease,
+      'body': '',
+      'assets': [
+        {
+          'name': 'decent-android-$version.apk',
+          'browser_download_url': 'https://example.com/$version.apk',
+        },
+      ],
+    };
+
+    AndroidUpdater updaterFor(List<Map<String, Object>> releases) {
+      return AndroidUpdater(
+        owner: 'tadelv',
+        repo: 'reaprime',
+        httpClient: MockClient(
+          (_) async => http.Response(jsonEncode(releases), 200),
+        ),
+      );
+    }
+
+    test('stable ignores prereleases', () async {
+      final updater = updaterFor([
+        release('0.7.15-beta.1', prerelease: true),
+        release('0.7.14', prerelease: false),
+      ]);
+
+      final update = await updater.checkForUpdate(
+        '0.7.13',
+        channel: UpdateChannel.stable,
+      );
+
+      expect(update?.version, '0.7.14');
+    });
+
+    test('beta includes prereleases and final releases', () async {
+      final updater = updaterFor([
+        release('0.7.15-beta.2', prerelease: true),
+        release('0.7.15', prerelease: false),
+      ]);
+
+      final update = await updater.checkForUpdate(
+        '0.7.15-beta.1',
+        channel: UpdateChannel.beta,
+      );
+
+      expect(update?.version, '0.7.15');
+    });
+
+    test('beta selects the highest semantic version', () async {
+      final updater = updaterFor([
+        release('0.7.15-beta.2', prerelease: true),
+        release('0.7.16-beta.1', prerelease: true),
+      ]);
+
+      final update = await updater.checkForUpdate(
+        '0.7.16-beta.0',
+        channel: UpdateChannel.beta,
+      );
+
+      expect(update?.version, '0.7.16-beta.1');
+    });
+  });
+
   group('AndroidUpdater.downloadUpdate streamed progress', () {
     late Directory tmp;
 

--- a/test/helpers/mock_settings_service.dart
+++ b/test/helpers/mock_settings_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:reaprime/src/services/android_updater.dart';
 import 'package:reaprime/src/settings/charging_mode.dart';
 import 'package:reaprime/src/settings/feature_flags.dart';
 import 'package:reaprime/src/settings/gateway_mode.dart';
@@ -23,6 +24,7 @@ class MockSettingsService extends SettingsService {
   String? _preferredScaleId;
   String _defaultSkinId = 'streamline.js';
   bool _automaticUpdateCheck = true;
+  UpdateChannel _updateChannel = UpdateChannel.stable;
   DateTime? _lastUpdateCheckTime;
   bool _telemetryConsent = false;
   bool _telemetryPromptShown = true; // skip prompt in tests
@@ -117,6 +119,11 @@ class MockSettingsService extends SettingsService {
   @override
   Future<void> setAutomaticUpdateCheck(bool value) async =>
       _automaticUpdateCheck = value;
+  @override
+  Future<UpdateChannel> updateChannel() async => _updateChannel;
+  @override
+  Future<void> setUpdateChannel(UpdateChannel channel) async =>
+      _updateChannel = channel;
   @override
   Future<DateTime?> lastUpdateCheckTime() async => _lastUpdateCheckTime;
   @override

--- a/test/unit/controllers/settings_controller_test.dart
+++ b/test/unit/controllers/settings_controller_test.dart
@@ -1,17 +1,22 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/android_updater.dart';
 import 'package:reaprime/src/settings/feature_flags.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/settings/settings_service.dart';
+
+import '../../helpers/mock_settings_service.dart';
 
 /// Spy settings service that tracks calls to setSimulatedDevices.
 class _SpySettingsService implements SettingsService {
   int setSimulatedDevicesCallCount = 0;
   int setEnableSimulatedWebViewsCallCount = 0;
   int setShowSkinExitInstructionsCallCount = 0;
+  int setUpdateChannelCallCount = 0;
   int setFeatureFlagCallCount = 0;
   Set<SimulatedDevicesTypes> _simulatedDevices = {};
   bool _enableSimulatedWebViews = false;
   bool _showSkinExitInstructions = true;
+  UpdateChannel _updateChannel = UpdateChannel.stable;
   final Map<String, bool?> _featureFlags = {};
   String? _preferredMachineId;
   String? _preferredScaleId;
@@ -39,6 +44,14 @@ class _SpySettingsService implements SettingsService {
   Future<void> setShowSkinExitInstructions(bool value) async {
     setShowSkinExitInstructionsCallCount++;
     _showSkinExitInstructions = value;
+  }
+
+  @override
+  Future<UpdateChannel> updateChannel() async => _updateChannel;
+  @override
+  Future<void> setUpdateChannel(UpdateChannel channel) async {
+    setUpdateChannelCallCount++;
+    _updateChannel = channel;
   }
 
   // Feature flags
@@ -273,6 +286,43 @@ void main() {
       await controller.setShowSkinExitInstructions(true);
 
       expect(spy.setShowSkinExitInstructionsCallCount, 0);
+      expect(notified, isFalse);
+    });
+  });
+
+  group('SettingsController.setUpdateChannel', () {
+    test('loads the persisted channel', () async {
+      final settings = MockSettingsService();
+      await settings.setUpdateChannel(UpdateChannel.beta);
+      final controller = SettingsController(settings);
+
+      await controller.loadSettings();
+
+      expect(controller.updateChannel, UpdateChannel.beta);
+    });
+
+    test('persists, updates, and notifies on change', () async {
+      final spy = _SpySettingsService();
+      final controller = SettingsController(spy);
+      var notified = false;
+      controller.addListener(() => notified = true);
+
+      await controller.setUpdateChannel(UpdateChannel.beta);
+
+      expect(controller.updateChannel, UpdateChannel.beta);
+      expect(spy.setUpdateChannelCallCount, 1);
+      expect(notified, isTrue);
+    });
+
+    test('is a no-op when unchanged', () async {
+      final spy = _SpySettingsService();
+      final controller = SettingsController(spy);
+      var notified = false;
+      controller.addListener(() => notified = true);
+
+      await controller.setUpdateChannel(UpdateChannel.stable);
+
+      expect(spy.setUpdateChannelCallCount, 0);
       expect(notified, isFalse);
     });
   });

--- a/test/update_check_service_test.dart
+++ b/test/update_check_service_test.dart
@@ -20,6 +20,7 @@ class _FakeUpdater extends AndroidUpdater {
   List<double> progressToEmit = const [];
 
   int checkCalls = 0;
+  UpdateChannel? lastChannel;
   int downloadCalls = 0;
   int installCalls = 0;
 
@@ -32,6 +33,7 @@ class _FakeUpdater extends AndroidUpdater {
     UpdateChannel channel = UpdateChannel.stable,
   }) async {
     checkCalls++;
+    lastChannel = channel;
     if (throwOnCheck) throw Exception('check boom');
     return nextCheck;
   }
@@ -71,14 +73,16 @@ UpdateInfo _update({String version = '9.9.9'}) => UpdateInfo(
 
 void main() {
   late _FakeUpdater updater;
+  late MockSettingsService settingsService;
   late WebUIStorage webUIStorage;
 
   UpdateCheckService build({bool isAndroid = true}) {
     updater = _FakeUpdater();
-    final settingsController = SettingsController(MockSettingsService());
+    settingsService = MockSettingsService();
+    final settingsController = SettingsController(settingsService);
     webUIStorage = WebUIStorage(settingsController);
     return UpdateCheckService(
-      settingsService: MockSettingsService(),
+      settingsService: settingsService,
       webUIStorage: webUIStorage,
       updater: updater,
       platformIsAndroid: isAndroid,
@@ -86,6 +90,16 @@ void main() {
   }
 
   group('checkForUpdate', () {
+    test('uses the selected update channel', () async {
+      final svc = build();
+      await settingsService.setUpdateChannel(UpdateChannel.beta);
+
+      await svc.checkForUpdate();
+
+      expect(updater.lastChannel, UpdateChannel.beta);
+      svc.dispose();
+    });
+
     test('emits available with details when an update is found', () async {
       final svc = build();
       updater.nextCheck = _update(version: '9.9.9');


### PR DESCRIPTION
## Summary

- Problem: update checks were hardcoded to Stable, while the existing version comparison discarded prerelease suffixes.
- Why it matters: users could not opt into prereleases, and beta-to-beta or beta-to-final upgrades were missed.
- What changed: added a persisted Stable/Beta picker under Settings > Updates, made Beta include final and prerelease releases, switched ordering to `pub_semver`, and made malformed/unsupported release entries independently skippable.
- What did NOT change (scope boundary): Development/Nightly builds remain deferred; the picker is hidden on iOS because GitHub releases cannot replace App Store/TestFlight builds.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [x] UI / Flutter widgets
- [x] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #82
- Related: N/A

## Root Cause (if bug fix)

- Root cause: `UpdateCheckService` always passed `UpdateChannel.stable`; the custom comparator stripped prerelease suffixes, and the old Beta filter excluded final releases.
- Missing detection or guardrail: updater tests did not cover channel filtering, semantic prerelease precedence, or mixed valid/unsupported release payloads.
- Contributing context (if known): GitHub orders releases by publication metadata, which is not a semantic-version guarantee.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/android_updater_download_test.dart`, `test/update_check_service_test.dart`, `test/unit/controllers/settings_controller_test.dart`
- Scenario the test should lock in: Stable excludes prereleases; Beta includes final and prerelease builds, selects the highest semantic version, and detects prerelease-to-final upgrades; malformed tags and releases without APKs do not suppress valid updates; the persisted setting reaches the updater.
- If no new test added, why not: N/A

## Documentation Obligations (required)

These are **not optional**. Stale specs mislead clients and agents.

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A — no docs affected

## Security Impact (required)

This app runs a local web server (port 8080) and connects to BLE/USB hardware.

- New or changed REST endpoints? (`Yes/No`) No
- New or changed WebSocket topics? (`Yes/No`) No
- New or changed network calls? (`Yes/No`) No — the existing GitHub Releases request is unchanged
- BLE/USB surface changed? (`Yes/No`) No
- File system access changed? (`Yes/No`) No
- Plugin sandbox boundary changed? (`Yes/No`) No
- If any `Yes`, explain risk and mitigation: N/A

## User-Visible Changes

- Settings > Updates now shows an Update channel picker on Android, macOS, Linux, and Windows.
- Stable remains the default and receives final releases only.
- Beta receives final and prerelease releases.
- Changing channel persists the selection and immediately re-checks for updates.
- iOS does not show the picker.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — no remaining changes
- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all 2538 tests pass
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds

### Manual verification (if applicable)

- OS / platform tested: macOS
- Simulated devices? (`simulate=1`): Yes — MockDe1 connected
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: started Decent.app with `scripts/sb-dev.sh`, connected MockDe1, confirmed the HTTP server, hot reloaded, checked error logs, and stopped cleanly.
- Edge cases checked: Stable filtering, Beta prerelease/final inclusion, beta-to-final precedence, API-order-independent highest-version selection, releases without APKs, non-semver tags, all-invalid payload followed by a valid check, unchanged-setting no-op.
- What you did **not** verify: physical iOS picker hiding, Android APK installation, or real hardware; none of those paths changed.

### Evidence

- [x] Test output (failing before + passing after)
- [x] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

Before implementation, `beta includes prereleases and final releases` failed with expected `0.7.15`, actual `null`. During review, mixed-payload tests likewise failed because one unsupported entry suppressed the valid release. After both fixes, focused tests and the full 2538-test suite pass. Simulated smoke reached `HTTP server ready`, `Connected to MockDe1`, and hot reload completed without matching SEVERE/error logs.

## Compatibility & Migration

- Backward compatible? (`Yes/No`) Yes
- Config / env changes needed? (`Yes/No`) No
- Database migration needed? (`Yes/No`) No
- If any `No` or `Yes`, explain exact steps: existing users default to Stable when no preference is stored; SharedPreferences persists future selections.

## Risks & Mitigations

- Risk: Beta intentionally includes every GitHub prerelease, including future alpha/nightly builds.
  - Mitigation: this is the agreed two-channel contract; add a separate Nightly channel only when nightly publishing exists.
