### PR TITLE
feat(plugins): disable repeatedly failing plugins

### DIFF
--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -253,6 +253,12 @@ const upload = await fetch("https://api.example.com/upload", {
 4. **Unloading**: `onUnload()` is called for cleanup
 5. **Removal**: Plugin files are deleted from storage
 
+### Load watchdog
+
+Decent.app records consecutive load failures for each plugin. After three failures, auto-load is disabled so the plugin no longer runs on subsequent launches. A plugin whose load was interrupted by an app exit is disabled on the next launch immediately, which also covers JavaScript evaluation that blocks before Dart's one-second timeout can fire.
+
+Disabled plugins remain installed and can be re-enabled from plugin settings or `POST /api/v1/plugins/:id/enable`. Re-enabling clears the failure count and gives the plugin a fresh attempt; a successful load also clears it.
+
 ## Example: Temperature Monitoring Plugin
 
 ```javascript

--- a/doc/plans/archive/plugin-load-watchdog/plugin-load-watchdog.md
+++ b/doc/plans/archive/plugin-load-watchdog/plugin-load-watchdog.md
@@ -1,0 +1,25 @@
+# Plugin load watchdog plan
+
+## Problem
+
+Plugin auto-load runs off the boot critical path, but a plugin that throws or never completes loading is retried on every launch. The existing `Future.any` timeout does not persist failures and cannot protect the next launch if synchronous JavaScript evaluation stalls the process.
+
+## Acceptance criteria
+
+- When a plugin load fails, Decent.app records one consecutive failure without failing initialization of other plugins.
+- When a plugin reaches three consecutive load failures, Decent.app disables its auto-load setting.
+- When a plugin loads successfully, Decent.app clears its consecutive failure count.
+- When the previous process ended during a plugin load, the next launch disables that plugin before auto-loading plugins.
+- When a user re-enables auto-load, Decent.app clears the watchdog state so the plugin gets a fresh attempt.
+- Plugin load attempts remain bounded by the existing one-second limit where the JavaScript runtime yields to Dart.
+
+## Implementation
+
+1. Add persistent SharedPreferences keys for the current load and per-plugin failure count.
+2. Wrap `PluginManager.loadPlugin` with `Future.timeout`; set/clear the current-load marker around it and update failure state on error.
+3. Recover a stale current-load marker during initialization before auto-load begins.
+4. Add focused service tests and document the lifecycle behavior in `doc/Plugins.md`.
+
+## Scope boundary
+
+No new plugin health-check callback, settings screen, API field, dependency, or JavaScript-runtime isolation. The existing settings and REST enable controls remain the re-enable path.

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -22,6 +22,10 @@ class PluginSettingsValidationException implements Exception {
 }
 
 class PluginLoaderService {
+  static const _loadTimeout = Duration(seconds: 1);
+  static const _maxConsecutiveLoadFailures = 3;
+  static const _loadingPluginKey = 'plugin.watchdog.loading';
+
   final PluginManager pluginManager;
   final bool _appStoreMode;
   final _log = Logger('PluginLoaderService');
@@ -54,6 +58,7 @@ class PluginLoaderService {
 
     // Initialize SharedPreferences
     _prefs = await SharedPreferences.getInstance();
+    await _recoverInterruptedPluginLoad();
 
     // Create plugins directory if it doesn't exist
     if (!_pluginsDir.existsSync()) {
@@ -151,6 +156,10 @@ class PluginLoaderService {
 
     // Remove plugin settings
     await _prefs.remove('plugin.settings.$pluginId');
+    await _prefs.remove(_loadFailureKey(pluginId));
+    if (_prefs.getString(_loadingPluginKey) == pluginId) {
+      await _prefs.remove(_loadingPluginKey);
+    }
   }
 
   /// Load plugin into the runtime
@@ -163,30 +172,32 @@ class PluginLoaderService {
     final manifest = _availablePluginsCache[pluginId]!;
     final pluginDir = Directory('${_pluginsDir.path}/$pluginId');
 
-    // Read plugin.js file
-    final pluginFile = File('${pluginDir.path}/plugin.js');
-    if (!pluginFile.existsSync()) {
-      throw Exception('plugin.js not found for plugin: $pluginId');
+    await _prefs.setString(_loadingPluginKey, pluginId);
+    try {
+      final pluginFile = File('${pluginDir.path}/plugin.js');
+      if (!pluginFile.existsSync()) {
+        throw Exception('plugin.js not found for plugin: $pluginId');
+      }
+
+      final jsCode = await pluginFile.readAsString();
+      final settings = await pluginSettings(pluginId);
+
+      await pluginManager
+          .loadPlugin(
+            id: pluginId,
+            manifest: manifest,
+            jsCode: jsCode,
+            settings: settings,
+          )
+          .timeout(_loadTimeout);
+    } catch (_) {
+      await _prefs.remove(_loadingPluginKey);
+      await _recordLoadFailure(pluginId);
+      rethrow;
     }
 
-    final jsCode = await pluginFile.readAsString();
-
-    final settings = await pluginSettings(pluginId);
-
-    // Load plugin using PluginManager
-    // FIXME: add watchdog so we don't break the app with unloadable plugins
-    await Future.any([
-      pluginManager.loadPlugin(
-        id: pluginId,
-        manifest: manifest,
-        jsCode: jsCode,
-        settings: settings,
-      ),
-      Future.delayed(Duration(seconds: 1), () {
-        throw Exception("load timeout occured");
-      }),
-    ]);
-
+    await _prefs.remove(_loadingPluginKey);
+    await _prefs.remove(_loadFailureKey(pluginId));
     _log.info('Plugin loaded: $pluginId');
   }
 
@@ -218,6 +229,12 @@ class PluginLoaderService {
 
   /// Store a setting in prefs, whether a specific plugin should be autoloaded at initialize
   Future<void> setPluginAutoLoad(String pluginId, bool enabled) async {
+    if (enabled) {
+      await _prefs.remove(_loadFailureKey(pluginId));
+      if (_prefs.getString(_loadingPluginKey) == pluginId) {
+        await _prefs.remove(_loadingPluginKey);
+      }
+    }
     await _prefs.setBool('plugin.autoload.$pluginId', enabled);
   }
 
@@ -306,6 +323,33 @@ class PluginLoaderService {
   }
 
   // Private helper methods
+
+  String _loadFailureKey(String pluginId) =>
+      'plugin.watchdog.loadFailures.$pluginId';
+
+  Future<void> _recordLoadFailure(String pluginId) async {
+    final failureKey = _loadFailureKey(pluginId);
+    final failures = (_prefs.getInt(failureKey) ?? 0) + 1;
+    await _prefs.setInt(failureKey, failures);
+    if (failures < _maxConsecutiveLoadFailures) return;
+
+    await _prefs.setBool('plugin.autoload.$pluginId', false);
+    _log.warning(
+      'Disabled auto-load for plugin $pluginId after $failures consecutive load failures',
+    );
+  }
+
+  Future<void> _recoverInterruptedPluginLoad() async {
+    final pluginId = _prefs.getString(_loadingPluginKey);
+    if (pluginId == null) return;
+
+    await _prefs.setInt(_loadFailureKey(pluginId), _maxConsecutiveLoadFailures);
+    await _prefs.setBool('plugin.autoload.$pluginId', false);
+    await _prefs.remove(_loadingPluginKey);
+    _log.warning(
+      'Disabled auto-load for plugin $pluginId after an interrupted load',
+    );
+  }
 
   Future<void> _copyBundledPlugins() async {
     // Get list of bundled plugins from assets

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -33,6 +33,7 @@ class PluginLoaderService {
   late Directory _pluginsDir;
   late SharedPreferences _prefs;
   final Map<String, PluginManifest> _availablePluginsCache = {};
+  Future<void> _pluginLoadQueue = Future.value();
 
   PluginLoaderService({
     required KeyValueStoreService kvStore,
@@ -164,7 +165,13 @@ class PluginLoaderService {
 
   /// Load plugin into the runtime
   /// by using the PluginManager loadPlugin method
-  Future<void> loadPlugin(String pluginId) async {
+  Future<void> loadPlugin(String pluginId) {
+    final load = _pluginLoadQueue.then((_) => _loadPlugin(pluginId));
+    _pluginLoadQueue = load.then<void>((_) {}, onError: (_, _) {});
+    return load;
+  }
+
+  Future<void> _loadPlugin(String pluginId) async {
     if (!_availablePluginsCache.containsKey(pluginId)) {
       throw Exception('Plugin not found: $pluginId');
     }

--- a/lib/src/services/webserver/plugins_handler.dart
+++ b/lib/src/services/webserver/plugins_handler.dart
@@ -57,10 +57,10 @@ final class PluginsHandler {
         if (pluginService.getPluginManifest(id) == null) {
           return jsonNotFound({'error': 'Plugin not found: $id'});
         }
+        await pluginService.setPluginAutoLoad(id, true);
         if (!pluginService.isPluginLoaded(id)) {
           await pluginService.loadPlugin(id);
         }
-        await pluginService.setPluginAutoLoad(id, true);
         return jsonOk({'message': 'Plugin enabled', 'id': id});
       } catch (e) {
         return jsonError({'error': 'Failed to enable plugin: $e'});

--- a/test/plugin_loader_service_watchdog_test.dart
+++ b/test/plugin_loader_service_watchdog_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -6,6 +7,34 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
 import 'package:reaprime/src/services/storage/kv_store_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+class _ControllablePluginLoaderService extends PluginLoaderService {
+  _ControllablePluginLoaderService({required super.kvStore})
+    : super(appStoreMode: false);
+
+  String? _pausedPluginId;
+  Completer<void>? _pauseEntered;
+  Completer<void>? _resume;
+
+  void pauseSettingsFor(String pluginId) {
+    _pausedPluginId = pluginId;
+    _pauseEntered = Completer<void>();
+    _resume = Completer<void>();
+  }
+
+  Future<void> waitUntilPaused() => _pauseEntered!.future;
+
+  void resume() => _resume!.complete();
+
+  @override
+  Future<Map<String, dynamic>> pluginSettings(String pluginId) async {
+    if (pluginId == _pausedPluginId) {
+      _pauseEntered!.complete();
+      await _resume!.future;
+    }
+    return super.pluginSettings(pluginId);
+  }
+}
 
 class _FakeKvStore implements KeyValueStoreService {
   final Map<String, Map<String, Object>> _store = {};
@@ -52,7 +81,7 @@ void main() {
   const pluginId = 'watchdog-test.reaplugin';
   late Directory tempDir;
   late Directory sourceDir;
-  late PluginLoaderService service;
+  late _ControllablePluginLoaderService service;
 
   void writePlugin(String js) {
     File('${sourceDir.path}/plugin.js').writeAsStringSync(js);
@@ -87,7 +116,7 @@ void main() {
     );
     writePlugin('function createPlugin() { throw new Error("boom"); }');
 
-    service = PluginLoaderService(kvStore: _FakeKvStore(), appStoreMode: false);
+    service = _ControllablePluginLoaderService(kvStore: _FakeKvStore());
     await service.initialize();
     await service.addPlugin(sourceDir.path);
     await service.setPluginAutoLoad(pluginId, true);
@@ -159,6 +188,51 @@ function createPlugin() {
       expect(await service.shouldAutoLoad(pluginId), isTrue);
     },
   );
+
+  test('serializes concurrent plugin loads', () async {
+    const secondPluginId = 'watchdog-second.reaplugin';
+    final secondSource = Directory('${tempDir.path}/second-source')
+      ..createSync();
+    File('${secondSource.path}/manifest.json').writeAsStringSync(
+      jsonEncode({
+        'id': secondPluginId,
+        'author': 'Test',
+        'name': 'Second watchdog test',
+        'description': 'Test plugin',
+        'version': '1.0.0',
+        'apiVersion': 1,
+        'permissions': <String>[],
+        'settings': <String, Object>{},
+        'api': <Object>[],
+      }),
+    );
+    File('${secondSource.path}/plugin.js').writeAsStringSync('''
+function createPlugin() {
+  return { id: "$secondPluginId", onLoad() {} };
+}
+''');
+    await service.addPlugin(secondSource.path);
+    File('${tempDir.path}/plugins/$pluginId/plugin.js').writeAsStringSync('''
+function createPlugin() {
+  return { id: "$pluginId", onLoad() {} };
+}
+''');
+
+    service.pauseSettingsFor(pluginId);
+    final firstLoad = service.loadPlugin(pluginId);
+    await service.waitUntilPaused();
+
+    var secondCompleted = false;
+    final secondLoad = service
+        .loadPlugin(secondPluginId)
+        .then((_) => secondCompleted = true);
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    expect(secondCompleted, isFalse);
+
+    service.resume();
+    await Future.wait([firstLoad, secondLoad]);
+  });
 
   test('next launch disables a plugin interrupted during load', () async {
     final prefs = await SharedPreferences.getInstance();

--- a/test/plugin_loader_service_watchdog_test.dart
+++ b/test/plugin_loader_service_watchdog_test.dart
@@ -1,0 +1,176 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+import 'package:reaprime/src/services/storage/kv_store_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeKvStore implements KeyValueStoreService {
+  final Map<String, Map<String, Object>> _store = {};
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> set({
+    String namespace = 'default',
+    required String key,
+    required Object value,
+  }) async {
+    _store.putIfAbsent(namespace, () => {})[key] = value;
+  }
+
+  @override
+  Future<bool> delete({
+    String namespace = 'default',
+    required String key,
+  }) async => _store[namespace]?.remove(key) != null;
+
+  @override
+  Future<Object?> get({
+    String namespace = 'default',
+    required String key,
+  }) async => _store[namespace]?[key];
+
+  @override
+  Future<List<String>> keys({String namespace = 'default'}) async =>
+      _store[namespace]?.keys.toList() ?? [];
+
+  @override
+  List<String> get namespaces => _store.keys.toList();
+
+  @override
+  Future<Map<String, Object>> getAll({String namespace = 'default'}) async =>
+      Map.from(_store[namespace] ?? {});
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const pluginId = 'watchdog-test.reaplugin';
+  late Directory tempDir;
+  late Directory sourceDir;
+  late PluginLoaderService service;
+
+  void writePlugin(String js) {
+    File('${sourceDir.path}/plugin.js').writeAsStringSync(js);
+  }
+
+  Future<void> expectLoadFailure() async {
+    await expectLater(service.loadPlugin(pluginId), throwsException);
+  }
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    tempDir = Directory.systemTemp.createTempSync('plugin_watchdog_test');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (_) async => tempDir.path,
+        );
+
+    sourceDir = Directory('${tempDir.path}/source')..createSync();
+    File('${sourceDir.path}/manifest.json').writeAsStringSync(
+      jsonEncode({
+        'id': pluginId,
+        'author': 'Test',
+        'name': 'Watchdog test',
+        'description': 'Test plugin',
+        'version': '1.0.0',
+        'apiVersion': 1,
+        'permissions': <String>[],
+        'settings': <String, Object>{},
+        'api': <Object>[],
+      }),
+    );
+    writePlugin('function createPlugin() { throw new Error("boom"); }');
+
+    service = PluginLoaderService(kvStore: _FakeKvStore(), appStoreMode: false);
+    await service.initialize();
+    await service.addPlugin(sourceDir.path);
+    await service.setPluginAutoLoad(pluginId, true);
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    tempDir.deleteSync(recursive: true);
+  });
+
+  test('disables auto-load after three consecutive load failures', () async {
+    await expectLoadFailure();
+    await expectLoadFailure();
+    expect(await service.shouldAutoLoad(pluginId), isTrue);
+
+    await expectLoadFailure();
+    expect(await service.shouldAutoLoad(pluginId), isFalse);
+  });
+
+  test('missing plugin code also counts as a load failure', () async {
+    File('${tempDir.path}/plugins/$pluginId/plugin.js').deleteSync();
+
+    await expectLoadFailure();
+    await expectLoadFailure();
+    await expectLoadFailure();
+
+    expect(await service.shouldAutoLoad(pluginId), isFalse);
+  });
+
+  test('successful load resets the consecutive failure count', () async {
+    await expectLoadFailure();
+    await expectLoadFailure();
+
+    writePlugin('''
+function createPlugin() {
+  return { id: "$pluginId", onLoad() {} };
+}
+''');
+    File(
+      '${tempDir.path}/plugins/$pluginId/plugin.js',
+    ).writeAsStringSync(File('${sourceDir.path}/plugin.js').readAsStringSync());
+    await service.loadPlugin(pluginId);
+
+    writePlugin('function createPlugin() { throw new Error("boom"); }');
+    File(
+      '${tempDir.path}/plugins/$pluginId/plugin.js',
+    ).writeAsStringSync(File('${sourceDir.path}/plugin.js').readAsStringSync());
+    await expectLoadFailure();
+    await expectLoadFailure();
+
+    expect(await service.shouldAutoLoad(pluginId), isTrue);
+  });
+
+  test(
+    'manually re-enabling auto-load gives the plugin a fresh attempt',
+    () async {
+      await expectLoadFailure();
+      await expectLoadFailure();
+      await expectLoadFailure();
+      expect(await service.shouldAutoLoad(pluginId), isFalse);
+
+      await service.setPluginAutoLoad(pluginId, true);
+      await expectLoadFailure();
+
+      expect(await service.shouldAutoLoad(pluginId), isTrue);
+    },
+  );
+
+  test('next launch disables a plugin interrupted during load', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('plugin.watchdog.loading', pluginId);
+
+    final nextLaunch = PluginLoaderService(
+      kvStore: _FakeKvStore(),
+      appStoreMode: false,
+    );
+    await nextLaunch.initialize();
+
+    expect(await nextLaunch.shouldAutoLoad(pluginId), isFalse);
+    expect(nextLaunch.isPluginLoaded(pluginId), isFalse);
+  });
+}

--- a/test/services/webserver/plugins_handler_watchdog_test.dart
+++ b/test/services/webserver/plugins_handler_watchdog_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+class _FakePluginManager extends Fake implements PluginManager {}
+
+class _FakePluginLoaderService extends Fake implements PluginLoaderService {
+  static const pluginId = 'watchdog-test.reaplugin';
+
+  final calls = <String>[];
+
+  @override
+  PluginManifest? getPluginManifest(String pluginId) => PluginManifest(
+    id: pluginId,
+    name: 'Watchdog test',
+    author: 'Test',
+    description: 'Test plugin',
+    version: '1.0.0',
+    apiVersion: 1,
+    permissions: const {},
+    settings: const {},
+    api: null,
+  );
+
+  @override
+  bool isPluginLoaded(String pluginId) => false;
+
+  @override
+  Future<void> loadPlugin(String pluginId) async {
+    calls.add('load');
+  }
+
+  @override
+  Future<void> setPluginAutoLoad(String pluginId, bool enabled) async {
+    calls.add('autoLoad:$enabled');
+  }
+}
+
+void main() {
+  test('enable resets watchdog state before retrying plugin load', () async {
+    final pluginService = _FakePluginLoaderService();
+    final app = Router().plus;
+    PluginsHandler(
+      pluginManager: _FakePluginManager(),
+      pluginService: pluginService,
+      appStoreMode: false,
+    ).addRoutes(app);
+
+    final response = await app.call(
+      Request(
+        'POST',
+        Uri.parse(
+          'http://localhost/api/v1/plugins/${_FakePluginLoaderService.pluginId}/enable',
+        ),
+      ),
+    );
+
+    expect(response.statusCode, 200);
+    expect(pluginService.calls, ['autoLoad:true', 'load']);
+  });
+}


### PR DESCRIPTION
## Summary

- Problem: failing or blocking plugins could be retried on every app launch.
- Why it matters: a bad plugin could repeatedly disrupt startup even though plugin initialization is off the boot critical path.
- What changed: persist per-plugin consecutive load failures, disable auto-load after three failures, and disable immediately on the next launch when a load was interrupted.
- What did NOT change: no new plugin health callback, settings screen, API field, dependency, or runtime isolation.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [x] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #79
- Related #

## Root Cause (if bug fix)

N/A — feature.

## Regression Test Plan (if bug fix or refactor)

N/A — feature. Focused service coverage was added for the watchdog behavior.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [x] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A — no docs affected

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `No`
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`
- If any `Yes`, explain risk and mitigation: N/A

## User-Visible Changes

A plugin is removed from startup auto-load after three consecutive load failures. If the app exits while a plugin is loading, that plugin is disabled on the next launch. Users can retry it through the existing plugin settings or enable endpoint.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — no remaining changes
- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all 2543 tests passed
- [x] `(cd packages/dye2-plugin && npm run build)` — N/A; no bundled plugin code changed

### Manual verification (if applicable)

- OS / platform tested: macOS test runner
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: focused `PluginLoaderService` tests exercise thrown loads, missing plugin code, success reset, manual re-enable, and interrupted-load recovery.
- Edge cases checked: three-failure threshold; successful reset; stale in-flight marker.
- What you did **not** verify: deliberate infinite-loop JavaScript on a running app; the next-launch recovery is covered deterministically through persisted state.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`
- Existing SharedPreferences installations need no migration; watchdog keys are created lazily.

## Risks & Mitigations

- Risk: the app may be terminated for an unrelated reason during the narrow plugin-load window, causing that plugin to be disabled on the next launch.
  - Mitigation: plugin loading is short, the plugin remains installed, and the existing settings/API enable action clears watchdog state for a fresh attempt.
