### PR TITLE
fix: make workflow device writes atomic

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -901,7 +901,20 @@ paths:
       summary: Update current workflow
       description: |
         Updates the current workflow. This is the **recommended method** for applying changes
-        to the machine and brewing parameters in one atomic operation.
+        to the machine and brewing parameters in one operation. The request is deep-merged
+        with the current workflow. Required direct rinse, steam, and hot-water writes are
+        completed before the new workflow is published.
+
+        Workflow updates captured in separate debounce windows are serialized. Each batch
+        reads the current workflow when it begins execution, so a later batch includes
+        earlier committed changes. The controller commit is atomic: if a required machine
+        write fails, the endpoint returns `500` and the application workflow remains
+        unchanged. Individual machine writes that completed before the failure are not
+        rolled back. Retrying the same request is safe because a failed batch did not commit
+        its workflow state, so the required writes are attempted again.
+
+        Profile synchronization remains asynchronous and is handled separately by
+        `WorkflowDeviceSync` after a successful workflow commit.
 
         You can update the complete workflow or just specific fields:
         - **context**: Set dose, grinder, coffee, and people metadata (recommended)
@@ -1009,7 +1022,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         "500":
-          description: Internal server error during DE1 side-effect writes
+          description: A required direct machine write failed. The application workflow remains unchanged; machine writes that completed before the failure are not rolled back.
           content:
             application/json:
               schema:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -913,8 +913,9 @@ paths:
         rolled back. Retrying the same request is safe because a failed batch did not commit
         its workflow state, so the required writes are attempted again.
 
