### PR TITLE
chore: finalise rename

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 Describe the problem and fix in 2–5 bullets:
 
-> **Naming:** The display name is **Decent.app**. The repo, package, and bundle ID use legacy `reaprime` / `streamline-bridge` — see the naming table in [`CLAUDE.md`](CLAUDE.md).
+> **Naming:** The display name is **Decaid**. The Dart package, bundle ID, database, and plugin extension retain legacy identifiers for compatibility — see the naming table in [`CLAUDE.md`](CLAUDE.md).
 
 - Problem:
 - Why it matters:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,9 +78,9 @@ If your output contradicts documented architecture or conventions, surface it ex
 
 ## Tracking
 
-GitHub Issues on `tadelv/reaprime` is the canonical issue tracker. Use `gh issue` commands for triage, labeling, and closing.
+GitHub Issues on `decentespresso/decaid` is the canonical issue tracker. Use `gh issue` commands for triage, labeling, and closing.
 
-**Triage labels** (used on `tadelv/reaprime`):
+**Triage labels** (used on `decentespresso/decaid`):
 
 | Label | Meaning |
 |-------|---------|
@@ -115,7 +115,7 @@ GitHub Issues on `tadelv/reaprime` is the canonical issue tracker. Use `gh issue
 | Plugin file extension | `.reaplugin` |
 | Bundle ID | `net.tadel.reaprime` |
 | Database name | `streamline_bridge` |
-| GitHub repo | `tadelv/reaprime` |
+| GitHub repo | `decentespresso/decaid` |
 
 **Decaid** combines "decade" and "Decent aide." The name marks ten years since the original `de1app` repository's first commit on May 14, 2016. Preserve `Decent.app` and ReaPrime where they are historical or internal identifiers.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to Decent.app
+# Contributing to Decaid
 
 Thanks for contributing. This guide tells you what's required to land a PR — items marked **(required)** are hard gates, not suggestions.
 
-> **Naming note:** The display name is **Decent.app**. The repo, package, and bundle ID still use legacy `reaprime` / `streamline-bridge` identifiers. See the naming table in [`CLAUDE.md`](CLAUDE.md) before renaming anything.
+> **Naming note:** The display name is **Decaid**. The repo, package, and bundle ID still use legacy `reaprime` / `streamline-bridge` identifiers. See the naming table in [`CLAUDE.md`](CLAUDE.md) before renaming anything.
 
 ## Quick Reference
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for contributing. This guide tells you what's required to land a PR — items marked **(required)** are hard gates, not suggestions.
 
-> **Naming note:** The display name is **Decaid**. The repo, package, and bundle ID still use legacy `reaprime` / `streamline-bridge` identifiers. See the naming table in [`CLAUDE.md`](CLAUDE.md) before renaming anything.
+> **Naming note:** The display name is **Decaid**. The Dart package, bundle ID, database, and plugin extension retain legacy identifiers for compatibility. See the naming table in [`CLAUDE.md`](CLAUDE.md) before renaming anything.
 
 ## Quick Reference
 
@@ -38,7 +38,7 @@ See [`CLAUDE.md`](CLAUDE.md) for the full command reference.
 
 ## Branching & PRs
 
-- Branch from `main`. Push to your fork, open a PR against `tadelv/reaprime:main`.
+- Branch from `main`. Push to your fork, open a PR against `decentespresso/decaid:main`.
 - One feature or fix per PR. No bundling unrelated changes.
 - Reference the issue: `Fixes #123` or `Related #123`.
 - A maintainer will review. Expect a few rounds of feedback.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Decent.app
+# Decaid
 
