### PR TITLE
fix: harden workflow REST serialization

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -1021,7 +1021,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         "500":
-          description: Internal server error during DE1 side-effect writes
+          description: A required direct machine write failed; the controller workflow remains unchanged
           content:
             application/json:
               schema:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -901,7 +901,18 @@ paths:
       summary: Update current workflow
       description: |
         Updates the current workflow. This is the **recommended method** for applying changes
-        to the machine and brewing parameters in one atomic operation.
+        to the machine and brewing parameters in one ordered mutation.
+
+        Each HTTP request is an independent mutation. Requests are processed in FIFO order,
+        and partial request bodies are deep-merged against the workflow state when that request
+        reaches the front of the queue. The server does not debounce or combine separate
+        requests. Machine side effects from workflow PUT requests do not execute concurrently,
+        so a request may wait behind an in-flight machine operation. Each response describes
+        the workflow resulting from that request. High-frequency clients should throttle input
+        on the client side rather than relying on server-side debounce.
+
+        Machine-write failures return an error response; this endpoint does not roll back
+        already-completed machine writes or controller state.
 
         You can update the complete workflow or just specific fields:
         - **context**: Set dose, grinder, coffee, and people metadata (recommended)

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -915,6 +915,9 @@ paths:
         committed. The machine writes are multi-step and may be partially applied; retrying
         the same request re-attempts the requested settings.
 
+        Bodies are limited to 1 MiB. At most eight workflow requests may be active or queued,
+        and a request that waits more than 30 seconds for its turn is skipped.
+
         You can update the complete workflow or just specific fields:
         - **context**: Set dose, grinder, coffee, and people metadata (recommended)
         - **profile**: Update the brewing profile
@@ -1020,8 +1023,26 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "413":
+          description: Request body exceeds the 1 MiB workflow payload limit
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Eight workflow requests are already active or queued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "500":
           description: A required direct machine write or request body read failed; the controller workflow remains unchanged
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: The request waited more than 30 seconds for its turn and was skipped
           content:
             application/json:
               schema:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -1023,6 +1023,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "408":
+          description: The client did not finish sending the request body within the timeout
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "413":
           description: Request body exceeds the 1 MiB workflow payload limit
           content:
@@ -1036,7 +1042,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         "500":
-          description: A required direct machine write or request body read failed; the controller workflow remains unchanged
+          description: A required direct machine write failed; the controller workflow remains unchanged
           content:
             application/json:
               schema:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -1021,7 +1021,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         "500":
-          description: A required direct machine write failed; the controller workflow remains unchanged
+          description: A required direct machine write or request body read failed; the controller workflow remains unchanged
           content:
             application/json:
               schema:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -337,6 +337,12 @@ paths:
       responses:
         "200":
           description: Profile updated successfully
+        "400":
+          description: Malformed JSON body
+        "503":
+          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+        "500":
+          description: No machine was ever connected
   /api/v1/machine/shotSettings:
     post:
       summary: Update Shot Settings
@@ -351,6 +357,12 @@ paths:
       responses:
         "200":
           description: Shot settings updated successfully
+        "400":
+          description: Malformed JSON body
+        "503":
+          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+        "500":
+          description: No machine was ever connected
   /api/v1/machine/capabilities:
     get:
       summary: List machine capabilities
@@ -492,6 +504,10 @@ paths:
                 $ref: "#/components/schemas/LedStripState"
         "404":
           description: Machine connected but does not support LED strip
+        "503":
+          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+        "500":
+          description: No machine was ever connected
   /api/v1/machine/settings:
     get:
       summary: Get machine settings
@@ -516,7 +532,13 @@ paths:
               $ref: "#/components/schemas/De1SettingsRequest"
       responses:
         "202":
-          description: Settings update accepted
+          description: Settings update accepted (one grouped serialized device write)
+        "400":
+          description: Malformed JSON body
+        "503":
+          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+        "500":
+          description: No machine was ever connected
 
   /api/v1/machine/settings/advanced:
     get:
@@ -542,7 +564,13 @@ paths:
               $ref: "#/components/schemas/De1AdvancedSettingsRequest"
       responses:
         "202":
-          description: Advanced settings update accepted
+          description: Advanced settings update accepted (one grouped serialized device write)
+        "400":
+          description: Malformed JSON body
+        "503":
+          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+        "500":
+          description: No machine was ever connected
 
   /api/v1/machine/settings/reset:
     delete:
@@ -554,7 +582,9 @@ paths:
       tags: [Machine]
       responses:
         "202":
-          description: Reset accepted
+          description: Reset accepted (one grouped serialized device write)
+        "503":
+          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
         "500":
           description: No DE1 connected
 
@@ -583,6 +613,12 @@ paths:
       responses:
         "202":
           description: Calibration settings updated successfully
+        "400":
+          description: Malformed JSON body
+        "503":
+          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+        "500":
+          description: No machine was ever connected
 
   /api/v1/machine/waterLevels:
     post:
@@ -597,6 +633,12 @@ paths:
       responses:
         "202":
           description: Levels updated
+        "400":
+          description: Malformed JSON body
+        "503":
+          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+        "500":
+          description: No machine was ever connected
 
   /api/v1/machine/firmware:
     get:
@@ -4202,6 +4244,47 @@ paths:
                     enum: [stalled, resumed, disconnected]
         "400":
           description: No scale connected or scale is not a MockScale
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+        "404":
+          description: Unknown command or endpoint not available (non-simulate build)
+
+  /api/v1/debug/machine/{command}:
+    post:
+      summary: Control mock machine (simulate mode only)
+      description: |
+        Debug endpoints for controlling the simulated machine. Only available
+        when the app is launched with a non-empty `simulate` Dart define.
+        Returns 404 on production builds.
+      tags: [Debug]
+      parameters:
+        - name: command
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [disconnect]
+          description: |
+            - `disconnect` — simulate machine disconnect (emits disconnected
+              state; no automatic reconnect)
+      responses:
+        "200":
+          description: Command executed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [disconnected]
+        "400":
+          description: No machine connected or machine is not a MockDe1
           content:
             application/json:
               schema:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -911,8 +911,9 @@ paths:
         the workflow resulting from that request. High-frequency clients should throttle input
         on the client side rather than relying on server-side debounce.
 
-        Machine-write failures return an error response; this endpoint does not roll back
-        already-completed machine writes or controller state.
+        Machine-write failures return an error response before the controller workflow is
+        committed. The machine writes are multi-step and may be partially applied; retrying
+        the same request re-attempts the requested settings.
 
         You can update the complete workflow or just specific fields:
         - **context**: Set dose, grinder, coffee, and people metadata (recommended)

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -1048,7 +1048,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         "503":
-          description: The request waited more than 30 seconds for its turn and was skipped
+          description: >
+            The request waited more than 30 seconds for its turn and was
+            skipped, or the machine disconnected mid-write and no replacement
+            machine appeared within the bounded wait (10 seconds). In both
+            cases the controller workflow is unchanged.
           content:
             application/json:
               schema:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -416,9 +416,13 @@ paths:
         "200":
           description: Setpoint accepted
         "400":
-          description: Temperature missing or out of range 0.0–80.0
+          description: Temperature missing or out of range 0.0–80.0, or malformed JSON
         "404":
           description: Machine connected but does not support cup warmer
+        "503":
+          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+        "500":
+          description: No machine was ever connected
   /api/v1/machine/ledStrip:
     get:
       summary: Get LED strip configuration
@@ -454,9 +458,13 @@ paths:
         "200":
           description: Configuration accepted
         "400":
-          description: Invalid request body
+          description: Invalid request body or malformed JSON
         "404":
           description: Machine connected but does not support LED strip
+        "503":
+          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+        "500":
+          description: No machine was ever connected
 
   /api/v1/machine/ledStrip/commit:
     post:
@@ -478,6 +486,10 @@ paths:
           description: Commit accepted
         "404":
           description: Machine connected but does not support LED strip
+        "503":
+          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+        "500":
+          description: No machine was ever connected
 
   /api/v1/machine/ledStrip/reset:
     post:

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -167,6 +167,56 @@ leaves controller workflow state unchanged; multi-step device writes may still b
 partially applied, so a retry re-attempts the requested settings. `WorkflowDeviceSync`
 remains the owner of asynchronous profile upload after controller changes.
 
+### Device-Write Retry and Machine Replacement
+
+`De1Controller.runDeviceWrite()` is the single serialization point for all REST
+machine writes (workflow PUTs, profile, shot settings, machine settings). The write
+callback receives the machine acquired inside the retry loop, so a disconnected
+interval (controller holding no machine) is handled by waiting — bounded by
+`ConnectionTimings.machineReplacementTimeout` (10 s) — for a non-null replacement and
+that generation's startup initialization to settle, then re-running the complete
+grouped write once on the replacement. The old machine is never written after the
+generation changes. If no replacement appears within the bound, the handler returns
+`503 Machine unavailable`; if there was never a machine at all, the first attempt
+fails fast with `500` (unchanged behavior). The first attempt never waits: the bounded
+wait only applies to retries after a mid-write disconnect.
+
+A machine disconnect observed during a workflow or settings write aborts the in-flight
+write (the device call throws), so the retry starts from the beginning of the grouped
+write on the replacement.
+
+### REST Route Serialization Audit
+
+All mutating machine routes in `de1handler.dart` route their physical writes through
+`runDeviceWrite` (one HTTP request = one queue entry, parse-then-write, controller
+streams published only after the grouped write succeeds):
+
+- `PUT /api/v1/workflow` (workflow handler, device writes via `updateWorkflowSettings`)
+- `POST /api/v1/machine/profile`
+- `POST /api/v1/machine/shotSettings`
+- `POST /api/v1/machine/settings` (all fields, one entry)
+- `POST /api/v1/machine/settings/advanced`
+- `POST /api/v1/machine/calibration`
+- `POST /api/v1/machine/waterLevels`
+- `PUT /api/v1/machine/cupWarmer`, `PUT /api/v1/machine/ledStrip`,
+  `POST /api/v1/machine/ledStrip/commit`, `POST /api/v1/machine/ledStrip/reset`
+
+Documented bypasses:
+
+- `PUT /api/v1/machine/state/<newState>`: latency-sensitive machine commands (a stop
+  request must not queue behind a settings or profile write) that target the state
+  characteristic, not the settings/MMR registers the queue serializes.
+- `DELETE /api/v1/machine/settings/reset` (`applySettingsDefaults`): the operation
+  itself resets the heater controller (`heaterPh2Timeout`), dropping the connection
+  mid-run, so retry-on-replacement semantics do not apply; writes are device-pinned
+  via the controller's current machine reference.
+- Raw low-level MMR commands via `/ws/v1/machine/raw`: intentionally unqueued (see
+  the machine WebSocket re-bind section); a delayed raw read/write could be stale.
+
+Writing `heaterPh2Timeout` (settings/advanced or reset) simulates a heater-controller
+disconnect on `MockDe1` and reboots the heater controller on real hardware; a queued
+write interrupted this way may return `500`/`503`.
+
 ### Status Codes
 
 | Code | Meaning |
@@ -177,4 +227,4 @@ remains the owner of asynchronous profile upload after controller changes.
 | 413 | Body exceeds 1 MiB limit |
 | 429 | Admission capacity full (8 active or queued requests) |
 | 500 | A required direct machine write failed |
-| 503 | Mutation timed out waiting for its execution turn |
+| 503 | Mutation timed out waiting for its execution turn, or no replacement machine appeared within the bounded wait |

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -206,7 +206,7 @@ streams published only after the grouped write succeeds):
 
 Every endpoint above can return `503` when the machine disconnects mid-write and no
 replacement appears within the bounded wait, and `400` for malformed JSON bodies
-(machine settings, advanced, reset, calibration, waterLevels, cupWarmer, ledStrip,
+(machine settings, advanced, calibration, waterLevels, cupWarmer, ledStrip,
 profile, and shot settings parse their complete body before reserving a queue entry).
 Machine-write failures otherwise map to `500`.
 

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -175,8 +175,9 @@ callback receives the machine acquired inside the retry loop, so a disconnected
 interval (controller holding no machine) is handled by waiting — bounded by
 `ConnectionTimings.machineReplacementTimeout` (10 s) — for a non-null replacement and
 that generation's startup initialization to settle, then re-running the complete
-grouped write once on the replacement. The old machine is never written after the
-generation changes. If no replacement appears within the bound, the handler returns
+grouped write once on the replacement. The old machine is never acquired for a new
+write after the generation changes (an already-running write may still finish on it,
+see below). If no replacement appears within the bound, the handler returns
 `503 Machine unavailable`; if there was never a machine at all, the first attempt
 fails fast with `500` (unchanged behavior). The first attempt never waits: the bounded
 wait only applies to retries after a mid-write disconnect.
@@ -197,7 +198,7 @@ streams published only after the grouped write succeeds):
 - `POST /api/v1/machine/shotSettings`
 - `POST /api/v1/machine/settings` (all fields, one entry)
 - `POST /api/v1/machine/settings/advanced`
-- `POST /api/v1/machine/settings/reset` (complete reset, one entry)
+- `DELETE /api/v1/machine/settings/reset` (complete reset, one entry)
 - `POST /api/v1/machine/calibration`
 - `POST /api/v1/machine/waterLevels`
 - `PUT /api/v1/machine/cupWarmer`, `PUT /api/v1/machine/ledStrip`,
@@ -222,8 +223,9 @@ Documented bypasses:
 `MockDe1.simulateDisconnect()` emits a disconnected connection state explicitly; it
 does not schedule a reconnect. It is exposed only through the simulate-mode
 `POST /api/v1/debug/machine/disconnect` route (via `DebugHandler`), mirroring the
-scale debug commands. Writing `heaterPh2Timeout` is an ordinary MMR write on both
-`MockDe1` and real hardware — it never disconnects or resets the machine.
+scale debug commands. Writing `heaterPh2Timeout` is an ordinary MMR write on
+`MockDe1`; on real hardware Decaid treats it as an ordinary MMR write — no reset
+behavior is documented.
 
 ### Status Codes
 

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -148,6 +148,8 @@ must not be coalesced without a future explicit client or session contract. The
 handler reads the workflow base when a queue entry reaches execution, then applies
 only that request's deep merge. Machine side effects from separate workflow PUTs
 must never overlap, and a failure must not poison the queue tail.
+Request bodies are read with a 30-second timeout before their queued operation
+executes; body-read failures are observed immediately and do not poison the queue.
 
 Direct machine writes complete before controller workflow state is committed. The
 handler commits with a controller revision check; if another workflow source changes

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -166,3 +166,15 @@ required writes before retrying the commit. A machine-write failure returns `500
 leaves controller workflow state unchanged; multi-step device writes may still be
 partially applied, so a retry re-attempts the requested settings. `WorkflowDeviceSync`
 remains the owner of asynchronous profile upload after controller changes.
+
+### Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200 | Workflow updated and committed |
+| 400 | Malformed or invalid JSON |
+| 408 | Client did not finish sending the body within the timeout |
+| 413 | Body exceeds 1 MiB limit |
+| 429 | Admission capacity full (8 active or queued requests) |
+| 500 | A required direct machine write failed |
+| 503 | Mutation timed out waiting for its execution turn |

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -149,8 +149,10 @@ handler reads the workflow base when a queue entry reaches execution, then appli
 only that request's deep merge. Machine side effects from separate workflow PUTs
 must never overlap, and a failure must not poison the queue tail.
 
-Direct machine writes complete before controller workflow state is committed. A
-machine-write failure returns `500` and leaves controller workflow state unchanged;
-multi-step device writes may still be partially applied, so a retry re-attempts the
-requested settings. `WorkflowDeviceSync` remains the owner of asynchronous profile
-upload after controller changes.
+Direct machine writes complete before controller workflow state is committed. The
+handler commits with a controller revision check; if another workflow source changes
+the controller during device I/O, the request rebases its merge and repeats the
+required writes before retrying the commit. A machine-write failure returns `500` and
+leaves controller workflow state unchanged; multi-step device writes may still be
+partially applied, so a retry re-attempts the requested settings. `WorkflowDeviceSync`
+remains the owner of asynchronous profile upload after controller changes.

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -146,10 +146,14 @@ Add protocol compatibility rules, API versioning decisions, and endpoint design 
 `WorkflowHandler`. One HTTP request is exactly one queue entry. Separate requests
 must not be coalesced without a future explicit client or session contract. The
 handler reads the workflow base when a queue entry reaches execution, then applies
-only that request's deep merge. Machine side effects from separate workflow PUTs
-must never overlap, and a failure must not poison the queue tail.
+only that request's deep merge. Machine side effects from workflow PUTs, profile
+sync, and Bengle workflow bridges share the `De1Controller` device-write queue.
+Each entry captures one machine and connection generation; workflow setting writes
+retry once on a replacement machine. A failure must not poison the queue tail.
 Request bodies are read with a 30-second timeout before their queued operation
 executes; body-read failures are observed immediately and do not poison the queue.
+Admission is limited to 1 MiB per body and eight active or queued requests. A request
+that waits 30 seconds for execution returns `503` and its queued mutation is skipped.
 
 Direct machine writes complete before controller workflow state is committed. The
 handler commits with a controller revision check; if another workflow source changes

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -139,3 +139,18 @@ Add protocol compatibility rules, API versioning decisions, and endpoint design 
 - Legacy HTTP `200` import bodies with embedded errors are partial or failed according to section progress.
 - Two-way push requires a complete pull unless `continueOnPullFailure: true` is explicitly requested.
 - Skipped push is represented as a `skipped` phase, and partial section processing is not transactional.
+
+## Workflow PUT Queue
+
+`PUT /api/v1/workflow` operations are serialized through one queue owned by
+`WorkflowHandler`. One HTTP request is exactly one queue entry. Separate requests
+must not be coalesced without a future explicit client or session contract. The
+handler reads the workflow base when a queue entry reaches execution, then applies
+only that request's deep merge. Machine side effects from separate workflow PUTs
+must never overlap, and a failure must not poison the queue tail.
+
+The final base commits controller workflow state before the existing direct machine
+writes. A machine-write failure returns `500`, but this path does not roll back
+already-completed machine writes or controller state. `WorkflowDeviceSync` remains
+the owner of asynchronous profile upload after controller changes.
+>>>>>>> 9ce4c366 (fix(api): serialize workflow PUT requests)

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -181,9 +181,10 @@ generation changes. If no replacement appears within the bound, the handler retu
 fails fast with `500` (unchanged behavior). The first attempt never waits: the bounded
 wait only applies to retries after a mid-write disconnect.
 
-A machine disconnect observed during a workflow or settings write aborts the in-flight
-write (the device call throws), so the retry starts from the beginning of the grouped
-write on the replacement.
+A machine generation change cannot cancel an in-flight native write: the old machine
+may receive a partial or complete attempt. Only after that attempt finishes does the
+post-write generation check reject it, and the retry then re-runs the complete grouped
+operation from the start on the replacement.
 
 ### REST Route Serialization Audit
 
@@ -196,26 +197,33 @@ streams published only after the grouped write succeeds):
 - `POST /api/v1/machine/shotSettings`
 - `POST /api/v1/machine/settings` (all fields, one entry)
 - `POST /api/v1/machine/settings/advanced`
+- `POST /api/v1/machine/settings/reset` (complete reset, one entry)
 - `POST /api/v1/machine/calibration`
 - `POST /api/v1/machine/waterLevels`
 - `PUT /api/v1/machine/cupWarmer`, `PUT /api/v1/machine/ledStrip`,
   `POST /api/v1/machine/ledStrip/commit`, `POST /api/v1/machine/ledStrip/reset`
+
+Every endpoint above can return `503` when the machine disconnects mid-write and no
+replacement appears within the bounded wait, and `400` for malformed JSON bodies
+(machine settings, advanced, reset, calibration, waterLevels, cupWarmer, ledStrip,
+profile, and shot settings parse their complete body before reserving a queue entry).
+Machine-write failures otherwise map to `500`.
 
 Documented bypasses:
 
 - `PUT /api/v1/machine/state/<newState>`: latency-sensitive machine commands (a stop
   request must not queue behind a settings or profile write) that target the state
   characteristic, not the settings/MMR registers the queue serializes.
-- `DELETE /api/v1/machine/settings/reset` (`applySettingsDefaults`): the operation
-  itself resets the heater controller (`heaterPh2Timeout`), dropping the connection
-  mid-run, so retry-on-replacement semantics do not apply; writes are device-pinned
-  via the controller's current machine reference.
 - Raw low-level MMR commands via `/ws/v1/machine/raw`: intentionally unqueued (see
   the machine WebSocket re-bind section); a delayed raw read/write could be stale.
 
-Writing `heaterPh2Timeout` (settings/advanced or reset) simulates a heater-controller
-disconnect on `MockDe1` and reboots the heater controller on real hardware; a queued
-write interrupted this way may return `500`/`503`.
+### Machine Disconnect Simulation (debug only)
+
+`MockDe1.simulateDisconnect()` emits a disconnected connection state explicitly; it
+does not schedule a reconnect. It is exposed only through the simulate-mode
+`POST /api/v1/debug/machine/disconnect` route (via `DebugHandler`), mirroring the
+scale debug commands. Writing `heaterPh2Timeout` is an ordinary MMR write on both
+`MockDe1` and real hardware — it never disconnects or resets the machine.
 
 ### Status Codes
 
@@ -226,5 +234,5 @@ write interrupted this way may return `500`/`503`.
 | 408 | Client did not finish sending the body within the timeout |
 | 413 | Body exceeds 1 MiB limit |
 | 429 | Admission capacity full (8 active or queued requests) |
-| 500 | A required direct machine write failed |
+| 500 | A required direct machine write failed, or no machine was ever connected |
 | 503 | Mutation timed out waiting for its execution turn, or no replacement machine appeared within the bounded wait |

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -149,9 +149,13 @@ handler reads the workflow base when a queue entry reaches execution, then appli
 only that request's deep merge. Machine side effects from workflow PUTs, profile
 sync, and Bengle workflow bridges share the `De1Controller` device-write queue.
 Each entry captures one machine and connection generation; workflow setting writes
-retry once on a replacement machine. A failure must not poison the queue tail.
+retry once on a replacement machine after that generation's startup initialization
+settles. Startup defaults finish before the generation barrier releases. A failure
+must not poison the queue tail.
 Request bodies are read with a 30-second timeout before their queued operation
 executes; body-read failures are observed immediately and do not poison the queue.
+The body stream subscription is cancelled on completion, error, size rejection, or
+timeout so expired readers cannot outlive admission accounting.
 Admission is limited to 1 MiB per body and eight active or queued requests. A request
 that waits 30 seconds for execution returns `503` and its queued mutation is skipped.
 

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -149,8 +149,8 @@ handler reads the workflow base when a queue entry reaches execution, then appli
 only that request's deep merge. Machine side effects from separate workflow PUTs
 must never overlap, and a failure must not poison the queue tail.
 
-The final base commits controller workflow state before the existing direct machine
-writes. A machine-write failure returns `500`, but this path does not roll back
-already-completed machine writes or controller state. `WorkflowDeviceSync` remains
-the owner of asynchronous profile upload after controller changes.
->>>>>>> 9ce4c366 (fix(api): serialize workflow PUT requests)
+Direct machine writes complete before controller workflow state is committed. A
+machine-write failure returns `500` and leaves controller workflow state unchanged;
+multi-step device writes may still be partially applied, so a retry re-attempts the
+requested settings. `WorkflowDeviceSync` remains the owner of asynchronous profile
+upload after controller changes.

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -42,7 +42,7 @@ For browser clients on a different origin, `ETag` is exposed via `Access-Control
 | GET | `/api/v1/machine/state` | Current machine state + substate | |
 | PUT | `/api/v1/machine/state/{newState}` | Request state change (`idle`, `sleep`, `espresso`, …) | |
 | GET | `/api/v1/machine/settings` | DE1 machine settings (temps, flows) | |
-| POST | `/api/v1/machine/settings` | Update machine settings | |
+| POST | `/api/v1/machine/settings` | Update machine settings (one grouped, serialized device write per request) | |
 | POST | `/api/v1/machine/shotSettings` | Update shot settings (steam temp, hot water, target volume, group temp) | |
 | GET | `/api/v1/machine/settings/advanced` | Advanced heater/phase settings | |
 | POST | `/api/v1/machine/settings/advanced` | Update advanced settings (heater phase flows/timeouts, idle temp, `heaterVoltage`, `refillKitSetting`) | |
@@ -182,7 +182,12 @@ than 30 seconds for execution return `503` without being applied. Machine-write 
 return an error before the controller workflow is committed. Multi-step machine writes may
 be partially applied, and retrying the same request re-attempts the requested settings.
 Request bodies have a 30-second read timeout; body-read failures return `408`
-without poisoning later queued mutations.
+without poisoning later queued mutations. If the machine disconnects while a
+workflow device write is in flight, the write is retried once on the replacement
+machine (waiting up to 10 seconds for one to appear); if no replacement arrives the
+request returns `503` and the workflow is not committed. A `stopAtTemperature`-only
+workflow change never touches the DE1 directly — the Bengle bridge applies it
+asynchronously — so it commits even while no machine is connected.
 
 ### Beans
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -46,7 +46,7 @@ For browser clients on a different origin, `ETag` is exposed via `Access-Control
 | POST | `/api/v1/machine/shotSettings` | Update shot settings (steam temp, hot water, target volume, group temp) | |
 | GET | `/api/v1/machine/settings/advanced` | Advanced heater/phase settings | |
 | POST | `/api/v1/machine/settings/advanced` | Update advanced settings (heater phase flows/timeouts, idle temp, `heaterVoltage`, `refillKitSetting`) | |
-| DELETE | `/api/v1/machine/settings/reset` | Reset machine settings to defaults (fan, heater idle/phase flows + ph2 timeout, refill kit auto, flow multiplier 1.0, steam purge 0) | |
+| DELETE | `/api/v1/machine/settings/reset` | Reset machine settings to defaults (fan, heater idle/phase flows + ph2 timeout, refill kit auto, flow multiplier 1.0, steam purge 0) — one grouped, serialized device write | |
 | GET | `/api/v1/machine/calibration` | Flow estimation calibration | |
 | POST | `/api/v1/machine/calibration` | Update calibration | |
 | POST | `/api/v1/machine/profile` | Upload profile to machine | |
@@ -386,8 +386,9 @@ Only registered when the app is launched with a non-empty `simulate` Dart define
 | POST | `/api/v1/debug/scale/stall` | Pause mock scale weight emission (stays "connected") | `debug_handler.dart` |
 | POST | `/api/v1/debug/scale/resume` | Resume weight emission after stall | `debug_handler.dart` |
 | POST | `/api/v1/debug/scale/disconnect` | Simulate scale disconnect (emits disconnected state, stops data) | `debug_handler.dart` |
+| POST | `/api/v1/debug/machine/disconnect` | Simulate mock machine disconnect (emits disconnected state, no auto-reconnect) | `debug_handler.dart` |
 
-Mock-scale command endpoints return 400 if no scale is connected or the connected scale is not a `MockScale`.
+Mock-scale command endpoints return 400 if no scale is connected or the connected scale is not a `MockScale`. The machine command endpoint returns 400 if no machine is connected or the connected machine is not a `MockDe1`, and 404 for unknown commands (any debug route 404s on production builds).
 
 ---
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -170,7 +170,14 @@ in-app stop will trigger on.
 | Method | Path | Description | Handler |
 |--------|------|-------------|---------|
 | GET | `/api/v1/workflow` | Get current workflow (profile + context) | `workflow_handler.dart` |
-| PUT | `/api/v1/workflow` | Update workflow (deep merge) | |
+| PUT | `/api/v1/workflow` | Update workflow (one ordered deep-merge mutation) | `workflow_handler.dart` |
+
+Each `PUT /api/v1/workflow` is one independent mutation. Requests run in FIFO order without
+cross-request or cross-client coalescing. Partial updates are deep-merged against the latest
+workflow state when each request executes, and each response contains that request's resulting
+workflow. Requests may wait behind machine I/O; the server does not debounce high-frequency
+input, so clients should throttle controls themselves. Machine-write failures return an error
+without rolling back already-completed machine writes or controller state.
 
 ### Beans
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -181,7 +181,7 @@ requests beyond the eight-entry active/queued limit return `429`, and requests w
 than 30 seconds for execution return `503` without being applied. Machine-write failures
 return an error before the controller workflow is committed. Multi-step machine writes may
 be partially applied, and retrying the same request re-attempts the requested settings.
-Request bodies have a 30-second read timeout; body-read failures return an error
+Request bodies have a 30-second read timeout; body-read failures return `408`
 without poisoning later queued mutations.
 
 ### Beans

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -179,6 +179,8 @@ workflow. Requests may wait behind machine I/O; the server does not debounce hig
 input, so clients should throttle controls themselves. Machine-write failures return an error
 before the controller workflow is committed. Multi-step machine writes may be partially
 applied, and retrying the same request re-attempts the requested settings.
+Request bodies have a 30-second read timeout; body-read failures return an error
+without poisoning later queued mutations.
 
 ### Beans
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -177,7 +177,8 @@ cross-request or cross-client coalescing. Partial updates are deep-merged agains
 workflow state when each request executes, and each response contains that request's resulting
 workflow. Requests may wait behind machine I/O; the server does not debounce high-frequency
 input, so clients should throttle controls themselves. Machine-write failures return an error
-without rolling back already-completed machine writes or controller state.
+before the controller workflow is committed. Multi-step machine writes may be partially
+applied, and retrying the same request re-attempts the requested settings.
 
 ### Beans
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -176,9 +176,11 @@ Each `PUT /api/v1/workflow` is one independent mutation. Requests run in FIFO or
 cross-request or cross-client coalescing. Partial updates are deep-merged against the latest
 workflow state when each request executes, and each response contains that request's resulting
 workflow. Requests may wait behind machine I/O; the server does not debounce high-frequency
-input, so clients should throttle controls themselves. Machine-write failures return an error
-before the controller workflow is committed. Multi-step machine writes may be partially
-applied, and retrying the same request re-attempts the requested settings.
+input, so clients should throttle controls themselves. Bodies larger than 1 MiB return `413`,
+requests beyond the eight-entry active/queued limit return `429`, and requests waiting more
+than 30 seconds for execution return `503` without being applied. Machine-write failures
+return an error before the controller workflow is committed. Multi-step machine writes may
+be partially applied, and retrying the same request re-attempts the requested settings.
 Request bodies have a 30-second read timeout; body-read failures return an error
 without poisoning later queued mutations.
 

--- a/lib/src/controllers/bengle_saw_bridge.dart
+++ b/lib/src/controllers/bengle_saw_bridge.dart
@@ -116,7 +116,11 @@ class BengleSawBridge {
         final generation = _de1.connectionGeneration;
         _inFlight = grams;
         try {
-          await machine.setStopAtWeightTarget(grams);
+          await _de1.runDeviceWrite((device) async {
+            if (identical(device, machine)) {
+              await machine.setStopAtWeightTarget(grams);
+            }
+          });
           if (_disposed) return;
           if (!_isCurrent(machine, generation)) continue;
           _lastPushed = grams;

--- a/lib/src/controllers/bengle_saw_bridge.dart
+++ b/lib/src/controllers/bengle_saw_bridge.dart
@@ -23,10 +23,9 @@ import 'package:reaprime/src/models/errors.dart';
 ///    Bengle reboot or a late connect after the app has been editing
 ///    the workflow).
 ///
-/// Generation-token + cancellable Timer pattern mirrors
-/// `De1Controller._shotSettingsDebounce` (comms-harden #5) so a
-/// disconnect during the debounce window cleanly drops the pending
-/// write instead of throwing on a stale `connectedDe1()`.
+/// A cancellable debounce timer feeds a serialized latest-value drain so a
+/// disconnect during the debounce window cleanly drops the pending write
+/// instead of throwing on a stale `connectedDe1()`.
 class BengleSawBridge {
   BengleSawBridge({
     required WorkflowController workflowController,
@@ -46,70 +45,87 @@ class BengleSawBridge {
 
   StreamSubscription<De1Interface?>? _de1Sub;
   Timer? _debounceTimer;
-  int _generation = 0;
   double? _lastPushed;
+  double? _desired;
+  double? _inFlight;
+  bool _forcePush = false;
+  bool _pushing = false;
+  bool _disposed = false;
 
   double _currentTargetYield() =>
       _workflow.currentWorkflow.context?.targetYield ?? 0.0;
 
   void _onWorkflowChange() {
     final next = _currentTargetYield();
-    if (next == _lastPushed) return;
+    _forcePush = false;
+    if (next == _lastPushed && (_inFlight == null || _inFlight == next)) {
+      _desired = null;
+      _debounceTimer?.cancel();
+      _debounceTimer = null;
+      return;
+    }
+    _desired = next;
     _debounceTimer?.cancel();
-    final generation = ++_generation;
-    _debounceTimer = Timer(debounce, () => _push(next, generation));
+    _debounceTimer = Timer(debounce, () {
+      _debounceTimer = null;
+      unawaited(_drain());
+    });
   }
 
   void _onDe1Change(De1Interface? device) {
     if (device is! BengleInterface) return;
-    // New Bengle connected — re-assert the current target so a Bengle
-    // reboot or late connect doesn't leave FW at its default.
-    final next = _currentTargetYield();
-    final generation = ++_generation;
-    _push(next, generation);
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    _desired = _currentTargetYield();
+    _forcePush = true;
+    unawaited(_drain());
   }
 
-  Future<void> _push(double grams, int generation) async {
-    if (generation != _generation) {
-      _log.fine('SAW write superseded (gen=$generation, current=$_generation)');
-      return;
-    }
-    final machine = _de1.connectedDe1OrNull;
-    if (machine is! BengleInterface) {
-      _log.fine('SAW write skipped — connected machine is not Bengle');
-      return;
-    }
+  Future<void> _drain() async {
+    if (_pushing || _disposed) return;
+    _pushing = true;
     try {
-      await machine.setStopAtWeightTarget(grams);
-      // Re-check the generation after the await: a workflow edit
-      // landing while the write was in flight bumped it and scheduled
-      // a newer debounce. Updating `_lastPushed` here would stamp the
-      // stale value and could short-circuit the next change-equality
-      // check in `_onWorkflowChange`.
-      if (generation == _generation) {
-        _lastPushed = grams;
+      while (!_disposed) {
+        final grams = _desired;
+        if (grams == null || (!_forcePush && grams == _lastPushed)) {
+          _desired = null;
+          _forcePush = false;
+          return;
+        }
+        final machine = _de1.connectedDe1OrNull;
+        if (machine is! BengleInterface) {
+          _log.fine('SAW write skipped — connected machine is not Bengle');
+          return;
+        }
+        _inFlight = grams;
+        try {
+          await machine.setStopAtWeightTarget(grams);
+          if (_disposed) return;
+          _lastPushed = grams;
+          _forcePush = false;
+          if (_desired == grams) _desired = null;
+          _log.info('SAW target written: ${grams}g');
+        } on DeviceNotConnectedException {
+          _log.fine('SAW write aborted — machine disconnected mid-call');
+          if (_desired == grams) return;
+        } catch (e, st) {
+          _log.warning('SAW write failed', e, st);
+          if (_desired == grams) return;
+        } finally {
+          _inFlight = null;
+        }
       }
-      _log.info('SAW target written: ${grams}g');
-    } on DeviceNotConnectedException {
-      // `_lastPushed` deliberately not updated — on Bengle reconnect
-      // `_onDe1Change` re-applies the current target, so the failed
-      // write self-recovers without needing an explicit retry.
-      _log.fine('SAW write aborted — machine disconnected mid-call');
-    } catch (e, st) {
-      // Same recovery story as DeviceNotConnectedException: leave
-      // `_lastPushed` alone so the next workflow edit (different
-      // value) or reconnect re-attempts. Identical-value retries
-      // after a transient failure are not handled — the bar for SAW
-      // is "FW eventually learns the target before the next shot",
-      // not "every write succeeds".
-      _log.warning('SAW write failed', e, st);
+    } finally {
+      _pushing = false;
     }
   }
 
   Future<void> dispose() async {
+    _disposed = true;
     _workflow.removeListener(_onWorkflowChange);
     _debounceTimer?.cancel();
     _debounceTimer = null;
+    _desired = null;
     await _de1Sub?.cancel();
     _de1Sub = null;
   }

--- a/lib/src/controllers/bengle_saw_bridge.dart
+++ b/lib/src/controllers/bengle_saw_bridge.dart
@@ -46,10 +46,12 @@ class BengleSawBridge {
   StreamSubscription<De1Interface?>? _de1Sub;
   Timer? _debounceTimer;
   double? _lastPushed;
+  int? _lastPushedGeneration;
   double? _desired;
+  int? _desiredGeneration;
   double? _inFlight;
-  bool _forcePush = false;
   bool _pushing = false;
+  bool _restartAfterDrain = false;
   bool _disposed = false;
 
   double _currentTargetYield() =>
@@ -57,14 +59,18 @@ class BengleSawBridge {
 
   void _onWorkflowChange() {
     final next = _currentTargetYield();
-    _forcePush = false;
-    if (next == _lastPushed && (_inFlight == null || _inFlight == next)) {
+    final generation = _de1.connectionGeneration;
+    if (next == _lastPushed &&
+        _lastPushedGeneration == generation &&
+        (_inFlight == null || _inFlight == next)) {
       _desired = null;
+      _desiredGeneration = null;
       _debounceTimer?.cancel();
       _debounceTimer = null;
       return;
     }
     _desired = next;
+    _desiredGeneration = generation;
     _debounceTimer?.cancel();
     _debounceTimer = Timer(debounce, () {
       _debounceTimer = null;
@@ -73,13 +79,21 @@ class BengleSawBridge {
   }
 
   void _onDe1Change(De1Interface? device) {
-    if (device is! BengleInterface) return;
+    if (device is! BengleInterface) {
+      if (_pushing) _restartAfterDrain = true;
+      return;
+    }
     _debounceTimer?.cancel();
     _debounceTimer = null;
     _desired = _currentTargetYield();
-    _forcePush = true;
+    _desiredGeneration = _de1.connectionGeneration;
+    if (_pushing) _restartAfterDrain = true;
     unawaited(_drain());
   }
+
+  bool _isCurrent(De1Interface machine, int generation) =>
+      identical(machine, _de1.connectedDe1OrNull) &&
+      generation == _de1.connectionGeneration;
 
   Future<void> _drain() async {
     if (_pushing || _disposed) return;
@@ -87,9 +101,11 @@ class BengleSawBridge {
     try {
       while (!_disposed) {
         final grams = _desired;
-        if (grams == null || (!_forcePush && grams == _lastPushed)) {
+        if (grams == null ||
+            (grams == _lastPushed &&
+                _desiredGeneration == _lastPushedGeneration)) {
           _desired = null;
-          _forcePush = false;
+          _desiredGeneration = null;
           return;
         }
         final machine = _de1.connectedDe1OrNull;
@@ -97,26 +113,49 @@ class BengleSawBridge {
           _log.fine('SAW write skipped — connected machine is not Bengle');
           return;
         }
+        final generation = _de1.connectionGeneration;
         _inFlight = grams;
         try {
           await machine.setStopAtWeightTarget(grams);
           if (_disposed) return;
+          if (!_isCurrent(machine, generation)) continue;
           _lastPushed = grams;
-          _forcePush = false;
-          if (_desired == grams) _desired = null;
+          _lastPushedGeneration = generation;
+          if (_desired == grams && _desiredGeneration == generation) {
+            _desired = null;
+            _desiredGeneration = null;
+          }
           _log.info('SAW target written: ${grams}g');
         } on DeviceNotConnectedException {
           _log.fine('SAW write aborted — machine disconnected mid-call');
-          if (_desired == grams) return;
+          if (!_isCurrent(machine, generation) ||
+              _desired != grams ||
+              _desiredGeneration != generation) {
+            continue;
+          }
+          return;
         } catch (e, st) {
           _log.warning('SAW write failed', e, st);
-          if (_desired == grams) return;
+          if (!_isCurrent(machine, generation) ||
+              _desired != grams ||
+              _desiredGeneration != generation) {
+            continue;
+          }
+          return;
         } finally {
           _inFlight = null;
         }
       }
     } finally {
+      final restart = _restartAfterDrain;
+      _restartAfterDrain = false;
       _pushing = false;
+      if (!_disposed &&
+          restart &&
+          _desired != null &&
+          _de1.connectedDe1OrNull is BengleInterface) {
+        unawaited(_drain());
+      }
     }
   }
 
@@ -126,6 +165,8 @@ class BengleSawBridge {
     _debounceTimer?.cancel();
     _debounceTimer = null;
     _desired = null;
+    _desiredGeneration = null;
+    _restartAfterDrain = false;
     await _de1Sub?.cancel();
     _de1Sub = null;
   }

--- a/lib/src/controllers/bengle_steam_stop_bridge.dart
+++ b/lib/src/controllers/bengle_steam_stop_bridge.dart
@@ -110,7 +110,11 @@ class BengleSteamStopBridge {
         final generation = _de1.connectionGeneration;
         _inFlight = celsius;
         try {
-          await machine.setStopAtTemperatureTarget(celsius);
+          await _de1.runDeviceWrite((device) async {
+            if (identical(device, machine)) {
+              await machine.setStopAtTemperatureTarget(celsius);
+            }
+          });
           if (_disposed) return;
           if (!_isCurrent(machine, generation)) continue;
           _lastPushed = celsius;

--- a/lib/src/controllers/bengle_steam_stop_bridge.dart
+++ b/lib/src/controllers/bengle_steam_stop_bridge.dart
@@ -38,10 +38,12 @@ class BengleSteamStopBridge {
   StreamSubscription<De1Interface?>? _de1Sub;
   Timer? _debounceTimer;
   double? _lastPushed;
+  int? _lastPushedGeneration;
   double? _desired;
+  int? _desiredGeneration;
   double? _inFlight;
-  bool _forcePush = false;
   bool _pushing = false;
+  bool _restartAfterDrain = false;
   bool _disposed = false;
 
   double _currentTarget() =>
@@ -49,14 +51,18 @@ class BengleSteamStopBridge {
 
   void _onWorkflowChange() {
     final next = _currentTarget();
-    _forcePush = false;
-    if (next == _lastPushed && (_inFlight == null || _inFlight == next)) {
+    final generation = _de1.connectionGeneration;
+    if (next == _lastPushed &&
+        _lastPushedGeneration == generation &&
+        (_inFlight == null || _inFlight == next)) {
       _desired = null;
+      _desiredGeneration = null;
       _debounceTimer?.cancel();
       _debounceTimer = null;
       return;
     }
     _desired = next;
+    _desiredGeneration = generation;
     _debounceTimer?.cancel();
     _debounceTimer = Timer(debounce, () {
       _debounceTimer = null;
@@ -65,13 +71,21 @@ class BengleSteamStopBridge {
   }
 
   void _onDe1Change(De1Interface? device) {
-    if (device is! BengleInterface) return;
+    if (device is! BengleInterface) {
+      if (_pushing) _restartAfterDrain = true;
+      return;
+    }
     _debounceTimer?.cancel();
     _debounceTimer = null;
     _desired = _currentTarget();
-    _forcePush = true;
+    _desiredGeneration = _de1.connectionGeneration;
+    if (_pushing) _restartAfterDrain = true;
     unawaited(_drain());
   }
+
+  bool _isCurrent(De1Interface machine, int generation) =>
+      identical(machine, _de1.connectedDe1OrNull) &&
+      generation == _de1.connectionGeneration;
 
   Future<void> _drain() async {
     if (_pushing || _disposed) return;
@@ -79,9 +93,11 @@ class BengleSteamStopBridge {
     try {
       while (!_disposed) {
         final celsius = _desired;
-        if (celsius == null || (!_forcePush && celsius == _lastPushed)) {
+        if (celsius == null ||
+            (celsius == _lastPushed &&
+                _desiredGeneration == _lastPushedGeneration)) {
           _desired = null;
-          _forcePush = false;
+          _desiredGeneration = null;
           return;
         }
         final machine = _de1.connectedDe1OrNull;
@@ -91,28 +107,49 @@ class BengleSteamStopBridge {
           );
           return;
         }
+        final generation = _de1.connectionGeneration;
         _inFlight = celsius;
         try {
           await machine.setStopAtTemperatureTarget(celsius);
           if (_disposed) return;
+          if (!_isCurrent(machine, generation)) continue;
           _lastPushed = celsius;
-          _forcePush = false;
-          if (_desired == celsius) _desired = null;
+          _lastPushedGeneration = generation;
+          if (_desired == celsius && _desiredGeneration == generation) {
+            _desired = null;
+            _desiredGeneration = null;
+          }
           _log.info('Stop-at-temperature target written: $celsius°C');
         } on DeviceNotConnectedException {
-          _log.fine(
-            'Steam-stop write aborted — machine disconnected mid-call',
-          );
-          if (_desired == celsius) return;
+          _log.fine('Steam-stop write aborted — machine disconnected mid-call');
+          if (!_isCurrent(machine, generation) ||
+              _desired != celsius ||
+              _desiredGeneration != generation) {
+            continue;
+          }
+          return;
         } catch (e, st) {
           _log.warning('Steam-stop write failed', e, st);
-          if (_desired == celsius) return;
+          if (!_isCurrent(machine, generation) ||
+              _desired != celsius ||
+              _desiredGeneration != generation) {
+            continue;
+          }
+          return;
         } finally {
           _inFlight = null;
         }
       }
     } finally {
+      final restart = _restartAfterDrain;
+      _restartAfterDrain = false;
       _pushing = false;
+      if (!_disposed &&
+          restart &&
+          _desired != null &&
+          _de1.connectedDe1OrNull is BengleInterface) {
+        unawaited(_drain());
+      }
     }
   }
 
@@ -122,6 +159,8 @@ class BengleSteamStopBridge {
     _debounceTimer?.cancel();
     _debounceTimer = null;
     _desired = null;
+    _desiredGeneration = null;
+    _restartAfterDrain = false;
     await _de1Sub?.cancel();
     _de1Sub = null;
   }

--- a/lib/src/controllers/bengle_steam_stop_bridge.dart
+++ b/lib/src/controllers/bengle_steam_stop_bridge.dart
@@ -9,8 +9,8 @@ import 'package:reaprime/src/models/errors.dart';
 
 /// Reflects `SteamSettings.stopAtTemperature` into the connected
 /// Bengle's `setStopAtTemperatureTarget` MMR endpoint. Mirrors
-/// [BengleSawBridge] — same debounce + generation-token + re-assert on
-/// reconnect shape.
+/// [BengleSawBridge] — same debounce + serialized latest-value drain +
+/// re-assert on reconnect shape.
 ///
 /// **Scaffolding.** While the FW MMR slot is stubbed
 /// (`BengleSteamMmr.stopAtTemperatureTarget.address == 0x00000000`),
@@ -37,57 +37,91 @@ class BengleSteamStopBridge {
 
   StreamSubscription<De1Interface?>? _de1Sub;
   Timer? _debounceTimer;
-  int _generation = 0;
   double? _lastPushed;
+  double? _desired;
+  double? _inFlight;
+  bool _forcePush = false;
+  bool _pushing = false;
+  bool _disposed = false;
 
   double _currentTarget() =>
       _workflow.currentWorkflow.steamSettings.stopAtTemperature;
 
   void _onWorkflowChange() {
     final next = _currentTarget();
-    if (next == _lastPushed) return;
+    _forcePush = false;
+    if (next == _lastPushed && (_inFlight == null || _inFlight == next)) {
+      _desired = null;
+      _debounceTimer?.cancel();
+      _debounceTimer = null;
+      return;
+    }
+    _desired = next;
     _debounceTimer?.cancel();
-    final generation = ++_generation;
-    _debounceTimer = Timer(debounce, () => _push(next, generation));
+    _debounceTimer = Timer(debounce, () {
+      _debounceTimer = null;
+      unawaited(_drain());
+    });
   }
 
   void _onDe1Change(De1Interface? device) {
     if (device is! BengleInterface) return;
-    final next = _currentTarget();
-    final generation = ++_generation;
-    _push(next, generation);
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    _desired = _currentTarget();
+    _forcePush = true;
+    unawaited(_drain());
   }
 
-  Future<void> _push(double celsius, int generation) async {
-    if (generation != _generation) {
-      _log.fine(
-        'Steam-stop write superseded '
-        '(gen=$generation, current=$_generation)',
-      );
-      return;
-    }
-    final machine = _de1.connectedDe1OrNull;
-    if (machine is! BengleInterface) {
-      _log.fine('Steam-stop write skipped — connected machine is not Bengle');
-      return;
-    }
+  Future<void> _drain() async {
+    if (_pushing || _disposed) return;
+    _pushing = true;
     try {
-      await machine.setStopAtTemperatureTarget(celsius);
-      if (generation == _generation) {
-        _lastPushed = celsius;
+      while (!_disposed) {
+        final celsius = _desired;
+        if (celsius == null || (!_forcePush && celsius == _lastPushed)) {
+          _desired = null;
+          _forcePush = false;
+          return;
+        }
+        final machine = _de1.connectedDe1OrNull;
+        if (machine is! BengleInterface) {
+          _log.fine(
+            'Steam-stop write skipped — connected machine is not Bengle',
+          );
+          return;
+        }
+        _inFlight = celsius;
+        try {
+          await machine.setStopAtTemperatureTarget(celsius);
+          if (_disposed) return;
+          _lastPushed = celsius;
+          _forcePush = false;
+          if (_desired == celsius) _desired = null;
+          _log.info('Stop-at-temperature target written: $celsius°C');
+        } on DeviceNotConnectedException {
+          _log.fine(
+            'Steam-stop write aborted — machine disconnected mid-call',
+          );
+          if (_desired == celsius) return;
+        } catch (e, st) {
+          _log.warning('Steam-stop write failed', e, st);
+          if (_desired == celsius) return;
+        } finally {
+          _inFlight = null;
+        }
       }
-      _log.info('Stop-at-temperature target written: $celsius°C');
-    } on DeviceNotConnectedException {
-      _log.fine('Steam-stop write aborted — machine disconnected mid-call');
-    } catch (e, st) {
-      _log.warning('Steam-stop write failed', e, st);
+    } finally {
+      _pushing = false;
     }
   }
 
   Future<void> dispose() async {
+    _disposed = true;
     _workflow.removeListener(_onWorkflowChange);
     _debounceTimer?.cancel();
     _debounceTimer = null;
+    _desired = null;
     await _de1Sub?.cancel();
     _de1Sub = null;
   }

--- a/lib/src/controllers/connection/connection_timings.dart
+++ b/lib/src/controllers/connection/connection_timings.dart
@@ -29,4 +29,9 @@ class ConnectionTimings {
   /// state=espresso request that hits the loop before the flash write
   /// returns aborts the shot to HeaterDown.
   static const profileDownloadGuard = Duration(milliseconds: 500);
+
+  /// Bounded wait for a replacement machine after a mid-write
+  /// disconnect before `De1Controller` device-write retry gives up
+  /// (HTTP 503).
+  static const machineReplacementTimeout = Duration(seconds: 10);
 }

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -638,7 +638,7 @@ class De1Controller {
       (device) => device.setSteamFlow(newFlow),
       retryOnReplacement: true,
     );
-    publishSteamFlow(newFlow);
+    _publishSteamFlow(newFlow);
   }
 
   Future<void> setHotWaterFlow(double newFlow) async {
@@ -646,7 +646,7 @@ class De1Controller {
       (device) => device.setHotWaterFlow(newFlow),
       retryOnReplacement: true,
     );
-    publishHotWaterFlow(newFlow);
+    _publishHotWaterFlow(newFlow);
   }
 
   Future<void> setFlushFlow(double newFlow) async {
@@ -654,13 +654,47 @@ class De1Controller {
       (device) => device.setFlushFlow(newFlow),
       retryOnReplacement: true,
     );
-    publishFlushFlow(newFlow);
+    _publishFlushFlow(newFlow);
+  }
+
+  /// One queued grouped write for `POST /api/v1/machine/settings`.
+  /// All physical writes share one queue entry; the controller flow
+  /// streams are published only after the grouped write completed and
+  /// its final machine-generation check passed, so the streams never
+  /// reflect values a machine did not receive.
+  Future<void> updateMachineSettings({
+    bool? usb,
+    int? fan,
+    double? flushTemp,
+    double? flushFlow,
+    double? flushTimeout,
+    double? hotWaterFlow,
+    double? steamFlow,
+    int? tankTemp,
+    int? steamPurgeMode,
+  }) async {
+    await runDeviceWrite((device) async {
+      if (usb != null) await device.setUsbChargerMode(usb);
+      if (fan != null) await device.setFanThreshhold(fan);
+      if (flushTemp != null) await device.setFlushTemperature(flushTemp);
+      if (flushFlow != null) await device.setFlushFlow(flushFlow);
+      if (flushTimeout != null) await device.setFlushTimeout(flushTimeout);
+      if (hotWaterFlow != null) await device.setHotWaterFlow(hotWaterFlow);
+      if (steamFlow != null) await device.setSteamFlow(steamFlow);
+      if (tankTemp != null) await device.setTankTempThreshold(tankTemp);
+      if (steamPurgeMode != null) {
+        await device.setSteamPurgeMode(steamPurgeMode);
+      }
+    }, retryOnReplacement: true);
+    if (flushFlow != null) _publishFlushFlow(flushFlow);
+    if (hotWaterFlow != null) _publishHotWaterFlow(hotWaterFlow);
+    if (steamFlow != null) _publishSteamFlow(steamFlow);
   }
 
   /// Publish-only steam-flow update. Call only after the physical write
-  /// has been applied (e.g. by a grouped [runDeviceWrite] callback), so
-  /// the stream cannot reflect a value the machine never received.
-  void publishSteamFlow(double newFlow) {
+  /// has been applied, so the stream cannot reflect a value the machine
+  /// never received.
+  void _publishSteamFlow(double newFlow) {
     final current = _steamDataController.valueOrNull;
     if (current != null) {
       _steamDataController.add(
@@ -673,8 +707,8 @@ class De1Controller {
     }
   }
 
-  /// Publish-only hot-water-flow update, see [publishSteamFlow].
-  void publishHotWaterFlow(double newFlow) {
+  /// Publish-only hot-water-flow update, see [_publishSteamFlow].
+  void _publishHotWaterFlow(double newFlow) {
     final current = _hotWaterDataController.valueOrNull;
     if (current != null) {
       _hotWaterDataController.add(
@@ -688,8 +722,8 @@ class De1Controller {
     }
   }
 
-  /// Publish-only flush-flow update, see [publishSteamFlow].
-  void publishFlushFlow(double newFlow) {
+  /// Publish-only flush-flow update, see [_publishSteamFlow].
+  void _publishFlushFlow(double newFlow) {
     final current = _rinseStream.valueOrNull;
     if (current != null) {
       _rinseStream.add(

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -425,12 +425,14 @@ class De1Controller {
     int generation,
   ) async {
     if (_initSettledSubject.valueOrNull == generation) return;
-    await _initSettledSubject.stream.firstWhere(
-      (settled) =>
-          settled == generation ||
-          generation != _connectionGeneration ||
-          !identical(device, _de1),
-    );
+    await _initSettledSubject.stream
+        .firstWhere(
+          (settled) =>
+              settled == generation ||
+              generation != _connectionGeneration ||
+              !identical(device, _de1),
+        )
+        .timeout(ConnectionTimings.initialShotSettingsTimeout);
   }
 
   Future<SteamFormSettings> steamSettings() async {
@@ -550,7 +552,11 @@ class De1Controller {
     Workflow updated,
   ) async {
     final rinseChanged = previous.rinseData != updated.rinseData;
-    final steamChanged = previous.steamSettings != updated.steamSettings;
+    final steamChanged =
+        previous.steamSettings.targetTemperature !=
+            updated.steamSettings.targetTemperature ||
+        previous.steamSettings.duration != updated.steamSettings.duration ||
+        previous.steamSettings.flow != updated.steamSettings.flow;
     final hotWaterChanged = previous.hotWaterData != updated.hotWaterData;
     if (!rinseChanged && !steamChanged && !hotWaterChanged) return;
 

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -401,6 +401,11 @@ class De1Controller {
       final device = connectedDe1();
       final generation = _connectionGeneration;
       try {
+        await _waitForInitialization(device, generation);
+        if (generation != _connectionGeneration || !identical(device, _de1)) {
+          if (attempt + 1 < attempts) continue;
+          break;
+        }
         final result = await write(device);
         if (generation == _connectionGeneration && identical(device, _de1)) {
           return result;
@@ -413,6 +418,19 @@ class De1Controller {
       }
     }
     throw StateError('Machine changed during device write');
+  }
+
+  Future<void> _waitForInitialization(
+    De1Interface device,
+    int generation,
+  ) async {
+    if (_initSettledSubject.valueOrNull == generation) return;
+    await _initSettledSubject.stream.firstWhere(
+      (settled) =>
+          settled == generation ||
+          generation != _connectionGeneration ||
+          !identical(device, _de1),
+    );
   }
 
   Future<SteamFormSettings> steamSettings() async {

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -135,8 +135,16 @@ class De1Controller {
 
   int get connectionGeneration => _connectionGeneration;
 
-  De1Controller({required DeviceController controller})
-    : _deviceController = controller {
+  /// Bounded wait for a replacement machine after a mid-write
+  /// disconnect (see [ConnectionTimings.machineReplacementTimeout]).
+  /// Overridable in tests to keep the timeout short.
+  final Duration machineReplacementTimeout;
+
+  De1Controller({
+    required DeviceController controller,
+    this.machineReplacementTimeout =
+        ConnectionTimings.machineReplacementTimeout,
+  }) : _deviceController = controller {
     _log.info("checking ${_deviceController.devices}");
   }
 
@@ -398,26 +406,57 @@ class De1Controller {
   ) async {
     final attempts = retryOnReplacement ? 2 : 1;
     for (var attempt = 0; attempt < attempts; attempt++) {
-      final device = connectedDe1();
+      // Machine acquisition is inside the retry logic: a disconnected
+      // interval (no machine at this moment) only blocks the first
+      // attempt when there was never a machine to begin with. After a
+      // generation change the retry waits for a replacement.
+      De1Interface device;
+      try {
+        device = connectedDe1();
+      } on DeviceNotConnectedException {
+        if (!retryOnReplacement || attempt == 0) rethrow;
+        final replacement = await _waitForMachineReplacement(
+          machineReplacementTimeout,
+        );
+        if (replacement == null) {
+          throw MachineReplacementTimeoutException(machineReplacementTimeout);
+        }
+        device = replacement;
+      }
       final generation = _connectionGeneration;
       try {
         await _waitForInitialization(device, generation);
-        if (generation != _connectionGeneration || !identical(device, _de1)) {
+        if (generation != _connectionGeneration ||
+            !identical(device, connectedDe1OrNull)) {
           if (attempt + 1 < attempts) continue;
           break;
         }
         final result = await write(device);
-        if (generation == _connectionGeneration && identical(device, _de1)) {
+        if (generation == _connectionGeneration &&
+            identical(device, connectedDe1OrNull)) {
           return result;
         }
       } catch (_) {
         if (attempt + 1 == attempts ||
-            (generation == _connectionGeneration && identical(device, _de1))) {
+            (generation == _connectionGeneration &&
+                identical(device, connectedDe1OrNull))) {
           rethrow;
         }
       }
     }
     throw StateError('Machine changed during device write');
+  }
+
+  /// Wait up to [timeout] for a non-null machine to appear on the
+  /// controller stream. Returns null if no machine appears in time.
+  Future<De1Interface?> _waitForMachineReplacement(Duration timeout) async {
+    try {
+      return await _de1Controller.stream
+          .firstWhere((de1) => de1 != null)
+          .timeout(timeout);
+    } on TimeoutException {
+      return null;
+    }
   }
 
   Future<void> _waitForInitialization(
@@ -430,7 +469,7 @@ class De1Controller {
           (settled) =>
               settled == generation ||
               generation != _connectionGeneration ||
-              !identical(device, _de1),
+              !identical(device, connectedDe1OrNull),
         )
         .timeout(ConnectionTimings.initialShotSettingsTimeout);
   }
@@ -599,6 +638,29 @@ class De1Controller {
       (device) => device.setSteamFlow(newFlow),
       retryOnReplacement: true,
     );
+    publishSteamFlow(newFlow);
+  }
+
+  Future<void> setHotWaterFlow(double newFlow) async {
+    await runDeviceWrite(
+      (device) => device.setHotWaterFlow(newFlow),
+      retryOnReplacement: true,
+    );
+    publishHotWaterFlow(newFlow);
+  }
+
+  Future<void> setFlushFlow(double newFlow) async {
+    await runDeviceWrite(
+      (device) => device.setFlushFlow(newFlow),
+      retryOnReplacement: true,
+    );
+    publishFlushFlow(newFlow);
+  }
+
+  /// Publish-only steam-flow update. Call only after the physical write
+  /// has been applied (e.g. by a grouped [runDeviceWrite] callback), so
+  /// the stream cannot reflect a value the machine never received.
+  void publishSteamFlow(double newFlow) {
     final current = _steamDataController.valueOrNull;
     if (current != null) {
       _steamDataController.add(
@@ -611,11 +673,8 @@ class De1Controller {
     }
   }
 
-  Future<void> setHotWaterFlow(double newFlow) async {
-    await runDeviceWrite(
-      (device) => device.setHotWaterFlow(newFlow),
-      retryOnReplacement: true,
-    );
+  /// Publish-only hot-water-flow update, see [publishSteamFlow].
+  void publishHotWaterFlow(double newFlow) {
     final current = _hotWaterDataController.valueOrNull;
     if (current != null) {
       _hotWaterDataController.add(
@@ -629,11 +688,8 @@ class De1Controller {
     }
   }
 
-  Future<void> setFlushFlow(double newFlow) async {
-    await runDeviceWrite(
-      (device) => device.setFlushFlow(newFlow),
-      retryOnReplacement: true,
-    );
+  /// Publish-only flush-flow update, see [publishSteamFlow].
+  void publishFlushFlow(double newFlow) {
     final current = _rinseStream.valueOrNull;
     if (current != null) {
       _rinseStream.add(

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -113,6 +113,7 @@ class De1Controller {
   final List<StreamSubscription<dynamic>> _subscriptions = [];
   bool _dataInitialized = false;
   Timer? _shotSettingsDebounce;
+  Future<void> _deviceWriteQueue = Future<void>.value();
 
   /// Bumped every time `_onDisconnect()` runs. Captured by the
   /// `_shotSettingsUpdate` debounce-timer closure at scheduling
@@ -377,6 +378,43 @@ class De1Controller {
   /// catching `DeviceNotConnectedException`.
   De1Interface? get connectedDe1OrNull => _de1;
 
+  Future<T> runDeviceWrite<T>(
+    Future<T> Function(De1Interface device) write, {
+    bool retryOnReplacement = false,
+  }) {
+    final operation = _deviceWriteQueue.then(
+      (_) => _runDeviceWrite(write, retryOnReplacement),
+    );
+    _deviceWriteQueue = operation.then<void>(
+      (_) {},
+      onError: (Object error, StackTrace stackTrace) {},
+    );
+    return operation;
+  }
+
+  Future<T> _runDeviceWrite<T>(
+    Future<T> Function(De1Interface device) write,
+    bool retryOnReplacement,
+  ) async {
+    final attempts = retryOnReplacement ? 2 : 1;
+    for (var attempt = 0; attempt < attempts; attempt++) {
+      final device = connectedDe1();
+      final generation = _connectionGeneration;
+      try {
+        final result = await write(device);
+        if (generation == _connectionGeneration && identical(device, _de1)) {
+          return result;
+        }
+      } catch (_) {
+        if (attempt + 1 == attempts ||
+            (generation == _connectionGeneration && identical(device, _de1))) {
+          rethrow;
+        }
+      }
+    }
+    throw StateError('Machine changed during device write');
+  }
+
   Future<SteamFormSettings> steamSettings() async {
     if (_de1 == null) {
       throw const DeviceNotConnectedException.machine();
@@ -393,14 +431,28 @@ class De1Controller {
   }
 
   Future<void> updateSteamSettings(SteamFormSettings settings) async {
-    De1ShotSettings shotSettings = await connectedDe1().shotSettings.first;
-    await connectedDe1().setSteamFlow(settings.targetFlow);
-    await connectedDe1().updateShotSettings(
+    await runDeviceWrite(
+      (device) => _writeSteamSettings(device, settings),
+      retryOnReplacement: true,
+    );
+    _publishSteamSettings(settings);
+  }
+
+  Future<void> _writeSteamSettings(
+    De1Interface device,
+    SteamFormSettings settings,
+  ) async {
+    final shotSettings = await device.shotSettings.first;
+    await device.setSteamFlow(settings.targetFlow);
+    await device.updateShotSettings(
       shotSettings.copyWith(
         targetSteamTemp: settings.steamEnabled ? settings.targetTemp : 0,
         targetSteamDuration: settings.targetDuration,
       ),
     );
+  }
+
+  void _publishSteamSettings(SteamFormSettings settings) {
     _steamDataController.add(
       SteamSettings(
         targetTemperature: settings.steamEnabled ? settings.targetTemp : 0,
@@ -425,16 +477,29 @@ class De1Controller {
   }
 
   Future<void> updateHotWaterSettings(HotWaterFormSettings settings) async {
-    await connectedDe1().setHotWaterFlow(settings.flow);
-    await connectedDe1().shotSettings.first.then((s) async {
-      await connectedDe1().updateShotSettings(
-        s.copyWith(
-          targetHotWaterTemp: settings.targetTemperature,
-          targetHotWaterVolume: settings.volume,
-          targetHotWaterDuration: settings.duration,
-        ),
-      );
-    });
+    await runDeviceWrite(
+      (device) => _writeHotWaterSettings(device, settings),
+      retryOnReplacement: true,
+    );
+    _publishHotWaterSettings(settings);
+  }
+
+  Future<void> _writeHotWaterSettings(
+    De1Interface device,
+    HotWaterFormSettings settings,
+  ) async {
+    await device.setHotWaterFlow(settings.flow);
+    final shotSettings = await device.shotSettings.first;
+    await device.updateShotSettings(
+      shotSettings.copyWith(
+        targetHotWaterTemp: settings.targetTemperature,
+        targetHotWaterVolume: settings.volume,
+        targetHotWaterDuration: settings.duration,
+      ),
+    );
+  }
+
+  void _publishHotWaterSettings(HotWaterFormSettings settings) {
     _hotWaterDataController.add(
       HotWaterData(
         targetTemperature: settings.targetTemperature,
@@ -446,13 +511,57 @@ class De1Controller {
   }
 
   Future<void> updateFlushSettings(RinseData settings) async {
-    await connectedDe1().setFlushTimeout(settings.duration.toDouble());
-    await connectedDe1().setFlushFlow(settings.flow);
-    await connectedDe1().setFlushTemperature(
-      settings.targetTemperature.toDouble(),
+    await runDeviceWrite(
+      (device) => _writeFlushSettings(device, settings),
+      retryOnReplacement: true,
     );
-
     _rinseStream.add(settings);
+  }
+
+  Future<void> _writeFlushSettings(
+    De1Interface device,
+    RinseData settings,
+  ) async {
+    await device.setFlushTimeout(settings.duration.toDouble());
+    await device.setFlushFlow(settings.flow);
+    await device.setFlushTemperature(settings.targetTemperature.toDouble());
+  }
+
+  Future<void> updateWorkflowSettings(
+    Workflow previous,
+    Workflow updated,
+  ) async {
+    final rinseChanged = previous.rinseData != updated.rinseData;
+    final steamChanged = previous.steamSettings != updated.steamSettings;
+    final hotWaterChanged = previous.hotWaterData != updated.hotWaterData;
+    if (!rinseChanged && !steamChanged && !hotWaterChanged) return;
+
+    final steam = SteamFormSettings(
+      steamEnabled: updated.steamSettings.duration > 0,
+      targetTemp: updated.steamSettings.targetTemperature,
+      targetDuration: updated.steamSettings.duration,
+      targetFlow: updated.steamSettings.flow,
+    );
+    final hotWater = HotWaterFormSettings(
+      targetTemperature: updated.hotWaterData.targetTemperature,
+      flow: updated.hotWaterData.flow,
+      volume: updated.hotWaterData.volume,
+      duration: updated.hotWaterData.duration,
+    );
+    await runDeviceWrite((device) async {
+      if (rinseChanged) {
+        await _writeFlushSettings(device, updated.rinseData);
+      }
+      if (steamChanged) {
+        await _writeSteamSettings(device, steam);
+      }
+      if (hotWaterChanged) {
+        await _writeHotWaterSettings(device, hotWater);
+      }
+    }, retryOnReplacement: true);
+    if (rinseChanged) _rinseStream.add(updated.rinseData);
+    if (steamChanged) _publishSteamSettings(steam);
+    if (hotWaterChanged) _publishHotWaterSettings(hotWater);
   }
 
   /// Flow setters live outside the DE1 shot-settings characteristic, so
@@ -462,7 +571,10 @@ class De1Controller {
   /// helpers replace it by writing the MMR value and updating the
   /// relevant data-controller directly.
   Future<void> setSteamFlow(double newFlow) async {
-    await connectedDe1().setSteamFlow(newFlow);
+    await runDeviceWrite(
+      (device) => device.setSteamFlow(newFlow),
+      retryOnReplacement: true,
+    );
     final current = _steamDataController.valueOrNull;
     if (current != null) {
       _steamDataController.add(
@@ -476,7 +588,10 @@ class De1Controller {
   }
 
   Future<void> setHotWaterFlow(double newFlow) async {
-    await connectedDe1().setHotWaterFlow(newFlow);
+    await runDeviceWrite(
+      (device) => device.setHotWaterFlow(newFlow),
+      retryOnReplacement: true,
+    );
     final current = _hotWaterDataController.valueOrNull;
     if (current != null) {
       _hotWaterDataController.add(
@@ -491,7 +606,10 @@ class De1Controller {
   }
 
   Future<void> setFlushFlow(double newFlow) async {
-    await connectedDe1().setFlushFlow(newFlow);
+    await runDeviceWrite(
+      (device) => device.setFlushFlow(newFlow),
+      retryOnReplacement: true,
+    );
     final current = _rinseStream.valueOrNull;
     if (current != null) {
       _rinseStream.add(

--- a/lib/src/controllers/de1_controller.defaults.dart
+++ b/lib/src/controllers/de1_controller.defaults.dart
@@ -110,23 +110,21 @@ extension Defaults on De1Controller {
     _rinseStream.add(settings);
   }
 
-  /// Bulk reset of firmware settings. Deliberately NOT wrapped in the
-  /// device-write retry queue: writing `heaterPh2Timeout` resets the
-  /// heater controller, which drops the connection mid-operation, so
-  /// retry-on-replacement semantics do not apply. Writes are
-  /// device-pinned via `_de1` and the REST route gates on a connected
-  /// machine before calling this.
-  Future<void> applySettingsDefaults() async {
-    await _de1?.setFanThreshhold(55);
+  /// Bulk reset of firmware settings. Writes through the passed
+  /// [device] (never a fresh `_de1` read) so the whole reset is one
+  /// queued, retryable group; call via [runDeviceWrite] from the REST
+  /// route. Does not reserve a queue entry itself.
+  Future<void> applySettingsDefaults(De1Interface device) async {
+    await device.setFanThreshhold(55);
 
-    await _de1?.setHeaterIdleTemp(95);
-    await _de1?.setHeaterPhase1Flow(2.0);
-    await _de1?.setHeaterPhase2Flow(4.0);
-    await _de1?.setHeaterPhase2Timeout(4.0);
+    await device.setHeaterIdleTemp(95);
+    await device.setHeaterPhase1Flow(2.0);
+    await device.setHeaterPhase2Flow(4.0);
+    await device.setHeaterPhase2Timeout(4.0);
 
-    await _de1?.setRefillKitSettings(.auto);
+    await device.setRefillKitSettings(.auto);
 
-    await _de1?.setFlowEstimation(1.0);
-    await _de1?.setSteamPurgeMode(0);
+    await device.setFlowEstimation(1.0);
+    await device.setSteamPurgeMode(0);
   }
 }

--- a/lib/src/controllers/de1_controller.defaults.dart
+++ b/lib/src/controllers/de1_controller.defaults.dart
@@ -110,6 +110,12 @@ extension Defaults on De1Controller {
     _rinseStream.add(settings);
   }
 
+  /// Bulk reset of firmware settings. Deliberately NOT wrapped in the
+  /// device-write retry queue: writing `heaterPh2Timeout` resets the
+  /// heater controller, which drops the connection mid-operation, so
+  /// retry-on-replacement semantics do not apply. Writes are
+  /// device-pinned via `_de1` and the REST route gates on a connected
+  /// machine before calling this.
   Future<void> applySettingsDefaults() async {
     await _de1?.setFanThreshhold(55);
 

--- a/lib/src/controllers/workflow_controller.dart
+++ b/lib/src/controllers/workflow_controller.dart
@@ -17,6 +17,7 @@ class WorkflowController extends ChangeNotifier {
     hotWaterData: HotWaterData.defaults(),
     rinseData: RinseData.defaults(),
   );
+  int _revision = 0;
 
   Workflow newWorkflow() {
     return Workflow(
@@ -33,9 +34,18 @@ class WorkflowController extends ChangeNotifier {
 
   Workflow get currentWorkflow => _currentWorkflow;
 
+  int get revision => _revision;
+
   void setWorkflow(Workflow newWorkflow) {
     _currentWorkflow = newWorkflow;
+    _revision++;
     notifyListeners();
+  }
+
+  bool setWorkflowIfRevision(Workflow newWorkflow, int expectedRevision) {
+    if (_revision != expectedRevision) return false;
+    setWorkflow(newWorkflow);
+    return true;
   }
 
   void updateWorkflow({
@@ -56,6 +66,7 @@ class WorkflowController extends ChangeNotifier {
       hotWaterData: hotWaterData,
       rinseData: rinseData,
     );
+    _revision++;
     notifyListeners();
   }
 }

--- a/lib/src/controllers/workflow_device_sync.dart
+++ b/lib/src/controllers/workflow_device_sync.dart
@@ -122,7 +122,7 @@ class WorkflowDeviceSync {
           return;
         }
         try {
-          await _de1.connectedDe1().setProfile(profile);
+          await _de1.runDeviceWrite((device) => device.setProfile(profile));
           if (generation != _generation) return;
           _lastPushedProfile = profile;
           _attempt = 0;

--- a/lib/src/models/device/impl/mock_de1/mock_de1.dart
+++ b/lib/src/models/device/impl/mock_de1/mock_de1.dart
@@ -578,6 +578,14 @@ class MockDe1 implements De1Interface, SimulatedDevice {
     _connectionState.add(ConnectionState.disconnected);
   }
 
+  /// Debug/simulation-only disconnect: emit a disconnected connection
+  /// state explicitly. No automatic reconnect (see
+  /// `POST /api/v1/debug/machine/disconnect`).
+  void simulateDisconnect() {
+    _stateTimer?.cancel();
+    _connectionState.add(ConnectionState.disconnected);
+  }
+
   bool _chargerOn = false;
   int _steamPurgeMode = 0; // 0 = normal, 1 = two tap stop
   double _flowEstimation = 1.0;
@@ -692,11 +700,15 @@ class MockDe1 implements De1Interface, SimulatedDevice {
 
   @override
   Future<int> getFanThreshhold() async {
-    return 50;
+    return _fanThreshhold;
   }
 
   @override
-  Future<void> setFanThreshhold(int temp) async {}
+  Future<void> setFanThreshhold(int temp) async {
+    _fanThreshhold = temp;
+  }
+
+  int _fanThreshhold = 50;
 
   double _steamFlow = 1.0;
   @override
@@ -762,41 +774,47 @@ class MockDe1 implements De1Interface, SimulatedDevice {
 
   @override
   Future<double> getHeaterIdleTemp() async {
-    return 98.0;
+    return _heaterIdleTemp;
   }
 
   @override
   Future<double> getHeaterPhase1Flow() async {
-    return 2.5;
+    return _heaterPhase1Flow;
   }
 
   @override
   Future<double> getHeaterPhase2Flow() async {
-    return 5.0;
+    return _heaterPhase2Flow;
   }
 
   @override
   Future<double> getHeaterPhase2Timeout() async {
-    return 5.0;
+    return _heaterPhase2Timeout;
+  }
+
+  double _heaterIdleTemp = 98.0;
+  double _heaterPhase1Flow = 2.5;
+  double _heaterPhase2Flow = 5.0;
+  double _heaterPhase2Timeout = 5.0;
+
+  @override
+  Future<void> setHeaterIdleTemp(double val) async {
+    _heaterIdleTemp = val;
   }
 
   @override
-  Future<void> setHeaterIdleTemp(double val) async {}
+  Future<void> setHeaterPhase1Flow(double val) async {
+    _heaterPhase1Flow = val;
+  }
 
   @override
-  Future<void> setHeaterPhase1Flow(double val) async {}
-
-  @override
-  Future<void> setHeaterPhase2Flow(double val) async {}
+  Future<void> setHeaterPhase2Flow(double val) async {
+    _heaterPhase2Flow = val;
+  }
 
   @override
   Future<void> setHeaterPhase2Timeout(double val) async {
-    // simulate disconnect
-    _connectionState.add(ConnectionState.disconnected);
-
-    Future.delayed(Duration(seconds: 10), () {
-      _connectionState.add(ConnectionState.connected);
-    });
+    _heaterPhase2Timeout = val;
   }
 
   @override

--- a/lib/src/models/errors.dart
+++ b/lib/src/models/errors.dart
@@ -96,6 +96,20 @@ class MmrTimeoutException implements Exception {
       'MmrTimeoutException: no response for $mmrItemName within $timeout';
 }
 
+/// Thrown by `De1Controller` device-write retry when a machine
+/// disconnected mid-write and no replacement machine appeared within
+/// the bounded replacement wait. REST handlers map this to HTTP 503.
+class MachineReplacementTimeoutException implements Exception {
+  final Duration timeout;
+
+  const MachineReplacementTimeoutException(this.timeout);
+
+  @override
+  String toString() =>
+      'MachineReplacementTimeoutException: no replacement machine '
+      'within $timeout';
+}
+
 /// Thrown synchronously by [De1Interface.updateFirmware] when a firmware
 /// operation is already in progress. Callers receive this before any async
 /// work begins, so an API handler can return HTTP 409 before opening a

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -69,8 +69,8 @@ class De1Handler {
       final dynamic json;
       try {
         json = jsonDecode(await r.readAsString());
-      } catch (e, st) {
-        return jsonError({'error': e.toString(), 'st': st.toString()});
+      } catch (e) {
+        return jsonBadRequest({'error': 'Invalid JSON body'});
       }
       if (json is! Map || json['temperature'] == null) {
         return jsonBadRequest({'error': 'temperature required'});
@@ -115,8 +115,8 @@ class De1Handler {
       final dynamic json;
       try {
         json = jsonDecode(await r.readAsString());
-      } catch (e, st) {
-        return jsonError({'error': e.toString(), 'st': st.toString()});
+      } catch (e) {
+        return jsonBadRequest({'error': 'Invalid JSON body'});
       }
       if (json is! Map) {
         return jsonBadRequest({'error': 'invalid JSON body'});
@@ -156,8 +156,8 @@ class De1Handler {
       final dynamic json;
       try {
         json = jsonDecode(await r.readAsString());
-      } catch (e, st) {
-        return jsonError({'error': e.toString(), 'st': st.toString()});
+      } catch (e) {
+        return jsonBadRequest({'error': 'Invalid JSON body'});
       }
       if (json is! Map) {
         return jsonBadRequest({'error': 'Request body must be a JSON object'});
@@ -181,8 +181,8 @@ class De1Handler {
       final dynamic json;
       try {
         json = jsonDecode(await r.readAsString());
-      } catch (e, st) {
-        return jsonError({'error': e.toString(), 'st': st.toString()});
+      } catch (e) {
+        return jsonBadRequest({'error': 'Invalid JSON body'});
       }
       if (json is! Map<String, dynamic>) {
         return jsonBadRequest({'error': 'Request body must be a JSON object'});
@@ -212,26 +212,20 @@ class De1Handler {
           ? null
           : parseInt(json['steamPurgeMode']);
 
-      return withQueuedDe1((device) async {
-        if (usb != null) await device.setUsbChargerMode(usb);
-        if (fan != null) await device.setFanThreshhold(fan);
-        if (flushTemp != null) await device.setFlushTemperature(flushTemp);
-        if (flushFlow != null) await device.setFlushFlow(flushFlow);
-        if (flushTimeout != null) await device.setFlushTimeout(flushTimeout);
-        if (hotWaterFlow != null) await device.setHotWaterFlow(hotWaterFlow);
-        if (steamFlow != null) await device.setSteamFlow(steamFlow);
-        if (tankTemp != null) await device.setTankTempThreshold(tankTemp);
-        if (steamPurgeMode != null) {
-          await device.setSteamPurgeMode(steamPurgeMode);
-        }
-        // Publish controller streams only after the grouped write
-        // succeeded, so the streams never reflect values the machine
-        // did not receive.
-        if (flushFlow != null) _controller.publishFlushFlow(flushFlow);
-        if (hotWaterFlow != null) _controller.publishHotWaterFlow(hotWaterFlow);
-        if (steamFlow != null) _controller.publishSteamFlow(steamFlow);
+      return _mapDe1WriteErrors(() async {
+        await _controller.updateMachineSettings(
+          usb: usb,
+          fan: fan,
+          flushTemp: flushTemp,
+          flushFlow: flushFlow,
+          flushTimeout: flushTimeout,
+          hotWaterFlow: hotWaterFlow,
+          steamFlow: steamFlow,
+          tankTemp: tankTemp,
+          steamPurgeMode: steamPurgeMode,
+        );
         return jsonAccepted();
-      }, retryOnReplacement: true);
+      });
     });
 
     app.get('/api/v1/machine/settings', () async {
@@ -254,8 +248,8 @@ class De1Handler {
       final dynamic json;
       try {
         json = jsonDecode(await r.readAsString());
-      } catch (e, st) {
-        return jsonError({'error': e.toString(), 'st': st.toString()});
+      } catch (e) {
+        return jsonBadRequest({'error': 'Invalid JSON body'});
       }
       if (json is! Map<String, dynamic>) {
         return jsonBadRequest({'error': 'Request body must be a JSON object'});
@@ -329,8 +323,8 @@ class De1Handler {
       final dynamic json;
       try {
         json = jsonDecode(await r.readAsString());
-      } catch (e, st) {
-        return jsonError({'error': e.toString(), 'st': st.toString()});
+      } catch (e) {
+        return jsonBadRequest({'error': 'Invalid JSON body'});
       }
       if (json is! Map) {
         return jsonBadRequest({'error': 'Request body must be a JSON object'});
@@ -347,8 +341,14 @@ class De1Handler {
     });
 
     app.delete('/api/v1/machine/settings/reset', (Request r) async {
-      return withDe1((de1) async {
-        await _controller.applySettingsDefaults();
+      // One shared queue entry: the whole reset retries on a replacement
+      // like other grouped settings writes, and every write uses the
+      // device passed into the queue callback.
+      return _mapDe1WriteErrors(() async {
+        await _controller.runDeviceWrite(
+          (device) => _controller.applySettingsDefaults(device),
+          retryOnReplacement: true,
+        );
         return jsonAccepted();
       });
     });
@@ -368,21 +368,11 @@ class De1Handler {
     }
   }
 
-  /// Like [withDe1], but runs [call] inside the shared device-write
-  /// queue ([De1Controller.runDeviceWrite]), so the physical writes
-  /// cannot interleave with workflow, profile, or shot-settings
-  /// mutations. Machine acquisition happens inside the queue entry;
-  /// a missing machine maps to `500` and an expired bounded
-  /// replacement wait maps to `503`.
-  Future<Response> withQueuedDe1(
-    Future<Response> Function(De1Interface device) call, {
-    bool retryOnReplacement = false,
-  }) async {
+  /// Maps the errors a queued machine write can produce: an expired
+  /// bounded replacement wait is `503`, a missing machine is `500`.
+  Future<Response> _mapDe1WriteErrors(Future<Response> Function() call) async {
     try {
-      return await _controller.runDeviceWrite(
-        call,
-        retryOnReplacement: retryOnReplacement,
-      );
+      return await call();
     } on MachineReplacementTimeoutException catch (e) {
       return jsonServiceUnavailable({
         'error': 'Machine unavailable',
@@ -393,6 +383,24 @@ class De1Handler {
     } catch (e, st) {
       return jsonError({'error': e.toString(), 'st': st.toString()});
     }
+  }
+
+  /// Like [withDe1], but runs [call] inside the shared device-write
+  /// queue ([De1Controller.runDeviceWrite]), so the physical writes
+  /// cannot interleave with workflow, profile, or shot-settings
+  /// mutations. Machine acquisition happens inside the queue entry;
+  /// a missing machine maps to `500` and an expired bounded
+  /// replacement wait maps to `503`.
+  Future<Response> withQueuedDe1(
+    Future<Response> Function(De1Interface device) call, {
+    bool retryOnReplacement = false,
+  }) {
+    return _mapDe1WriteErrors(
+      () => _controller.runDeviceWrite(
+        call,
+        retryOnReplacement: retryOnReplacement,
+      ),
+    );
   }
 
   /// Attach a machine-gated socket to the current [De1Interface] instance and
@@ -551,7 +559,12 @@ class De1Handler {
     return withDe1((_) async {
       final payload = await request.readAsString();
 
-      Map<String, dynamic> json = jsonDecode(payload);
+      Map<String, dynamic> json;
+      try {
+        json = jsonDecode(payload);
+      } catch (e) {
+        return jsonBadRequest({'error': 'Invalid JSON body'});
+      }
       Profile profile = Profile.fromJson(json);
       await _controller.runDeviceWrite(
         (device) => device.setProfile(profile),
@@ -565,7 +578,12 @@ class De1Handler {
     return withDe1((_) async {
       final payload = await request.readAsString();
 
-      Map<String, dynamic> json = jsonDecode(payload);
+      Map<String, dynamic> json;
+      try {
+        json = jsonDecode(payload);
+      } catch (e) {
+        return jsonBadRequest({'error': 'Invalid JSON body'});
+      }
       De1ShotSettings settings = De1ShotSettings.fromJson(json);
       await _controller.runDeviceWrite(
         (device) => device.updateShotSettings(settings),

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -435,12 +435,15 @@ class De1Handler {
   }
 
   Future<Response> _profileHandler(Request request) async {
-    return withDe1((de1) async {
+    return withDe1((_) async {
       final payload = await request.readAsString();
 
       Map<String, dynamic> json = jsonDecode(payload);
       Profile profile = Profile.fromJson(json);
-      await de1.setProfile(profile);
+      await _controller.runDeviceWrite(
+        (device) => device.setProfile(profile),
+        retryOnReplacement: true,
+      );
       return jsonOk(null);
     });
   }

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -165,13 +165,21 @@ class De1Handler {
           await de1.setFanThreshhold(parseInt(json['fan']));
         }
         if (json['flushTemp'] != null) {
-          await de1.setFlushTemperature(parseDouble(json['flushTemp']));
+          await _controller.runDeviceWrite(
+            (device) =>
+                device.setFlushTemperature(parseDouble(json['flushTemp'])),
+            retryOnReplacement: true,
+          );
         }
         if (json['flushFlow'] != null) {
           await _controller.setFlushFlow(parseDouble(json['flushFlow']));
         }
         if (json['flushTimeout'] != null) {
-          await de1.setFlushTimeout(parseDouble(json['flushTimeout']));
+          await _controller.runDeviceWrite(
+            (device) =>
+                device.setFlushTimeout(parseDouble(json['flushTimeout'])),
+            retryOnReplacement: true,
+          );
         }
         if (json['hotWaterFlow'] != null) {
           await _controller.setHotWaterFlow(parseDouble(json['hotWaterFlow']));
@@ -449,12 +457,15 @@ class De1Handler {
   }
 
   Future<Response> _shotSettingsHandler(Request request) async {
-    return withDe1((de1) async {
+    return withDe1((_) async {
       final payload = await request.readAsString();
 
       Map<String, dynamic> json = jsonDecode(payload);
       De1ShotSettings settings = De1ShotSettings.fromJson(json);
-      await de1.updateShotSettings(settings);
+      await _controller.runDeviceWrite(
+        (device) => device.updateShotSettings(settings),
+        retryOnReplacement: true,
+      );
       return jsonOk(null);
     });
   }

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -66,21 +66,26 @@ class De1Handler {
     });
 
     app.put('/api/v1/machine/cupWarmer', (Request r) async {
-      return withDe1((de1) async {
+      final dynamic json;
+      try {
+        json = jsonDecode(await r.readAsString());
+      } catch (e, st) {
+        return jsonError({'error': e.toString(), 'st': st.toString()});
+      }
+      if (json is! Map || json['temperature'] == null) {
+        return jsonBadRequest({'error': 'temperature required'});
+      }
+      final t = parseDouble(json['temperature']);
+      if (t < 0.0 || t > 80.0) {
+        return jsonBadRequest({'error': 'temperature out of range 0.0-80.0'});
+      }
+      return withQueuedDe1((de1) async {
         if (de1 is! BengleInterface) {
           return jsonNotFound({'error': 'cupWarmer not supported'});
         }
-        final json = jsonDecode(await r.readAsString());
-        if (json is! Map || json['temperature'] == null) {
-          return jsonBadRequest({'error': 'temperature required'});
-        }
-        final t = parseDouble(json['temperature']);
-        if (t < 0.0 || t > 80.0) {
-          return jsonBadRequest({'error': 'temperature out of range 0.0-80.0'});
-        }
         await de1.setCupWarmerTemperature(t);
         return jsonOk({'status': 'accepted'});
-      });
+      }, retryOnReplacement: true);
     });
 
     // Sockets
@@ -107,95 +112,126 @@ class De1Handler {
     });
 
     app.put('/api/v1/machine/ledStrip', (Request r) async {
-      return withDe1((de1) async {
+      final dynamic json;
+      try {
+        json = jsonDecode(await r.readAsString());
+      } catch (e, st) {
+        return jsonError({'error': e.toString(), 'st': st.toString()});
+      }
+      if (json is! Map) {
+        return jsonBadRequest({'error': 'invalid JSON body'});
+      }
+      final state = LedStripState.fromJson(json as Map<String, dynamic>);
+      return withQueuedDe1((de1) async {
         if (de1 is! BengleInterface) {
           return jsonNotFound({'error': 'ledStrip not supported'});
         }
-        final json = jsonDecode(await r.readAsString());
-        if (json is! Map) {
-          return jsonBadRequest({'error': 'invalid JSON body'});
-        }
-        final state = LedStripState.fromJson(json as Map<String, dynamic>);
         await de1.setLedStrip(state);
         return jsonOk({'status': 'accepted'});
-      });
+      }, retryOnReplacement: true);
     });
 
     app.post('/api/v1/machine/ledStrip/commit', (Request _) async {
-      return withDe1((de1) async {
+      return withQueuedDe1((de1) async {
         if (de1 is! BengleInterface) {
           return jsonNotFound({'error': 'ledStrip not supported'});
         }
         await de1.commitLedStrip();
         return jsonAccepted();
-      });
+      }, retryOnReplacement: true);
     });
 
     app.post('/api/v1/machine/ledStrip/reset', (Request _) async {
-      return withDe1((de1) async {
+      return withQueuedDe1((de1) async {
         if (de1 is! BengleInterface) {
           return jsonNotFound({'error': 'ledStrip not supported'});
         }
         await de1.resetLedStrip();
         final state = await de1.getLedStripState();
         return jsonOk(state.toJson());
-      });
+      }, retryOnReplacement: true);
     });
 
     app.post('/api/v1/machine/waterLevels', (Request r) async {
-      return withDe1((de1) async {
-        var json = jsonDecode(await r.readAsString());
-        if (json['refillLevel'] != null) {
-          await de1.setRefillLevel((json['refillLevel'] as num).toInt());
+      final dynamic json;
+      try {
+        json = jsonDecode(await r.readAsString());
+      } catch (e, st) {
+        return jsonError({'error': e.toString(), 'st': st.toString()});
+      }
+      if (json is! Map) {
+        return jsonBadRequest({'error': 'Request body must be a JSON object'});
+      }
+      final refillLevel = json['refillLevel'] == null
+          ? null
+          : (json['refillLevel'] as num).toInt();
+      return withQueuedDe1((de1) async {
+        if (refillLevel != null) {
+          await de1.setRefillLevel(refillLevel);
         }
         return jsonAccepted();
-      });
+      }, retryOnReplacement: true);
     });
 
     // MMR?
 
     app.post('/api/v1/machine/settings', (Request r) async {
-      return withDe1((de1) async {
-        var json = jsonDecode(await r.readAsString());
-        log.info("have: $json");
-        if (json['usb'] != null) {
-          await de1.setUsbChargerMode(json['usb'] == 'enable');
-        }
-        if (json['fan'] != null) {
-          await de1.setFanThreshhold(parseInt(json['fan']));
-        }
-        if (json['flushTemp'] != null) {
-          await _controller.runDeviceWrite(
-            (device) =>
-                device.setFlushTemperature(parseDouble(json['flushTemp'])),
-            retryOnReplacement: true,
-          );
-        }
-        if (json['flushFlow'] != null) {
-          await _controller.setFlushFlow(parseDouble(json['flushFlow']));
-        }
-        if (json['flushTimeout'] != null) {
-          await _controller.runDeviceWrite(
-            (device) =>
-                device.setFlushTimeout(parseDouble(json['flushTimeout'])),
-            retryOnReplacement: true,
-          );
-        }
-        if (json['hotWaterFlow'] != null) {
-          await _controller.setHotWaterFlow(parseDouble(json['hotWaterFlow']));
-        }
-        if (json['steamFlow'] != null) {
-          await _controller.setSteamFlow(parseDouble(json['steamFlow']));
-        }
-        if (json['tankTemp'] != null) {
-          await de1.setTankTempThreshold(parseInt(json['tankTemp']));
-        }
-        if (json['steamPurgeMode'] != null) {
-          await de1.setSteamPurgeMode(parseInt(json['steamPurgeMode']));
-        }
+      // Parse the complete payload before reserving a queue entry so a
+      // single request is exactly one grouped device write.
+      final dynamic json;
+      try {
+        json = jsonDecode(await r.readAsString());
+      } catch (e, st) {
+        return jsonError({'error': e.toString(), 'st': st.toString()});
+      }
+      if (json is! Map<String, dynamic>) {
+        return jsonBadRequest({'error': 'Request body must be a JSON object'});
+      }
+      log.info("have: $json");
+      final usb = json['usb'] == null ? null : json['usb'] == 'enable';
+      final fan = json['fan'] == null ? null : parseInt(json['fan']);
+      final flushTemp = json['flushTemp'] == null
+          ? null
+          : parseDouble(json['flushTemp']);
+      final flushFlow = json['flushFlow'] == null
+          ? null
+          : parseDouble(json['flushFlow']);
+      final flushTimeout = json['flushTimeout'] == null
+          ? null
+          : parseDouble(json['flushTimeout']);
+      final hotWaterFlow = json['hotWaterFlow'] == null
+          ? null
+          : parseDouble(json['hotWaterFlow']);
+      final steamFlow = json['steamFlow'] == null
+          ? null
+          : parseDouble(json['steamFlow']);
+      final tankTemp = json['tankTemp'] == null
+          ? null
+          : parseInt(json['tankTemp']);
+      final steamPurgeMode = json['steamPurgeMode'] == null
+          ? null
+          : parseInt(json['steamPurgeMode']);
 
+      return withQueuedDe1((device) async {
+        if (usb != null) await device.setUsbChargerMode(usb);
+        if (fan != null) await device.setFanThreshhold(fan);
+        if (flushTemp != null) await device.setFlushTemperature(flushTemp);
+        if (flushFlow != null) await device.setFlushFlow(flushFlow);
+        if (flushTimeout != null) await device.setFlushTimeout(flushTimeout);
+        if (hotWaterFlow != null) await device.setHotWaterFlow(hotWaterFlow);
+        if (steamFlow != null) await device.setSteamFlow(steamFlow);
+        if (tankTemp != null) await device.setTankTempThreshold(tankTemp);
+        if (steamPurgeMode != null) {
+          await device.setSteamPurgeMode(steamPurgeMode);
+        }
+        // Publish controller streams only after the grouped write
+        // succeeded, so the streams never reflect values the machine
+        // did not receive.
+        if (flushFlow != null) _controller.publishFlushFlow(flushFlow);
+        if (hotWaterFlow != null) _controller.publishHotWaterFlow(hotWaterFlow);
+        if (steamFlow != null) _controller.publishSteamFlow(steamFlow);
         return jsonAccepted();
-      });
+      }, retryOnReplacement: true);
     });
 
     app.get('/api/v1/machine/settings', () async {
@@ -215,36 +251,57 @@ class De1Handler {
     });
 
     app.post('/api/v1/machine/settings/advanced', (Request r) async {
-      return withDe1((de1) async {
-        var json = jsonDecode(await r.readAsString());
-        if (json['heaterPh1Flow'] != null) {
-          await de1.setHeaterPhase1Flow(parseDouble(json['heaterPh1Flow']));
-        }
-        if (json['heaterPh2Flow'] != null) {
-          await de1.setHeaterPhase2Flow(parseDouble(json['heaterPh2Flow']));
-        }
-        if (json['heaterIdleTemp'] != null) {
-          await de1.setHeaterIdleTemp(parseDouble(json['heaterIdleTemp']));
-        }
-        if (json['heaterPh2Timeout'] != null) {
-          await de1.setHeaterPhase2Timeout(
-            parseDouble(json['heaterPh2Timeout']),
-          );
-        }
-        if (json['heaterVoltage'] != null) {
-          await de1.setHeaterVoltage(
-            De1HeaterVoltage.fromInt(parseInt(json['heaterVoltage'])),
-          );
-        }
-        if (json['refillKitSetting'] != null) {
-          await de1.setRefillKitSettings(
-            De1RefillKitSettings.values.firstWhere(
+      final dynamic json;
+      try {
+        json = jsonDecode(await r.readAsString());
+      } catch (e, st) {
+        return jsonError({'error': e.toString(), 'st': st.toString()});
+      }
+      if (json is! Map<String, dynamic>) {
+        return jsonBadRequest({'error': 'Request body must be a JSON object'});
+      }
+      final heaterPh1Flow = json['heaterPh1Flow'] == null
+          ? null
+          : parseDouble(json['heaterPh1Flow']);
+      final heaterPh2Flow = json['heaterPh2Flow'] == null
+          ? null
+          : parseDouble(json['heaterPh2Flow']);
+      final heaterIdleTemp = json['heaterIdleTemp'] == null
+          ? null
+          : parseDouble(json['heaterIdleTemp']);
+      final heaterPh2Timeout = json['heaterPh2Timeout'] == null
+          ? null
+          : parseDouble(json['heaterPh2Timeout']);
+      final heaterVoltage = json['heaterVoltage'] == null
+          ? null
+          : De1HeaterVoltage.fromInt(parseInt(json['heaterVoltage']));
+      final refillKitSetting = json['refillKitSetting'] == null
+          ? null
+          : De1RefillKitSettings.values.firstWhere(
               (e) => e.hex == parseInt(json['refillKitSetting']),
-            ),
-          );
+            );
+
+      return withQueuedDe1((de1) async {
+        if (heaterPh1Flow != null) {
+          await de1.setHeaterPhase1Flow(heaterPh1Flow);
+        }
+        if (heaterPh2Flow != null) {
+          await de1.setHeaterPhase2Flow(heaterPh2Flow);
+        }
+        if (heaterIdleTemp != null) {
+          await de1.setHeaterIdleTemp(heaterIdleTemp);
+        }
+        if (heaterPh2Timeout != null) {
+          await de1.setHeaterPhase2Timeout(heaterPh2Timeout);
+        }
+        if (heaterVoltage != null) {
+          await de1.setHeaterVoltage(heaterVoltage);
+        }
+        if (refillKitSetting != null) {
+          await de1.setRefillKitSettings(refillKitSetting);
         }
         return jsonAccepted();
-      });
+      }, retryOnReplacement: true);
     });
 
     app.get('/api/v1/machine/settings/advanced', () async {
@@ -269,13 +326,24 @@ class De1Handler {
     });
 
     app.post('/api/v1/machine/calibration', (Request r) async {
-      return withDe1((de1) async {
-        var json = jsonDecode(await r.readAsString());
-        if (json['flowMultiplier'] != null) {
-          await de1.setFlowEstimation(parseDouble(json['flowMultiplier']));
+      final dynamic json;
+      try {
+        json = jsonDecode(await r.readAsString());
+      } catch (e, st) {
+        return jsonError({'error': e.toString(), 'st': st.toString()});
+      }
+      if (json is! Map) {
+        return jsonBadRequest({'error': 'Request body must be a JSON object'});
+      }
+      final flowMultiplier = json['flowMultiplier'] == null
+          ? null
+          : parseDouble(json['flowMultiplier']);
+      return withQueuedDe1((de1) async {
+        if (flowMultiplier != null) {
+          await de1.setFlowEstimation(flowMultiplier);
         }
         return jsonAccepted();
-      });
+      }, retryOnReplacement: true);
     });
 
     app.delete('/api/v1/machine/settings/reset', (Request r) async {
@@ -290,6 +358,38 @@ class De1Handler {
     try {
       var de1 = _controller.connectedDe1();
       return await call(de1);
+    } on MachineReplacementTimeoutException catch (e) {
+      return jsonServiceUnavailable({
+        'error': 'Machine unavailable',
+        'message': '$e',
+      });
+    } catch (e, st) {
+      return jsonError({'error': e.toString(), 'st': st.toString()});
+    }
+  }
+
+  /// Like [withDe1], but runs [call] inside the shared device-write
+  /// queue ([De1Controller.runDeviceWrite]), so the physical writes
+  /// cannot interleave with workflow, profile, or shot-settings
+  /// mutations. Machine acquisition happens inside the queue entry;
+  /// a missing machine maps to `500` and an expired bounded
+  /// replacement wait maps to `503`.
+  Future<Response> withQueuedDe1(
+    Future<Response> Function(De1Interface device) call, {
+    bool retryOnReplacement = false,
+  }) async {
+    try {
+      return await _controller.runDeviceWrite(
+        call,
+        retryOnReplacement: retryOnReplacement,
+      );
+    } on MachineReplacementTimeoutException catch (e) {
+      return jsonServiceUnavailable({
+        'error': 'Machine unavailable',
+        'message': '$e',
+      });
+    } on DeviceNotConnectedException catch (e) {
+      return jsonError({'error': e.toString()});
     } catch (e, st) {
       return jsonError({'error': e.toString(), 'st': st.toString()});
     }
@@ -395,6 +495,11 @@ class De1Handler {
     });
   }
 
+  /// Machine state transitions (espresso/steam/idle/...) deliberately
+  /// bypass the shared device-write queue: they are latency-sensitive
+  /// commands — a stop request must not wait behind a settings or
+  /// workflow write — and they target the state characteristic, not the
+  /// settings/MMR registers the queue serializes.
   Future<Response> _requestStateHandler(
     Request request,
     String newState,

--- a/lib/src/services/webserver/debug_handler.dart
+++ b/lib/src/services/webserver/debug_handler.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
 
 import 'package:logging/logging.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
 import 'package:reaprime/src/models/device/impl/mock_scale/mock_scale.dart';
 import 'package:reaprime/src/services/update_check_service.dart';
 import 'package:reaprime/src/services/webserver/json_response.dart';
@@ -11,13 +13,16 @@ import 'package:shelf_plus/shelf_plus.dart';
 /// Only registered when running in simulate mode.
 class DebugHandler {
   final ScaleController _scaleController;
+  final De1Controller _de1Controller;
   final UpdateCheckService? _updateCheckService;
   final Logger _log = Logger('DebugHandler');
 
   DebugHandler({
     required ScaleController scaleController,
+    required De1Controller de1Controller,
     UpdateCheckService? updateCheckService,
   }) : _scaleController = scaleController,
+       _de1Controller = de1Controller,
        _updateCheckService = updateCheckService;
 
   Map<String, int> get _flowSmoothing => {
@@ -94,6 +99,22 @@ class DebugHandler {
         case 'disconnect':
           _log.info('Simulating MockScale disconnect');
           mock.simulateDisconnect();
+          return jsonOk({'status': 'disconnected'});
+        default:
+          return jsonNotFound({'error': 'Unknown command: $command'});
+      }
+    });
+
+    app.post('/api/v1/debug/machine/<command>', (request, command) async {
+      final de1 = _de1Controller.connectedDe1OrNull;
+      if (de1 is! MockDe1) {
+        return jsonBadRequest({'error': 'Connected machine is not a MockDe1'});
+      }
+
+      switch (command) {
+        case 'disconnect':
+          _log.info('Simulating MockDe1 disconnect');
+          de1.simulateDisconnect();
           return jsonOk({'status': 'disconnected'});
         default:
           return jsonNotFound({'error': 'Unknown command: $command'});

--- a/lib/src/services/webserver/debug_handler.dart
+++ b/lib/src/services/webserver/debug_handler.dart
@@ -106,19 +106,18 @@ class DebugHandler {
     });
 
     app.post('/api/v1/debug/machine/<command>', (request, command) async {
+      // Validate the command before touching the machine so an unknown
+      // command always returns 404 regardless of connection state.
+      if (command != 'disconnect') {
+        return jsonNotFound({'error': 'Unknown command: $command'});
+      }
       final de1 = _de1Controller.connectedDe1OrNull;
       if (de1 is! MockDe1) {
         return jsonBadRequest({'error': 'Connected machine is not a MockDe1'});
       }
-
-      switch (command) {
-        case 'disconnect':
-          _log.info('Simulating MockDe1 disconnect');
-          de1.simulateDisconnect();
-          return jsonOk({'status': 'disconnected'});
-        default:
-          return jsonNotFound({'error': 'Unknown command: $command'});
-      }
+      _log.info('Simulating MockDe1 disconnect');
+      de1.simulateDisconnect();
+      return jsonOk({'status': 'disconnected'});
     });
   }
 }

--- a/lib/src/services/webserver/json_response.dart
+++ b/lib/src/services/webserver/json_response.dart
@@ -53,6 +53,9 @@ Response jsonNotFound(Object? data) =>
 Response jsonConflict(Object? data) =>
     Response(409, body: jsonEncode(data), headers: _jsonHeaders);
 
+Response jsonRequestTimeout(Object? data) =>
+    Response(408, body: jsonEncode(data), headers: _jsonHeaders);
+
 Response jsonPayloadTooLarge(Object? data) =>
     Response(413, body: jsonEncode(data), headers: _jsonHeaders);
 

--- a/lib/src/services/webserver/json_response.dart
+++ b/lib/src/services/webserver/json_response.dart
@@ -53,6 +53,12 @@ Response jsonNotFound(Object? data) =>
 Response jsonConflict(Object? data) =>
     Response(409, body: jsonEncode(data), headers: _jsonHeaders);
 
+Response jsonPayloadTooLarge(Object? data) =>
+    Response(413, body: jsonEncode(data), headers: _jsonHeaders);
+
+Response jsonTooManyRequests(Object? data) =>
+    Response(429, body: jsonEncode(data), headers: _jsonHeaders);
+
 Response jsonError(Object? data) =>
     Response.internalServerError(body: jsonEncode(data), headers: _jsonHeaders);
 

--- a/lib/src/services/webserver/workflow_handler.dart
+++ b/lib/src/services/webserver/workflow_handler.dart
@@ -11,9 +11,12 @@ import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/services/webserver/json_response.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
+const _workflowBodyReadTimeout = Duration(seconds: 30);
+
 class WorkflowHandler {
   final WorkflowController _controller;
   final De1Controller _de1controller;
+  final Duration bodyReadTimeout;
 
   static final _log = Logger('WorkflowHandler');
   Future<void> _workflowQueue = Future<void>.value();
@@ -21,6 +24,7 @@ class WorkflowHandler {
   WorkflowHandler({
     required WorkflowController controller,
     required De1Controller de1controller,
+    this.bodyReadTimeout = _workflowBodyReadTimeout,
   }) : _controller = controller,
        _de1controller = de1controller;
 
@@ -35,7 +39,13 @@ class WorkflowHandler {
   }
 
   Future<Response> _updateWorkflow(Request req) {
-    final payload = req.readAsString();
+    final payload = req.readAsString().timeout(bodyReadTimeout);
+    unawaited(
+      payload.then<void>(
+        (_) {},
+        onError: (Object error, StackTrace stackTrace) {},
+      ),
+    );
     final operation = _workflowQueue.then((_) => _applyPayload(payload));
     _workflowQueue = operation.then<void>(
       (_) {},

--- a/lib/src/services/webserver/workflow_handler.dart
+++ b/lib/src/services/webserver/workflow_handler.dart
@@ -63,37 +63,40 @@ class WorkflowHandler {
 
   Future<Response> _applyUpdate(Map<String, dynamic> merge) async {
     try {
-      final oldWorkflow = _controller.currentWorkflow;
-      final currentJson = oldWorkflow.toJson();
-      final resultJson = deepMergeJson(currentJson, merge);
-      final updatedWorkflow = Workflow.fromJson(resultJson);
+      while (true) {
+        final oldWorkflow = _controller.currentWorkflow;
+        final revision = _controller.revision;
+        final currentJson = oldWorkflow.toJson();
+        final resultJson = deepMergeJson(currentJson, merge);
+        final updatedWorkflow = Workflow.fromJson(resultJson);
 
-      if (oldWorkflow.rinseData != updatedWorkflow.rinseData) {
-        await _de1controller.updateFlushSettings(updatedWorkflow.rinseData);
+        if (oldWorkflow.rinseData != updatedWorkflow.rinseData) {
+          await _de1controller.updateFlushSettings(updatedWorkflow.rinseData);
+        }
+        if (oldWorkflow.steamSettings != updatedWorkflow.steamSettings) {
+          await _de1controller.updateSteamSettings(
+            SteamFormSettings(
+              steamEnabled: updatedWorkflow.steamSettings.duration > 0,
+              targetTemp: updatedWorkflow.steamSettings.targetTemperature,
+              targetDuration: updatedWorkflow.steamSettings.duration,
+              targetFlow: updatedWorkflow.steamSettings.flow,
+            ),
+          );
+        }
+        if (oldWorkflow.hotWaterData != updatedWorkflow.hotWaterData) {
+          await _de1controller.updateHotWaterSettings(
+            HotWaterFormSettings(
+              targetTemperature: updatedWorkflow.hotWaterData.targetTemperature,
+              flow: updatedWorkflow.hotWaterData.flow,
+              volume: updatedWorkflow.hotWaterData.volume,
+              duration: updatedWorkflow.hotWaterData.duration,
+            ),
+          );
+        }
+        if (_controller.setWorkflowIfRevision(updatedWorkflow, revision)) {
+          return jsonOk(updatedWorkflow.toJson());
+        }
       }
-      if (oldWorkflow.steamSettings != updatedWorkflow.steamSettings) {
-        await _de1controller.updateSteamSettings(
-          SteamFormSettings(
-            steamEnabled: updatedWorkflow.steamSettings.duration > 0,
-            targetTemp: updatedWorkflow.steamSettings.targetTemperature,
-            targetDuration: updatedWorkflow.steamSettings.duration,
-            targetFlow: updatedWorkflow.steamSettings.flow,
-          ),
-        );
-      }
-      if (oldWorkflow.hotWaterData != updatedWorkflow.hotWaterData) {
-        await _de1controller.updateHotWaterSettings(
-          HotWaterFormSettings(
-            targetTemperature: updatedWorkflow.hotWaterData.targetTemperature,
-            flow: updatedWorkflow.hotWaterData.flow,
-            volume: updatedWorkflow.hotWaterData.volume,
-            duration: updatedWorkflow.hotWaterData.duration,
-          ),
-        );
-      }
-      _controller.setWorkflow(updatedWorkflow);
-
-      return jsonOk(updatedWorkflow.toJson());
     } on ArgumentError catch (e) {
       return jsonBadRequest({'error': 'Invalid request', 'message': '$e'});
     } on FormatException catch (e) {

--- a/lib/src/services/webserver/workflow_handler.dart
+++ b/lib/src/services/webserver/workflow_handler.dart
@@ -16,12 +16,7 @@ class WorkflowHandler {
   final De1Controller _de1controller;
 
   static final _log = Logger('WorkflowHandler');
-
-  Timer? _debounceTimer;
-  Map<String, dynamic> _pendingMerge = {};
-  final List<Completer<Response>> _pendingResponses = [];
-
-  static const _debounceDuration = Duration(milliseconds: 400);
+  Future<void> _workflowQueue = Future<void>.value();
 
   WorkflowHandler({
     required WorkflowController controller,
@@ -41,25 +36,28 @@ class WorkflowHandler {
 
   Future<Response> _updateWorkflow(Request req) async {
     final payload = await req.readAsString();
-    final Map<String, dynamic> json = jsonDecode(payload);
+    dynamic decoded;
+    try {
+      decoded = jsonDecode(payload);
+    } on FormatException catch (e) {
+      return jsonBadRequest({'error': 'Invalid request', 'message': '$e'});
+    }
+    if (decoded is! Map<String, dynamic>) {
+      return jsonBadRequest({'error': 'Request body must be a JSON object'});
+    }
 
-    _pendingMerge = deepMergeJson(_pendingMerge, json);
-
-    final completer = Completer<Response>();
-    _pendingResponses.add(completer);
-
-    _debounceTimer?.cancel();
-    _debounceTimer = Timer(_debounceDuration, _applyPendingUpdate);
-
-    return completer.future;
+    final merge = Map<String, dynamic>.from(decoded);
+    final operation = _workflowQueue.then((_) => _applyUpdate(merge));
+    _workflowQueue = operation.then<void>(
+      (_) {},
+      onError: (Object error, StackTrace stackTrace) {
+        _log.severe('Error completing workflow queue entry', error, stackTrace);
+      },
+    );
+    return operation;
   }
 
-  Future<void> _applyPendingUpdate() async {
-    final merge = _pendingMerge;
-    final responses = List<Completer<Response>>.from(_pendingResponses);
-    _pendingMerge = {};
-    _pendingResponses.clear();
-
+  Future<Response> _applyUpdate(Map<String, dynamic> merge) async {
     try {
       final oldWorkflow = _controller.currentWorkflow;
       final currentJson = oldWorkflow.toJson();
@@ -95,37 +93,14 @@ class WorkflowHandler {
         );
       }
 
-      for (final completer in responses) {
-        completer.complete(jsonOk(updatedWorkflow.toJson()));
-      }
+      return jsonOk(updatedWorkflow.toJson());
     } on ArgumentError catch (e) {
-      // Client sent a payload that fails validation (e.g. an invalid
-      // enum value like ExitType 'weight', or a missing required
-      // profile field). Return a clean 400 — matching the pattern in
-      // profile_handler.dart — so the HTTP request does not hang.
-      // _pendingMerge was already cleared above, so subsequent PUTs
-      // start from a clean slate.
-      for (final completer in responses) {
-        completer.complete(
-          jsonBadRequest({'error': 'Invalid request', 'message': '$e'}),
-        );
-      }
+      return jsonBadRequest({'error': 'Invalid request', 'message': '$e'});
     } on FormatException catch (e) {
-      for (final completer in responses) {
-        completer.complete(
-          jsonBadRequest({'error': 'Invalid request', 'message': '$e'}),
-        );
-      }
+      return jsonBadRequest({'error': 'Invalid request', 'message': '$e'});
     } catch (e, st) {
-      // Unexpected error — likely a server-side failure during DE1
-      // side-effects (BLE writes, controller updates). Log it and
-      // return 500 so the request still doesn't hang.
-      _log.severe('Error in _applyPendingUpdate', e, st);
-      for (final completer in responses) {
-        completer.complete(
-          jsonError({'error': 'Internal server error', 'message': '$e'}),
-        );
-      }
+      _log.severe('Error in workflow queue entry', e, st);
+      return jsonError({'error': 'Internal server error', 'message': '$e'});
     }
   }
 }

--- a/lib/src/services/webserver/workflow_handler.dart
+++ b/lib/src/services/webserver/workflow_handler.dart
@@ -7,6 +7,7 @@ import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/models/data/json_utils.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
+import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/services/webserver/json_response.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
@@ -64,24 +65,39 @@ class WorkflowHandler {
       ),
     );
     var expired = false;
+    var slotReleased = false;
+    // Release the admission slot exactly once, no matter which path
+    // (timer expiry, normal completion, or skipped queue entry) wins.
+    void releaseSlot() {
+      if (slotReleased) return;
+      slotReleased = true;
+      _pendingRequests--;
+    }
+
     final response = Completer<Response>();
     late final Timer waitTimer;
-    final operation = _workflowQueue
-        .then((_) async {
-          if (expired) return;
-          waitTimer.cancel();
-          final result = await _applyPayload(payload);
-          if (!response.isCompleted) response.complete(result);
-        })
-        .whenComplete(() => _pendingRequests--);
+    final operation = _workflowQueue.then((_) async {
+      if (expired) return;
+      waitTimer.cancel();
+      try {
+        final result = await _applyPayload(payload);
+        if (!response.isCompleted) response.complete(result);
+      } finally {
+        releaseSlot();
+      }
+    });
     _workflowQueue = operation.then<void>(
       (_) {},
       onError: (Object error, StackTrace stackTrace) {
         _log.severe('Error completing workflow queue entry', error, stackTrace);
+        releaseSlot();
       },
     );
     waitTimer = Timer(queueWaitTimeout, () {
       expired = true;
+      // Release the slot immediately even though the skipped queue
+      // entry may not have reached the front yet.
+      releaseSlot();
       if (!response.isCompleted) {
         response.complete(
           jsonServiceUnavailable({'error': 'Workflow request queue timed out'}),
@@ -159,6 +175,11 @@ class WorkflowHandler {
           return jsonOk(updatedWorkflow.toJson());
         }
       }
+    } on MachineReplacementTimeoutException catch (e) {
+      return jsonServiceUnavailable({
+        'error': 'Machine unavailable',
+        'message': '$e',
+      });
     } on ArgumentError catch (e) {
       return jsonBadRequest({'error': 'Invalid request', 'message': '$e'});
     } on FormatException catch (e) {

--- a/lib/src/services/webserver/workflow_handler.dart
+++ b/lib/src/services/webserver/workflow_handler.dart
@@ -129,6 +129,11 @@ class WorkflowHandler {
       return jsonPayloadTooLarge({
         'error': 'Workflow request body is too large',
       });
+    } on TimeoutException {
+      return jsonRequestTimeout({
+        'error': 'Request timeout',
+        'message': 'Client did not finish sending the request body',
+      });
     } on FormatException catch (e) {
       return jsonBadRequest({'error': 'Invalid request', 'message': '$e'});
     } catch (e, st) {

--- a/lib/src/services/webserver/workflow_handler.dart
+++ b/lib/src/services/webserver/workflow_handler.dart
@@ -1,30 +1,41 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
-import 'package:reaprime/src/home_feature/forms/hot_water_form.dart';
-import 'package:reaprime/src/home_feature/forms/steam_form.dart';
 import 'package:reaprime/src/models/data/json_utils.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/services/webserver/json_response.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
 const _workflowBodyReadTimeout = Duration(seconds: 30);
+const _workflowQueueWaitTimeout = Duration(seconds: 30);
+const _workflowMaxBodyBytes = 1024 * 1024;
+const _workflowMaxPendingRequests = 8;
+
+class _WorkflowPayloadTooLarge implements Exception {}
 
 class WorkflowHandler {
   final WorkflowController _controller;
   final De1Controller _de1controller;
   final Duration bodyReadTimeout;
+  final Duration queueWaitTimeout;
+  final int maxBodyBytes;
+  final int maxPendingRequests;
 
   static final _log = Logger('WorkflowHandler');
   Future<void> _workflowQueue = Future<void>.value();
+  int _pendingRequests = 0;
 
   WorkflowHandler({
     required WorkflowController controller,
     required De1Controller de1controller,
     this.bodyReadTimeout = _workflowBodyReadTimeout,
+    this.queueWaitTimeout = _workflowQueueWaitTimeout,
+    this.maxBodyBytes = _workflowMaxBodyBytes,
+    this.maxPendingRequests = _workflowMaxPendingRequests,
   }) : _controller = controller,
        _de1controller = de1controller;
 
@@ -39,21 +50,60 @@ class WorkflowHandler {
   }
 
   Future<Response> _updateWorkflow(Request req) {
-    final payload = req.readAsString().timeout(bodyReadTimeout);
+    if (_pendingRequests >= maxPendingRequests) {
+      return Future.value(
+        jsonTooManyRequests({'error': 'Workflow request queue is full'}),
+      );
+    }
+    _pendingRequests++;
+    final payload = _readPayload(req).timeout(bodyReadTimeout);
     unawaited(
       payload.then<void>(
         (_) {},
         onError: (Object error, StackTrace stackTrace) {},
       ),
     );
-    final operation = _workflowQueue.then((_) => _applyPayload(payload));
+    var expired = false;
+    final response = Completer<Response>();
+    late final Timer waitTimer;
+    final operation = _workflowQueue
+        .then((_) async {
+          if (expired) return;
+          waitTimer.cancel();
+          final result = await _applyPayload(payload);
+          if (!response.isCompleted) response.complete(result);
+        })
+        .whenComplete(() => _pendingRequests--);
     _workflowQueue = operation.then<void>(
       (_) {},
       onError: (Object error, StackTrace stackTrace) {
         _log.severe('Error completing workflow queue entry', error, stackTrace);
       },
     );
-    return operation;
+    waitTimer = Timer(queueWaitTimeout, () {
+      expired = true;
+      if (!response.isCompleted) {
+        response.complete(
+          jsonServiceUnavailable({'error': 'Workflow request queue timed out'}),
+        );
+      }
+    });
+    return response.future;
+  }
+
+  Future<String> _readPayload(Request req) async {
+    final declaredLength = int.tryParse(req.headers['content-length'] ?? '');
+    if (declaredLength != null && declaredLength > maxBodyBytes) {
+      throw _WorkflowPayloadTooLarge();
+    }
+    final bytes = BytesBuilder(copy: false);
+    await for (final chunk in req.read()) {
+      if (bytes.length + chunk.length > maxBodyBytes) {
+        throw _WorkflowPayloadTooLarge();
+      }
+      bytes.add(chunk);
+    }
+    return utf8.decode(bytes.takeBytes());
   }
 
   Future<Response> _applyPayload(Future<String> payloadFuture) async {
@@ -63,6 +113,10 @@ class WorkflowHandler {
         return jsonBadRequest({'error': 'Request body must be a JSON object'});
       }
       return await _applyUpdate(Map<String, dynamic>.from(decoded));
+    } on _WorkflowPayloadTooLarge {
+      return jsonPayloadTooLarge({
+        'error': 'Workflow request body is too large',
+      });
     } on FormatException catch (e) {
       return jsonBadRequest({'error': 'Invalid request', 'message': '$e'});
     } catch (e, st) {
@@ -80,29 +134,10 @@ class WorkflowHandler {
         final resultJson = deepMergeJson(currentJson, merge);
         final updatedWorkflow = Workflow.fromJson(resultJson);
 
-        if (oldWorkflow.rinseData != updatedWorkflow.rinseData) {
-          await _de1controller.updateFlushSettings(updatedWorkflow.rinseData);
-        }
-        if (oldWorkflow.steamSettings != updatedWorkflow.steamSettings) {
-          await _de1controller.updateSteamSettings(
-            SteamFormSettings(
-              steamEnabled: updatedWorkflow.steamSettings.duration > 0,
-              targetTemp: updatedWorkflow.steamSettings.targetTemperature,
-              targetDuration: updatedWorkflow.steamSettings.duration,
-              targetFlow: updatedWorkflow.steamSettings.flow,
-            ),
-          );
-        }
-        if (oldWorkflow.hotWaterData != updatedWorkflow.hotWaterData) {
-          await _de1controller.updateHotWaterSettings(
-            HotWaterFormSettings(
-              targetTemperature: updatedWorkflow.hotWaterData.targetTemperature,
-              flow: updatedWorkflow.hotWaterData.flow,
-              volume: updatedWorkflow.hotWaterData.volume,
-              duration: updatedWorkflow.hotWaterData.duration,
-            ),
-          );
-        }
+        await _de1controller.updateWorkflowSettings(
+          oldWorkflow,
+          updatedWorkflow,
+        );
         if (_controller.setWorkflowIfRevision(updatedWorkflow, revision)) {
           return jsonOk(updatedWorkflow.toJson());
         }

--- a/lib/src/services/webserver/workflow_handler.dart
+++ b/lib/src/services/webserver/workflow_handler.dart
@@ -56,7 +56,7 @@ class WorkflowHandler {
       );
     }
     _pendingRequests++;
-    final payload = _readPayload(req).timeout(bodyReadTimeout);
+    final payload = _readPayload(req);
     unawaited(
       payload.then<void>(
         (_) {},
@@ -96,14 +96,26 @@ class WorkflowHandler {
     if (declaredLength != null && declaredLength > maxBodyBytes) {
       throw _WorkflowPayloadTooLarge();
     }
+    final deadline = Stopwatch()..start();
     final bytes = BytesBuilder(copy: false);
-    await for (final chunk in req.read()) {
-      if (bytes.length + chunk.length > maxBodyBytes) {
-        throw _WorkflowPayloadTooLarge();
+    final iterator = StreamIterator<List<int>>(req.read());
+    try {
+      while (true) {
+        final remaining = bodyReadTimeout - deadline.elapsed;
+        if (remaining <= Duration.zero) {
+          throw TimeoutException('Workflow request body timed out');
+        }
+        if (!await iterator.moveNext().timeout(remaining)) break;
+        final chunk = iterator.current;
+        if (bytes.length + chunk.length > maxBodyBytes) {
+          throw _WorkflowPayloadTooLarge();
+        }
+        bytes.add(chunk);
       }
-      bytes.add(chunk);
+      return utf8.decode(bytes.takeBytes());
+    } finally {
+      await iterator.cancel();
     }
-    return utf8.decode(bytes.takeBytes());
   }
 
   Future<Response> _applyPayload(Future<String> payloadFuture) async {

--- a/lib/src/services/webserver/workflow_handler.dart
+++ b/lib/src/services/webserver/workflow_handler.dart
@@ -34,20 +34,9 @@ class WorkflowHandler {
     return jsonOk(workflow.toJson());
   }
 
-  Future<Response> _updateWorkflow(Request req) async {
-    final payload = await req.readAsString();
-    dynamic decoded;
-    try {
-      decoded = jsonDecode(payload);
-    } on FormatException catch (e) {
-      return jsonBadRequest({'error': 'Invalid request', 'message': '$e'});
-    }
-    if (decoded is! Map<String, dynamic>) {
-      return jsonBadRequest({'error': 'Request body must be a JSON object'});
-    }
-
-    final merge = Map<String, dynamic>.from(decoded);
-    final operation = _workflowQueue.then((_) => _applyUpdate(merge));
+  Future<Response> _updateWorkflow(Request req) {
+    final payload = req.readAsString();
+    final operation = _workflowQueue.then((_) => _applyPayload(payload));
     _workflowQueue = operation.then<void>(
       (_) {},
       onError: (Object error, StackTrace stackTrace) {
@@ -57,6 +46,21 @@ class WorkflowHandler {
     return operation;
   }
 
+  Future<Response> _applyPayload(Future<String> payloadFuture) async {
+    try {
+      final decoded = jsonDecode(await payloadFuture);
+      if (decoded is! Map<String, dynamic>) {
+        return jsonBadRequest({'error': 'Request body must be a JSON object'});
+      }
+      return await _applyUpdate(Map<String, dynamic>.from(decoded));
+    } on FormatException catch (e) {
+      return jsonBadRequest({'error': 'Invalid request', 'message': '$e'});
+    } catch (e, st) {
+      _log.severe('Error reading workflow request', e, st);
+      return jsonError({'error': 'Internal server error', 'message': '$e'});
+    }
+  }
+
   Future<Response> _applyUpdate(Map<String, dynamic> merge) async {
     try {
       final oldWorkflow = _controller.currentWorkflow;
@@ -64,11 +68,6 @@ class WorkflowHandler {
       final resultJson = deepMergeJson(currentJson, merge);
       final updatedWorkflow = Workflow.fromJson(resultJson);
 
-      _controller.setWorkflow(updatedWorkflow);
-      // Profile push is owned by WorkflowDeviceSync — it observes
-      // `setWorkflow` and uploads the profile if it changed. Keeping a
-      // second setProfile call here would race against that listener and
-      // write every BLE frame twice (see the profile-double-upload P0).
       if (oldWorkflow.rinseData != updatedWorkflow.rinseData) {
         await _de1controller.updateFlushSettings(updatedWorkflow.rinseData);
       }
@@ -92,6 +91,7 @@ class WorkflowHandler {
           ),
         );
       }
+      _controller.setWorkflow(updatedWorkflow);
 
       return jsonOk(updatedWorkflow.toJson());
     } on ArgumentError catch (e) {

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -289,6 +289,7 @@ Future<void> startWebServer(
   if (simulateEnv.isNotEmpty) {
     debugHandler = DebugHandler(
       scaleController: scaleController,
+      de1Controller: de1Controller,
       updateCheckService: updateCheckService,
     );
   }

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -19,6 +19,7 @@ import 'package:reaprime/src/models/data/shot_state_event.dart';
 import 'package:reaprime/src/models/data/utils.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/models/device/sensor.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';

--- a/test/controllers/bengle_saw_bridge_test.dart
+++ b/test/controllers/bengle_saw_bridge_test.dart
@@ -38,11 +38,28 @@ class _RecordingBengle implements BengleInterface {
 
   final List<double> sawWrites = [];
   double _saw = 0.0;
+  double? blockedSaw;
+  Completer<void>? sawEntered;
+  Completer<void>? sawRelease;
+  int _inFlight = 0;
+  int maxInFlight = 0;
 
   @override
   Future<void> setStopAtWeightTarget(double grams) async {
     sawWrites.add(grams);
-    _saw = grams;
+    _inFlight++;
+    maxInFlight = maxInFlight < _inFlight ? _inFlight : maxInFlight;
+    try {
+      if (grams == blockedSaw) {
+        if (!(sawEntered?.isCompleted ?? true)) {
+          sawEntered!.complete();
+        }
+        await sawRelease!.future;
+      }
+      _saw = grams;
+    } finally {
+      _inFlight--;
+    }
   }
 
   @override
@@ -147,6 +164,37 @@ void main() {
     await pumpDebounce();
 
     expect(bengle.sawWrites, [32.0]);
+    await bridge.dispose();
+  });
+
+  test('latest target waits for an in-flight write', () async {
+    final bengle = _RecordingBengle();
+    await connectBengle(bengle);
+
+    final bridge = BengleSawBridge(
+      workflowController: workflow,
+      de1Controller: de1Controller,
+      debounce: _debounce,
+    );
+    await Future<void>.delayed(Duration.zero);
+    bengle.sawWrites.clear();
+
+    final base = workflow.currentWorkflow.context ?? const WorkflowContext();
+    bengle.blockedSaw = 30.0;
+    bengle.sawEntered = Completer<void>();
+    bengle.sawRelease = Completer<void>();
+    workflow.updateWorkflow(context: base.copyWith(targetYield: 30.0));
+    await bengle.sawEntered!.future;
+
+    workflow.updateWorkflow(context: base.copyWith(targetYield: 31.0));
+    await pumpDebounce();
+    expect(bengle.sawWrites, [30.0]);
+    expect(bengle.maxInFlight, 1);
+
+    bengle.sawRelease!.complete();
+    await pumpDebounce();
+    expect(bengle.sawWrites, [30.0, 31.0]);
+    expect(bengle.maxInFlight, 1);
     await bridge.dispose();
   });
 

--- a/test/controllers/bengle_saw_bridge_test.dart
+++ b/test/controllers/bengle_saw_bridge_test.dart
@@ -198,6 +198,37 @@ void main() {
     await bridge.dispose();
   });
 
+  test('reconnect writes the target to the replacement Bengle', () async {
+    final oldBengle = _RecordingBengle();
+    await connectBengle(oldBengle);
+
+    final bridge = BengleSawBridge(
+      workflowController: workflow,
+      de1Controller: de1Controller,
+      debounce: _debounce,
+    );
+    await Future<void>.delayed(Duration.zero);
+    oldBengle.sawWrites.clear();
+
+    final base = workflow.currentWorkflow.context ?? const WorkflowContext();
+    oldBengle.blockedSaw = 30.0;
+    oldBengle.sawEntered = Completer<void>();
+    oldBengle.sawRelease = Completer<void>();
+    workflow.updateWorkflow(context: base.copyWith(targetYield: 30.0));
+    await oldBengle.sawEntered!.future.timeout(const Duration(seconds: 2));
+
+    final replacement = _RecordingBengle();
+    await connectBengle(replacement);
+    await Future<void>.delayed(Duration.zero);
+    expect(replacement.sawWrites, isEmpty);
+
+    oldBengle.sawRelease!.complete();
+    await Future<void>.delayed(Duration.zero);
+    expect(replacement.sawWrites, [30.0]);
+    expect(oldBengle.maxInFlight, 1);
+    await bridge.dispose();
+  });
+
   test('no write when connected machine is not Bengle', () async {
     final de1 = TestDe1();
     await de1Controller.connectToDe1(de1);

--- a/test/controllers/bengle_saw_bridge_test.dart
+++ b/test/controllers/bengle_saw_bridge_test.dart
@@ -84,13 +84,40 @@ class _RecordingBengle implements BengleInterface {
   @override
   Future<void> disconnect() async {}
 
-  /// Stays `false` so [De1Controller._initializeData] never runs and
-  /// we don't have to model the shotSettings handshake here.
   @override
-  Stream<bool> get ready => Stream<bool>.value(false);
+  Stream<bool> get ready => Stream<bool>.value(true);
 
   @override
-  Stream<De1ShotSettings> get shotSettings => const Stream.empty();
+  Stream<De1ShotSettings> get shotSettings => Stream.value(
+    De1ShotSettings(
+      steamSetting: 0,
+      targetSteamTemp: 150,
+      targetSteamDuration: 30,
+      targetHotWaterTemp: 75,
+      targetHotWaterVolume: 50,
+      targetHotWaterDuration: 30,
+      targetShotVolume: 36,
+      groupTemp: 94,
+    ),
+  );
+
+  @override
+  Future<void> setFanThreshhold(int temp) async {}
+
+  @override
+  Future<double> getSteamFlow() async => 0;
+
+  @override
+  Future<double> getHotWaterFlow() async => 0;
+
+  @override
+  Future<double> getFlushFlow() async => 0;
+
+  @override
+  Future<double> getFlushTimeout() async => 0;
+
+  @override
+  Future<double> getFlushTemperature() async => 0;
 
   @override
   dynamic noSuchMethod(Invocation invocation) => null;

--- a/test/controllers/bengle_steam_stop_bridge_test.dart
+++ b/test/controllers/bengle_steam_stop_bridge_test.dart
@@ -195,6 +195,36 @@ void main() {
     await bridge.dispose();
   });
 
+  test('reconnect writes the target to the replacement Bengle', () async {
+    final oldBengle = _RecordingBengle();
+    await connectBengle(oldBengle);
+
+    final bridge = BengleSteamStopBridge(
+      workflowController: workflow,
+      de1Controller: de1Controller,
+      debounce: _debounce,
+    );
+    await Future<void>.delayed(Duration.zero);
+    oldBengle.stopAtTempWrites.clear();
+
+    oldBengle.blockedTarget = 65.0;
+    oldBengle.targetEntered = Completer<void>();
+    oldBengle.targetRelease = Completer<void>();
+    setStopAtTemp(65.0);
+    await oldBengle.targetEntered!.future.timeout(const Duration(seconds: 2));
+
+    final replacement = _RecordingBengle();
+    await connectBengle(replacement);
+    await Future<void>.delayed(Duration.zero);
+    expect(replacement.stopAtTempWrites, isEmpty);
+
+    oldBengle.targetRelease!.complete();
+    await Future<void>.delayed(Duration.zero);
+    expect(replacement.stopAtTempWrites, [65.0]);
+    expect(oldBengle.maxInFlight, 1);
+    await bridge.dispose();
+  });
+
   test('no write when connected machine is not Bengle', () async {
     final de1 = TestDe1();
     await de1Controller.connectToDe1(de1);

--- a/test/controllers/bengle_steam_stop_bridge_test.dart
+++ b/test/controllers/bengle_steam_stop_bridge_test.dart
@@ -83,12 +83,40 @@ class _RecordingBengle implements BengleInterface {
   @override
   Future<void> disconnect() async {}
 
-  /// Stays `false` so [De1Controller._initializeData] never runs.
   @override
-  Stream<bool> get ready => Stream<bool>.value(false);
+  Stream<bool> get ready => Stream<bool>.value(true);
 
   @override
-  Stream<De1ShotSettings> get shotSettings => const Stream.empty();
+  Stream<De1ShotSettings> get shotSettings => Stream.value(
+    De1ShotSettings(
+      steamSetting: 0,
+      targetSteamTemp: 150,
+      targetSteamDuration: 30,
+      targetHotWaterTemp: 75,
+      targetHotWaterVolume: 50,
+      targetHotWaterDuration: 30,
+      targetShotVolume: 36,
+      groupTemp: 94,
+    ),
+  );
+
+  @override
+  Future<void> setFanThreshhold(int temp) async {}
+
+  @override
+  Future<double> getSteamFlow() async => 0;
+
+  @override
+  Future<double> getHotWaterFlow() async => 0;
+
+  @override
+  Future<double> getFlushFlow() async => 0;
+
+  @override
+  Future<double> getFlushTimeout() async => 0;
+
+  @override
+  Future<double> getFlushTemperature() async => 0;
 
   @override
   dynamic noSuchMethod(Invocation invocation) => null;

--- a/test/controllers/bengle_steam_stop_bridge_test.dart
+++ b/test/controllers/bengle_steam_stop_bridge_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/bengle_steam_stop_bridge.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
@@ -32,11 +34,28 @@ class _RecordingBengle implements BengleInterface {
 
   final List<double> stopAtTempWrites = [];
   double _target = 0.0;
+  double? blockedTarget;
+  Completer<void>? targetEntered;
+  Completer<void>? targetRelease;
+  int _inFlight = 0;
+  int maxInFlight = 0;
 
   @override
   Future<void> setStopAtTemperatureTarget(double celsius) async {
     stopAtTempWrites.add(celsius);
-    _target = celsius;
+    _inFlight++;
+    maxInFlight = maxInFlight < _inFlight ? _inFlight : maxInFlight;
+    try {
+      if (celsius == blockedTarget) {
+        if (!(targetEntered?.isCompleted ?? true)) {
+          targetEntered!.complete();
+        }
+        await targetRelease!.future;
+      }
+      _target = celsius;
+    } finally {
+      _inFlight--;
+    }
   }
 
   @override
@@ -143,6 +162,36 @@ void main() {
     await pumpDebounce();
 
     expect(bengle.stopAtTempWrites, [65.0]);
+    await bridge.dispose();
+  });
+
+  test('latest target waits for an in-flight write', () async {
+    final bengle = _RecordingBengle();
+    await connectBengle(bengle);
+
+    final bridge = BengleSteamStopBridge(
+      workflowController: workflow,
+      de1Controller: de1Controller,
+      debounce: _debounce,
+    );
+    await Future<void>.delayed(Duration.zero);
+    bengle.stopAtTempWrites.clear();
+
+    bengle.blockedTarget = 65.0;
+    bengle.targetEntered = Completer<void>();
+    bengle.targetRelease = Completer<void>();
+    setStopAtTemp(65.0);
+    await bengle.targetEntered!.future;
+
+    setStopAtTemp(70.0);
+    await pumpDebounce();
+    expect(bengle.stopAtTempWrites, [65.0]);
+    expect(bengle.maxInFlight, 1);
+
+    bengle.targetRelease!.complete();
+    await pumpDebounce();
+    expect(bengle.stopAtTempWrites, [65.0, 70.0]);
+    expect(bengle.maxInFlight, 1);
     await bridge.dispose();
   });
 

--- a/test/controllers/de1_controller_dispose_test.dart
+++ b/test/controllers/de1_controller_dispose_test.dart
@@ -43,8 +43,8 @@ void main() {
       Object? uncaught;
       await runZonedGuarded(
         () async {
-          // Backdoor on MockDe1 that pushes a `disconnected` event.
-          await mockDe1.setHeaterPhase2Timeout(0);
+          // Debug-only disconnect simulation on MockDe1.
+          mockDe1.simulateDisconnect();
           await Future<void>.delayed(const Duration(milliseconds: 50));
         },
         (error, _) {

--- a/test/services/webserver/de1handler_cup_warmer_test.dart
+++ b/test/services/webserver/de1handler_cup_warmer_test.dart
@@ -9,7 +9,6 @@ import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
-import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/services/webserver_service.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
@@ -18,32 +17,19 @@ import '../../helpers/mock_settings_service.dart';
 import '../../helpers/test_scale.dart';
 import '../../helpers/test_scale_controller.dart';
 
-class _FixedDe1Controller extends De1Controller {
-  _FixedDe1Controller({required super.controller, this.device});
-
-  De1Interface? device;
-
-  @override
-  De1Interface connectedDe1() {
-    final d = device;
-    if (d == null) throw const DeviceNotConnectedException.machine();
-    return d;
-  }
-}
-
 void main() {
   late Handler handler;
-  late _FixedDe1Controller controller;
+  late De1Controller controller;
   late SettingsController settingsController;
   late TestScaleController scaleController;
 
   Future<void> wireWith(De1Interface? device) async {
     final deviceController = DeviceController([MockDeviceDiscoveryService()]);
     await deviceController.initialize();
-    controller = _FixedDe1Controller(
-      controller: deviceController,
-      device: device,
-    );
+    controller = De1Controller(controller: deviceController);
+    if (device != null) {
+      await controller.connectToDe1(device);
+    }
 
     final mockSettings = MockSettingsService();
     settingsController = SettingsController(mockSettings);

--- a/test/services/webserver/de1handler_led_strip_test.dart
+++ b/test/services/webserver/de1handler_led_strip_test.dart
@@ -10,7 +10,6 @@ import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
 import 'package:reaprime/src/models/device/led_strip.dart';
-import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/services/webserver_service.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
@@ -19,32 +18,19 @@ import '../../helpers/mock_settings_service.dart';
 import '../../helpers/test_scale.dart';
 import '../../helpers/test_scale_controller.dart';
 
-class _FixedDe1Controller extends De1Controller {
-  _FixedDe1Controller({required super.controller, this.device});
-
-  De1Interface? device;
-
-  @override
-  De1Interface connectedDe1() {
-    final d = device;
-    if (d == null) throw const DeviceNotConnectedException.machine();
-    return d;
-  }
-}
-
 void main() {
   late Handler handler;
-  late _FixedDe1Controller controller;
+  late De1Controller controller;
   late SettingsController settingsController;
   late TestScaleController scaleController;
 
   Future<void> wireWith(De1Interface? device) async {
     final deviceController = DeviceController([MockDeviceDiscoveryService()]);
     await deviceController.initialize();
-    controller = _FixedDe1Controller(
-      controller: deviceController,
-      device: device,
-    );
+    controller = De1Controller(controller: deviceController);
+    if (device != null) {
+      await controller.connectToDe1(device);
+    }
 
     final mockSettings = MockSettingsService();
     settingsController = SettingsController(mockSettings);

--- a/test/services/webserver/de1handler_settings_reset_test.dart
+++ b/test/services/webserver/de1handler_settings_reset_test.dart
@@ -7,7 +7,6 @@ import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
-import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/services/webserver_service.dart';
 import 'package:shelf_plus/shelf_plus.dart';
@@ -17,32 +16,19 @@ import '../../helpers/mock_settings_service.dart';
 import '../../helpers/test_scale.dart';
 import '../../helpers/test_scale_controller.dart';
 
-class _FixedDe1Controller extends De1Controller {
-  _FixedDe1Controller({required super.controller, this.device});
-
-  De1Interface? device;
-
-  @override
-  De1Interface connectedDe1() {
-    final d = device;
-    if (d == null) throw const DeviceNotConnectedException.machine();
-    return d;
-  }
-}
-
 void main() {
   late Handler handler;
-  late _FixedDe1Controller controller;
+  late De1Controller controller;
   late SettingsController settingsController;
   late TestScaleController scaleController;
 
   Future<void> wireWith(De1Interface? device) async {
     final deviceController = DeviceController([MockDeviceDiscoveryService()]);
     await deviceController.initialize();
-    controller = _FixedDe1Controller(
-      controller: deviceController,
-      device: device,
-    );
+    controller = De1Controller(controller: deviceController);
+    if (device != null) {
+      await controller.connectToDe1(device);
+    }
 
     final mockSettings = MockSettingsService();
     settingsController = SettingsController(mockSettings);

--- a/test/services/webserver/de1handler_settings_reset_test.dart
+++ b/test/services/webserver/de1handler_settings_reset_test.dart
@@ -125,6 +125,23 @@ void main() {
       expect(body['refillKitSetting'], 2);
     });
 
+    test(
+      'writes and reads back heaterPh2Timeout without disconnecting',
+      () async {
+        final de1 = MockDe1();
+        await wireWith(de1);
+
+        final res = await post('/api/v1/machine/settings/advanced', {
+          'heaterPh2Timeout': 7.0,
+        });
+        expect(res.statusCode, 202);
+
+        expect(await de1.getHeaterPhase2Timeout(), 7.0);
+        // An ordinary MMR write must not drop the machine connection.
+        expect(controller.connectedDe1OrNull, same(de1));
+      },
+    );
+
     test('returns 500 when no DE1 connected', () async {
       await wireWith(null);
       final res = await post('/api/v1/machine/settings/advanced', {
@@ -139,6 +156,24 @@ void main() {
       await wireWith(MockDe1());
       final res = await delete('/api/v1/machine/settings/reset');
       expect(res.statusCode, 202);
+    });
+
+    test('applies the baseline defaults to the mock', () async {
+      final de1 = MockDe1();
+      await wireWith(de1);
+
+      final res = await delete('/api/v1/machine/settings/reset');
+      expect(res.statusCode, 202);
+
+      expect(await de1.getFanThreshhold(), 55);
+      expect(await de1.getHeaterIdleTemp(), 95);
+      expect(await de1.getHeaterPhase1Flow(), 2.0);
+      expect(await de1.getHeaterPhase2Flow(), 4.0);
+      expect(await de1.getHeaterPhase2Timeout(), 4.0);
+      expect(await de1.getRefillKitSettings(), De1RefillKitSettings.auto);
+      expect(await de1.getFlowEstimation(), 1.0);
+      expect(await de1.getSteamPurgeMode(), 0);
+      expect(controller.connectedDe1OrNull, same(de1));
     });
 
     test('returns 500 when no DE1 connected', () async {

--- a/test/services/webserver/debug_handler_test.dart
+++ b/test/services/webserver/debug_handler_test.dart
@@ -142,5 +142,13 @@ void main() {
       final res = await machineCommand('frobnicate');
       expect(res.statusCode, 404);
     });
+
+    test(
+      'unknown commands return 404 even without a connected machine',
+      () async {
+        final res = await machineCommand('frobnicate');
+        expect(res.statusCode, 404);
+      },
+    );
   });
 }

--- a/test/services/webserver/debug_handler_test.dart
+++ b/test/services/webserver/debug_handler_test.dart
@@ -1,22 +1,39 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
 import 'package:reaprime/src/services/webserver/debug_handler.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
+import '../../helpers/mock_device_discovery_service.dart';
+import '../../helpers/test_de1.dart';
+
 void main() {
   late ScaleController scaleController;
+  late De1Controller de1Controller;
   late Handler handler;
 
-  setUp(() {
+  setUp(() async {
     scaleController = ScaleController();
+    final deviceController = DeviceController([MockDeviceDiscoveryService()]);
+    await deviceController.initialize();
+    de1Controller = De1Controller(controller: deviceController);
     final app = Router().plus;
-    DebugHandler(scaleController: scaleController).addRoutes(app);
+    DebugHandler(
+      scaleController: scaleController,
+      de1Controller: de1Controller,
+    ).addRoutes(app);
     handler = app.call;
   });
 
-  tearDown(() => scaleController.dispose());
+  tearDown(() async {
+    scaleController.dispose();
+    await de1Controller.dispose();
+  });
 
   Future<Response> get() async => await handler(
     Request('GET', Uri.parse('http://localhost/api/v1/debug/flow-smoothing')),
@@ -28,6 +45,13 @@ void main() {
       Uri.parse('http://localhost/api/v1/debug/flow-smoothing'),
       headers: {'content-type': 'application/json'},
       body: jsonEncode(body),
+    ),
+  );
+
+  Future<Response> machineCommand(String command) async => await handler(
+    Request(
+      'POST',
+      Uri.parse('http://localhost/api/v1/debug/machine/$command'),
     ),
   );
 
@@ -61,6 +85,62 @@ void main() {
     expect(jsonDecode(await current.readAsString()), {
       'windowMs': 600,
       'movingAverageSamples': 10,
+    });
+  });
+
+  group('POST /api/v1/debug/machine', () {
+    test(
+      'disconnect emits a disconnected state and clears the machine',
+      () async {
+        final mock = MockDe1();
+        await de1Controller.connectToDe1(mock);
+
+        final res = await machineCommand('disconnect');
+        expect(res.statusCode, 200);
+        expect(jsonDecode(await res.readAsString()), {
+          'status': 'disconnected',
+        });
+
+        await Future<void>.delayed(Duration.zero);
+        expect(de1Controller.connectedDe1OrNull, isNull);
+      },
+    );
+
+    test('rejects with 400 when no machine is connected', () async {
+      final res = await machineCommand('disconnect');
+      expect(res.statusCode, 400);
+    });
+
+    test(
+      'rejects with 400 when the connected machine is not a MockDe1',
+      () async {
+        final testDe1 = TestDe1();
+        await de1Controller.connectToDe1(testDe1);
+        testDe1.emitShotSettings(
+          De1ShotSettings(
+            steamSetting: 0,
+            targetSteamTemp: 150,
+            targetSteamDuration: 30,
+            targetHotWaterTemp: 75,
+            targetHotWaterVolume: 50,
+            targetHotWaterDuration: 30,
+            targetShotVolume: 36,
+            groupTemp: 94.0,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        final res = await machineCommand('disconnect');
+        expect(res.statusCode, 400);
+      },
+    );
+
+    test('unknown commands return 404', () async {
+      final mock = MockDe1();
+      await de1Controller.connectToDe1(mock);
+
+      final res = await machineCommand('frobnicate');
+      expect(res.statusCode, 404);
     });
   });
 }

--- a/test/unit/devices/mock_de1_test.dart
+++ b/test/unit/devices/mock_de1_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart' as device;
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+
+void main() {
+  test(
+    'setHeaterPhase2Timeout stores the value and does not change connection state',
+    () async {
+      final mock = MockDe1();
+      final states = <device.ConnectionState>[];
+      final sub = mock.connectionState.listen(states.add);
+
+      await mock.setHeaterPhase2Timeout(7.5);
+
+      expect(await mock.getHeaterPhase2Timeout(), 7.5);
+      // Writing an ordinary MMR setting must not drop the machine.
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(states, isNot(contains(device.ConnectionState.disconnected)));
+      await sub.cancel();
+    },
+  );
+
+  test('simulateDisconnect emits a disconnected state explicitly', () async {
+    final mock = MockDe1();
+    final states = <device.ConnectionState>[];
+    final sub = mock.connectionState.listen(states.add);
+
+    mock.simulateDisconnect();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(states, contains(device.ConnectionState.disconnected));
+    await sub.cancel();
+  });
+}

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -53,6 +53,13 @@ class SpyDe1 implements De1Interface {
   final List<double> setFlushFlowCalls = [];
   final List<double> setFlushTimeoutCalls = [];
   final List<double> setFlushTemperatureCalls = [];
+  final List<double> steamFlowEntryOrder = [];
+  final List<double> steamFlowCompletionOrder = [];
+
+  double? blockedSteamFlow;
+  Completer<void>? steamFlowEntered;
+  Completer<void>? steamFlowRelease;
+  double? failSteamFlow;
 
   /// Every emit that crosses the `shotSettings` stream, in order. This
   /// is the stream `/ws/v1/machine/shotSettings` subscribes to.
@@ -77,7 +84,19 @@ class SpyDe1 implements De1Interface {
 
   @override
   Future<void> setSteamFlow(double newFlow) async {
+    steamFlowEntryOrder.add(newFlow);
     setSteamFlowCalls.add(newFlow);
+    if (newFlow == blockedSteamFlow) {
+      if (!(steamFlowEntered?.isCompleted ?? true)) {
+        steamFlowEntered!.complete();
+      }
+      await steamFlowRelease!.future;
+    }
+    if (newFlow == failSteamFlow) {
+      failSteamFlow = null;
+      throw StateError('selected steam write failed');
+    }
+    steamFlowCompletionOrder.add(newFlow);
   }
 
   @override
@@ -248,10 +267,7 @@ class SpyDe1 implements De1Interface {
 }
 
 Future<void> _settleHandler() async {
-  // Workflow handler debounce is 400 ms (private constant). Wait
-  // comfortably past that so _applyPendingUpdate fires and the
-  // downstream controller writes run to completion.
-  await Future<void>.delayed(const Duration(milliseconds: 600));
+  await Future<void>.delayed(Duration.zero);
 }
 
 void main() {
@@ -282,12 +298,26 @@ void main() {
     spy.dispose();
   });
 
-  Future<Response> put(Map<String, dynamic> body) async {
+  Future<Response> put(
+    Map<String, dynamic> body, {
+    Map<String, String> headers = const {},
+  }) async {
     return await handler(
       Request(
         'PUT',
         Uri.parse('http://localhost/api/v1/workflow'),
         body: jsonEncode(body),
+        headers: {'content-type': 'application/json', ...headers},
+      ),
+    );
+  }
+
+  Future<Response> putRaw(String body) async {
+    return await handler(
+      Request(
+        'PUT',
+        Uri.parse('http://localhost/api/v1/workflow'),
+        body: body,
         headers: {'content-type': 'application/json'},
       ),
     );
@@ -551,6 +581,170 @@ void main() {
         final last = spy.emittedShotSettings.last;
         expect(last.targetSteamDuration, equals(44));
         expect(last.targetHotWaterDuration, equals(55));
+      },
+    );
+  });
+
+  group('PUT /api/v1/workflow — request isolation', () {
+    test('rapid PUTs from separate clients are not merged', () async {
+      await _settleHandler();
+      final initial = workflowController.currentWorkflow;
+      final firstName = 'First request';
+      final secondDescription = 'Second request';
+
+      final firstFuture = put(
+        {'name': firstName},
+        headers: {'x-test-client': 'first'},
+      );
+      final secondFuture = put(
+        {'description': secondDescription},
+        headers: {'x-test-client': 'second'},
+      );
+
+      final responses = await Future.wait([firstFuture, secondFuture]);
+      expect(responses[0].statusCode, 200);
+      expect(responses[1].statusCode, 200);
+
+      final firstBody = jsonDecode(await responses[0].readAsString());
+      final secondBody = jsonDecode(await responses[1].readAsString());
+      expect(firstBody['name'], firstName);
+      expect(firstBody['description'], initial.description);
+      expect(secondBody['name'], firstName);
+      expect(secondBody['description'], secondDescription);
+      expect(firstBody, isNot(equals(secondBody)));
+      expect(workflowController.currentWorkflow.name, firstName);
+      expect(workflowController.currentWorkflow.description, secondDescription);
+    });
+
+    test(
+      'continuous PUT traffic does not wait for an inactivity window',
+      () async {
+        await _settleHandler();
+        final trafficStarted = Completer<void>();
+        final laterFutures = <Future<Response>>[];
+        final firstFuture = put({'name': 'first'});
+        final trafficFuture = () async {
+          for (var i = 0; i < 4; i++) {
+            await Future<void>.delayed(const Duration(milliseconds: 100));
+            if (!trafficStarted.isCompleted) {
+              trafficStarted.complete();
+            }
+            laterFutures.add(put({'name': 'later-$i'}));
+          }
+        }();
+
+        late final Response firstResponse;
+        try {
+          await trafficStarted.future.timeout(const Duration(seconds: 1));
+          firstResponse = await firstFuture.timeout(
+            const Duration(milliseconds: 250),
+          );
+        } finally {
+          await trafficFuture;
+        }
+
+        expect(firstResponse.statusCode, 200);
+        final firstBody = jsonDecode(await firstResponse.readAsString());
+        expect(firstBody['name'], 'first');
+        final laterResponses = await Future.wait(laterFutures);
+        expect(
+          laterResponses.every((response) => response.statusCode == 200),
+          isTrue,
+        );
+        expect(workflowController.currentWorkflow.name, 'later-3');
+      },
+    );
+
+    test(
+      'a later workflow PUT cannot overtake an in-flight device apply',
+      () async {
+        await _settleHandler();
+        final initial = workflowController.currentWorkflow;
+        final firstFlow = initial.steamSettings.flow + 1;
+        final secondFlow = initial.steamSettings.flow + 2;
+        final entered = Completer<void>();
+        final release = Completer<void>();
+        spy.blockedSteamFlow = firstFlow;
+        spy.steamFlowEntered = entered;
+        spy.steamFlowRelease = release;
+
+        final firstFuture = put({
+          'steamSettings': {'flow': firstFlow},
+        });
+        await entered.future.timeout(const Duration(seconds: 2));
+        final secondFuture = put({
+          'steamSettings': {'flow': secondFlow},
+        });
+        var secondCompleted = false;
+        unawaited(secondFuture.then((_) => secondCompleted = true));
+
+        try {
+          await Future<void>.delayed(const Duration(milliseconds: 500));
+          expect(spy.steamFlowEntryOrder, [firstFlow]);
+          expect(secondCompleted, isFalse);
+        } finally {
+          release.complete();
+        }
+
+        final responses = await Future.wait([
+          firstFuture.timeout(const Duration(seconds: 2)),
+          secondFuture.timeout(const Duration(seconds: 2)),
+        ]);
+        expect(responses[0].statusCode, 200);
+        expect(responses[1].statusCode, 200);
+        expect(spy.steamFlowEntryOrder, [firstFlow, secondFlow]);
+        expect(spy.steamFlowCompletionOrder, [firstFlow, secondFlow]);
+        expect(spy.setSteamFlowCalls.last, secondFlow);
+        expect(
+          workflowController.currentWorkflow.steamSettings.flow,
+          secondFlow,
+        );
+      },
+    );
+
+    test('a failed workflow PUT does not poison later queue entries', () async {
+      await _settleHandler();
+      final initial = workflowController.currentWorkflow;
+      final failedFlow = initial.steamSettings.flow + 1;
+      final laterFlow = initial.steamSettings.flow + 2;
+      final entered = Completer<void>();
+      spy.failSteamFlow = failedFlow;
+      spy.blockedSteamFlow = failedFlow;
+      spy.steamFlowEntered = entered;
+      spy.steamFlowRelease = Completer<void>()..complete();
+
+      final failedFuture = put({
+        'steamSettings': {'flow': failedFlow},
+      });
+      await entered.future.timeout(const Duration(seconds: 2));
+      final laterFuture = put({
+        'steamSettings': {'flow': laterFlow},
+      });
+
+      final responses = await Future.wait([
+        failedFuture.timeout(const Duration(seconds: 2)),
+        laterFuture.timeout(const Duration(seconds: 2)),
+      ]);
+      expect(responses[0].statusCode, 500);
+      expect(responses[1].statusCode, 200);
+      expect(spy.setSteamFlowCalls.last, laterFlow);
+      expect(workflowController.currentWorkflow.steamSettings.flow, laterFlow);
+    });
+
+    test(
+      'malformed or non-object JSON returns 400 without poisoning the queue',
+      () async {
+        await _settleHandler();
+
+        final malformedResponse = await putRaw('{');
+        expect(malformedResponse.statusCode, 400);
+
+        final badResponse = await putRaw('[]');
+        expect(badResponse.statusCode, 400);
+
+        final goodResponse = await put({'name': 'after invalid shape'});
+        expect(goodResponse.statusCode, 200);
+        expect(workflowController.currentWorkflow.name, 'after invalid shape');
       },
     );
   });

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -29,7 +29,7 @@ import '../helpers/mock_device_discovery_service.dart';
 /// read-modify-write races on the controller surface reproduce here
 /// exactly like they do on the running app.
 class SpyDe1 implements De1Interface {
-  SpyDe1({De1ShotSettings? seed, this.readyState = true}) {
+  SpyDe1({De1ShotSettings? seed, bool readyState = true}) {
     _shotSettings = BehaviorSubject.seeded(
       seed ??
           De1ShotSettings(
@@ -43,10 +43,11 @@ class SpyDe1 implements De1Interface {
             groupTemp: 94.0,
           ),
     );
+    _ready = BehaviorSubject.seeded(readyState);
   }
 
   late final BehaviorSubject<De1ShotSettings> _shotSettings;
-  final bool readyState;
+  late final BehaviorSubject<bool> _ready;
 
   final List<De1ShotSettings> updateShotSettingsCalls = [];
   final List<Profile> setProfileCalls = [];
@@ -148,9 +149,12 @@ class SpyDe1 implements De1Interface {
   @override
   Future<void> dispose() async {
     _shotSettings.close();
+    _ready.close();
     _connectionState.close();
     _snapshot.close();
   }
+
+  void setReady(bool ready) => _ready.add(ready);
 
   @override
   String get deviceId => 'spy-de1';
@@ -183,7 +187,7 @@ class SpyDe1 implements De1Interface {
   @override
   Future<void> requestState(MachineState newState) async {}
   @override
-  Stream<bool> get ready => Stream.value(readyState);
+  Stream<bool> get ready => _ready.stream;
   @override
   Stream<De1WaterLevels> get waterLevels => const Stream.empty();
   @override
@@ -706,8 +710,10 @@ void main() {
 
     test('a workflow PUT retries on a replacement machine', () async {
       await _settleHandler();
-      final nextFlow =
-          workflowController.currentWorkflow.steamSettings.flow + 1;
+      final initial = workflowController.currentWorkflow;
+      final defaultFlow = initial.steamSettings.flow;
+      final nextFlow = defaultFlow + 1;
+      de1Controller.defaultWorkflow = initial;
       final entered = Completer<void>();
       final release = Completer<void>();
       spy.blockedSteamFlow = nextFlow;
@@ -723,9 +729,18 @@ void main() {
       await de1Controller.connectToDe1(replacement);
       release.complete();
 
+      var completed = false;
+      unawaited(future.then((_) => completed = true));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(completed, isFalse);
+      expect(replacement.setSteamFlowCalls, isEmpty);
+
+      replacement.setReady(true);
+
       final response = await future.timeout(const Duration(seconds: 2));
       expect(response.statusCode, 200);
-      expect(replacement.setSteamFlowCalls, [nextFlow]);
+      expect(replacement.setSteamFlowCalls, [defaultFlow, nextFlow]);
+      expect(replacement.steamFlowCompletionOrder, [defaultFlow, nextFlow]);
       expect(workflowController.currentWorkflow.steamSettings.flow, nextFlow);
       await replacement.dispose();
     });
@@ -945,7 +960,12 @@ void main() {
         );
         final timeoutApp = Router().plus;
         timeoutHandler.addRoutes(timeoutApp);
-        final body = StreamController<List<int>>();
+        final cancelled = Completer<void>();
+        final body = StreamController<List<int>>(
+          onCancel: () {
+            if (!cancelled.isCompleted) cancelled.complete();
+          },
+        );
         final stalledFuture = Future<Response>.sync(
           () => timeoutApp.call(
             Request(
@@ -957,16 +977,15 @@ void main() {
           ),
         );
 
-        try {
-          final stalledResponse = await stalledFuture.timeout(
-            const Duration(seconds: 2),
-          );
-          expect(stalledResponse.statusCode, 500);
-          final nextResponse = await put({'name': 'after body timeout'});
-          expect(nextResponse.statusCode, 200);
-        } finally {
-          await body.close();
-        }
+        final stalledResponse = await stalledFuture.timeout(
+          const Duration(seconds: 2),
+        );
+        expect(stalledResponse.statusCode, 500);
+        await cancelled.future.timeout(const Duration(seconds: 2));
+        expect(body.hasListener, isFalse);
+        final nextResponse = await put({'name': 'after body timeout'});
+        expect(nextResponse.statusCode, 200);
+        await body.close();
       },
     );
 

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -827,6 +827,86 @@ void main() {
     );
 
     test(
+      'a queued body-read failure is observed without poisoning the queue',
+      () async {
+        await _settleHandler();
+        final initial = workflowController.currentWorkflow;
+        final blockedFlow = initial.steamSettings.flow + 1;
+        final entered = Completer<void>();
+        final release = Completer<void>();
+        spy.blockedSteamFlow = blockedFlow;
+        spy.steamFlowEntered = entered;
+        spy.steamFlowRelease = release;
+
+        final firstFuture = put({
+          'steamSettings': {'flow': blockedFlow},
+        });
+        await entered.future.timeout(const Duration(seconds: 2));
+
+        final body = StreamController<List<int>>();
+        final failedFuture = Future<Response>.sync(
+          () => handler(
+            Request(
+              'PUT',
+              Uri.parse('http://localhost/api/v1/workflow'),
+              body: body.stream,
+              headers: {'content-type': 'application/json'},
+            ),
+          ),
+        );
+        body.addError(StateError('body read failed'));
+        await body.close();
+        await Future<void>.delayed(Duration.zero);
+        release.complete();
+
+        final responses = await Future.wait([
+          firstFuture.timeout(const Duration(seconds: 2)),
+          failedFuture.timeout(const Duration(seconds: 2)),
+        ]);
+        expect(responses[0].statusCode, 200);
+        expect(responses[1].statusCode, 500);
+        final nextResponse = await put({'name': 'after body failure'});
+        expect(nextResponse.statusCode, 200);
+      },
+    );
+
+    test(
+      'a stalled body cannot hold the workflow queue indefinitely',
+      () async {
+        await _settleHandler();
+        final timeoutHandler = WorkflowHandler(
+          controller: workflowController,
+          de1controller: de1Controller,
+          bodyReadTimeout: const Duration(milliseconds: 20),
+        );
+        final timeoutApp = Router().plus;
+        timeoutHandler.addRoutes(timeoutApp);
+        final body = StreamController<List<int>>();
+        final stalledFuture = Future<Response>.sync(
+          () => timeoutApp.call(
+            Request(
+              'PUT',
+              Uri.parse('http://localhost/api/v1/workflow'),
+              body: body.stream,
+              headers: {'content-type': 'application/json'},
+            ),
+          ),
+        );
+
+        try {
+          final stalledResponse = await stalledFuture.timeout(
+            const Duration(seconds: 2),
+          );
+          expect(stalledResponse.statusCode, 500);
+          final nextResponse = await put({'name': 'after body timeout'});
+          expect(nextResponse.statusCode, 200);
+        } finally {
+          await body.close();
+        }
+      },
+    );
+
+    test(
       'malformed or non-object JSON returns 400 without poisoning the queue',
       () async {
         await _settleHandler();

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -732,6 +732,69 @@ void main() {
     });
 
     test(
+      'an identical retry re-applies a failed workflow device write',
+      () async {
+        await _settleHandler();
+        final initial = workflowController.currentWorkflow;
+        final failedFlow = initial.steamSettings.flow + 1;
+        spy.failSteamFlow = failedFlow;
+
+        final failedResponse = await put({
+          'steamSettings': {'flow': failedFlow},
+        });
+        expect(failedResponse.statusCode, 500);
+        expect(
+          workflowController.currentWorkflow.steamSettings.flow,
+          initial.steamSettings.flow,
+        );
+
+        final retryResponse = await put({
+          'steamSettings': {'flow': failedFlow},
+        });
+        expect(retryResponse.statusCode, 200);
+        expect(spy.setSteamFlowCalls, [failedFlow, failedFlow]);
+        expect(
+          workflowController.currentWorkflow.steamSettings.flow,
+          failedFlow,
+        );
+      },
+    );
+
+    test(
+      'request order is reserved before a streamed body completes',
+      () async {
+        await _settleHandler();
+        final body = StreamController<List<int>>();
+        final firstFuture = handler(
+          Request(
+            'PUT',
+            Uri.parse('http://localhost/api/v1/workflow'),
+            body: body.stream,
+            headers: {'content-type': 'application/json'},
+          ),
+        );
+        final secondFuture = put({'name': 'second'});
+        var secondCompleted = false;
+        unawaited(secondFuture.then((_) => secondCompleted = true));
+
+        await Future<void>.delayed(Duration.zero);
+        expect(secondCompleted, isFalse);
+
+        body.add(utf8.encode(jsonEncode({'name': 'first'})));
+        await body.close();
+
+        final responses = await Future.wait([firstFuture, secondFuture]);
+        expect(responses[0].statusCode, 200);
+        expect(responses[1].statusCode, 200);
+        final firstBody = jsonDecode(await responses[0].readAsString());
+        final secondBody = jsonDecode(await responses[1].readAsString());
+        expect(firstBody['name'], 'first');
+        expect(secondBody['name'], 'second');
+        expect(workflowController.currentWorkflow.name, 'second');
+      },
+    );
+
+    test(
       'malformed or non-object JSON returns 400 without poisoning the queue',
       () async {
         await _settleHandler();

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -61,6 +61,14 @@ class SpyDe1 implements De1Interface {
   final List<double> setFlushFlowCalls = [];
   final List<double> setFlushTimeoutCalls = [];
   final List<double> setFlushTemperatureCalls = [];
+  final List<int> setFanThreshholdCalls = [];
+  final List<double> setHeaterIdleTempCalls = [];
+  final List<double> setHeaterPhase1FlowCalls = [];
+  final List<double> setHeaterPhase2FlowCalls = [];
+  final List<double> setHeaterPhase2TimeoutCalls = [];
+  final List<double> setFlowEstimationCalls = [];
+  final List<int> setSteamPurgeModeCalls = [];
+  final List<De1RefillKitSettings> setRefillKitSettingsCalls = [];
   final List<double> steamFlowEntryOrder = [];
   final List<double> steamFlowCompletionOrder = [];
 
@@ -73,6 +81,10 @@ class SpyDe1 implements De1Interface {
   Completer<void>? steamFlowEntered;
   Completer<void>? steamFlowRelease;
   double? failSteamFlow;
+  double? blockedHeaterPhase2Flow;
+  Completer<void>? heaterPhase2FlowEntered;
+  Completer<void>? heaterPhase2FlowRelease;
+  double? failHeaterPhase2Flow;
 
   /// Every emit that crosses the `shotSettings` stream, in order. This
   /// is the stream `/ws/v1/machine/shotSettings` subscribes to.
@@ -215,7 +227,11 @@ class SpyDe1 implements De1Interface {
   @override
   Future<void> setRefillLevel(int newRefillLevel) async {}
   @override
-  Future<void> setFanThreshhold(int temp) async {}
+  Future<void> setFanThreshhold(int temp) async {
+    setFanThreshholdCalls.add(temp);
+    writeOrder.add('fan:$temp');
+  }
+
   @override
   Future<int> getFanThreshhold() async => 55;
   @override
@@ -242,13 +258,21 @@ class SpyDe1 implements De1Interface {
   @override
   double? get cachedFlowEstimation => 1.0;
   @override
-  Future<void> setFlowEstimation(double multiplier) async {}
+  Future<void> setFlowEstimation(double multiplier) async {
+    setFlowEstimationCalls.add(multiplier);
+    writeOrder.add('flowEstimation:$multiplier');
+  }
+
   @override
   Future<bool> getUsbChargerMode() async => false;
   @override
   Future<void> setUsbChargerMode(bool t) async {}
   @override
-  Future<void> setSteamPurgeMode(int mode) async {}
+  Future<void> setSteamPurgeMode(int mode) async {
+    setSteamPurgeModeCalls.add(mode);
+    writeOrder.add('steamPurgeMode:$mode');
+  }
+
   @override
   Future<int> getSteamPurgeMode() async => 0;
   @override
@@ -262,19 +286,45 @@ class SpyDe1 implements De1Interface {
   @override
   Future<double> getHeaterPhase1Flow() async => 0;
   @override
-  Future<void> setHeaterPhase1Flow(double val) async {}
+  Future<void> setHeaterPhase1Flow(double val) async {
+    setHeaterPhase1FlowCalls.add(val);
+    writeOrder.add('heaterPh1:$val');
+  }
+
   @override
   Future<double> getHeaterPhase2Flow() async => 0;
   @override
-  Future<void> setHeaterPhase2Flow(double val) async {}
+  Future<void> setHeaterPhase2Flow(double val) async {
+    setHeaterPhase2FlowCalls.add(val);
+    writeOrder.add('heaterPh2:$val');
+    if (val == blockedHeaterPhase2Flow) {
+      if (!(heaterPhase2FlowEntered?.isCompleted ?? true)) {
+        heaterPhase2FlowEntered!.complete();
+      }
+      await heaterPhase2FlowRelease!.future;
+    }
+    if (val == failHeaterPhase2Flow) {
+      failHeaterPhase2Flow = null;
+      throw StateError('selected heater phase-2 flow write failed');
+    }
+  }
+
   @override
   Future<double> getHeaterPhase2Timeout() async => 0;
   @override
-  Future<void> setHeaterPhase2Timeout(double val) async {}
+  Future<void> setHeaterPhase2Timeout(double val) async {
+    setHeaterPhase2TimeoutCalls.add(val);
+    writeOrder.add('heaterPh2Timeout:$val');
+  }
+
   @override
   Future<double> getHeaterIdleTemp() async => 0;
   @override
-  Future<void> setHeaterIdleTemp(double val) async {}
+  Future<void> setHeaterIdleTemp(double val) async {
+    setHeaterIdleTempCalls.add(val);
+    writeOrder.add('heaterIdleTemp:$val');
+  }
+
   @override
   FirmwareUpdateState get firmwareUpdateState => FirmwareUpdateState.idle;
   @override
@@ -291,10 +341,18 @@ class SpyDe1 implements De1Interface {
   @override
   Future<void> setHeaterVoltage(De1HeaterVoltage voltage) async {}
   @override
-  Future<void> setRefillKitSettings(De1RefillKitSettings settings) async {}
+  Future<void> setRefillKitSettings(De1RefillKitSettings settings) async {
+    setRefillKitSettingsCalls.add(settings);
+    writeOrder.add('refillKit:$settings');
+  }
 }
 
-Future<void> _settleHandler() async {
+Future<void> _settleHandler(SpyDe1 spy) async {
+  // Wait for the connect-time startup defaults (fan write) to land so
+  // writeOrder traces start from a clean slate in each test.
+  while (spy.setFanThreshholdCalls.isEmpty) {
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+  }
   await Future<void>.delayed(Duration.zero);
 }
 
@@ -354,7 +412,7 @@ void main() {
   group('PUT /api/v1/workflow — redundant writes', () {
     test('steam-only PUT does not trigger hot-water or flush writes', () async {
       // Clear any emits from initial seed + DE1 controller init.
-      await _settleHandler();
+      await _settleHandler(spy);
       spy.updateShotSettingsCalls.clear();
       spy.setSteamFlowCalls.clear();
       spy.setHotWaterFlowCalls.clear();
@@ -369,7 +427,7 @@ void main() {
           'steamSettings': {'duration': 30},
         }),
       );
-      await _settleHandler();
+      await _settleHandler(spy);
 
       expect(
         spy.setHotWaterFlowCalls,
@@ -413,7 +471,7 @@ void main() {
     });
 
     test('no-op PUT (same values) issues no DE1 writes', () async {
-      await _settleHandler();
+      await _settleHandler(spy);
       final snapshot = workflowController.currentWorkflow;
       spy.updateShotSettingsCalls.clear();
       spy.setSteamFlowCalls.clear();
@@ -430,7 +488,7 @@ void main() {
           'rinseData': snapshot.rinseData.toJson(),
         }),
       );
-      await _settleHandler();
+      await _settleHandler(spy);
 
       expect(spy.updateShotSettingsCalls, isEmpty);
       expect(spy.setSteamFlowCalls, isEmpty);
@@ -446,7 +504,7 @@ void main() {
 
   group('PUT /api/v1/workflow — parse errors (issue #338)', () {
     test('invalid ExitType returns 400 instead of hanging forever', () async {
-      await _settleHandler();
+      await _settleHandler(spy);
 
       // Send a profile step with an invalid ExitType ('weight'
       // is not a valid member of ExitType {pressure, flow}).
@@ -470,7 +528,7 @@ void main() {
 
       // Wait for the debounce timer to fire and _applyPendingUpdate
       // to run (or, pre-fix, to throw silently and hang).
-      await _settleHandler();
+      await _settleHandler(spy);
 
       // With the fix, the completer is completed with a 400 response
       // instead of never completing.
@@ -485,7 +543,7 @@ void main() {
     test(
       'after a failed parse, a subsequent valid PUT succeeds normally',
       () async {
-        await _settleHandler();
+        await _settleHandler(spy);
 
         // First: an invalid PUT that will fail to parse.
         final badFuture = put({
@@ -505,7 +563,7 @@ void main() {
             ],
           },
         });
-        await _settleHandler();
+        await _settleHandler(spy);
         final badResponse = await badFuture;
         expect(badResponse.statusCode, equals(400));
 
@@ -514,7 +572,7 @@ void main() {
         final goodFuture = put({
           'steamSettings': {'duration': 25},
         });
-        await _settleHandler();
+        await _settleHandler(spy);
         final goodResponse = await goodFuture;
         expect(goodResponse.statusCode, equals(200));
         final goodBody = jsonDecode(await goodResponse.readAsString());
@@ -530,12 +588,12 @@ void main() {
         // catch block in _applyPendingUpdate. Without the catch,
         // this ArgumentError would escape the fire-and-forget Timer
         // callback and hang the request.
-        await _settleHandler();
+        await _settleHandler(spy);
 
         final future = put({
           'profile': {'title': ''},
         });
-        await _settleHandler();
+        await _settleHandler(spy);
 
         final response = await future;
         expect(response.statusCode, equals(400));
@@ -550,7 +608,7 @@ void main() {
     test(
       'multi-field PUT: final shot-settings write reflects BOTH changes',
       () async {
-        await _settleHandler();
+        await _settleHandler(spy);
         spy.updateShotSettingsCalls.clear();
         spy.emittedShotSettings.clear();
 
@@ -560,7 +618,7 @@ void main() {
             'hotWaterData': {'duration': 55},
           }),
         );
-        await _settleHandler();
+        await _settleHandler(spy);
 
         expect(
           spy.updateShotSettingsCalls,
@@ -590,7 +648,7 @@ void main() {
     test(
       'WebSocket-observable stream: final emit reflects BOTH changes',
       () async {
-        await _settleHandler();
+        await _settleHandler(spy);
         spy.emittedShotSettings.clear();
 
         unawaited(
@@ -599,7 +657,7 @@ void main() {
             'hotWaterData': {'duration': 55},
           }),
         );
-        await _settleHandler();
+        await _settleHandler(spy);
 
         expect(
           spy.emittedShotSettings,
@@ -615,7 +673,7 @@ void main() {
 
   group('PUT /api/v1/workflow — request isolation', () {
     test('rapid PUTs from separate clients are not merged', () async {
-      await _settleHandler();
+      await _settleHandler(spy);
       final initial = workflowController.currentWorkflow;
       final firstName = 'First request';
       final secondDescription = 'Second request';
@@ -647,7 +705,7 @@ void main() {
     test(
       'continuous PUT traffic does not wait for an inactivity window',
       () async {
-        await _settleHandler();
+        await _settleHandler(spy);
         final trafficStarted = Completer<void>();
         final laterFutures = <Future<Response>>[];
         final firstFuture = put({'name': 'first'});
@@ -686,7 +744,7 @@ void main() {
     test(
       'a later workflow PUT cannot overtake an in-flight device apply',
       () async {
-        await _settleHandler();
+        await _settleHandler(spy);
         final initial = workflowController.currentWorkflow;
         final firstFlow = initial.steamSettings.flow + 1;
         final secondFlow = initial.steamSettings.flow + 2;
@@ -733,7 +791,7 @@ void main() {
     test(
       'a workflow PUT retries on a replacement attached after a disconnected gap',
       () async {
-        await _settleHandler();
+        await _settleHandler(spy);
         final initial = workflowController.currentWorkflow;
         final defaultFlow = initial.steamSettings.flow;
         final nextFlow = defaultFlow + 1;
@@ -781,7 +839,7 @@ void main() {
     );
 
     test('profile sync waits behind a workflow device write', () async {
-      await _settleHandler();
+      await _settleHandler(spy);
       final sync = WorkflowDeviceSync(
         workflowController: workflowController,
         de1Controller: de1Controller,
@@ -817,7 +875,7 @@ void main() {
     });
 
     test('a failed workflow PUT does not poison later queue entries', () async {
-      await _settleHandler();
+      await _settleHandler(spy);
       final initial = workflowController.currentWorkflow;
       final failedFlow = initial.steamSettings.flow + 1;
       final laterFlow = initial.steamSettings.flow + 2;
@@ -848,7 +906,7 @@ void main() {
     test(
       'an identical retry re-applies a failed workflow device write',
       () async {
-        await _settleHandler();
+        await _settleHandler(spy);
         final initial = workflowController.currentWorkflow;
         final failedFlow = initial.steamSettings.flow + 1;
         spy.failSteamFlow = failedFlow;
@@ -877,7 +935,7 @@ void main() {
     test(
       'a concurrent controller mutation survives a blocked REST apply',
       () async {
-        await _settleHandler();
+        await _settleHandler(spy);
         final initial = workflowController.currentWorkflow;
         final nextFlow = initial.steamSettings.flow + 1;
         final entered = Completer<void>();
@@ -907,7 +965,7 @@ void main() {
     test(
       'request order is reserved before a streamed body completes',
       () async {
-        await _settleHandler();
+        await _settleHandler(spy);
         final body = StreamController<List<int>>();
         final firstFuture = Future<Response>.sync(
           () => handler(
@@ -943,7 +1001,7 @@ void main() {
     test(
       'a queued body-read failure is observed without poisoning the queue',
       () async {
-        await _settleHandler();
+        await _settleHandler(spy);
         final initial = workflowController.currentWorkflow;
         final blockedFlow = initial.steamSettings.flow + 1;
         final entered = Completer<void>();
@@ -987,7 +1045,7 @@ void main() {
     test(
       'a stalled body cannot hold the workflow queue indefinitely',
       () async {
-        await _settleHandler();
+        await _settleHandler(spy);
         final timeoutHandler = WorkflowHandler(
           controller: workflowController,
           de1controller: de1Controller,
@@ -1124,7 +1182,7 @@ void main() {
     test(
       'malformed or non-object JSON returns 400 without poisoning the queue',
       () async {
-        await _settleHandler();
+        await _settleHandler(spy);
 
         final malformedResponse = await putRaw('{');
         expect(malformedResponse.statusCode, 400);
@@ -1141,7 +1199,7 @@ void main() {
     test(
       'an expired 503 request releases admission capacity while an earlier write remains blocked',
       () async {
-        await _settleHandler();
+        await _settleHandler(spy);
         final initial = workflowController.currentWorkflow;
         final blockedFlow = initial.steamSettings.flow + 1;
         final entered = Completer<void>();
@@ -1260,7 +1318,7 @@ void main() {
     test(
       'a stopAtTemperature-only PUT causes no DE1 steam-setting write while preserving the workflow value',
       () async {
-        await _settleHandler();
+        await _settleHandler(spy);
         spy.updateShotSettingsCalls.clear();
         spy.setSteamFlowCalls.clear();
         spy.setHotWaterFlowCalls.clear();
@@ -1358,7 +1416,7 @@ void main() {
     test(
       'fields from one settings request cannot be interleaved with another device write',
       () async {
-        await _settleHandler();
+        await _settleHandler(spy);
         final initial = workflowController.currentWorkflow;
         final blockedFlow = initial.steamSettings.flow + 1;
         final settingsSteamFlow = initial.steamSettings.flow + 2;
@@ -1410,7 +1468,7 @@ void main() {
     test(
       'machine replacement cannot split one settings request across old and new machines',
       () async {
-        await _settleHandler();
+        await _settleHandler(spy);
         final initial = workflowController.currentWorkflow;
         final steamFlow = initial.steamSettings.flow + 1;
         final hotWaterFlow = initial.hotWaterData.flow + 1;
@@ -1421,6 +1479,7 @@ void main() {
         spy.failSteamFlow = steamFlow;
         spy.steamFlowEntered = entered;
         spy.steamFlowRelease = release;
+        spy.writeOrder.clear();
 
         final settingsFuture = postSettings({
           'flushTemp': flushTemp,
@@ -1449,15 +1508,17 @@ void main() {
         await de1Controller.connectToDe1(replacement);
         expect(completed, isFalse);
         replacement.setReady(true);
+        replacement.writeOrder.clear();
 
         final response = await settingsFuture.timeout(
           const Duration(seconds: 3),
         );
         expect(response.statusCode, 202);
-        // The replacement receives the complete grouped write; the old
-        // machine's writes stop at the failed steam write (nothing after
-        // the disconnect reached it).
-        expect(replacement.writeOrder, [
+        // The replacement receives the complete grouped write (its own
+        // startup fan write precedes it); the old machine's writes stop
+        // at the failed steam write (nothing after the disconnect
+        // reached it).
+        expect(replacement.writeOrder.sublist(1), [
           'flushTemp:${flushTemp.toDouble()}',
           'hotWater:$hotWaterFlow',
           'steam:$steamFlow',
@@ -1466,6 +1527,298 @@ void main() {
           'flushTemp:${flushTemp.toDouble()}',
           'hotWater:$hotWaterFlow',
           'steam:$steamFlow',
+        ]);
+        await replacement.dispose();
+      },
+    );
+
+    test(
+      'a successful settings request publishes each changed flow exactly once',
+      () async {
+        await _settleHandler(spy);
+        final initial = workflowController.currentWorkflow;
+        final steamFlow = initial.steamSettings.flow + 2;
+        final hotWaterFlow = initial.hotWaterData.flow + 1;
+        final flushFlow = initial.rinseData.flow + 1;
+
+        final steamEmits = <double>[];
+        final hotWaterEmits = <double>[];
+        final flushEmits = <double>[];
+        final steamSub = de1Controller.steamData
+            .map((e) => e.flow)
+            .listen(steamEmits.add);
+        final hotWaterSub = de1Controller.hotWaterData
+            .map((e) => e.flow)
+            .listen(hotWaterEmits.add);
+        final flushSub = de1Controller.rinseData
+            .map((e) => e.flow)
+            .listen(flushEmits.add);
+
+        final response = await postSettings({
+          'steamFlow': steamFlow,
+          'hotWaterFlow': hotWaterFlow,
+          'flushFlow': flushFlow,
+        });
+        expect(response.statusCode, 202);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(steamEmits.where((f) => f == steamFlow).length, 1);
+        expect(hotWaterEmits.where((f) => f == hotWaterFlow).length, 1);
+        expect(flushEmits.where((f) => f == flushFlow).length, 1);
+        await steamSub.cancel();
+        await hotWaterSub.cancel();
+        await flushSub.cancel();
+      },
+    );
+
+    test(
+      'no flow publication occurs before a replacement retry succeeds',
+      () async {
+        await _settleHandler(spy);
+        final initial = workflowController.currentWorkflow;
+        final steamFlow = initial.steamSettings.flow + 2;
+        final entered = Completer<void>();
+        final release = Completer<void>();
+        spy.blockedSteamFlow = steamFlow;
+        spy.steamFlowEntered = entered;
+        spy.steamFlowRelease = release;
+
+        final steamEmits = <double>[];
+        final steamSub = de1Controller.steamData
+            .map((e) => e.flow)
+            .listen(steamEmits.add);
+
+        final settingsFuture = postSettings({'steamFlow': steamFlow});
+        await entered.future.timeout(const Duration(seconds: 2));
+
+        // The machine disconnects mid-write; the request now waits for a
+        // replacement. No stream may publish the requested value yet.
+        spy.setConnectionState(ConnectionState.disconnected);
+        release.complete();
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(steamEmits.where((f) => f == steamFlow), isEmpty);
+
+        final replacement = SpyDe1(readyState: false);
+        await de1Controller.connectToDe1(replacement);
+        replacement.setReady(true);
+        final response = await settingsFuture.timeout(
+          const Duration(seconds: 3),
+        );
+        expect(response.statusCode, 202);
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(steamEmits.where((f) => f == steamFlow).length, 1);
+        await steamSub.cancel();
+        await replacement.dispose();
+      },
+    );
+
+    test('no flow publication occurs when replacement waiting fails', () async {
+      final shortSpy = SpyDe1();
+      final shortController = De1Controller(
+        controller: deviceController,
+        machineReplacementTimeout: const Duration(milliseconds: 100),
+      );
+      await shortController.connectToDe1(shortSpy);
+      await Future<void>.delayed(Duration.zero);
+      final mockSettings = MockSettingsService();
+      final settingsController = SettingsController(mockSettings);
+      await settingsController.loadSettings();
+      final shortDe1Handler = De1Handler(
+        controller: shortController,
+        settingsController: settingsController,
+        scaleController: TestScaleController(TestScale()),
+        workflowController: WorkflowController(),
+      );
+      final shortApp = Router().plus;
+      shortDe1Handler.addRoutes(shortApp);
+      final shortCall = shortApp.call;
+
+      final initial = WorkflowController().currentWorkflow;
+      final steamFlow = initial.steamSettings.flow + 2;
+      final entered = Completer<void>();
+      final release = Completer<void>();
+      shortSpy.blockedSteamFlow = steamFlow;
+      shortSpy.steamFlowEntered = entered;
+      shortSpy.steamFlowRelease = release;
+
+      final steamEmits = <double>[];
+      final steamSub = shortController.steamData
+          .map((e) => e.flow)
+          .listen(steamEmits.add);
+
+      final settingsFuture = () async {
+        return await shortCall(
+          Request(
+            'POST',
+            Uri.parse('http://localhost/api/v1/machine/settings'),
+            body: jsonEncode({'steamFlow': steamFlow}),
+            headers: {'content-type': 'application/json'},
+          ),
+        );
+      }();
+      await entered.future.timeout(const Duration(seconds: 2));
+
+      shortSpy.setConnectionState(ConnectionState.disconnected);
+      release.complete();
+
+      final response = await settingsFuture.timeout(const Duration(seconds: 5));
+      expect(response.statusCode, 503);
+      expect(steamEmits.where((f) => f == steamFlow), isEmpty);
+      await steamSub.cancel();
+      await shortController.dispose();
+      await shortSpy.dispose();
+    });
+
+    test('malformed JSON in a settings request returns 400', () async {
+      final response = await settingsHandler(
+        Request(
+          'POST',
+          Uri.parse('http://localhost/api/v1/machine/settings'),
+          body: '{not json',
+          headers: {'content-type': 'application/json'},
+        ),
+      );
+      expect(response.statusCode, 400);
+    });
+  });
+
+  group('DELETE /api/v1/machine/settings/reset — shared write queue', () {
+    late Handler resetHandler;
+
+    setUp(() async {
+      final mockSettings = MockSettingsService();
+      final settingsController = SettingsController(mockSettings);
+      await settingsController.loadSettings();
+      final de1Handler = De1Handler(
+        controller: de1Controller,
+        settingsController: settingsController,
+        scaleController: TestScaleController(TestScale()),
+        workflowController: workflowController,
+      );
+      final app = Router().plus;
+      de1Handler.addRoutes(app);
+      resetHandler = app.call;
+    });
+
+    Future<Response> deleteReset() async => await resetHandler(
+      Request(
+        'DELETE',
+        Uri.parse('http://localhost/api/v1/machine/settings/reset'),
+      ),
+    );
+
+    test(
+      'a reset cannot interleave with another queued machine write',
+      () async {
+        await _settleHandler(spy);
+        final initial = workflowController.currentWorkflow;
+        final blockedFlow = initial.steamSettings.flow + 1;
+        final laterSteamFlow = initial.steamSettings.flow + 2;
+        final entered = Completer<void>();
+        final release = Completer<void>();
+        spy.blockedSteamFlow = blockedFlow;
+        spy.steamFlowEntered = entered;
+        spy.steamFlowRelease = release;
+        spy.writeOrder.clear();
+
+        // Workflow PUT A blocks the queue.
+        final firstFuture = put({
+          'steamSettings': {'flow': blockedFlow},
+        });
+        await entered.future.timeout(const Duration(seconds: 2));
+
+        // Reset DELETE B and workflow PUT C queue behind it.
+        final resetFuture = deleteReset();
+        final laterFuture = put({
+          'steamSettings': {'flow': laterSteamFlow},
+        });
+
+        release.complete();
+        final responses = await Future.wait([
+          firstFuture,
+          resetFuture,
+          laterFuture,
+        ]).timeout(const Duration(seconds: 3));
+
+        expect(responses[0].statusCode, 200);
+        expect(responses[1].statusCode, 202);
+        expect(responses[2].statusCode, 200);
+        // The complete reset sequence is contiguous between the two
+        // workflow steam writes: no field of the reset may be split off
+        // by another queue entry.
+        expect(spy.writeOrder, [
+          'steam:$blockedFlow',
+          'fan:55',
+          'heaterIdleTemp:95.0',
+          'heaterPh1:2.0',
+          'heaterPh2:4.0',
+          'heaterPh2Timeout:4.0',
+          'refillKit:De1RefillKitSettings.auto',
+          'flowEstimation:1.0',
+          'steamPurgeMode:0',
+          'steam:$laterSteamFlow',
+        ]);
+      },
+    );
+
+    test(
+      'machine replacement cannot split a reset across old and new machines',
+      () async {
+        await _settleHandler(spy);
+        final entered = Completer<void>();
+        final release = Completer<void>();
+        spy.blockedHeaterPhase2Flow = 4.0;
+        spy.failHeaterPhase2Flow = 4.0;
+        spy.heaterPhase2FlowEntered = entered;
+        spy.heaterPhase2FlowRelease = release;
+        spy.writeOrder.clear();
+
+        final resetFuture = deleteReset();
+        await entered.future.timeout(const Duration(seconds: 2));
+        expect(spy.setFanThreshholdCalls, [55, 55]); // startup + reset
+        expect(spy.setHeaterIdleTempCalls, [95]);
+        expect(spy.setHeaterPhase1FlowCalls, [2.0]);
+
+        // The machine disconnects while the reset write is blocked; the
+        // controller now has no machine.
+        spy.setConnectionState(ConnectionState.disconnected);
+        await Future<void>.delayed(Duration.zero);
+        expect(de1Controller.connectedDe1OrNull, isNull);
+        release.complete();
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        var completed = false;
+        unawaited(resetFuture.then((_) => completed = true));
+        expect(completed, isFalse);
+
+        // Attach the replacement only after the old write finished.
+        final replacement = SpyDe1(readyState: false);
+        await de1Controller.connectToDe1(replacement);
+        replacement.setReady(true);
+        replacement.writeOrder.clear();
+
+        final response = await resetFuture.timeout(const Duration(seconds: 3));
+        expect(response.statusCode, 202);
+        // The replacement receives the complete reset (its own startup
+        // fan write is the first entry, then the full reset sequence);
+        // the old machine never receives the writes after the failed
+        // heater phase-2 write.
+        expect(replacement.writeOrder.sublist(1), [
+          'fan:55',
+          'heaterIdleTemp:95.0',
+          'heaterPh1:2.0',
+          'heaterPh2:4.0',
+          'heaterPh2Timeout:4.0',
+          'refillKit:De1RefillKitSettings.auto',
+          'flowEstimation:1.0',
+          'steamPurgeMode:0',
+        ]);
+        expect(spy.writeOrder, [
+          'fan:55',
+          'heaterIdleTemp:95.0',
+          'heaterPh1:2.0',
+          'heaterPh2:4.0',
         ]);
         await replacement.dispose();
       },

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -761,16 +761,48 @@ void main() {
     );
 
     test(
+      'a concurrent controller mutation survives a blocked REST apply',
+      () async {
+        await _settleHandler();
+        final initial = workflowController.currentWorkflow;
+        final nextFlow = initial.steamSettings.flow + 1;
+        final entered = Completer<void>();
+        final release = Completer<void>();
+        spy.blockedSteamFlow = nextFlow;
+        spy.steamFlowEntered = entered;
+        spy.steamFlowRelease = release;
+
+        final future = put({
+          'steamSettings': {'flow': nextFlow},
+        });
+        await entered.future.timeout(const Duration(seconds: 2));
+
+        workflowController.setWorkflow(
+          initial.copyWith(name: 'Concurrent workflow'),
+        );
+        release.complete();
+
+        final response = await future.timeout(const Duration(seconds: 2));
+        expect(response.statusCode, 200);
+        expect(workflowController.currentWorkflow.name, 'Concurrent workflow');
+        expect(workflowController.currentWorkflow.steamSettings.flow, nextFlow);
+        expect(spy.setSteamFlowCalls, [nextFlow, nextFlow]);
+      },
+    );
+
+    test(
       'request order is reserved before a streamed body completes',
       () async {
         await _settleHandler();
         final body = StreamController<List<int>>();
-        final firstFuture = handler(
-          Request(
-            'PUT',
-            Uri.parse('http://localhost/api/v1/workflow'),
-            body: body.stream,
-            headers: {'content-type': 'application/json'},
+        final firstFuture = Future<Response>.sync(
+          () => handler(
+            Request(
+              'PUT',
+              Uri.parse('http://localhost/api/v1/workflow'),
+              body: body.stream,
+              headers: {'content-type': 'application/json'},
+            ),
           ),
         );
         final secondFuture = put({'name': 'second'});

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/controllers/workflow_device_sync.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/firmware_update_state.dart';
@@ -28,7 +29,7 @@ import '../helpers/mock_device_discovery_service.dart';
 /// read-modify-write races on the controller surface reproduce here
 /// exactly like they do on the running app.
 class SpyDe1 implements De1Interface {
-  SpyDe1({De1ShotSettings? seed}) {
+  SpyDe1({De1ShotSettings? seed, this.readyState = true}) {
     _shotSettings = BehaviorSubject.seeded(
       seed ??
           De1ShotSettings(
@@ -45,6 +46,7 @@ class SpyDe1 implements De1Interface {
   }
 
   late final BehaviorSubject<De1ShotSettings> _shotSettings;
+  final bool readyState;
 
   final List<De1ShotSettings> updateShotSettingsCalls = [];
   final List<Profile> setProfileCalls = [];
@@ -181,7 +183,7 @@ class SpyDe1 implements De1Interface {
   @override
   Future<void> requestState(MachineState newState) async {}
   @override
-  Stream<bool> get ready => Stream.value(true);
+  Stream<bool> get ready => Stream.value(readyState);
   @override
   Stream<De1WaterLevels> get waterLevels => const Stream.empty();
   @override
@@ -702,6 +704,68 @@ void main() {
       },
     );
 
+    test('a workflow PUT retries on a replacement machine', () async {
+      await _settleHandler();
+      final nextFlow =
+          workflowController.currentWorkflow.steamSettings.flow + 1;
+      final entered = Completer<void>();
+      final release = Completer<void>();
+      spy.blockedSteamFlow = nextFlow;
+      spy.steamFlowEntered = entered;
+      spy.steamFlowRelease = release;
+
+      final future = put({
+        'steamSettings': {'flow': nextFlow},
+      });
+      await entered.future.timeout(const Duration(seconds: 2));
+
+      final replacement = SpyDe1(readyState: false);
+      await de1Controller.connectToDe1(replacement);
+      release.complete();
+
+      final response = await future.timeout(const Duration(seconds: 2));
+      expect(response.statusCode, 200);
+      expect(replacement.setSteamFlowCalls, [nextFlow]);
+      expect(workflowController.currentWorkflow.steamSettings.flow, nextFlow);
+      await replacement.dispose();
+    });
+
+    test('profile sync waits behind a workflow device write', () async {
+      await _settleHandler();
+      final sync = WorkflowDeviceSync(
+        workflowController: workflowController,
+        de1Controller: de1Controller,
+      );
+      addTearDown(sync.dispose);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      spy.setProfileCalls.clear();
+      final nextFlow =
+          workflowController.currentWorkflow.steamSettings.flow + 1;
+      final entered = Completer<void>();
+      final release = Completer<void>();
+      spy.blockedSteamFlow = nextFlow;
+      spy.steamFlowEntered = entered;
+      spy.steamFlowRelease = release;
+
+      final future = put({
+        'steamSettings': {'flow': nextFlow},
+      });
+      await entered.future.timeout(const Duration(seconds: 2));
+      final initial = workflowController.currentWorkflow;
+      final profile = Profile.fromJson({
+        ...initial.profile.toJson(),
+        'title': 'Queued profile',
+      });
+      workflowController.setWorkflow(initial.copyWith(profile: profile));
+      await Future<void>.delayed(Duration.zero);
+      expect(spy.setProfileCalls, isEmpty);
+
+      release.complete();
+      expect((await future).statusCode, 200);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(spy.setProfileCalls, [profile]);
+    });
+
     test('a failed workflow PUT does not poison later queue entries', () async {
       await _settleHandler();
       final initial = workflowController.currentWorkflow;
@@ -905,6 +969,103 @@ void main() {
         }
       },
     );
+
+    test('an oversized workflow body returns 413', () async {
+      final limitedHandler = WorkflowHandler(
+        controller: workflowController,
+        de1controller: de1Controller,
+        maxBodyBytes: 16,
+      );
+      final limitedApp = Router().plus;
+      limitedHandler.addRoutes(limitedApp);
+
+      final response = await limitedApp.call(
+        Request(
+          'PUT',
+          Uri.parse('http://localhost/api/v1/workflow'),
+          body: jsonEncode({'name': 'this body is too large'}),
+          headers: {'content-type': 'application/json'},
+        ),
+      );
+
+      expect(response.statusCode, 413);
+    });
+
+    test('workflow queue rejects excess requests with 429', () async {
+      final limitedHandler = WorkflowHandler(
+        controller: workflowController,
+        de1controller: de1Controller,
+        maxPendingRequests: 1,
+      );
+      final limitedApp = Router().plus;
+      limitedHandler.addRoutes(limitedApp);
+      final body = StreamController<List<int>>();
+      final first = limitedApp.call(
+        Request(
+          'PUT',
+          Uri.parse('http://localhost/api/v1/workflow'),
+          body: body.stream,
+          headers: {'content-type': 'application/json'},
+        ),
+      );
+
+      final rejected = await limitedApp.call(
+        Request(
+          'PUT',
+          Uri.parse('http://localhost/api/v1/workflow'),
+          body: jsonEncode({'name': 'rejected'}),
+          headers: {'content-type': 'application/json'},
+        ),
+      );
+      expect(rejected.statusCode, 429);
+
+      body.add(utf8.encode(jsonEncode({'name': 'accepted'})));
+      await body.close();
+      expect((await first).statusCode, 200);
+    });
+
+    test('an expired queued workflow PUT is skipped with 503', () async {
+      final limitedHandler = WorkflowHandler(
+        controller: workflowController,
+        de1controller: de1Controller,
+        queueWaitTimeout: const Duration(milliseconds: 20),
+      );
+      final limitedApp = Router().plus;
+      limitedHandler.addRoutes(limitedApp);
+      final initial = workflowController.currentWorkflow;
+      final blockedFlow = initial.steamSettings.flow + 1;
+      final entered = Completer<void>();
+      final release = Completer<void>();
+      spy.blockedSteamFlow = blockedFlow;
+      spy.steamFlowEntered = entered;
+      spy.steamFlowRelease = release;
+
+      final first = limitedApp.call(
+        Request(
+          'PUT',
+          Uri.parse('http://localhost/api/v1/workflow'),
+          body: jsonEncode({
+            'steamSettings': {'flow': blockedFlow},
+          }),
+          headers: {'content-type': 'application/json'},
+        ),
+      );
+      await entered.future.timeout(const Duration(seconds: 2));
+      final expired = await limitedApp.call(
+        Request(
+          'PUT',
+          Uri.parse('http://localhost/api/v1/workflow'),
+          body: jsonEncode({'name': 'expired'}),
+          headers: {'content-type': 'application/json'},
+        ),
+      );
+
+      expect(expired.statusCode, 503);
+      release.complete();
+      expect((await first).statusCode, 200);
+      await Future<void>.delayed(Duration.zero);
+      expect(workflowController.currentWorkflow.name, initial.name);
+    });
 
     test(
       'malformed or non-object JSON returns 400 without poisoning the queue',

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -980,7 +980,7 @@ void main() {
         final stalledResponse = await stalledFuture.timeout(
           const Duration(seconds: 2),
         );
-        expect(stalledResponse.statusCode, 500);
+        expect(stalledResponse.statusCode, 408);
         await cancelled.future.timeout(const Duration(seconds: 2));
         expect(body.hasListener, isFalse);
         final nextResponse = await put({'name': 'after body timeout'});

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -16,10 +16,15 @@ import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/services/webserver/workflow_handler.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
 import '../helpers/mock_device_discovery_service.dart';
+import '../helpers/mock_settings_service.dart';
+import '../helpers/test_scale.dart';
+import '../helpers/test_scale_controller.dart';
 
 /// Observes every call the WorkflowHandler + De1Controller make on the
 /// DE1 surface. Used to pin the contract down to the device boundary.
@@ -59,6 +64,11 @@ class SpyDe1 implements De1Interface {
   final List<double> steamFlowEntryOrder = [];
   final List<double> steamFlowCompletionOrder = [];
 
+  /// Ordered trace of every physical flow/register write this spy
+  /// received, used to prove that one request's writes stay contiguous
+  /// (no interleaving from another queue entry).
+  final List<String> writeOrder = [];
+
   double? blockedSteamFlow;
   Completer<void>? steamFlowEntered;
   Completer<void>? steamFlowRelease;
@@ -89,6 +99,7 @@ class SpyDe1 implements De1Interface {
   Future<void> setSteamFlow(double newFlow) async {
     steamFlowEntryOrder.add(newFlow);
     setSteamFlowCalls.add(newFlow);
+    writeOrder.add('steam:$newFlow');
     if (newFlow == blockedSteamFlow) {
       if (!(steamFlowEntered?.isCompleted ?? true)) {
         steamFlowEntered!.complete();
@@ -105,21 +116,32 @@ class SpyDe1 implements De1Interface {
   @override
   Future<void> setHotWaterFlow(double newFlow) async {
     setHotWaterFlowCalls.add(newFlow);
+    writeOrder.add('hotWater:$newFlow');
   }
 
   @override
   Future<void> setFlushFlow(double newFlow) async {
     setFlushFlowCalls.add(newFlow);
+    writeOrder.add('flush:$newFlow');
   }
 
   @override
   Future<void> setFlushTimeout(double newTimeout) async {
     setFlushTimeoutCalls.add(newTimeout);
+    writeOrder.add('flushTimeout:$newTimeout');
   }
 
   @override
   Future<void> setFlushTemperature(double newTemp) async {
     setFlushTemperatureCalls.add(newTemp);
+    writeOrder.add('flushTemp:$newTemp');
+  }
+
+  /// Drive the connection-state stream; a `disconnected` emission makes
+  /// `De1Controller` run `_onDisconnect()` (generation bump, machine
+  /// cleared), which is how tests model a real disconnect gap.
+  void setConnectionState(ConnectionState state) {
+    _connectionState.add(state);
   }
 
   // ---- Uninteresting plumbing ----
@@ -708,42 +730,55 @@ void main() {
       },
     );
 
-    test('a workflow PUT retries on a replacement machine', () async {
-      await _settleHandler();
-      final initial = workflowController.currentWorkflow;
-      final defaultFlow = initial.steamSettings.flow;
-      final nextFlow = defaultFlow + 1;
-      de1Controller.defaultWorkflow = initial;
-      final entered = Completer<void>();
-      final release = Completer<void>();
-      spy.blockedSteamFlow = nextFlow;
-      spy.steamFlowEntered = entered;
-      spy.steamFlowRelease = release;
+    test(
+      'a workflow PUT retries on a replacement attached after a disconnected gap',
+      () async {
+        await _settleHandler();
+        final initial = workflowController.currentWorkflow;
+        final defaultFlow = initial.steamSettings.flow;
+        final nextFlow = defaultFlow + 1;
+        de1Controller.defaultWorkflow = initial;
+        final entered = Completer<void>();
+        final release = Completer<void>();
+        spy.blockedSteamFlow = nextFlow;
+        spy.steamFlowEntered = entered;
+        spy.steamFlowRelease = release;
 
-      final future = put({
-        'steamSettings': {'flow': nextFlow},
-      });
-      await entered.future.timeout(const Duration(seconds: 2));
+        final future = put({
+          'steamSettings': {'flow': nextFlow},
+        });
+        await entered.future.timeout(const Duration(seconds: 2));
 
-      final replacement = SpyDe1(readyState: false);
-      await de1Controller.connectToDe1(replacement);
-      release.complete();
+        // The machine disconnects while the write is still blocked: the
+        // controller now has NO machine (a real disconnected interval).
+        spy.setConnectionState(ConnectionState.disconnected);
+        await Future<void>.delayed(Duration.zero);
+        expect(de1Controller.connectedDe1OrNull, isNull);
 
-      var completed = false;
-      unawaited(future.then((_) => completed = true));
-      await Future<void>.delayed(const Duration(milliseconds: 20));
-      expect(completed, isFalse);
-      expect(replacement.setSteamFlowCalls, isEmpty);
+        // Release the old write; it finishes on the old machine, but the
+        // generation has changed so the retry must wait for a replacement.
+        release.complete();
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        var completed = false;
+        unawaited(future.then((_) => completed = true));
+        expect(completed, isFalse);
 
-      replacement.setReady(true);
+        // Attach the replacement only after the old write finished.
+        final replacement = SpyDe1(readyState: false);
+        await de1Controller.connectToDe1(replacement);
+        expect(completed, isFalse);
+        expect(replacement.setSteamFlowCalls, isEmpty);
 
-      final response = await future.timeout(const Duration(seconds: 2));
-      expect(response.statusCode, 200);
-      expect(replacement.setSteamFlowCalls, [defaultFlow, nextFlow]);
-      expect(replacement.steamFlowCompletionOrder, [defaultFlow, nextFlow]);
-      expect(workflowController.currentWorkflow.steamSettings.flow, nextFlow);
-      await replacement.dispose();
-    });
+        replacement.setReady(true);
+
+        final response = await future.timeout(const Duration(seconds: 2));
+        expect(response.statusCode, 200);
+        expect(replacement.setSteamFlowCalls, [defaultFlow, nextFlow]);
+        expect(replacement.steamFlowCompletionOrder, [defaultFlow, nextFlow]);
+        expect(workflowController.currentWorkflow.steamSettings.flow, nextFlow);
+        await replacement.dispose();
+      },
+    );
 
     test('profile sync waits behind a workflow device write', () async {
       await _settleHandler();
@@ -1100,6 +1135,339 @@ void main() {
         final goodResponse = await put({'name': 'after invalid shape'});
         expect(goodResponse.statusCode, 200);
         expect(workflowController.currentWorkflow.name, 'after invalid shape');
+      },
+    );
+
+    test(
+      'an expired 503 request releases admission capacity while an earlier write remains blocked',
+      () async {
+        await _settleHandler();
+        final initial = workflowController.currentWorkflow;
+        final blockedFlow = initial.steamSettings.flow + 1;
+        final entered = Completer<void>();
+        final release = Completer<void>();
+        spy.blockedSteamFlow = blockedFlow;
+        spy.steamFlowEntered = entered;
+        spy.steamFlowRelease = release;
+
+        final expiringHandler = WorkflowHandler(
+          controller: workflowController,
+          de1controller: de1Controller,
+          queueWaitTimeout: const Duration(milliseconds: 100),
+        );
+        final expiringApp = Router().plus;
+        expiringHandler.addRoutes(expiringApp);
+        final expiringCall = expiringApp.call;
+        Future<Response> expPut(Map<String, dynamic> body) async {
+          return await expiringCall(
+            Request(
+              'PUT',
+              Uri.parse('http://localhost/api/v1/workflow'),
+              body: jsonEncode(body),
+              headers: {'content-type': 'application/json'},
+            ),
+          );
+        }
+
+        // Block the queue with the first mutation.
+        final firstFuture = expPut({
+          'steamSettings': {'flow': blockedFlow},
+        });
+        await entered.future.timeout(const Duration(seconds: 2));
+
+        // A second request expires with 503 and must release its slot
+        // immediately even though its queue entry never reaches the
+        // front (the first write is still blocked).
+        final expiredResponse = await expPut({
+          'steamSettings': {'flow': blockedFlow + 1},
+        });
+        expect(expiredResponse.statusCode, 503);
+
+        // maxPendingRequests is 8. With the expired slot released, seven
+        // further requests are admitted (each 503 after its own wait); if
+        // the expired slot had leaked, the seventh would be rejected 429.
+        for (var i = 0; i < 7; i++) {
+          final response = await expPut({
+            'steamSettings': {'flow': blockedFlow + 2 + i},
+          });
+          expect(response.statusCode, 503, reason: 'request $i must not 429');
+        }
+
+        release.complete();
+        expect((await firstFuture).statusCode, 200);
+      },
+    );
+
+    test(
+      'a workflow PUT returns 503 when no replacement appears within the bounded wait',
+      () async {
+        final shortSpy = SpyDe1();
+        final shortWaitController = De1Controller(
+          controller: deviceController,
+          machineReplacementTimeout: const Duration(milliseconds: 100),
+        );
+        await shortWaitController.connectToDe1(shortSpy);
+        final shortWorkflowController = WorkflowController();
+        final shortHandler = WorkflowHandler(
+          controller: shortWorkflowController,
+          de1controller: shortWaitController,
+        );
+        final shortApp = Router().plus;
+        shortHandler.addRoutes(shortApp);
+        final shortCall = shortApp.call;
+
+        final initial = shortWorkflowController.currentWorkflow;
+        final nextFlow = initial.steamSettings.flow + 1;
+        final entered = Completer<void>();
+        final release = Completer<void>();
+        shortSpy.blockedSteamFlow = nextFlow;
+        shortSpy.steamFlowEntered = entered;
+        shortSpy.steamFlowRelease = release;
+
+        final future = () async {
+          return await shortCall(
+            Request(
+              'PUT',
+              Uri.parse('http://localhost/api/v1/workflow'),
+              body: jsonEncode({
+                'steamSettings': {'flow': nextFlow},
+              }),
+              headers: {'content-type': 'application/json'},
+            ),
+          );
+        }();
+        await entered.future.timeout(const Duration(seconds: 2));
+
+        // The machine disconnects mid-write and no replacement ever
+        // appears within the bounded wait.
+        shortSpy.setConnectionState(ConnectionState.disconnected);
+        release.complete();
+
+        final response = await future.timeout(const Duration(seconds: 5));
+        expect(response.statusCode, 503);
+        expect(
+          shortWorkflowController.currentWorkflow.steamSettings.flow,
+          initial.steamSettings.flow,
+          reason: 'workflow must not be committed without a machine',
+        );
+        await shortWaitController.dispose();
+        await shortSpy.dispose();
+      },
+    );
+  });
+
+  group('PUT /api/v1/workflow — stop-at-temperature guarantee', () {
+    test(
+      'a stopAtTemperature-only PUT causes no DE1 steam-setting write while preserving the workflow value',
+      () async {
+        await _settleHandler();
+        spy.updateShotSettingsCalls.clear();
+        spy.setSteamFlowCalls.clear();
+        spy.setHotWaterFlowCalls.clear();
+        spy.setFlushFlowCalls.clear();
+        spy.setFlushTimeoutCalls.clear();
+        spy.setFlushTemperatureCalls.clear();
+
+        final response = await put({
+          'steamSettings': {'stopAtTemperature': 60},
+        });
+
+        expect(response.statusCode, 200);
+        expect(
+          workflowController.currentWorkflow.steamSettings.stopAtTemperature,
+          60,
+        );
+        expect(spy.updateShotSettingsCalls, isEmpty);
+        expect(spy.setSteamFlowCalls, isEmpty);
+        expect(spy.setHotWaterFlowCalls, isEmpty);
+        expect(spy.setFlushFlowCalls, isEmpty);
+        expect(spy.setFlushTimeoutCalls, isEmpty);
+        expect(spy.setFlushTemperatureCalls, isEmpty);
+      },
+    );
+
+    test(
+      'a stopAtTemperature-only PUT commits while no machine is connected',
+      () async {
+        final isolatedSpy = SpyDe1();
+        final isolatedController = De1Controller(controller: deviceController);
+        await isolatedController.connectToDe1(isolatedSpy);
+        await isolatedController.dispose();
+        final isolatedWorkflowController = WorkflowController();
+        final isolatedHandler = WorkflowHandler(
+          controller: isolatedWorkflowController,
+          de1controller: isolatedController,
+        );
+        final isolatedApp = Router().plus;
+        isolatedHandler.addRoutes(isolatedApp);
+
+        final response = await isolatedApp.call(
+          Request(
+            'PUT',
+            Uri.parse('http://localhost/api/v1/workflow'),
+            body: jsonEncode({
+              'steamSettings': {'stopAtTemperature': 65},
+            }),
+            headers: {'content-type': 'application/json'},
+          ),
+        );
+
+        expect(response.statusCode, 200);
+        expect(
+          isolatedWorkflowController
+              .currentWorkflow
+              .steamSettings
+              .stopAtTemperature,
+          65,
+        );
+        expect(isolatedSpy.updateShotSettingsCalls, isEmpty);
+        await isolatedSpy.dispose();
+      },
+    );
+  });
+
+  group('POST /api/v1/machine/settings — shared write queue', () {
+    late Handler settingsHandler;
+
+    setUp(() async {
+      final mockSettings = MockSettingsService();
+      final settingsController = SettingsController(mockSettings);
+      await settingsController.loadSettings();
+      final de1Handler = De1Handler(
+        controller: de1Controller,
+        settingsController: settingsController,
+        scaleController: TestScaleController(TestScale()),
+        workflowController: workflowController,
+      );
+      final app = Router().plus;
+      de1Handler.addRoutes(app);
+      settingsHandler = app.call;
+    });
+
+    Future<Response> postSettings(Map<String, dynamic> body) async {
+      return await settingsHandler(
+        Request(
+          'POST',
+          Uri.parse('http://localhost/api/v1/machine/settings'),
+          body: jsonEncode(body),
+          headers: {'content-type': 'application/json'},
+        ),
+      );
+    }
+
+    test(
+      'fields from one settings request cannot be interleaved with another device write',
+      () async {
+        await _settleHandler();
+        final initial = workflowController.currentWorkflow;
+        final blockedFlow = initial.steamSettings.flow + 1;
+        final settingsSteamFlow = initial.steamSettings.flow + 2;
+        final settingsHotWaterFlow = initial.hotWaterData.flow + 1;
+        final laterSteamFlow = initial.steamSettings.flow + 3;
+        final entered = Completer<void>();
+        final release = Completer<void>();
+        spy.blockedSteamFlow = blockedFlow;
+        spy.steamFlowEntered = entered;
+        spy.steamFlowRelease = release;
+        spy.writeOrder.clear();
+
+        // Workflow PUT A blocks the queue.
+        final firstFuture = put({
+          'steamSettings': {'flow': blockedFlow},
+        });
+        await entered.future.timeout(const Duration(seconds: 2));
+
+        // Settings POST B arrives while A is blocked, then workflow PUT C.
+        final settingsFuture = postSettings({
+          'steamFlow': settingsSteamFlow,
+          'hotWaterFlow': settingsHotWaterFlow,
+        });
+        final laterFuture = put({
+          'steamSettings': {'flow': laterSteamFlow},
+        });
+
+        release.complete();
+        final responses = await Future.wait([
+          firstFuture,
+          settingsFuture,
+          laterFuture,
+        ]).timeout(const Duration(seconds: 3));
+
+        expect(responses[0].statusCode, 200);
+        expect(responses[1].statusCode, 202);
+        expect(responses[2].statusCode, 200);
+        // B's two fields must be contiguous: no write from A or C may
+        // land between the hot-water and steam writes of one request.
+        expect(spy.writeOrder, [
+          'steam:$blockedFlow',
+          'hotWater:$settingsHotWaterFlow',
+          'steam:$settingsSteamFlow',
+          'steam:$laterSteamFlow',
+        ]);
+      },
+    );
+
+    test(
+      'machine replacement cannot split one settings request across old and new machines',
+      () async {
+        await _settleHandler();
+        final initial = workflowController.currentWorkflow;
+        final steamFlow = initial.steamSettings.flow + 1;
+        final hotWaterFlow = initial.hotWaterData.flow + 1;
+        final flushTemp = initial.rinseData.targetTemperature + 1;
+        final entered = Completer<void>();
+        final release = Completer<void>();
+        spy.blockedSteamFlow = steamFlow;
+        spy.failSteamFlow = steamFlow;
+        spy.steamFlowEntered = entered;
+        spy.steamFlowRelease = release;
+
+        final settingsFuture = postSettings({
+          'flushTemp': flushTemp,
+          'steamFlow': steamFlow,
+          'hotWaterFlow': hotWaterFlow,
+        });
+        await entered.future.timeout(const Duration(seconds: 2));
+        expect(spy.setFlushTemperatureCalls, [flushTemp]);
+        expect(spy.setHotWaterFlowCalls, [hotWaterFlow]);
+        expect(spy.setSteamFlowCalls, [steamFlow]);
+
+        // The machine disconnects while the settings write is blocked;
+        // the controller now has no machine.
+        spy.setConnectionState(ConnectionState.disconnected);
+        await Future<void>.delayed(Duration.zero);
+        expect(de1Controller.connectedDe1OrNull, isNull);
+        release.complete();
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        var completed = false;
+        unawaited(settingsFuture.then((_) => completed = true));
+        expect(completed, isFalse);
+
+        // Attach the replacement only after the old write finished.
+        final replacement = SpyDe1(readyState: false);
+        await de1Controller.connectToDe1(replacement);
+        expect(completed, isFalse);
+        replacement.setReady(true);
+
+        final response = await settingsFuture.timeout(
+          const Duration(seconds: 3),
+        );
+        expect(response.statusCode, 202);
+        // The replacement receives the complete grouped write; the old
+        // machine's writes stop at the failed steam write (nothing after
+        // the disconnect reached it).
+        expect(replacement.writeOrder, [
+          'flushTemp:${flushTemp.toDouble()}',
+          'hotWater:$hotWaterFlow',
+          'steam:$steamFlow',
+        ]);
+        expect(spy.writeOrder, [
+          'flushTemp:${flushTemp.toDouble()}',
+          'hotWater:$hotWaterFlow',
+          'steam:$steamFlow',
+        ]);
+        await replacement.dispose();
       },
     );
   });


### PR DESCRIPTION
## Summary

- Problem: Workflow PUT requests could publish controller state before required device writes completed, a concurrent non-REST workflow change could be overwritten by a stale REST snapshot, and direct machine writes could interleave between a grouped workflow read and its final commit. `stopAtTemperature` changes triggered direct DE1 writes even though the Bengle bridge owns that setting, an unready or replaced machine could stall or strand the request queue, and `MockDe1.setHeaterPhase2Timeout()` simulated a machine disconnect as a debugging artifact (with no firmware basis), which justified a queue bypass for the settings reset and false claims in docs.
- What changed:
  - **Serialized device-write queue**: `De1Controller.runDeviceWrite()` serializes all REST machine writes behind one queue. Workflow PUTs, profile, shotSettings, machine settings, settings/advanced, settings/reset, calibration, waterLevels, cupWarmer, and the ledStrip routes all write through it. Documented bypasses: `PUT /api/v1/machine/state/<newState>` (latency-sensitive commands; a stop must not queue behind a settings write) and raw low-level WS commands.
  - **Independent FIFO**: One HTTP request = one queue entry; no server-side debounce or coalescing.
  - **Revision/CAS rebasing**: concurrent controller changes re-read and retry inside the same mutation slot; the commit cannot clobber a newer state.
  - **Stop-at-temperature guarantee**: `SteamSettings.stopAtTemperature` is owned by the Bengle steam-stop bridge; only `targetTemperature`, `duration`, and `flow` changes write to the DE1. A `stopAtTemperature`-only PUT commits with no DE1 write, even with no machine connected.
  - **Admission accounting**: max 8 active/queued requests (429); an expired 503 request releases its slot immediately and exactly once, even before its skipped queue entry reaches the front.
  - **Timeouts**: body read 30 s (408), body size 1 MiB (413), queue wait 30 s (503), replacement wait 10 s (503).
  - **Disconnect-to-replacement gap**: machine acquisition lives inside the retry loop. When the generation changes mid-write, the retry waits (bounded) for a non-null replacement and its startup initialization, then re-runs the complete grouped operation from the start on the replacement. An in-flight native write cannot be cancelled: the old machine may receive a partial or complete attempt; only after it finishes does the post-write generation check reject it. The old machine is never acquired for a new write after the generation change. No replacement within the bound → 503, workflow not committed. First-attempt no-machine behavior is unchanged (500).
  - **Publish only after final success**: `POST /api/v1/machine/settings` is one controller-owned grouped operation (`updateMachineSettings`); flow streams are published only after the grouped write and its final machine-generation check succeed — each changed flow exactly once. A failed write, a machine change without a successful retry, or a 503 replacement timeout publishes nothing. The publish-only helpers are now private.
  - **Settings reset is queued**: `DELETE /api/v1/machine/settings/reset` is one shared queue entry; every write uses the device from the queue callback, and the complete reset retries on a replacement.
  - **`heaterPh2Timeout` is an ordinary MMR setting**: `MockDe1` stores and returns it like every other setting; the old disconnect/reconnect artifact is removed. Machine-disconnect simulation moved to a new simulate-only debug API: `MockDe1.simulateDisconnect()` + `POST /api/v1/debug/machine/disconnect` (200 on MockDe1, 400 with no/non-mock machine, 404 unknown command regardless of connection state).
  - **Malformed JSON → 400** in the rewritten machine handlers (was 500).
- What did NOT change: existing endpoint paths, request/response shapes, WebSocket behavior (#539 preserved and tested), Bengle bridge ownership. The only new endpoint is the simulate-only `POST /api/v1/debug/machine/disconnect`.

## Status Codes

| Code | Meaning |
|------|---------|
| 200 | Workflow updated and committed |
| 400 | Malformed or invalid JSON |
| 408 | Client did not finish sending the body within 30 s |
| 413 | Body exceeds 1 MiB |
| 429 | Eight requests already active or queued |
| 500 | A required direct machine write failed, or no machine was ever connected |
| 503 | Queue wait exceeded 30 s, or no replacement machine appeared within 10 s after a mid-write disconnect |

503 and 500 apply to every queued machine endpoint: workflow PUT, profile, shotSettings, settings, settings/advanced, settings/reset, calibration, waterLevels, cupWarmer, ledStrip, ledStrip/commit, ledStrip/reset. Body-bearing queued endpoints also return 400 for malformed JSON.

## Verification

### Local gates (all run on the final branch)

- [x] `dart format lib test` — clean
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 2690 tests passed, 0 failures
- [x] `flutter test test/webserver/workflow_handler_test.dart` — 34 passed
- [x] `flutter test test/services/webserver/debug_handler_test.dart` — 7 passed
- [x] `flutter test test/services/webserver/de1handler_settings_reset_test.dart` — 15 passed
- [x] `flutter test test/unit/devices/mock_de1_test.dart` — 2 passed
- [x] `flutter test test/webserver/de1handler_machine_swap_ws_test.dart` — 16 passed (#539 preserved)
- [x] `flutter test test/services/webserver/` — 290 passed (cup warmer, LED strip, settings reset, no-scale, debug, profile, feedback, presence, plugins)
- [x] `(cd packages/dye2-plugin && npm run build)` — built
- [x] `git diff --check` — clean
- [x] Both OpenAPI/AsyncAPI specs parse

### Regression tests added

1. Workflow PUT retries on a replacement attached only after a real disconnected gap; the replacement receives the complete write.
2. An expired 503 request releases admission capacity while an earlier write remains blocked (7 further requests admitted, none 429).
3. A workflow PUT returns 503 when no replacement appears within the bounded wait; the workflow is not committed.
4. `stopAtTemperature`-only PUT causes no DE1 steam-setting write (connected) and commits with no machine connected.
5. One `/api/v1/machine/settings` request cannot interleave with another device write; a machine replacement cannot split it across old and new machines (replacement gets the complete group).
6. A successful settings request publishes each changed flow exactly once; no flow publication occurs before a replacement retry succeeds; none occurs when replacement waiting fails (503).
7. `MockDe1.setHeaterPhase2Timeout` round-trips without changing connection state; `simulateDisconnect` emits disconnected explicitly.
8. `POST /api/v1/debug/machine/disconnect`: 200 + disconnect on MockDe1, 400 with no machine or non-MockDe1, 404 unknown command with and without a connected machine.
9. `POST /machine/settings/advanced` with `heaterPh2Timeout` succeeds without disconnecting the mock.
10. `DELETE /machine/settings/reset` applies the baseline defaults, cannot interleave with another queued write, and cannot split across old and replacement machines.

### Compatibility

- Independent FIFO: all bundled callers (`dye2-plugin` pickers, `decent-profile` plugin) issue single-shot PUTs; none depend on server-side coalescing.
- `POST /api/v1/machine/settings` keeps the same accepted fields and responses; fields are applied as one grouped serialized write instead of several.
- `DELETE /api/v1/machine/settings/reset` keeps its 202/500 responses; it is now queued and retryable.

## Risks

- Multi-step device writes may be partially applied before a failure; retrying re-attempts all requested settings.
- A machine that disconnects mid-write and returns a different instance causes the write to be re-run once on the replacement; a long-running write may therefore reach two machines, and the old machine may receive a partial or complete attempt before the generation check rejects it.
- The debug machine-disconnect endpoint is registered only in simulate mode; it cannot affect production hardware.
- No reset or disconnect behavior is documented for writing `heaterPh2Timeout` on real hardware; this PR neither relies on nor asserts any.