-        Profile synchronization remains asynchronous and is handled separately by
-        `WorkflowDeviceSync` after a successful workflow commit.
+        Profile synchronization and Bengle stop-at-temperature target updates
+        remain asynchronous and are handled separately by `WorkflowDeviceSync`
+        and `BengleSteamStopBridge` after a successful workflow commit.
 
         You can update the complete workflow or just specific fields:
         - **context**: Set dose, grinder, coffee, and people metadata (recommended)

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -118,3 +118,17 @@ All four machine sockets: `/ws/v1/machine/snapshot`, `/ws/v1/machine/shotSetting
 ## Keeping Notes Fresh
 
 Add protocol compatibility rules, API versioning decisions, and endpoint design rationale. Prune when specs are updated.
+
+## Workflow Commit Ordering
+
+`WorkflowHandler` reads the workflow base when a debounced batch reaches the
+serialized mutation queue, then performs changed direct rinse, steam, and
+hot-water writes before calling `WorkflowController.setWorkflow`. This keeps a
+failed machine write from publishing uncommitted controller state. Separate
+debounced batches are serialized so later merges include earlier successful
+commits and failed batches leave the next batch reading the unchanged state.
+
+`WorkflowDeviceSync` remains responsible only for asynchronous profile upload
+and retry after the eventual successful controller commit. This provides
+controller commit atomicity, not machine rollback: individual writes that
+completed before a later failure may already have reached the machine.

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -129,6 +129,8 @@ debounced batches are serialized so later merges include earlier successful
 commits and failed batches leave the next batch reading the unchanged state.
 
 `WorkflowDeviceSync` remains responsible only for asynchronous profile upload
-and retry after the eventual successful controller commit. This provides
-controller commit atomicity, not machine rollback: individual writes that
-completed before a later failure may already have reached the machine.
+and retry after the eventual successful controller commit. `BengleSteamStopBridge`
+similarly applies `SteamSettings.stopAtTemperature` asynchronously after the
+commit when a Bengle is connected. This provides controller commit atomicity,
+not machine rollback: individual writes that completed before a later failure
+may already have reached the machine.

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -136,8 +136,9 @@ enters `steam` and finalized when it leaves. Today no probe is wired in
 production, so `SteamSnapshot.milkTemperature` is `null` on every frame —
 the API surface is scaffolding for skin developers and for future
 probe / FW support. `SteamSettings.stopAtTemperature` (in
-`/api/v1/workflow`) is the target the future FW-autonomous stop or
-in-app stop will trigger on.
+`/api/v1/workflow`) is stored in the workflow and applied asynchronously by
+`BengleSteamStopBridge` when a Bengle is connected. It is the target the
+future FW-autonomous stop or in-app stop will trigger on.
 
 | Method | Path | Description | Handler |
 |--------|------|-------------|---------|
@@ -182,8 +183,9 @@ If a required direct machine write fails, the endpoint returns `500` and the
 controller workflow remains unchanged. Earlier individual machine writes are
 not rolled back, so this is controller commit atomicity rather than machine
 rollback. Retrying the exact request reissues the required writes. Profile
-uploads remain asynchronous and are owned and retried separately by
-`WorkflowDeviceSync` after the successful workflow commit.
+uploads and Bengle stop-at-temperature target updates remain asynchronous and
+are owned and retried separately by `WorkflowDeviceSync` and
+`BengleSteamStopBridge` after the successful workflow commit.
 
 ### Beans
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -172,6 +172,19 @@ in-app stop will trigger on.
 | GET | `/api/v1/workflow` | Get current workflow (profile + context) | `workflow_handler.dart` |
 | PUT | `/api/v1/workflow` | Update workflow (deep merge) | |
 
+`PUT /api/v1/workflow` deep-merges the request body with the current workflow.
+Requests captured in separate debounce windows execute serially, and each batch
+reads its workflow base when it starts. Changed rinse, steam, and hot-water
+settings are written to the machine before the controller publishes the new
+workflow and the request returns `200`.
+
+If a required direct machine write fails, the endpoint returns `500` and the
+controller workflow remains unchanged. Earlier individual machine writes are
+not rolled back, so this is controller commit atomicity rather than machine
+rollback. Retrying the exact request reissues the required writes. Profile
+uploads remain asynchronous and are owned and retried separately by
+`WorkflowDeviceSync` after the successful workflow commit.
+
 ### Beans
 
 | Method | Path | Description | Handler |

--- a/lib/src/controllers/workflow_controller.dart
+++ b/lib/src/controllers/workflow_controller.dart
@@ -17,6 +17,7 @@ class WorkflowController extends ChangeNotifier {
     hotWaterData: HotWaterData.defaults(),
     rinseData: RinseData.defaults(),
   );
+  int _revision = 0;
 
   Workflow newWorkflow() {
     return Workflow(
@@ -33,9 +34,20 @@ class WorkflowController extends ChangeNotifier {
 
   Workflow get currentWorkflow => _currentWorkflow;
 
+  int get revision => _revision;
+
   void setWorkflow(Workflow newWorkflow) {
     _currentWorkflow = newWorkflow;
+    _revision++;
     notifyListeners();
+  }
+
+  bool setWorkflowIfRevision(Workflow newWorkflow, int expectedRevision) {
+    if (_revision != expectedRevision) {
+      return false;
+    }
+    setWorkflow(newWorkflow);
+    return true;
   }
 
   void updateWorkflow({
@@ -56,6 +68,7 @@ class WorkflowController extends ChangeNotifier {
       hotWaterData: hotWaterData,
       rinseData: rinseData,
     );
+    _revision++;
     notifyListeners();
   }
 }

--- a/lib/src/services/webserver/workflow_handler.dart
+++ b/lib/src/services/webserver/workflow_handler.dart
@@ -79,41 +79,45 @@ class WorkflowHandler {
     List<Completer<Response>> responses,
   ) async {
     try {
-      final oldWorkflow = _controller.currentWorkflow;
-      final currentJson = oldWorkflow.toJson();
-      final resultJson = deepMergeJson(currentJson, merge);
-      final updatedWorkflow = Workflow.fromJson(resultJson);
+      while (true) {
+        final oldWorkflow = _controller.currentWorkflow;
+        final revision = _controller.revision;
+        final resultJson = deepMergeJson(oldWorkflow.toJson(), merge);
+        final updatedWorkflow = Workflow.fromJson(resultJson);
 
-      // Profile push is owned by WorkflowDeviceSync — it observes
-      // `setWorkflow` and uploads the profile if it changed. Keeping a
-      // second setProfile call here would race against that listener and
-      // write every BLE frame twice (see the profile-double-upload P0).
-      if (oldWorkflow.rinseData != updatedWorkflow.rinseData) {
-        await _de1controller.updateFlushSettings(updatedWorkflow.rinseData);
-      }
-      if (oldWorkflow.steamSettings != updatedWorkflow.steamSettings) {
-        await _de1controller.updateSteamSettings(
-          SteamFormSettings(
-            steamEnabled: updatedWorkflow.steamSettings.duration > 0,
-            targetTemp: updatedWorkflow.steamSettings.targetTemperature,
-            targetDuration: updatedWorkflow.steamSettings.duration,
-            targetFlow: updatedWorkflow.steamSettings.flow,
-          ),
-        );
-      }
-      if (oldWorkflow.hotWaterData != updatedWorkflow.hotWaterData) {
-        await _de1controller.updateHotWaterSettings(
-          HotWaterFormSettings(
-            targetTemperature: updatedWorkflow.hotWaterData.targetTemperature,
-            flow: updatedWorkflow.hotWaterData.flow,
-            volume: updatedWorkflow.hotWaterData.volume,
-            duration: updatedWorkflow.hotWaterData.duration,
-          ),
-        );
-      }
+        // Profile push is owned by WorkflowDeviceSync — it observes
+        // `setWorkflow` and uploads the profile if it changed. Keeping a
+        // second setProfile call here would race against that listener and
+        // write every BLE frame twice (see the profile-double-upload P0).
+        if (oldWorkflow.rinseData != updatedWorkflow.rinseData) {
+          await _de1controller.updateFlushSettings(updatedWorkflow.rinseData);
+        }
+        if (oldWorkflow.steamSettings != updatedWorkflow.steamSettings) {
+          await _de1controller.updateSteamSettings(
+            SteamFormSettings(
+              steamEnabled: updatedWorkflow.steamSettings.duration > 0,
+              targetTemp: updatedWorkflow.steamSettings.targetTemperature,
+              targetDuration: updatedWorkflow.steamSettings.duration,
+              targetFlow: updatedWorkflow.steamSettings.flow,
+            ),
+          );
+        }
+        if (oldWorkflow.hotWaterData != updatedWorkflow.hotWaterData) {
+          await _de1controller.updateHotWaterSettings(
+            HotWaterFormSettings(
+              targetTemperature: updatedWorkflow.hotWaterData.targetTemperature,
+              flow: updatedWorkflow.hotWaterData.flow,
+              volume: updatedWorkflow.hotWaterData.volume,
+              duration: updatedWorkflow.hotWaterData.duration,
+            ),
+          );
+        }
 
-      _controller.setWorkflow(updatedWorkflow);
-      _completeResponses(responses, () => jsonOk(updatedWorkflow.toJson()));
+        if (_controller.setWorkflowIfRevision(updatedWorkflow, revision)) {
+          _completeResponses(responses, () => jsonOk(updatedWorkflow.toJson()));
+          return;
+        }
+      }
     } on ArgumentError catch (e) {
       // Client sent a payload that fails validation (e.g. an invalid
       // enum value like ExitType 'weight', or a missing required

--- a/lib/src/services/webserver/workflow_handler.dart
+++ b/lib/src/services/webserver/workflow_handler.dart
@@ -20,6 +20,7 @@ class WorkflowHandler {
   Timer? _debounceTimer;
   Map<String, dynamic> _pendingMerge = {};
   final List<Completer<Response>> _pendingResponses = [];
+  Future<void> _mutationTail = Future<void>.value();
 
   static const _debounceDuration = Duration(milliseconds: 400);
 
@@ -49,24 +50,40 @@ class WorkflowHandler {
     _pendingResponses.add(completer);
 
     _debounceTimer?.cancel();
-    _debounceTimer = Timer(_debounceDuration, _applyPendingUpdate);
+    _debounceTimer = Timer(_debounceDuration, _capturePendingUpdate);
 
     return completer.future;
   }
 
-  Future<void> _applyPendingUpdate() async {
-    final merge = _pendingMerge;
+  void _capturePendingUpdate() {
+    final merge = Map<String, dynamic>.from(_pendingMerge);
     final responses = List<Completer<Response>>.from(_pendingResponses);
     _pendingMerge = {};
     _pendingResponses.clear();
 
+    _mutationTail = _mutationTail.then<void>((_) async {
+      try {
+        await _applyPendingUpdate(merge, responses);
+      } catch (e, st) {
+        _log.severe('Error in queued workflow update', e, st);
+        _completeResponses(
+          responses,
+          () => jsonError({'error': 'Internal server error', 'message': '$e'}),
+        );
+      }
+    });
+  }
+
+  Future<void> _applyPendingUpdate(
+    Map<String, dynamic> merge,
+    List<Completer<Response>> responses,
+  ) async {
     try {
       final oldWorkflow = _controller.currentWorkflow;
       final currentJson = oldWorkflow.toJson();
       final resultJson = deepMergeJson(currentJson, merge);
       final updatedWorkflow = Workflow.fromJson(resultJson);
 
-      _controller.setWorkflow(updatedWorkflow);
       // Profile push is owned by WorkflowDeviceSync — it observes
       // `setWorkflow` and uploads the profile if it changed. Keeping a
       // second setProfile call here would race against that listener and
@@ -95,9 +112,8 @@ class WorkflowHandler {
         );
       }
 
-      for (final completer in responses) {
-        completer.complete(jsonOk(updatedWorkflow.toJson()));
-      }
+      _controller.setWorkflow(updatedWorkflow);
+      _completeResponses(responses, () => jsonOk(updatedWorkflow.toJson()));
     } on ArgumentError catch (e) {
       // Client sent a payload that fails validation (e.g. an invalid
       // enum value like ExitType 'weight', or a missing required
@@ -105,26 +121,34 @@ class WorkflowHandler {
       // profile_handler.dart — so the HTTP request does not hang.
       // _pendingMerge was already cleared above, so subsequent PUTs
       // start from a clean slate.
-      for (final completer in responses) {
-        completer.complete(
-          jsonBadRequest({'error': 'Invalid request', 'message': '$e'}),
-        );
-      }
+      _completeResponses(
+        responses,
+        () => jsonBadRequest({'error': 'Invalid request', 'message': '$e'}),
+      );
     } on FormatException catch (e) {
-      for (final completer in responses) {
-        completer.complete(
-          jsonBadRequest({'error': 'Invalid request', 'message': '$e'}),
-        );
-      }
+      _completeResponses(
+        responses,
+        () => jsonBadRequest({'error': 'Invalid request', 'message': '$e'}),
+      );
     } catch (e, st) {
       // Unexpected error — likely a server-side failure during DE1
       // side-effects (BLE writes, controller updates). Log it and
       // return 500 so the request still doesn't hang.
       _log.severe('Error in _applyPendingUpdate', e, st);
-      for (final completer in responses) {
-        completer.complete(
-          jsonError({'error': 'Internal server error', 'message': '$e'}),
-        );
+      _completeResponses(
+        responses,
+        () => jsonError({'error': 'Internal server error', 'message': '$e'}),
+      );
+    }
+  }
+
+  void _completeResponses(
+    List<Completer<Response>> responses,
+    Response Function() createResponse,
+  ) {
+    for (final completer in responses) {
+      if (!completer.isCompleted) {
+        completer.complete(createResponse());
       }
     }
   }

--- a/lib/src/services/webserver/workflow_handler.dart
+++ b/lib/src/services/webserver/workflow_handler.dart
@@ -85,20 +85,25 @@ class WorkflowHandler {
         final resultJson = deepMergeJson(oldWorkflow.toJson(), merge);
         final updatedWorkflow = Workflow.fromJson(resultJson);
 
-        // Profile push is owned by WorkflowDeviceSync — it observes
-        // `setWorkflow` and uploads the profile if it changed. Keeping a
-        // second setProfile call here would race against that listener and
-        // write every BLE frame twice (see the profile-double-upload P0).
+        // Profile push and Bengle stop-at-temperature target updates are
+        // owned by listeners after `setWorkflow` commits the workflow.
         if (oldWorkflow.rinseData != updatedWorkflow.rinseData) {
           await _de1controller.updateFlushSettings(updatedWorkflow.rinseData);
         }
-        if (oldWorkflow.steamSettings != updatedWorkflow.steamSettings) {
+        final oldSteamSettings = oldWorkflow.steamSettings;
+        final updatedSteamSettings = updatedWorkflow.steamSettings;
+        final steamSettingsChanged =
+            oldSteamSettings.targetTemperature !=
+                updatedSteamSettings.targetTemperature ||
+            oldSteamSettings.duration != updatedSteamSettings.duration ||
+            oldSteamSettings.flow != updatedSteamSettings.flow;
+        if (steamSettingsChanged) {
           await _de1controller.updateSteamSettings(
             SteamFormSettings(
-              steamEnabled: updatedWorkflow.steamSettings.duration > 0,
-              targetTemp: updatedWorkflow.steamSettings.targetTemperature,
-              targetDuration: updatedWorkflow.steamSettings.duration,
-              targetFlow: updatedWorkflow.steamSettings.flow,
+              steamEnabled: updatedSteamSettings.duration > 0,
+              targetTemp: updatedSteamSettings.targetTemperature,
+              targetDuration: updatedSteamSettings.duration,
+              targetFlow: updatedSteamSettings.flow,
             ),
           );
         }

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -408,6 +408,38 @@ void main() {
         reason: 'identical profile must not be re-sent',
       );
     });
+
+    test(
+      'stop-at-temperature-only PUT commits without direct DE1 writes',
+      () async {
+        await _settleHandler();
+        spy.updateShotSettingsCalls.clear();
+        spy.setSteamFlowCalls.clear();
+        spy.setHotWaterFlowCalls.clear();
+        spy.setFlushFlowCalls.clear();
+        spy.setFlushTimeoutCalls.clear();
+        spy.setFlushTemperatureCalls.clear();
+        await de1Controller.dispose();
+
+        final future = put({
+          'steamSettings': {'stopAtTemperature': 60},
+        });
+        await _settleHandler();
+        final response = await future;
+
+        expect(response.statusCode, equals(200));
+        expect(
+          workflowController.currentWorkflow.steamSettings.stopAtTemperature,
+          equals(60),
+        );
+        expect(spy.updateShotSettingsCalls, isEmpty);
+        expect(spy.setSteamFlowCalls, isEmpty);
+        expect(spy.setHotWaterFlowCalls, isEmpty);
+        expect(spy.setFlushFlowCalls, isEmpty);
+        expect(spy.setFlushTimeoutCalls, isEmpty);
+        expect(spy.setFlushTemperatureCalls, isEmpty);
+      },
+    );
   });
 
   group('PUT /api/v1/workflow — parse errors (issue #338)', () {

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -676,15 +676,16 @@ void main() {
         );
 
         var secondCompleted = false;
-        final secondFuture = put({
-          'hotWaterData': {
-            'duration': initial.hotWaterData.duration + 1,
-            'flow': initial.hotWaterData.flow + 0.5,
-          },
-        }).then((response) {
-          secondCompleted = true;
-          return response;
-        });
+        final secondFuture =
+            put({
+              'hotWaterData': {
+                'duration': initial.hotWaterData.duration + 1,
+                'flow': initial.hotWaterData.flow + 0.5,
+              },
+            }).then((response) {
+              secondCompleted = true;
+              return response;
+            });
         await Future<void>.delayed(const Duration(milliseconds: 600));
 
         expect(spy.setHotWaterFlowCalls, isEmpty);
@@ -708,6 +709,41 @@ void main() {
           workflowController.currentWorkflow.hotWaterData.duration,
           equals(initial.hotWaterData.duration + 1),
         );
+      },
+    );
+
+    test(
+      'preserves a concurrent controller change during a blocked device write',
+      () async {
+        await _settleHandler();
+        final initial = workflowController.currentWorkflow;
+        final entered = Completer<void>();
+        final release = Completer<void>();
+        spy.steamFlowEntered = entered;
+        spy.steamFlowRelease = release;
+        final nextDuration = initial.steamSettings.duration + 1;
+        final nextFlow = initial.steamSettings.flow + 0.1;
+
+        final future = put({
+          'steamSettings': {'duration': nextDuration, 'flow': nextFlow},
+        });
+
+        await entered.future.timeout(const Duration(seconds: 2));
+        workflowController.setWorkflow(
+          initial.copyWith(name: 'Concurrent workflow'),
+        );
+
+        release.complete();
+        final response = await future.timeout(const Duration(seconds: 2));
+
+        expect(response.statusCode, equals(200));
+        expect(workflowController.currentWorkflow.name, 'Concurrent workflow');
+        expect(
+          workflowController.currentWorkflow.steamSettings.duration,
+          nextDuration,
+        );
+        expect(workflowController.currentWorkflow.steamSettings.flow, nextFlow);
+        expect(spy.setSteamFlowCalls, [nextFlow, nextFlow]);
       },
     );
   });

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -7,6 +7,7 @@ import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/firmware_update_state.dart';
 import 'package:reaprime/src/models/device/de1_rawmessage.dart';
@@ -53,6 +54,9 @@ class SpyDe1 implements De1Interface {
   final List<double> setFlushFlowCalls = [];
   final List<double> setFlushTimeoutCalls = [];
   final List<double> setFlushTemperatureCalls = [];
+  bool failNextHotWaterFlow = false;
+  Completer<void>? steamFlowEntered;
+  Completer<void>? steamFlowRelease;
 
   /// Every emit that crosses the `shotSettings` stream, in order. This
   /// is the stream `/ws/v1/machine/shotSettings` subscribes to.
@@ -78,11 +82,21 @@ class SpyDe1 implements De1Interface {
   @override
   Future<void> setSteamFlow(double newFlow) async {
     setSteamFlowCalls.add(newFlow);
+    final entered = steamFlowEntered;
+    final release = steamFlowRelease;
+    if (entered != null && !entered.isCompleted) {
+      entered.complete();
+      await release!.future;
+    }
   }
 
   @override
   Future<void> setHotWaterFlow(double newFlow) async {
     setHotWaterFlowCalls.add(newFlow);
+    if (failNextHotWaterFlow) {
+      failNextHotWaterFlow = false;
+      throw StateError('injected hot-water flow failure');
+    }
   }
 
   @override
@@ -247,6 +261,16 @@ class SpyDe1 implements De1Interface {
   Future<void> setRefillKitSettings(De1RefillKitSettings settings) async {}
 }
 
+class CountingWorkflowController extends WorkflowController {
+  int setWorkflowCalls = 0;
+
+  @override
+  void setWorkflow(Workflow newWorkflow) {
+    setWorkflowCalls++;
+    super.setWorkflow(newWorkflow);
+  }
+}
+
 Future<void> _settleHandler() async {
   // Workflow handler debounce is 400 ms (private constant). Wait
   // comfortably past that so _applyPendingUpdate fires and the
@@ -258,7 +282,7 @@ void main() {
   late SpyDe1 spy;
   late DeviceController deviceController;
   late De1Controller de1Controller;
-  late WorkflowController workflowController;
+  late CountingWorkflowController workflowController;
   late Handler handler;
 
   setUp(() async {
@@ -267,7 +291,7 @@ void main() {
     await deviceController.initialize();
     de1Controller = De1Controller(controller: deviceController);
     await de1Controller.connectToDe1(spy);
-    workflowController = WorkflowController();
+    workflowController = CountingWorkflowController();
 
     final workflowHandler = WorkflowHandler(
       controller: workflowController,
@@ -551,6 +575,139 @@ void main() {
         final last = spy.emittedShotSettings.last;
         expect(last.targetSteamDuration, equals(44));
         expect(last.targetHotWaterDuration, equals(55));
+      },
+    );
+  });
+
+  group('PUT /api/v1/workflow — write-before-commit', () {
+    test(
+      'failed direct write leaves workflow uncommitted and exact retry reissues writes',
+      () async {
+        await _settleHandler();
+        final initial = workflowController.currentWorkflow;
+        final body = <String, dynamic>{
+          'rinseData': {
+            'targetTemperature': initial.rinseData.targetTemperature + 1,
+            'duration': initial.rinseData.duration + 1,
+            'flow': initial.rinseData.flow + 0.5,
+          },
+          'steamSettings': {
+            'targetTemperature': initial.steamSettings.targetTemperature + 1,
+            'duration': initial.steamSettings.duration + 1,
+            'flow': initial.steamSettings.flow + 0.1,
+          },
+          'hotWaterData': {
+            'targetTemperature': initial.hotWaterData.targetTemperature + 1,
+            'duration': initial.hotWaterData.duration + 1,
+            'volume': initial.hotWaterData.volume + 1,
+            'flow': initial.hotWaterData.flow + 0.5,
+          },
+        };
+        spy.failNextHotWaterFlow = true;
+        spy.setFlushTimeoutCalls.clear();
+        spy.setSteamFlowCalls.clear();
+        spy.setHotWaterFlowCalls.clear();
+
+        final failedFuture = put(body);
+        await _settleHandler();
+        final failedResponse = await failedFuture;
+
+        expect(failedResponse.statusCode, equals(500));
+        expect(workflowController.setWorkflowCalls, equals(0));
+        expect(workflowController.currentWorkflow.rinseData, initial.rinseData);
+        expect(
+          workflowController.currentWorkflow.steamSettings,
+          initial.steamSettings,
+        );
+        expect(
+          workflowController.currentWorkflow.hotWaterData,
+          initial.hotWaterData,
+        );
+        expect(spy.setFlushTimeoutCalls, [body['rinseData']['duration']]);
+        expect(spy.setSteamFlowCalls, [body['steamSettings']['flow']]);
+        expect(spy.setHotWaterFlowCalls, [body['hotWaterData']['flow']]);
+
+        final retryFuture = put(body);
+        await _settleHandler();
+        final retryResponse = await retryFuture;
+
+        expect(retryResponse.statusCode, equals(200));
+        expect(workflowController.setWorkflowCalls, equals(1));
+        expect(spy.setFlushTimeoutCalls.length, equals(2));
+        expect(spy.setSteamFlowCalls.length, equals(2));
+        expect(spy.setHotWaterFlowCalls.length, equals(2));
+        expect(
+          workflowController.currentWorkflow.rinseData.flow,
+          equals(body['rinseData']['flow']),
+        );
+        expect(
+          workflowController.currentWorkflow.steamSettings.flow,
+          equals(body['steamSettings']['flow']),
+        );
+        expect(
+          workflowController.currentWorkflow.hotWaterData.flow,
+          equals(body['hotWaterData']['flow']),
+        );
+      },
+    );
+
+    test(
+      'a later workflow batch waits for the in-flight batch and merges from its committed result',
+      () async {
+        await _settleHandler();
+        final initial = workflowController.currentWorkflow;
+        final entered = Completer<void>();
+        final release = Completer<void>();
+        spy.steamFlowEntered = entered;
+        spy.steamFlowRelease = release;
+        spy.setHotWaterFlowCalls.clear();
+        final firstFuture = put({
+          'steamSettings': {
+            'duration': initial.steamSettings.duration + 1,
+            'flow': initial.steamSettings.flow + 0.1,
+          },
+        });
+
+        await entered.future.timeout(const Duration(seconds: 2));
+        expect(workflowController.setWorkflowCalls, equals(0));
+        expect(
+          workflowController.currentWorkflow.steamSettings,
+          initial.steamSettings,
+        );
+
+        var secondCompleted = false;
+        final secondFuture = put({
+          'hotWaterData': {
+            'duration': initial.hotWaterData.duration + 1,
+            'flow': initial.hotWaterData.flow + 0.5,
+          },
+        }).then((response) {
+          secondCompleted = true;
+          return response;
+        });
+        await Future<void>.delayed(const Duration(milliseconds: 600));
+
+        expect(spy.setHotWaterFlowCalls, isEmpty);
+        expect(secondCompleted, isFalse);
+        expect(workflowController.currentWorkflow, initial);
+
+        release.complete();
+        final responses = await Future.wait([
+          firstFuture,
+          secondFuture,
+        ]).timeout(const Duration(seconds: 2));
+
+        expect(responses[0].statusCode, equals(200));
+        expect(responses[1].statusCode, equals(200));
+        expect(workflowController.setWorkflowCalls, equals(2));
+        expect(
+          workflowController.currentWorkflow.steamSettings.duration,
+          equals(initial.steamSettings.duration + 1),
+        );
+        expect(
+          workflowController.currentWorkflow.hotWaterData.duration,
+          equals(initial.hotWaterData.duration + 1),
+        );
       },
     );
   });


### PR DESCRIPTION
## Summary

- Problem: Workflow PUT requests could publish controller state before required device writes completed, and a newer non-REST workflow change could then be overwritten by the stale REST snapshot.
- Why it matters: Failed writes could expose uncommitted workflow state, while concurrent profile, context, or workflow changes could be lost and a reverted profile could be synchronized to the machine.
- What changed: Serialized debounced REST batches, performed direct device writes before publishing workflow state, and added revision/CAS rebasing so concurrent controller changes are preserved. Steam stop-at-temperature changes remain owned by the asynchronous Bengle bridge.
- What did NOT change (scope boundary): Endpoint paths, request/response shapes, and device write APIs remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all)

- [x] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [x] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes: N/A
- Related: N/A

## Root Cause (if bug fix)

- Root cause: The handler captured `currentWorkflow`, performed asynchronous device writes, and committed the captured snapshot without checking whether `WorkflowController` had changed. It also compared all `SteamSettings` fields even though `stopAtTemperature` is applied asynchronously by `BengleSteamStopBridge`.
- Missing detection or guardrail: There was no workflow mutation revision or synchronous compare-and-set commit, and no separation between direct DE1 fields and the asynchronous Bengle target.
- Contributing context (if known): REST request serialization did not cover UI and other application paths that call `setWorkflow` directly.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/webserver/workflow_handler_test.dart`
- Scenario the test should lock in: Block a steam device write, commit an unrelated controller workflow change, release the write, and verify the unrelated change survives while the REST steam update is applied and the direct write is reissued. A disconnected stop-at-temperature-only PUT must commit without direct DE1 writes.
- If no new test added, why not: N/A

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml`
- [x] API docs updated: `doc/Api.md`
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A - no docs affected

## Security Impact (required)

This app runs a local web server (port 8080) and connects to BLE/USB hardware.

- New or changed REST endpoints? No
- New or changed WebSocket topics? No
- New or changed network calls? No
- BLE/USB surface changed? No
- File system access changed? No
- Plugin sandbox boundary changed? No
- If any Yes, explain risk and mitigation: N/A

## User-Visible Changes

Workflow updates now publish only after required direct device writes succeed, concurrent workflow changes are preserved, and stop-at-temperature targets are applied asynchronously by the Bengle bridge.

## Verification

### Local gates (run before pushing)

- [x] `dart format` on all changed Dart files - clean
- [x] `flutter analyze` - no issues found
- [ ] `flutter test` - full suite has unrelated existing failures
- [ ] `(cd packages/dye2-plugin && npm run build)` - not run; plugin code is unchanged

### Manual verification (if applicable)

- OS / platform tested: Windows 11
- Simulated devices? (`simulate=1`): No
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: The stop-at-temperature regression passed; all 11 tests in `test/webserver/workflow_handler_test.dart` passed; `flutter analyze` reported no issues.
- Edge cases checked: Failed direct writes, exact retries, serialized REST batches, concurrent controller mutation during a blocked write, CAS rebase, stop-only updates while disconnected, and repeated final direct settings.
- What you did not verify: Real hardware behavior and a completely green full suite.

### Evidence

- [x] Test output (focused regression and complete workflow-handler test file passed)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? Yes
- Config / env changes needed? No
- Database migration needed? No
- If any No or Yes, explain exact steps: None

## Risks & Mitigations

- Risk: A continuously mutating workflow controller can cause repeated device writes before the CAS succeeds.
  - Mitigation: REST requests remain serialized, rebases only repeat direct writes whose final values differ, and the synchronous CAS prevents stale commits.