-> **Decent.app** connects your Decent Espresso machine to beautiful,
+> **Decaid** connects your Decent Espresso machine to beautiful,
 modern user interfaces (called "skins").  
 Think of it as the bridge between your
 DE1 (or Bengle) and sleek touchscreen experiences like [Streamline.js](https://github.com/allofmeng/streamline_project).
@@ -13,7 +13,7 @@ DE1 (or Bengle) and sleek touchscreen experiences like [Streamline.js](https://g
 - Works with scales to automatically stop shots at your target weight
 - Runs on Android tablets, desktop computers, and more
 
-**For developers:** Decent.app provides
+**For developers:** Decaid provides
 a complete REST and WebSocket API, making it
 easy to build custom interfaces without dealing with the
 complexity of machine communication and device connectivity.
@@ -49,7 +49,7 @@ complexity of machine communication and device connectivity.
 
 To browse the complete API documentation:
 
-1. Start Decent.app
+1. Start Decaid
 2. Navigate to [http://localhost:4001](http://localhost:4001)
 
 Or:  
@@ -76,11 +76,11 @@ The API provides:
 
 ### Background Operation
 
-On Android, Decent.app can run as a foreground service, maintaining stable connections to your machine and scale while tucked away in the background.
+On Android, Decaid can run as a foreground service, maintaining stable connections to your machine and scale while tucked away in the background.
 
 ## WebUI / Skins
 
-Similar to the original DE1 app, Decent.app supports loading and displaying different "skins" (web-based UIs).
+Similar to the original DE1 app, Decaid supports loading and displaying different "skins" (web-based UIs).
 
 ### Accessing Skins
 
@@ -144,7 +144,7 @@ Similar to the original DE1 app, Decent.app supports loading and displaying diff
 
 ## Plugins
 
-Decent.app features a JavaScript plugin system for dynamic functionality expansion.
+Decaid features a JavaScript plugin system for dynamic functionality expansion.
 
 **Capabilities:**
 - React to machine state changes
@@ -283,14 +283,21 @@ make dual-build
 
 ## About the Name
 
-**Decent.app** (formerly REA → ReaPrime → Streamline Bridge) is the companion app for Decent Espresso machines.
+**Decaid** (formerly REA → ReaPrime → Streamline Bridge) is the companion app for Decent Espresso machines.
 
 ### The Evolution
 
-The original name **REA** stood for "Reasonable Espresso App" — a tongue-in-cheek reference to brewing something "reasonably decent" with a Decent Espresso machine. As the project evolved through **ReaPrime** and **Streamline Bridge**, users found the naming confusing. **Decent.app** is simple, direct, and says exactly what it is.
+The original name **REA** stood for "Reasonable Espresso App" — a tongue-in-cheek reference to brewing something "reasonably decent" with a Decent Espresso machine.
+As the project evolved through **ReaPrime** and **Streamline Bridge**,
+users found the naming confusing. **Decent.app** is simple, direct,
+and says exactly what it is.  
+
+However, 2026 marks the 10th anniversary of the first original
+de1app commited first commit into the repo, therefore we decided to name it 'Decaid',
+to signify the ten years of Decent as well as an app, that will **aid** you in making *decent* espresso. 
 
 - **Codebase & repo** still use legacy identifiers (`reaprime`, `tadelv/reaprime`) to avoid breaking App Store / Firebase / Google Play bindings.
-- **Display name** is **Decent** on iOS / Android launchers; **Decent.app** on macOS Finder and in written reference.
+- **Display name** is **Decaid** on iOS / Android launchers; **Decaid.app** on macOS Finder and in written reference.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -287,14 +287,9 @@ make dual-build
 
 ### The Evolution
 
-The original name **REA** stood for "Reasonable Espresso App" — a tongue-in-cheek reference to brewing something "reasonably decent" with a Decent Espresso machine.
-As the project evolved through **ReaPrime** and **Streamline Bridge**,
-users found the naming confusing. **Decent.app** is simple, direct,
-and says exactly what it is.  
+The original name **REA** stood for "Reasonable Espresso App" — a tongue-in-cheek reference to brewing something "reasonably decent" with a Decent Espresso machine. As the project evolved through **ReaPrime** and **Streamline Bridge**, it eventually became **Decent.app**.
 
-However, 2026 marks the 10th anniversary of the first original
-de1app commited first commit into the repo, therefore we decided to name it 'Decaid',
-to signify the ten years of Decent as well as an app, that will **aid** you in making *decent* espresso. 
+In 2026, ten years after the first commit to the original **de1app** repository on May 14, 2016, we renamed the app **Decaid**. The name commemorates that decade of Decent Espresso history while capturing the app's purpose: it **aids** you in making *decent* espresso.
 
 - **Codebase & repo** still use legacy identifiers (`reaprime`, `tadelv/reaprime`) to avoid breaking App Store / Firebase / Google Play bindings.
 - **Display name** is **Decaid** on iOS / Android launchers; **Decaid.app** on macOS Finder and in written reference.

--- a/README.md
+++ b/README.md
@@ -291,8 +291,8 @@ The original name **REA** stood for "Reasonable Espresso App" — a tongue-in-ch
 
 In 2026, ten years after the first commit to the original **de1app** repository on May 14, 2016, we renamed the app **Decaid**. The name commemorates that decade of Decent Espresso history while capturing the app's purpose: it **aids** you in making *decent* espresso.
 
-- **Codebase & repo** still use legacy identifiers (`reaprime`, `tadelv/reaprime`) to avoid breaking App Store / Firebase / Google Play bindings.
-- **Display name** is **Decaid** on iOS / Android launchers; **Decaid.app** on macOS Finder and in written reference.
+- **Internal identifiers** remain unchanged (`reaprime` Dart package, `net.tadel.reaprime` bundle ID, `streamline_bridge` database, and `.reaplugin` extension) to avoid breaking existing integrations.
+- **Display name** is **Decaid** on all platforms. On macOS, Finder displays the application bundle as **Decaid.app**; use **Decaid** in prose.
 
 ## Credits
 
@@ -310,6 +310,6 @@ See the [LICENSE](LICENSE.txt) file for details.
 
 ---
 
-**Need help?** Check our [documentation](/doc) or open an [issue](https://github.com/tadelv/reaprime/issues).
+**Need help?** Check our [documentation](/doc) or open an [issue](https://github.com/decentespresso/decaid/issues).
 
 

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -98,7 +98,7 @@ paths:
             type: boolean
             default: true
         - name: quick
-          description: If true, Decent.app returns an empty array immediately while the same scan-first policy continues in the background. Useful when polling for device updates manually.
+          description: If true, Decaid returns an empty array immediately while the same scan-first policy continues in the background. Useful when polling for device updates manually.
           in: query
           schema:
             type: boolean
@@ -5064,7 +5064,7 @@ components:
       type: object
       properties:
         gatewayMode:
-          description: Control whether Decent acts as gateway. Disabled means gateway is disabled, full means full gateway mode. Tracking means decent will not show graphs, but will control the shot (stop at weight)
+          description: Control whether Decaid acts as gateway. Disabled means gateway is disabled, full means full gateway mode. Tracking means Decaid will not show graphs, but will control the shot (stop at weight)
           type: string
           enum: ["disabled", "full", "tracking"]
           nullable: true

--- a/assets/defaultProfiles/manifest.json
+++ b/assets/defaultProfiles/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "description": "Default espresso profiles bundled with Decent.app",
+  "description": "Default espresso profiles bundled with Decaid",
   "profiles": [
     "7g_basket.json",
     "80s_Espresso.json",

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Decent.app exposes REST and WebSocket APIs on port 8080. Full OpenAPI specs are in [`assets/api/rest_v1.yml`](../assets/api/rest_v1.yml) and [`assets/api/websocket_v1.yml`](../assets/api/websocket_v1.yml). Interactive docs are available at port 4001 when the app is running.
+Decaid exposes REST and WebSocket APIs on port 8080. Full OpenAPI specs are in [`assets/api/rest_v1.yml`](../assets/api/rest_v1.yml) and [`assets/api/websocket_v1.yml`](../assets/api/websocket_v1.yml). Interactive docs are available at port 4001 when the app is running.
 
 For skin development, see [`doc/Skins.md`](Skins.md). For plugin development, see [`doc/Plugins.md`](Plugins.md).
 

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -1,17 +1,17 @@
 
-# Decent.app Plugin Development Guide
+# Decaid Plugin Development Guide
 
 ## Overview
 
-> **Note on naming:** Plugin JS APIs use `Rea`-prefixed names (`fetchReaSettings`, `updateReaSetting`, `convertReaToVisualizerFormat`) for backwards compatibility with existing plugins. These were not renamed during the app rename from ReaPrime to Decent.app.
+> **Note on naming:** Plugin JS APIs use `Rea`-prefixed names (`fetchReaSettings`, `updateReaSetting`, `convertReaToVisualizerFormat`) for backwards compatibility with existing plugins. These were not renamed during the app rename from ReaPrime to Decaid.
 
-Decent.app plugins are JavaScript modules that extend the functionality of Decent.app.
+Decaid plugins are JavaScript modules that extend the functionality of Decaid.
 Plugins run in a sandboxed JavaScript environment and can react to machine events,
-store data, make HTTP requests, and emit events through the Decent.app API.
+store data, make HTTP requests, and emit events through the Decaid API.
 
 ## Plugin Structure
 
-A Decent.app plugin consists of two required files:
+A Decaid plugin consists of two required files:
 
 ### 1. `manifest.json` - Plugin metadata and configuration
 
@@ -126,7 +126,7 @@ host.storage({
 });
 ```
 
-**Note:** namespace is not used by Decent.app internally, the plugin storage is namespaced to the plugins' identifier.
+**Note:** namespace is not used by Decaid internally, the plugin storage is namespaced to the plugins' identifier.
 
 ### `host.decentProxy(path, options)`
 Call the Decent account proxy without exposing stored credentials to plugin code. The plugin must declare the `proxy.decent_api` permission in `manifest.json`; calls without that permission are rejected and logged.
@@ -206,7 +206,7 @@ host.emit("timeToReady", {
 ```
 
 The event name is tied to the api endpoint, defined in the plugin manifest.
-When Decent.app matches an external request to an endpoint that is defined in the
+When Decaid matches an external request to an endpoint that is defined in the
 plugins manifest,
 it will send over events emitted by the plugin.
 
@@ -216,7 +216,7 @@ Example:
 npx wscat -c ws://localhost:8080/ws/v1/plugins/time-to-ready.reaplugin/timeToReady
 
 ```
-Will open a websocket through which Decent.app will forward all the `timeToReady` events
+Will open a websocket through which Decaid will forward all the `timeToReady` events
 
 ## HTTP Requests
 
@@ -255,7 +255,7 @@ const upload = await fetch("https://api.example.com/upload", {
 
 ### Load watchdog
 
-Decent.app records consecutive load failures for each plugin. After three failures, auto-load is disabled so the plugin no longer runs on subsequent launches. A plugin whose load was interrupted by an app exit is disabled on the next launch immediately, which also covers JavaScript evaluation that blocks before Dart's one-second timeout can fire.
+Decaid records consecutive load failures for each plugin. After three failures, auto-load is disabled so the plugin no longer runs on subsequent launches. A plugin whose load was interrupted by an app exit is disabled on the next launch immediately, which also covers JavaScript evaluation that blocks before Dart's one-second timeout can fire.
 
 Disabled plugins remain installed and can be re-enabled from plugin settings or `POST /api/v1/plugins/:id/enable`. Re-enabling clears the failure count and gives the plugin a fresh attempt; a successful load also clears it.
 
@@ -381,9 +381,9 @@ When receiving `stateUpdate` events, the payload contains:
 - Use `host.log()` extensively during development
 - Check Flutter app logs for JavaScript errors
 - Test with simple plugins first, then add complexity
-- When iterating, it helps to debug on a platform that can access Decent.app
+- When iterating, it helps to debug on a platform that can access Decaid
 documents. This way, you can edit plugin source directly and simply reload
-it in Decent.app UI.
+it in Decaid UI.
 
 ## API Reference
 
@@ -406,14 +406,14 @@ it in Decent.app UI.
 - HTTP requests are proxied through Flutter (respects system proxy settings)
 - Storage is isolated per plugin
 - No filesystem access beyond the plugin's own directory
-- No network access to localhost/private IPs (except for Decent.app API)
+- No network access to localhost/private IPs (except for Decaid API)
 
 ## Reference Implementation: DYE2 Plugin
 
 The DYE2 (Describe Your Espresso) plugin in `packages/dye2-plugin/` is a production bundled plugin that demonstrates advanced patterns:
 
 - **TypeScript + Vite build pipeline** — compiles to flutter_js-compatible IIFE bundle
-- **REST API client** — calls back into the Decent.app REST API for bean/grinder CRUD
+- **REST API client** — calls back into the Decaid REST API for bean/grinder CRUD
 - **HTML template rendering** — server-side HTML generation with form handling
 - **Dev server** — Vite dev server for fast iteration without rebuilding the Flutter app
 

--- a/doc/Profiles.md
+++ b/doc/Profiles.md
@@ -175,7 +175,7 @@ Manifest structure:
 ```json
 {
   "version": "1.0.0",
-  "description": "Default espresso profiles bundled with Decent.app",
+  "description": "Default espresso profiles bundled with Decaid",
   "profiles": [
     "best_practice.json",
     "cremina.json",

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -28,13 +28,13 @@ git push origin v1.0.0-alpha.1
 
 ### Step 2: Monitor the Build
 
-1. Go to https://github.com/tadelv/reaprime/actions
+1. Go to https://github.com/decentespresso/decaid/actions
 2. Watch the "Create Release" workflow
 3. Wait for it to complete (usually 5-10 minutes)
 
 ### Step 3: Verify the Release
 
-1. Go to https://github.com/tadelv/reaprime/releases
+1. Go to https://github.com/decentespresso/decaid/releases
 2. Your new release should appear with all platform artifacts attached
 3. Download and test the relevant artifacts
 

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -1,10 +1,10 @@
 # Release Guide
 
-This document describes how to create releases for Decent.app.
+This document describes how to create releases for Decaid.
 
 ## Creating a Release
 
-Decent.app uses git tags to trigger automatic releases. When you push a tag, GitHub Actions will:
+Decaid uses git tags to trigger automatic releases. When you push a tag, GitHub Actions will:
 1. Build all supported platforms
 2. Export the iOS archive for TestFlight
 3. Generate release notes from merged pull requests using GitHub's release-notes generator
@@ -40,7 +40,7 @@ git push origin v1.0.0-alpha.1
 
 ## Version Numbering
 
-Decent.app follows [Semantic Versioning](https://semver.org/):
+Decaid follows [Semantic Versioning](https://semver.org/):
 
 - **MAJOR.MINOR.PATCH** (e.g., `v1.2.3`)
   - **MAJOR**: Breaking changes or major new features

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -1,12 +1,12 @@
 # Skins.md
 
-## WebUI Development Guide for Decent.app
+## WebUI Development Guide for Decaid
 
-This guide covers how to develop custom web-based user interfaces (skins) for the Decent.app gateway. Skins connect to the Decent.app API to control espresso machines, read sensor data, and create custom user experiences.
+This guide covers how to develop custom web-based user interfaces (skins) for the Decaid gateway. Skins connect to the Decaid API to control espresso machines, read sensor data, and create custom user experiences.
 
 ### What is a Skin?
 
-A **skin** is a web application that communicates with Decent.app via REST and WebSocket APIs. Skins can:
+A **skin** is a web application that communicates with Decaid via REST and WebSocket APIs. Skins can:
 - Display real-time machine state (temperatures, pressures, flow rates)
 - Control espresso shot execution and machine state
 - Manage profiles and workflows
@@ -40,8 +40,7 @@ The **Streamline Project** is a reference implementation:
          │ (REST & WebSocket)
          ▼
 ┌─────────────────┐
-│ Streamline-     │
-│ Bridge Gateway  │
+│ Decaid          │
 │   :8080         │
 └────────┬────────┘
          │ BLE/Serial
@@ -60,10 +59,10 @@ The **Streamline Project** is a reference implementation:
 
 ### Embedded Skin Lifecycle
 
-On Android and iOS, Decent.app pauses the embedded WebView while the app is
+On Android and iOS, Decaid pauses the embedded WebView while the app is
 backgrounded. After ten minutes in the background, it unloads the page and
 reloads the selected skin when the app returns. Skin state that must survive
-this reload should be persisted through the Decent.app API or browser storage.
+this reload should be persisted through the Decaid API or browser storage.
 
 ---
 
@@ -71,7 +70,7 @@ this reload should be persisted through the Decent.app API or browser storage.
 
 ### 1. Basic Connection
 
-Connect to the gateway at `http://<gateway-ip>:8080`
+Connect to the Decaid gateway at `http://<gateway-ip>:8080`
 
 ```javascript
 const GATEWAY_URL = 'http://192.168.1.100:8080';
@@ -170,7 +169,7 @@ Returns all discovered devices with their connection states.
 GET /api/v1/devices/scan
 ```
 
-Triggers a scan-first connection cycle. With the default `connect=true`, Decent.app preserves connected devices and automatically fills only missing machine and scale slots. Preferred devices connect without prompting when found; missing preferred devices or multiple candidates produce machine-first, then scale ambiguity on `ws/v1/devices`. Set `connect=false` for discovery only. Use `quick=true` to return immediately without waiting for scan results.
+Triggers a scan-first connection cycle. With the default `connect=true`, Decaid preserves connected devices and automatically fills only missing machine and scale slots. Preferred devices connect without prompting when found; missing preferred devices or multiple candidates produce machine-first, then scale ambiguity on `ws/v1/devices`. Set `connect=false` for discovery only. Use `quick=true` to return immediately without waiting for scan results.
 
 #### Connect to Device
 ```http
@@ -761,7 +760,7 @@ Permanently deletes a shot record.
 
 ### Coffee Beans, Grinders & Workflows
 
-Decent.app manages coffee beans, bean batches, and grinders as first-class entities that can be linked to workflows and shot records.
+Decaid manages coffee beans, bean batches, and grinders as first-class entities that can be linked to workflows and shot records.
 
 #### How It Fits Together
 
@@ -978,7 +977,7 @@ DELETE /api/v1/grinders/{id}
 
 ### Profiles API
 
-Decent.app uses content-based hashing for profile IDs. Profile IDs are calculated from execution-relevant fields, meaning identical profiles have the same ID across all devices.
+Decaid uses content-based hashing for profile IDs. Profile IDs are calculated from execution-relevant fields, meaning identical profiles have the same ID across all devices.
 
 #### List All Profiles
 ```http
@@ -1144,7 +1143,7 @@ Restores a bundled default profile from assets by filename.
 
 ### Sensors API
 
-Decent.app supports extensible sensor devices that can provide custom data streams.
+Decaid supports extensible sensor devices that can provide custom data streams.
 
 #### List Connected Sensors
 ```http
@@ -1208,7 +1207,7 @@ Content-Type: application/json
 
 ### REA Settings
 
-Configure Decent.app gateway behavior.
+Configure Decaid gateway behavior.
 
 #### Get REA Settings
 ```http
@@ -1256,7 +1255,7 @@ GET /api/v1/settings
 - `displayOff`: Turn off scale display when machine sleeps
 - `disconnect`: Disconnect scale when machine sleeps
 
-#### Update Decent.app Settings
+#### Update Decaid Settings
 ```http
 POST /api/v1/settings
 Content-Type: application/json
@@ -1274,7 +1273,7 @@ Only include fields you want to update. Changes take effect immediately.
 
 ### Key-Value Store
 
-Decent.app provides a simple key-value store for client applications to persist data.
+Decaid provides a simple key-value store for client applications to persist data.
 
 #### List Keys in Namespace
 ```http
@@ -1590,7 +1589,7 @@ Returns 404 if the schedule ID doesn't exist.
 
 ### Build Info
 
-Retrieve build-time metadata about the running Decent.app instance. Useful for skins that want to display version information or check compatibility.
+Retrieve build-time metadata about the running Decaid instance. Useful for skins that want to display version information or check compatibility.
 
 #### Get Build Info
 ```http
@@ -2606,7 +2605,7 @@ Here's a complete minimal skin implementation:
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Minimal Decent.app Skin</title>
+  <title>Minimal Decaid Skin</title>
   <style>
     body {
       font-family: 'Segoe UI', system-ui, sans-serif;
@@ -2866,12 +2865,12 @@ Here's a complete minimal skin implementation:
 - Check browser console for WebSocket errors
 - Verify connection state: `ws.readyState` (1 = OPEN)
 - Implement reconnection logic (see Best Practices)
-- Check if machine is actually connected to Decent.app
+- Check if machine is actually connected to Decaid
 
 ### Commands Don't Execute
 - Check HTTP response status codes
 - Verify machine is in correct state for the operation
-- Review Decent.app logs: Connect to `ws://<ip>:8080/ws/v1/logs`
+- Review Decaid logs: Connect to `ws://<ip>:8080/ws/v1/logs`
 - Ensure machine is connected: `GET /api/v1/devices`
 
 ### Profile Upload Fails
@@ -2905,11 +2904,11 @@ This serves OpenAPI/Swagger documentation with:
 
 ## Skin Development & Deployment
 
-This section covers how to develop, build, and deploy custom WebUI skins for Decent.app, including support for modern web frameworks like Next.js, React, Vue, Svelte, and others.
+This section covers how to develop, build, and deploy custom WebUI skins for Decaid, including support for modern web frameworks like Next.js, React, Vue, Svelte, and others.
 
 ### Understanding Skin Distribution
 
-Decent.app supports multiple skin installation methods:
+Decaid supports multiple skin installation methods:
 
 1. **Bundled Asset Skins**: Skins packaged with the Flutter app (in `assets/web/`)
 2. **Remote Bundled Skins**: Skins auto-downloaded from hardcoded GitHub URLs on app startup
@@ -2956,7 +2955,7 @@ The endpoint only serves files from already-installed skins — install the asse
 
 ### Skin Metadata: manifest.json
 
-While optional, including a `manifest.json` helps Decent.app display better skin information:
+While optional, including a `manifest.json` helps Decaid display better skin information:
 
 ```json
 {
@@ -3008,12 +3007,12 @@ npm run build
 
 This creates an `out/` directory with static HTML/CSS/JS files.
 
-### 2. Test Locally with Decent.app
+### 2. Test Locally with Decaid
 
 **Option A: Live-Edit Mode** (recommended for development on desktop):
 
 1. Build your skin (`npm run build`)
-2. In Decent.app **Settings**, select **"Live-edit from folder..."**
+2. In Decaid **Settings**, select **"Live-edit from folder..."**
 3. Point it at your build output directory (e.g., `out/` or `dist/`)
 4. Edit, rebuild, and refresh — no reinstallation needed
 
@@ -3039,12 +3038,12 @@ curl -X POST http://localhost:8080/api/v1/webui/skins/install/url \
 npm run dev
 
 # Access directly at http://localhost:3000
-# Connect to Decent.app API at http://<gateway-ip>:8080
+# Connect to Decaid API at http://<gateway-ip>:8080
 ```
 
 ### 3. Connect to Gateway During Development
 
-When developing locally, your skin needs to connect to the Decent.app gateway:
+When developing locally, your skin needs to connect to the Decaid gateway:
 
 ```javascript
 // Use environment variable or config
@@ -3219,7 +3218,7 @@ Then install from the `dist` branch:
 
 ---
 
-## Configuring Decent.app for Auto-Download
+## Configuring Decaid for Auto-Download
 
 ### For Remote Bundled Skins (Auto-Download on Startup)
 
@@ -3249,7 +3248,7 @@ static const List<Map<String, dynamic>> _remoteWebUISources = [
 ];
 ```
 
-**Decent.app will:**
+**Decaid will:**
 - Download skins on first app startup
 - Check for updates on subsequent startups
 - For GitHub releases: checks for new release tags
@@ -3270,7 +3269,7 @@ The Settings screen provides a skin selector dropdown with built-in management:
 **Live-Edit Mode (Development):**
 1. Select **"Live-edit from folder..."** in the skin dropdown
 2. Pick a folder containing your skin's build output
-3. Decent.app serves files directly from that folder — no copying
+3. Decaid serves files directly from that folder — no copying
 4. Edit your skin files and refresh the browser to see changes instantly
 
 Live-edit validates that the selected folder contains an `index.html`.
@@ -3278,7 +3277,7 @@ Live-edit validates that the selected folder contains an `index.html`.
 **Deleting a Skin:**
 - Non-bundled skins show a delete button (trash icon) in the dropdown
 - Confirmation dialog prevents accidental deletion
-- If the deleted skin is currently active, Decent.app switches to the default skin
+- If the deleted skin is currently active, Decaid switches to the default skin
 
 **Platform Support:**
 
@@ -3392,7 +3391,7 @@ The default skin preference:
 
 ## Version Management & Updates
 
-Decent.app tracks skin metadata in `.rea_metadata.json`:
+Decaid tracks skin metadata in `.rea_metadata.json`:
 
 ```json
 {
@@ -3432,7 +3431,7 @@ NEXT_PUBLIC_GATEWAY_URL=http://localhost:8080
 NEXT_PUBLIC_WS_URL=ws://localhost:8080
 ```
 
-**Why localhost in production?** When served by Decent.app, the skin runs on the same device as the gateway.
+**Why localhost in production?** When served by Decaid, the skin runs on the same device as the gateway.
 
 ### 2. Static Export Configuration
 
@@ -3594,12 +3593,12 @@ During development with skin on `localhost:3000` and gateway on `192.168.1.100:8
 - Use explicit gateway IP in `NEXT_PUBLIC_WS_URL`
 - Check browser console for connection errors
 
-### Skin Not Appearing in Decent.app
+### Skin Not Appearing in Decaid
 
 - Verify directory name or `manifest.json` `id` field
 - Check `ApplicationDocuments/web-ui/` directory exists
 - Ensure `index.html` is at root of skin directory
-- Review Decent.app logs for installation errors
+- Review Decaid logs for installation errors
 
 ### Updates Not Detected
 
@@ -3743,7 +3742,7 @@ Once your skin is ready for public use:
    - Provide setup instructions
 
 2. **Add to community list:**
-   - Submit PR to Decent.app documentation
+   - Submit PR to Decaid documentation
    - Share on Decent Diaspora forums
 
 3. **Consider open-sourcing:**
@@ -3778,7 +3777,7 @@ Once your skin is ready for public use:
 
 **For Auto-Updates:**
 - Add your skin to `_remoteWebUISources` in `webui_storage.dart`
-- Decent.app will auto-download and check for updates
+- Decaid will auto-download and check for updates
 - Uses HTTP headers for efficient version detection
 
-For questions or issues, open an issue on the [Decent.app GitHub repository](https://github.com/tadelv/reaprime).
+For questions or issues, open an issue on the [Decaid GitHub repository](https://github.com/decentespresso/decaid).

--- a/packages/dye2-plugin/README.md
+++ b/packages/dye2-plugin/README.md
@@ -1,10 +1,10 @@
 # DYE2 Plugin
 
-DYE2 (Describe Your Espresso 2) is a first-party plugin for [Decent.app](../../README.md) that provides bean, grinder, and equipment management UI for Decent Espresso machines.
+DYE2 (Describe Your Espresso 2) is a first-party plugin for [Decaid](../../README.md) that provides bean, grinder, and equipment management UI for Decent Espresso machines.
 
 ## Goal
 
-The core Decent.app stores beans, grinders, and batches in its database and exposes them via REST API — but provides no management UI for these entities. DYE2 fills that gap: it serves HTML pages with Web Components for full CRUD operations, plus lightweight pickers that skins can embed to select beans/grinders for the current workflow.
+The core Decaid stores beans, grinders, and batches in its database and exposes them via REST API — but provides no management UI for these entities. DYE2 fills that gap: it serves HTML pages with Web Components for full CRUD operations, plus lightweight pickers that skins can embed to select beans/grinders for the current workflow.
 
 Long-term, DYE2 will expand to cover shot annotations (TDS, extraction yield, tasting notes), equipment tracking (baskets, portafilters), water chemistry, and commercial blend management.
 
@@ -13,12 +13,12 @@ Long-term, DYE2 will expand to cover shot annotations (TDS, extraction yield, ta
 DYE2 runs across two JavaScript runtimes:
 
 1. **flutter_js** (server-side) — executes `plugin.js`, handles the plugin lifecycle, and routes HTTP requests to page generators that return HTML strings.
-2. **Browser** (client-side) — renders the HTML pages served by the plugin. Web Components in the page call the core Decent.app REST API directly via `fetch()`.
+2. **Browser** (client-side) — renders the HTML pages served by the plugin. Web Components in the page call the core Decaid REST API directly via `fetch()`.
 
-The plugin itself is essentially an HTTP server: it receives requests from the Decent.app plugin framework and returns HTML responses. All data persistence goes through the core REST API (`/api/v1/beans`, `/api/v1/grinders`, `/api/v1/workflow`), not through plugin-local storage.
+The plugin itself is essentially an HTTP server: it receives requests from the Decaid plugin framework and returns HTML responses. All data persistence goes through the core REST API (`/api/v1/beans`, `/api/v1/grinders`, `/api/v1/workflow`), not through plugin-local storage.
 
 ```
-Browser                          Decent.app            flutter_js
+Browser                          Decaid            flutter_js
 ──────                          ─────────────────                ──────────
   │ GET /api/v1/plugins/                │                            │
   │   dye2.reaplugin/beans              │                            │
@@ -116,13 +116,13 @@ After building, the Flutter app picks up the plugin from `assets/plugins/dye2.re
 
 ## Local Development
 
-The normal workflow — build plugin, hot-restart Flutter app, navigate to the plugin page — is slow for UI iteration. The dev server shortcuts this: it loads the built `plugin.js` in a Node.js VM, serves pages directly in the browser, and proxies REST API calls to a running Decent.app instance. Edit source, save, and the browser shows the result within seconds.
+The normal workflow — build plugin, hot-restart Flutter app, navigate to the plugin page — is slow for UI iteration. The dev server shortcuts this: it loads the built `plugin.js` in a Node.js VM, serves pages directly in the browser, and proxies REST API calls to a running Decaid instance. Edit source, save, and the browser shows the result within seconds.
 
 ### Prerequisites
 
 - Node.js 20+
 - `npm install` (one time)
-- A running Decent.app instance (for API data). Start one with:
+- A running Decaid instance (for API data). Start one with:
   ```bash
   # From the repo root
   flutter run --dart-define=simulate=1 -d macos   # or linux, chrome, etc.
@@ -156,7 +156,7 @@ The pages served by the dev server are functionally identical to what the Flutte
 ### How it works
 
 ```
-Browser                    Dev Server (:4444)              Decent.app (:8080)
+Browser                    Dev Server (:4444)              Decaid (:8080)
 ──────                    ──────────────────              ─────────────────────────
   │ GET /beans                  │                                │
   │────────────────────────────>│                                │
@@ -172,7 +172,7 @@ Browser                    Dev Server (:4444)              Decent.app (:8080)
 ```
 
 - Plugin pages (`/beans`, `/grinders`, `/bean-picker`, `/grinder-picker`) are served by running the plugin's `__httpRequestHandler` in a Node.js VM sandbox
-- API requests (`/api/v1/*`) are proxied to the Decent.app instance
+- API requests (`/api/v1/*`) are proxied to the Decaid instance
 - `plugin.js` is watched with `fs.watch()` and auto-reloaded on change (debounced)
 
 ### Configuration
@@ -180,7 +180,7 @@ Browser                    Dev Server (:4444)              Decent.app (:8080)
 | Env var | Default | Description |
 |---------|---------|-------------|
 | `PORT` | `4444` | Dev server port |
-| `BRIDGE_URL` | `http://localhost:8080` | Decent.app URL to proxy API calls to |
+| `BRIDGE_URL` | `http://localhost:8080` | Decaid URL to proxy API calls to |
 
 ```bash
 PORT=5000 BRIDGE_URL=http://192.168.1.5:8080 npm run serve
@@ -251,7 +251,7 @@ customElements.define('dye2-example', Dye2Example);
 Key constraints:
 - Components are compiled to **string constants** and inlined into HTML `<script>` tags — they do not execute in flutter_js.
 - No framework dependencies — vanilla `HTMLElement`, `innerHTML`, `addEventListener`.
-- All data operations use `fetch()` against the core Decent.app REST API.
+- All data operations use `fetch()` against the core Decaid REST API.
 - Use `escapeHtml()` from `utils/html.ts` for any user-provided data rendered into HTML.
 
 ### Core REST API endpoints used by DYE2

--- a/packages/dye2-plugin/README.md
+++ b/packages/dye2-plugin/README.md
@@ -18,7 +18,7 @@ DYE2 runs across two JavaScript runtimes:
 The plugin itself is essentially an HTTP server: it receives requests from the Decaid plugin framework and returns HTML responses. All data persistence goes through the core REST API (`/api/v1/beans`, `/api/v1/grinders`, `/api/v1/workflow`), not through plugin-local storage.
 
 ```
-Browser                          Decaid            flutter_js
+Browser                          Decaid                flutter_js
 ──────                          ─────────────────                ──────────
   │ GET /api/v1/plugins/                │                            │
   │   dye2.reaplugin/beans              │                            │


### PR DESCRIPTION
## Summary

- Problem:
The rename to 'Decaid' was missing a few pieces. This PR completes the rename and explains the rationale behind the name change. 

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Documentation Obligations (required)

These are **not optional**. Stale specs mislead clients and agents.

- [x] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [x] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [x] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [x] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [x] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A — no docs affected

## User-Visible Changes

The app and documentation are now represented with the name "Decaid"

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — no remaining changes
- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds