### PR TITLE
fix(sync): harden backup import status handling

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3870,10 +3870,12 @@ paths:
 
         Only the specified sections are synced. If no sections are provided,
         all available sections are synced. A partial local import or remote
-        import response is a partial phase. A fatal single phase returns 502;
-        two-way mode returns 207 when one phase is partial or when one phase is
-        fatal while the other completes or is partial. Two fatal phases return
-        502.
+        import response is a partial or failed phase. By default, two-way mode
+        skips push unless pull is complete. Set `bestEffort` to true to opt in
+        to continuing after an incomplete pull. A fatal single phase returns
+        502; two-way mode returns 207 when one phase is incomplete or fatal
+        while the other is complete, partial, failed, or skipped. Two fatal
+        phases return 502.
       tags: [Data Management]
       requestBody:
         required: true
@@ -3908,6 +3910,13 @@ paths:
                     type: string
                     enum: [profiles, shots, workflow, settings, store, beans, grinders]
                   description: Data sections to sync. Defaults to all sections if omitted.
+                bestEffort:
+                  type: boolean
+                  default: false
+                  description: |
+                    In two_way mode, continue with push after a partial,
+                    failed, or fatal pull. Defaults to false to avoid pushing
+                    stale local data after an unsuccessful pull.
       responses:
         "200":
           description: Sync completed successfully
@@ -3916,7 +3925,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/SyncResult"
         "207":
-          description: At least one phase is partial, or one two-way phase is fatal while the other completes or is partial
+          description: At least one phase is partial, failed, or skipped, or one two-way phase is fatal while the other completes or is incomplete
           content:
             application/json:
               schema:
@@ -5986,12 +5995,22 @@ components:
       properties:
         pull:
           type: object
-          description: Per-section results for the pull phase (present for pull and two_way modes)
+          description: Phase result for pull (present for pull and two_way modes)
+          properties:
+            phaseStatus:
+              type: string
+              enum: [complete, partial, failed, fatal, skipped]
+              description: Semantic status of the phase.
           additionalProperties:
             $ref: "#/components/schemas/SectionImportResult"
         push:
           type: object
-          description: Per-section results for the push phase (present for push and two_way modes)
+          description: Phase result for push (present for push and two_way modes)
+          properties:
+            phaseStatus:
+              type: string
+              enum: [complete, partial, failed, fatal, skipped]
+              description: Semantic status of the phase.
           additionalProperties:
             $ref: "#/components/schemas/SectionImportResult"
         error:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3872,10 +3872,11 @@ paths:
         all available sections are synced. A partial local import or remote
         import response is a partial or failed phase. By default, two-way mode
         skips push unless pull is complete. Set `bestEffort` to true to opt in
-        to continuing after an incomplete pull. A fatal single phase returns
-        502; two-way mode returns 207 when one phase is incomplete or fatal
-        while the other is complete, partial, failed, or skipped. Two fatal
-        phases return 502.
+        to continuing after an incomplete pull. A complete single-direction
+        operation returns 200, a partial operation returns 207, and a failed
+        or fatal operation returns 502. Two-way mode returns 207 only when at
+        least one phase is complete or partial; it returns 502 when every phase
+        is failed, fatal, or skipped.
       tags: [Data Management]
       requestBody:
         required: true
@@ -3925,7 +3926,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/SyncResult"
         "207":
-          description: At least one phase is partial, failed, or skipped, or one two-way phase is fatal while the other completes or is incomplete
+          description: A single phase is partial, or a two-way operation has at least one complete or partial phase and another incomplete phase
           content:
             application/json:
               schema:
@@ -3942,7 +3943,7 @@ paths:
                   message:
                     type: string
         "502":
-          description: Target Bridge unreachable or returned an error
+          description: Target Bridge unreachable or returned an error, or the requested phase failed without partial success
           content:
             application/json:
               schema:
@@ -5988,34 +5989,49 @@ components:
           items:
             type: string
           description: Warning messages (e.g., platform mismatch for device preferences)
+        status:
+          type: string
+          enum: [complete, partial, failed, skipped]
+          description: Semantic outcome of importing this section
 
     SyncResult:
       type: object
       description: Result of a data sync operation. Contains per-phase results keyed by direction.
       properties:
         pull:
-          type: object
           description: Phase result for pull (present for pull and two_way modes)
-          properties:
-            phaseStatus:
-              type: string
-              enum: [complete, partial, failed, fatal, skipped]
-              description: Semantic status of the phase.
-          additionalProperties:
-            $ref: "#/components/schemas/SectionImportResult"
+          $ref: "#/components/schemas/SyncPhaseResult"
         push:
-          type: object
           description: Phase result for push (present for push and two_way modes)
-          properties:
-            phaseStatus:
-              type: string
-              enum: [complete, partial, failed, fatal, skipped]
-              description: Semantic status of the phase.
-          additionalProperties:
-            $ref: "#/components/schemas/SectionImportResult"
+          $ref: "#/components/schemas/SyncPhaseResult"
+
+    SyncPhaseResult:
+      type: object
+      description: Result of one sync phase, including section results or phase-level failure details
+      properties:
+        phaseStatus:
+          type: string
+          enum: [complete, partial, failed, fatal, skipped]
+          description: Semantic status of the phase
+        message:
+          type: string
+          description: Human-readable phase result or skip reason
+        reason:
+          type: string
+          description: Machine-readable reason for a skipped phase
         error:
           type: string
-          description: Error message if a phase failed (present in 207 responses)
+          description: Phase-level error category
+        status:
+          type: integer
+          description: HTTP status returned by the target, when applicable
+        sections:
+          type: array
+          items:
+            type: string
+          description: Sections that could not be exported
+      additionalProperties:
+        $ref: "#/components/schemas/SectionImportResult"
 
     WorkflowContext:
       type: object

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3780,10 +3780,18 @@ paths:
       summary: Import app data from archive
       description: |
         Imports app data from a ZIP archive previously created by the export
-        endpoint. Each JSON file in the archive is processed independently —
-        missing files are skipped. Unknown files are ignored for forward
-        compatibility. Use the onConflict parameter to control how duplicate
-        records are handled.
+        endpoint. Each recognized JSON section is processed independently.
+        Missing sections are allowed, but the archive must contain at least one
+        recognized selected section. Unknown files and metadata.json alone do
+        not constitute an importable backup. Metadata is optional for legacy
+        archives without metadata.json, but is validated when present. Use the
+        onConflict parameter to control how duplicate records are handled.
+
+        A 200 response means every processed section completed without errors.
+        A 207 response means recognized sections were processed but at least
+        one section returned or encountered an error. Warnings and conflict
+        skips do not cause 207. Sections are not imported transactionally; a
+        successful section is not rolled back when another section fails.
       tags: [Data Management]
       parameters:
         - in: query
@@ -3805,11 +3813,13 @@ paths:
               format: binary
       responses:
         "200":
-          description: Import completed successfully
+          description: At least one recognized section was processed and all processed sections completed without errors
           content:
             application/json:
               schema:
                 type: object
+                additionalProperties:
+                  $ref: "#/components/schemas/SectionImportResult"
                 properties:
                   profiles:
                     $ref: "#/components/schemas/SectionImportResult"
@@ -3821,8 +3831,22 @@ paths:
                     $ref: "#/components/schemas/SectionImportResult"
                   store:
                     $ref: "#/components/schemas/SectionImportResult"
+                  steams:
+                    $ref: "#/components/schemas/SectionImportResult"
+                  beans:
+                    $ref: "#/components/schemas/SectionImportResult"
+                  grinders:
+                    $ref: "#/components/schemas/SectionImportResult"
+        "207":
+          description: Recognized sections were processed, but one or more sections contain errors
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: "#/components/schemas/SectionImportResult"
         "400":
-          description: Invalid archive, unsupported format version, or invalid onConflict value
+          description: Invalid ZIP, malformed or unsupported metadata, unknown requested selection, no recognized data sections, or invalid onConflict value
           content:
             application/json:
               schema:
@@ -3842,10 +3866,14 @@ paths:
         instance over the network. Supports three modes:
         - **pull**: imports data from the target into this instance
         - **push**: exports data from this instance to the target
-        - **two_way**: performs pull then push (returns 207 if one phase fails)
+        - **two_way**: performs pull then push
 
         Only the specified sections are synced. If no sections are provided,
-        all available sections are synced.
+        all available sections are synced. A partial local import or remote
+        import response is a partial phase. A fatal single phase returns 502;
+        two-way mode returns 207 when one phase is partial or when one phase is
+        fatal while the other completes or is partial. Two fatal phases return
+        502.
       tags: [Data Management]
       requestBody:
         required: true
@@ -3888,7 +3916,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/SyncResult"
         "207":
-          description: Partial success (two_way mode, one phase failed)
+          description: At least one phase is partial, or one two-way phase is fatal while the other completes or is partial
           content:
             application/json:
               schema:

--- a/assets/plugins/settings.reaplugin/plugin.js
+++ b/assets/plugins/settings.reaplugin/plugin.js
@@ -1334,11 +1334,18 @@ function createPlugin(host) {
                     headers: { 'Content-Type': 'application/zip' },
                     body: fileInput.files[0]
                 });
-                if (response.ok) {
+                const result = await response.json().catch(() => ({}));
+                if (response.status === 200) {
                     showToast('Data imported successfully');
                     setTimeout(() => location.reload(), 1000);
+                } else if (response.status === 207) {
+                    const errors = Object.values(result)
+                        .filter(section => section && Array.isArray(section.errors))
+                        .flatMap(section => section.errors);
+                    const detail = errors.length ? ': ' + errors.join('; ') : '';
+                    showToast('Data import partially completed' + detail, true);
                 } else {
-                    const error = await response.text();
+                    const error = result.message || result.error || ('Server returned ' + response.status);
                     showToast('Failed to import data: ' + error, true);
                 }
             } catch (e) {

--- a/assets/plugins/settings.reaplugin/plugin.js
+++ b/assets/plugins/settings.reaplugin/plugin.js
@@ -927,6 +927,12 @@ function createPlugin(host) {
                                 </select>
                             </div>
                         </div>
+                        <div class="setting-item">
+                            <label class="setting-label" for="syncBestEffort">Continue after incomplete pull</label>
+                            <div class="setting-control">
+                                <input type="checkbox" id="syncBestEffort">
+                            </div>
+                        </div>
                     </div>
                     <div style="margin-bottom: 10px;">
                         <span class="setting-label" style="display: block; margin-bottom: 8px;">Sections to sync:</span>
@@ -1359,6 +1365,7 @@ function createPlugin(host) {
 
             const mode = document.getElementById('syncMode').value;
             const onConflict = document.getElementById('syncConflict').value;
+            const bestEffort = document.getElementById('syncBestEffort').checked;
             const sectionCheckboxes = document.querySelectorAll('.sync-section:checked');
             const sections = Array.from(sectionCheckboxes).map(cb => cb.value);
 
@@ -1372,13 +1379,21 @@ function createPlugin(host) {
                 const response = await fetch(baseUrl + '/api/v1/data/sync', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ target, mode, onConflict, sections })
+                    body: JSON.stringify({ target, mode, onConflict, sections, bestEffort })
                 });
-                if (response.ok) {
-                    const result = await response.json();
+                const result = await response.json().catch(() => ({}));
+                if (response.status === 200) {
                     showToast('Sync completed successfully');
+                } else if (response.status === 207) {
+                    const errors = Object.values(result)
+                        .filter(phase => phase && typeof phase === 'object')
+                        .flatMap(phase => Object.values(phase))
+                        .filter(section => section && Array.isArray(section.errors))
+                        .flatMap(section => section.errors);
+                    const detail = errors.length ? ': ' + errors.join('; ') : '';
+                    showToast('Sync partially completed' + detail, true);
                 } else {
-                    const error = await response.text();
+                    const error = result.message || result.error || ('Server returned ' + response.status);
                     showToast('Sync failed: ' + error, true);
                 }
             } catch (e) {

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -30,7 +30,8 @@ Read this when changing REST endpoints, WebSocket topics, API specs, auth proxy,
 - `200` means all processed import sections completed without errors. Any section error, including a returned `SectionImportResult.errors` list, means `207`.
 - Section errors remain isolated so other recognized sections may import. Imports are not transactional and successful sections are not rolled back.
 - `DataImportOutcome` (or its equivalent) is the source of import completeness classification; clients must not infer it by reparsing the section response map.
-- Data sync preserves complete, partial, and fatal phase states. A remote import `207` is a partial push, not a target failure.
+- Section results serialize their `status` (`complete`, `partial`, `failed`, or `skipped`) alongside counts and messages.
+- Data sync preserves complete, partial, failed, fatal, and skipped phase states. A remote import `207` is a partial push, not a target failure. A fully failed single-direction phase returns `502`; two-way returns `207` only when at least one phase completes or partially completes.
 - Data sync classifies remote section errors from the response body even when a legacy peer returns HTTP `200`.
 - Two-way sync skips push after any non-complete pull unless the request explicitly sets `bestEffort: true`.
 - Export section failures are fatal and never produce a ZIP that silently omits a requested section.

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -31,6 +31,10 @@ Read this when changing REST endpoints, WebSocket topics, API specs, auth proxy,
 - Section errors remain isolated so other recognized sections may import. Imports are not transactional and successful sections are not rolled back.
 - `DataImportOutcome` (or its equivalent) is the source of import completeness classification; clients must not infer it by reparsing the section response map.
 - Data sync preserves complete, partial, and fatal phase states. A remote import `207` is a partial push, not a target failure.
+- Data sync classifies remote section errors from the response body even when a legacy peer returns HTTP `200`.
+- Two-way sync skips push after any non-complete pull unless the request explicitly sets `bestEffort: true`.
+- Export section failures are fatal and never produce a ZIP that silently omits a requested section.
+- Onboarding and settings clients must preserve successful counts and section errors for HTTP `207` imports.
 - UI clients must not collapse `207` into complete success.
 
 ## WebSocket Conventions

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -24,6 +24,15 @@ Read this when changing REST endpoints, WebSocket topics, API specs, auth proxy,
 - Content-based hash IDs for profile deduplication (`ProfileController`).
 - ETag / `If-None-Match` support on cacheable resources (#203).
 
+### Backup Import and Sync Invariants
+
+- A successful backup import requires at least one recognized selected payload; metadata alone is not payload.
+- `200` means all processed import sections completed without errors. Any section error, including a returned `SectionImportResult.errors` list, means `207`.
+- Section errors remain isolated so other recognized sections may import. Imports are not transactional and successful sections are not rolled back.
+- `DataImportOutcome` (or its equivalent) is the source of import completeness classification; clients must not infer it by reparsing the section response map.
+- Data sync preserves complete, partial, and fatal phase states. A remote import `207` is a partial push, not a target failure.
+- UI clients must not collapse `207` into complete success.
+
 ## WebSocket Conventions
 
 - WebSocket topics are path-based: `/ws/v1/machine/state`, `/ws/v1/machine/shotState`, `/ws/v1/scale/snapshot`, etc.

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -300,7 +300,7 @@ same request prevent all fields from being stored (validation is atomic).
 | POST | `/api/v1/data/import` | Import from ZIP (raw bytes, `Content-Type: application/zip`) | |
 | POST | `/api/v1/data/sync` | Sync with another Bridge instance | `data_sync_handler.dart` |
 
-Sync accepts: `target` (URL), `mode` (pull/push/two_way), `onConflict` (skip/overwrite), `sections` (array: profiles, shots, workflow, settings, store, beans, grinders).
+Sync accepts: `target` (URL), `mode` (pull/push/two_way), `onConflict` (skip/overwrite), `sections` (array: profiles, shots, workflow, settings, store, beans, grinders), and optional `bestEffort` (boolean, default `false`).
 
 Backups are ZIP archives with one JSON file per registered section. Import
 matches files by their registered section names; unknown files are ignored, but
@@ -318,12 +318,16 @@ section contains errors; successful sections, counts, warnings, and errors are
 all retained. Warnings and conflict-strategy skips alone still return `200`.
 Clients must inspect both the HTTP status and each section result.
 
-Data sync preserves the same phase distinction. A complete pull or push is
-represented by `200`; a partial local import or remote import response is
-represented by `207`. A two-way sync returns `207` when either phase is partial,
-or when one phase is fatal and the other succeeds or is partial. A fatal single
-phase, or two fatal phases, returns `502`. Phase results remain under `pull` and
-`push`, including successful sections and fatal error details.
+Data sync preserves complete, partial, failed, fatal, and skipped phase states.
+Each phase result includes `phaseStatus`. A complete pull or push is represented
+by `200`; a partial or semantically failed import is represented by `207`. In
+`two_way` mode, push is skipped unless pull is complete. Set `bestEffort` to
+`true` to explicitly continue after an incomplete pull. A skipped push is
+reported with `phaseStatus: skipped` and its reason. A fatal single phase, or
+two fatal phases, returns `502`; two-way operations with one fatal phase return
+`207` when the other phase is complete, partial, failed, or skipped. Phase
+results remain under `pull` and `push`, including successful sections and error
+details.
 
 ### Account
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -302,6 +302,29 @@ same request prevent all fields from being stored (validation is atomic).
 
 Sync accepts: `target` (URL), `mode` (pull/push/two_way), `onConflict` (skip/overwrite), `sections` (array: profiles, shots, workflow, settings, store, beans, grinders).
 
+Backups are ZIP archives with one JSON file per registered section. Import
+matches files by their registered section names; unknown files are ignored, but
+an archive must contain at least one recognized selected section. `metadata.json`
+is not payload: metadata-only, empty, and unknown-only archives return `400`.
+Metadata is optional for legacy archives without it. When present, its JSON and
+`formatVersion` are validated before any section is imported. Sections are
+processed independently and are not transactional, so successful sections are
+not rolled back when another section fails.
+
+`POST /api/v1/data/import` preserves its section-keyed response body. `200`
+means at least one recognized section was processed and every processed section
+completed without errors. `207 Multi-Status` means at least one processed
+section contains errors; successful sections, counts, warnings, and errors are
+all retained. Warnings and conflict-strategy skips alone still return `200`.
+Clients must inspect both the HTTP status and each section result.
+
+Data sync preserves the same phase distinction. A complete pull or push is
+represented by `200`; a partial local import or remote import response is
+represented by `207`. A two-way sync returns `207` when either phase is partial,
+or when one phase is fatal and the other succeeds or is partial. A fatal single
+phase, or two fatal phases, returns `502`. Phase results remain under `pull` and
+`push`, including successful sections and fatal error details.
+
 ### Account
 
 | Method | Path | Description | Handler |

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -316,18 +316,20 @@ means at least one recognized section was processed and every processed section
 completed without errors. `207 Multi-Status` means at least one processed
 section contains errors; successful sections, counts, warnings, and errors are
 all retained. Warnings and conflict-strategy skips alone still return `200`.
-Clients must inspect both the HTTP status and each section result.
+Each section result includes a semantic `status`; clients must inspect both the
+HTTP status and each section result.
 
 Data sync preserves complete, partial, failed, fatal, and skipped phase states.
-Each phase result includes `phaseStatus`. A complete pull or push is represented
-by `200`; a partial or semantically failed import is represented by `207`. In
+Each phase result includes `phaseStatus` and each section result includes
+`status`. A complete single-direction operation returns `200`; a partial
+operation returns `207`; a failed or fatal operation returns `502`. In
 `two_way` mode, push is skipped unless pull is complete. Set `bestEffort` to
 `true` to explicitly continue after an incomplete pull. A skipped push is
-reported with `phaseStatus: skipped` and its reason. A fatal single phase, or
-two fatal phases, returns `502`; two-way operations with one fatal phase return
-`207` when the other phase is complete, partial, failed, or skipped. Phase
-results remain under `pull` and `push`, including successful sections and error
-details.
+reported with `phaseStatus: skipped` and its reason. Two-way operations return
+`207` when at least one phase completes or partially completes and another is
+incomplete; operations with no successful or partial phase return `502`.
+Phase results remain under `pull` and `push`, including successful sections and
+phase-level error details.
 
 ### Account
 

--- a/lib/src/import/import_result.dart
+++ b/lib/src/import/import_result.dart
@@ -56,6 +56,35 @@ class ImportResult {
     this.settingsApplied = false,
     this.errors = const [],
   });
+
+  factory ImportResult.fromBackupSections(Map<String, dynamic> sections) {
+    int count(String section, String field) {
+      final value = sections[section];
+      if (value is! Map) return 0;
+      return value[field] is int ? value[field] as int : 0;
+    }
+
+    final errors = <ImportError>[];
+    for (final entry in sections.entries) {
+      final value = entry.value;
+      if (value is! Map || value['errors'] is! List) continue;
+      for (final error in value['errors'] as List) {
+        errors.add(ImportError(filename: entry.key, reason: error.toString()));
+      }
+    }
+
+    return ImportResult(
+      shotsImported: count('shots', 'imported'),
+      shotsSkipped: count('shots', 'skipped'),
+      profilesImported: count('profiles', 'imported'),
+      profilesSkipped: count('profiles', 'skipped'),
+      beansCreated: count('beans', 'imported'),
+      beansSkipped: count('beans', 'skipped'),
+      grindersCreated: count('grinders', 'imported'),
+      grindersSkipped: count('grinders', 'skipped'),
+      errors: errors,
+    );
+  }
   bool get hasErrors => errors.isNotEmpty;
   ImportResult operator +(ImportResult other) {
     return ImportResult(

--- a/lib/src/onboarding_feature/steps/import_step.dart
+++ b/lib/src/onboarding_feature/steps/import_step.dart
@@ -19,6 +19,7 @@ import 'package:reaprime/src/controllers/persistence_controller.dart';
 import 'package:reaprime/src/services/storage/storage_service.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/settings/backup_import_response.dart';
 
 enum _ImportPhase {
   pickSource,
@@ -198,14 +199,11 @@ class _ImportStepViewState extends State<_ImportStepView> {
         final response = await request.close();
         final responseBody = await response.transform(utf8.decoder).join();
 
-        if (response.statusCode != 200) {
-          throw Exception(
-            'Server returned ${response.statusCode}: $responseBody',
-          );
-        }
-
-        final responseJson = jsonDecode(responseBody) as Map<String, dynamic>;
-        final result = _zipResponseToImportResult(responseJson);
+        final importResponse = BackupImportResponse.fromHttp(
+          response.statusCode,
+          responseBody,
+        );
+        final result = importResponse.toImportResult();
 
         widget.persistenceController.notifyShotsChanged();
 
@@ -235,24 +233,6 @@ class _ImportStepViewState extends State<_ImportStepView> {
         });
       }
     }
-  }
-
-  ImportResult _zipResponseToImportResult(Map<String, dynamic> json) {
-    int imported(String key) =>
-        (json[key] is Map ? json[key]['imported'] as int? : null) ?? 0;
-    int skipped(String key) =>
-        (json[key] is Map ? json[key]['skipped'] as int? : null) ?? 0;
-
-    return ImportResult(
-      shotsImported: imported('shots'),
-      shotsSkipped: skipped('shots'),
-      profilesImported: imported('profiles'),
-      profilesSkipped: skipped('profiles'),
-      beansCreated: imported('beans'),
-      beansSkipped: skipped('beans'),
-      grindersCreated: imported('grinders'),
-      grindersSkipped: skipped('grinders'),
-    );
   }
 
   Future<void> _onImportAll() async {

--- a/lib/src/services/webserver/data_export/data_export_section.dart
+++ b/lib/src/services/webserver/data_export/data_export_section.dart
@@ -1,6 +1,8 @@
 /// Strategy for handling conflicts during import.
 enum ConflictStrategy { skip, overwrite }
 
+enum DataOutcomeStatus { complete, partial, failed, skipped }
+
 /// Result of importing a single section.
 class SectionImportResult {
   final int imported;
@@ -14,6 +16,13 @@ class SectionImportResult {
     this.errors = const [],
     this.warnings = const [],
   });
+
+  DataOutcomeStatus get status {
+    if (errors.isEmpty) return DataOutcomeStatus.complete;
+    return imported > 0 || skipped > 0
+        ? DataOutcomeStatus.partial
+        : DataOutcomeStatus.failed;
+  }
 
   Map<String, dynamic> toJson() => {
     'imported': imported,

--- a/lib/src/services/webserver/data_export/data_export_section.dart
+++ b/lib/src/services/webserver/data_export/data_export_section.dart
@@ -25,6 +25,7 @@ class SectionImportResult {
   }
 
   Map<String, dynamic> toJson() => {
+    'status': status.name,
     'imported': imported,
     'skipped': skipped,
     if (errors.isNotEmpty) 'errors': errors,

--- a/lib/src/services/webserver/data_export_handler.dart
+++ b/lib/src/services/webserver/data_export_handler.dart
@@ -8,6 +8,38 @@ import 'package:reaprime/src/services/webserver/data_export/data_export_section.
 import 'package:reaprime/src/services/webserver/json_response.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
+class InvalidBackupException implements Exception {
+  final String message;
+  final String reason;
+  final Object? cause;
+
+  const InvalidBackupException({
+    required this.message,
+    required this.reason,
+    this.cause,
+  });
+
+  @override
+  String toString() => 'InvalidBackupException: $reason';
+}
+
+class DataImportOutcome {
+  final Map<String, dynamic> sectionResults;
+  final int recognizedSections;
+  final Set<String> failedSections;
+
+  DataImportOutcome({
+    required Map<String, dynamic> sectionResults,
+    required this.recognizedSections,
+    required Set<String> failedSections,
+  }) : sectionResults = Map.unmodifiable(sectionResults),
+       failedSections = Set.unmodifiable(failedSections);
+
+  bool get isPartial => failedSections.isNotEmpty;
+
+  Map<String, dynamic> toJson() => sectionResults;
+}
+
 class DataExportHandler {
   static const int _currentFormatVersion = 1;
 
@@ -85,45 +117,39 @@ class DataExportHandler {
   /// If [sections] is provided, only sections whose filename (without .json)
   /// matches an entry in the list are processed.
   ///
-  /// Throws [FormatException] if the archive format version is unsupported.
-  /// Throws [ArchiveException] if the ZIP is invalid.
-  Future<Map<String, dynamic>> importFromBytes(
+  Future<DataImportOutcome> importFromBytes(
     List<int> zipBytes,
     ConflictStrategy strategy, {
     List<String>? sections,
   }) async {
-    final archive = ZipDecoder().decodeBytes(zipBytes);
-
-    // Parse metadata
-    String? sourcePlatform;
-    final metadataFile = archive.findFile('metadata.json');
-    if (metadataFile != null) {
-      final metadataJson = jsonDecode(utf8.decode(metadataFile.content));
-      final formatVersion = metadataJson['formatVersion'] as int?;
-      if (formatVersion != null && formatVersion > _currentFormatVersion) {
-        throw FormatException(
-          'This archive was created with format version $formatVersion, '
-          'but this app only supports up to version $_currentFormatVersion. '
-          'Please update the app.',
-        );
-      }
-      sourcePlatform = metadataJson['platform'] as String?;
-    } else {
-      _log.warning('Import archive missing metadata.json');
+    final Archive archive;
+    try {
+      archive = ZipDecoder().decodeBytes(zipBytes);
+    } catch (e, st) {
+      _log.severe('Error decoding backup archive', e, st);
+      throw InvalidBackupException(
+        message: 'Could not read the backup ZIP archive.',
+        reason: 'invalid_zip',
+        cause: e,
+      );
     }
 
+    final sourcePlatform = _readMetadata(archive);
+    final selectedSections = _resolveImportSections(sections);
+
     final results = <String, dynamic>{};
+    final failedSections = <String>{};
+    var recognizedSections = 0;
 
-    for (final section in _sections) {
+    for (final section in selectedSections) {
       final key = _sectionKey(section);
-      if (sections != null && !sections.contains(key)) continue;
-
       final file = archive.findFile(section.filename);
       if (file == null) continue;
+      recognizedSections++;
 
       try {
         final data = jsonDecode(utf8.decode(file.content));
-        final result = await section.import(data, strategy);
+        var result = await section.import(data, strategy);
 
         if (section.filename == 'settings.json' &&
             sourcePlatform != null &&
@@ -134,24 +160,36 @@ class DataExportHandler {
             'work on \'${Platform.operatingSystem}\' — device IDs are '
             'platform-specific. Devices will need to be re-paired.',
           );
-          results[key] = SectionImportResult(
+          result = SectionImportResult(
             imported: result.imported,
             skipped: result.skipped,
             errors: result.errors,
             warnings: warnings,
-          ).toJson();
-        } else {
-          results[key] = result.toJson();
+          );
         }
+        results[key] = result.toJson();
+        if (result.errors.isNotEmpty) failedSections.add(key);
       } catch (e, st) {
         _log.severe('Error importing ${section.filename}', e, st);
         results[key] = {
           'errors': ['Failed to process ${section.filename}: $e'],
         };
+        failedSections.add(key);
       }
     }
 
-    return results;
+    if (recognizedSections == 0) {
+      throw const InvalidBackupException(
+        message: 'The archive does not contain any recognized data sections.',
+        reason: 'no_recognized_sections',
+      );
+    }
+
+    return DataImportOutcome(
+      sectionResults: results,
+      recognizedSections: recognizedSections,
+      failedSections: failedSections,
+    );
   }
 
   Future<Response> _handleImport(Request request) async {
@@ -171,16 +209,13 @@ class DataExportHandler {
       }
 
       final bytes = await request.read().expand((b) => b).toList();
-      final results = await importFromBytes(bytes, strategy);
-      return jsonOk(results);
-    } on ArchiveException catch (e) {
+      final outcome = await importFromBytes(bytes, strategy);
+      return outcome.isPartial
+          ? jsonMultiStatus(outcome.toJson())
+          : jsonOk(outcome.toJson());
+    } on InvalidBackupException catch (e) {
       return jsonBadRequest({
-        'error': 'Invalid archive',
-        'message': 'Could not read ZIP file: $e',
-      });
-    } on FormatException catch (e) {
-      return jsonBadRequest({
-        'error': 'Unsupported export format',
+        'error': 'Invalid backup archive',
         'message': e.message,
       });
     } catch (e, st) {
@@ -196,4 +231,79 @@ class DataExportHandler {
 
   String _sectionKey(DataExportSection section) =>
       section.filename.replaceAll('.json', '');
+
+  String? _readMetadata(Archive archive) {
+    final metadataFile = archive.findFile('metadata.json');
+    if (metadataFile == null) {
+      _log.warning('Import archive missing metadata.json');
+      return null;
+    }
+
+    final dynamic decoded;
+    try {
+      decoded = jsonDecode(utf8.decode(metadataFile.content));
+    } catch (e, st) {
+      _log.severe('Error decoding backup metadata', e, st);
+      throw InvalidBackupException(
+        message: 'The archive metadata is invalid.',
+        reason: 'invalid_metadata_json',
+        cause: e,
+      );
+    }
+
+    if (decoded is! Map) {
+      throw const InvalidBackupException(
+        message: 'The archive metadata is invalid.',
+        reason: 'metadata_not_object',
+      );
+    }
+
+    final metadata = Map<String, dynamic>.from(decoded);
+    final formatVersion = metadata['formatVersion'];
+    if (formatVersion != null && formatVersion is! int) {
+      throw const InvalidBackupException(
+        message: 'The archive metadata formatVersion must be an integer.',
+        reason: 'invalid_format_version_type',
+      );
+    }
+    if (formatVersion is int && formatVersion > _currentFormatVersion) {
+      throw InvalidBackupException(
+        message:
+            'This archive was created with format version $formatVersion, '
+            'but this app only supports up to version $_currentFormatVersion. '
+            'Please update the app.',
+        reason: 'unsupported_format_version',
+      );
+    }
+
+    final sourcePlatform = metadata['platform'];
+    if (sourcePlatform != null && sourcePlatform is! String) {
+      throw const InvalidBackupException(
+        message: 'The archive metadata is invalid.',
+        reason: 'invalid_platform_type',
+      );
+    }
+    return sourcePlatform as String?;
+  }
+
+  List<DataExportSection> _resolveImportSections(List<String>? sections) {
+    if (sections == null) return _sections;
+
+    final requested = sections.toSet();
+    final unknown = requested
+        .where(
+          (key) => !_sections.any((section) => _sectionKey(section) == key),
+        )
+        .toList(growable: false);
+    if (unknown.isNotEmpty) {
+      throw InvalidBackupException(
+        message: 'Unknown requested backup section(s): ${unknown.join(', ')}',
+        reason: 'unknown_selected_section',
+      );
+    }
+
+    return _sections
+        .where((section) => requested.contains(_sectionKey(section)))
+        .toList(growable: false);
+  }
 }

--- a/lib/src/services/webserver/data_export_handler.dart
+++ b/lib/src/services/webserver/data_export_handler.dart
@@ -81,6 +81,8 @@ class DataExportHandler {
   DataExportHandler({required List<DataExportSection> sections})
     : _sections = sections;
 
+  List<String> get sectionKeys => List.unmodifiable(_sections.map(_sectionKey));
+
   void addRoutes(RouterPlus app) {
     app.get('/api/v1/data/export', _handleExport);
     app.post('/api/v1/data/import', _handleImport);

--- a/lib/src/services/webserver/data_export_handler.dart
+++ b/lib/src/services/webserver/data_export_handler.dart
@@ -169,6 +169,7 @@ class DataExportHandler {
     List<int> zipBytes,
     ConflictStrategy strategy, {
     List<String>? sections,
+    bool strictSections = false,
   }) async {
     final Archive archive;
     try {
@@ -193,7 +194,17 @@ class DataExportHandler {
     for (final section in selectedSections) {
       final key = _sectionKey(section);
       final file = archive.findFile(section.filename);
-      if (file == null) continue;
+      if (file == null) {
+        if (strictSections) {
+          final result = SectionImportResult(
+            errors: ['Missing requested section: ${section.filename}.'],
+          );
+          results[key] = result.toJson();
+          sectionStatuses[key] = result.status;
+          failedSections.add(key);
+        }
+        continue;
+      }
       recognizedSections++;
 
       try {
@@ -221,15 +232,17 @@ class DataExportHandler {
         if (result.errors.isNotEmpty) failedSections.add(key);
       } catch (e, st) {
         _log.severe('Error importing ${section.filename}', e, st);
-        results[key] = {
-          'errors': ['Failed to process ${section.filename}: $e'],
-        };
-        sectionStatuses[key] = DataOutcomeStatus.failed;
+        final result = SectionImportResult(
+          errors: ['Failed to process ${section.filename}: $e'],
+        );
+        results[key] = result.toJson();
+        sectionStatuses[key] = result.status;
         failedSections.add(key);
       }
     }
 
-    if (recognizedSections == 0) {
+    if (recognizedSections == 0 &&
+        (!strictSections || selectedSections.isEmpty)) {
       throw const InvalidBackupException(
         message: 'The archive does not contain any recognized data sections.',
         reason: 'no_recognized_sections',

--- a/lib/src/services/webserver/data_export_handler.dart
+++ b/lib/src/services/webserver/data_export_handler.dart
@@ -23,21 +23,53 @@ class InvalidBackupException implements Exception {
   String toString() => 'InvalidBackupException: $reason';
 }
 
+class DataExportException implements Exception {
+  final String message;
+  final Set<String> failedSections;
+
+  DataExportException({
+    required this.message,
+    required Set<String> failedSections,
+  }) : failedSections = Set.unmodifiable(failedSections);
+
+  @override
+  String toString() => 'DataExportException: $message';
+}
+
 class DataImportOutcome {
   final Map<String, dynamic> sectionResults;
+  final Map<String, DataOutcomeStatus> sectionStatuses;
   final int recognizedSections;
   final Set<String> failedSections;
 
   DataImportOutcome({
     required Map<String, dynamic> sectionResults,
+    required Map<String, DataOutcomeStatus> sectionStatuses,
     required this.recognizedSections,
     required Set<String> failedSections,
   }) : sectionResults = Map.unmodifiable(sectionResults),
+       sectionStatuses = Map.unmodifiable(sectionStatuses),
        failedSections = Set.unmodifiable(failedSections);
 
   bool get isPartial => failedSections.isNotEmpty;
 
+  DataOutcomeStatus get status {
+    if (failedSections.isEmpty) return DataOutcomeStatus.complete;
+    return sectionStatuses.values.every(
+          (status) => status == DataOutcomeStatus.failed,
+        )
+        ? DataOutcomeStatus.failed
+        : DataOutcomeStatus.partial;
+  }
+
+  bool get isFailed => status == DataOutcomeStatus.failed;
+
   Map<String, dynamic> toJson() => sectionResults;
+
+  Map<String, dynamic> toSyncJson() => {
+    'phaseStatus': status.name,
+    ...sectionResults,
+  };
 }
 
 class DataExportHandler {
@@ -60,6 +92,7 @@ class DataExportHandler {
   /// matches an entry in the list are included.
   Future<List<int>> exportToBytes({List<String>? sections}) async {
     final archive = Archive();
+    final failedSections = <String>{};
 
     final metadata = {
       'formatVersion': _currentFormatVersion,
@@ -81,7 +114,15 @@ class DataExportHandler {
         _addJsonToArchive(archive, section.filename, data);
       } catch (e, st) {
         _log.severe('Error exporting ${section.filename}', e, st);
+        failedSections.add(_sectionKey(section));
       }
+    }
+
+    if (failedSections.isNotEmpty) {
+      throw DataExportException(
+        message: 'Failed to export section(s): ${failedSections.join(', ')}.',
+        failedSections: failedSections,
+      );
     }
 
     return ZipEncoder().encode(archive);
@@ -107,6 +148,13 @@ class DataExportHandler {
         },
       );
     } catch (e, st) {
+      if (e is DataExportException) {
+        return jsonError({
+          'error': 'Export failed',
+          'message': e.message,
+          'sections': e.failedSections.toList(growable: false),
+        });
+      }
       _log.severe('Error in _handleExport', e, st);
       return jsonError({'error': 'Internal server error', 'message': '$e'});
     }
@@ -138,6 +186,7 @@ class DataExportHandler {
     final selectedSections = _resolveImportSections(sections);
 
     final results = <String, dynamic>{};
+    final sectionStatuses = <String, DataOutcomeStatus>{};
     final failedSections = <String>{};
     var recognizedSections = 0;
 
@@ -168,12 +217,14 @@ class DataExportHandler {
           );
         }
         results[key] = result.toJson();
+        sectionStatuses[key] = result.status;
         if (result.errors.isNotEmpty) failedSections.add(key);
       } catch (e, st) {
         _log.severe('Error importing ${section.filename}', e, st);
         results[key] = {
           'errors': ['Failed to process ${section.filename}: $e'],
         };
+        sectionStatuses[key] = DataOutcomeStatus.failed;
         failedSections.add(key);
       }
     }
@@ -187,6 +238,7 @@ class DataExportHandler {
 
     return DataImportOutcome(
       sectionResults: results,
+      sectionStatuses: sectionStatuses,
       recognizedSections: recognizedSections,
       failedSections: failedSections,
     );

--- a/lib/src/services/webserver/data_sync_handler.dart
+++ b/lib/src/services/webserver/data_sync_handler.dart
@@ -11,13 +11,14 @@ import 'package:shelf_plus/shelf_plus.dart';
 /// Sync modes for data synchronization between two Decent instances.
 enum SyncMode { pull, push, twoWay }
 
-enum SyncPhaseStatus { complete, partial, fatal }
+enum SyncPhaseStatus { complete, partial, failed, fatal, skipped }
 
 class SyncPhaseOutcome {
   final SyncPhaseStatus status;
   final Map<String, dynamic> result;
 
-  const SyncPhaseOutcome({required this.status, required this.result});
+  SyncPhaseOutcome({required this.status, required Map<String, dynamic> result})
+    : result = Map.unmodifiable({...result, 'phaseStatus': status.name});
 }
 
 /// Exception thrown when the sync target returns an error.
@@ -131,30 +132,40 @@ class DataSyncHandler {
     }
 
     final sections = (body['sections'] as List<dynamic>?)?.cast<String>();
+    final bestEffortValue = body['bestEffort'];
+    if (bestEffortValue != null && bestEffortValue is! bool) {
+      return jsonBadRequest({
+        'error': 'Invalid bestEffort value',
+        'message': '"bestEffort" must be a boolean',
+      });
+    }
+    final bestEffort = bestEffortValue as bool? ?? false;
 
     // Execute sync
     final results = <String, dynamic>{};
     var fatalPhases = 0;
-    var partialPhase = false;
+    var incompletePhase = false;
+    SyncPhaseOutcome? pullOutcome;
 
     // Pull phase
     if (mode == SyncMode.pull || mode == SyncMode.twoWay) {
-      final pullOutcome = await _runPhase(
-        () => _pull(target, strategy, sections),
-      );
+      pullOutcome = await _runPhase(() => _pull(target, strategy, sections));
       results['pull'] = pullOutcome.result;
       fatalPhases += pullOutcome.status == SyncPhaseStatus.fatal ? 1 : 0;
-      partialPhase |= pullOutcome.status == SyncPhaseStatus.partial;
+      incompletePhase |= pullOutcome.status != SyncPhaseStatus.complete;
     }
 
     // Push phase
     if (mode == SyncMode.push || mode == SyncMode.twoWay) {
-      final pushOutcome = await _runPhase(
-        () => _push(target, strategy, sections),
-      );
+      final pushOutcome =
+          mode == SyncMode.twoWay &&
+              !bestEffort &&
+              pullOutcome?.status != SyncPhaseStatus.complete
+          ? _skippedPushOutcome()
+          : await _runPhase(() => _push(target, strategy, sections));
       results['push'] = pushOutcome.result;
       fatalPhases += pushOutcome.status == SyncPhaseStatus.fatal ? 1 : 0;
-      partialPhase |= pushOutcome.status == SyncPhaseStatus.partial;
+      incompletePhase |= pushOutcome.status != SyncPhaseStatus.complete;
     }
 
     if (fatalPhases > 0 && mode == SyncMode.twoWay && fatalPhases < 2) {
@@ -165,7 +176,7 @@ class DataSyncHandler {
       return jsonBadGateway(results);
     }
 
-    if (partialPhase) return jsonMultiStatus(results);
+    if (incompletePhase) return jsonMultiStatus(results);
 
     return jsonOk(results);
   }
@@ -208,10 +219,13 @@ class DataSyncHandler {
       sections: sections,
     );
     return SyncPhaseOutcome(
-      status: outcome.isPartial
-          ? SyncPhaseStatus.partial
-          : SyncPhaseStatus.complete,
-      result: outcome.toJson(),
+      status: switch (outcome.status) {
+        DataOutcomeStatus.complete => SyncPhaseStatus.complete,
+        DataOutcomeStatus.partial => SyncPhaseStatus.partial,
+        DataOutcomeStatus.failed => SyncPhaseStatus.failed,
+        DataOutcomeStatus.skipped => SyncPhaseStatus.skipped,
+      },
+      result: outcome.toSyncJson(),
     );
   }
 
@@ -262,17 +276,62 @@ class DataSyncHandler {
       );
     }
 
+    final result = Map<String, dynamic>.from(decoded);
+    final sectionResults = result.entries
+        .where((entry) => entry.key != 'phaseStatus' && entry.value is Map)
+        .toList(growable: false);
+    if (sectionResults.isEmpty) {
+      throw SyncTargetException(
+        'Target returned no section results',
+        statusCode: response.statusCode,
+        responseBody: response.body,
+      );
+    }
+    final failedSections = sectionResults
+        .where((entry) => _hasSectionErrors(entry.value))
+        .length;
+
     return SyncPhaseOutcome(
       status: response.statusCode == 207
-          ? SyncPhaseStatus.partial
-          : SyncPhaseStatus.complete,
-      result: Map<String, dynamic>.from(decoded),
+          ? failedSections == sectionResults.length
+                ? SyncPhaseStatus.failed
+                : SyncPhaseStatus.partial
+          : failedSections == 0
+          ? SyncPhaseStatus.complete
+          : failedSections == sectionResults.length
+          ? SyncPhaseStatus.failed
+          : SyncPhaseStatus.partial,
+      result: result,
     );
+  }
+
+  SyncPhaseOutcome _skippedPushOutcome() => SyncPhaseOutcome(
+    status: SyncPhaseStatus.skipped,
+    result: {
+      'message':
+          'Push skipped because pull did not complete. Set bestEffort to true to continue.',
+      'reason': 'pull_not_complete',
+    },
+  );
+
+  bool _hasSectionErrors(Object? value) {
+    if (value is! Map) return false;
+    final errors = value['errors'];
+    if (errors == null) return false;
+    if (errors is! List) return true;
+    return errors.isNotEmpty;
   }
 
   Map<String, dynamic> _errorResult(Object error) {
     if (error is InvalidBackupException) {
       return {'error': 'Invalid backup archive', 'message': error.message};
+    }
+    if (error is DataExportException) {
+      return {
+        'error': 'Local export failed',
+        'message': error.message,
+        'sections': error.failedSections.toList(growable: false),
+      };
     }
     if (error is SyncTargetException) {
       return {

--- a/lib/src/services/webserver/data_sync_handler.dart
+++ b/lib/src/services/webserver/data_sync_handler.dart
@@ -223,7 +223,7 @@ class DataSyncHandler {
       response.bodyBytes,
       strategy,
       sections: sections,
-      strictSections: sections != null,
+      strictSections: true,
     );
     return SyncPhaseOutcome(
       status: switch (outcome.status) {
@@ -284,8 +284,26 @@ class DataSyncHandler {
     }
 
     final result = Map<String, dynamic>.from(decoded);
-    final sectionResults = result.entries
-        .where((entry) => entry.key != 'phaseStatus' && entry.value is Map)
+    final expectedSections = (sections ?? _exportHandler.sectionKeys).toSet();
+    final normalizedResult = Map<String, dynamic>.from(result);
+    for (final section in expectedSections) {
+      normalizedResult[section] = _normalizeSectionResult(
+        result[section],
+        section,
+      );
+    }
+    for (final entry in result.entries) {
+      if (entry.key != 'phaseStatus' &&
+          !expectedSections.contains(entry.key) &&
+          entry.value is Map) {
+        normalizedResult[entry.key] = _normalizeSectionResult(
+          entry.value,
+          entry.key,
+        );
+      }
+    }
+    final sectionResults = expectedSections
+        .map((section) => MapEntry(section, normalizedResult[section]))
         .toList(growable: false);
     if (sectionResults.isEmpty) {
       throw SyncTargetException(
@@ -311,7 +329,7 @@ class DataSyncHandler {
           : failedSections == sectionResults.length
           ? SyncPhaseStatus.failed
           : SyncPhaseStatus.partial,
-      result: result,
+      result: normalizedResult,
     );
   }
 
@@ -355,6 +373,28 @@ class DataSyncHandler {
     final skipped = value['skipped'];
     return !((imported is num && imported > 0) ||
         (skipped is num && skipped > 0));
+  }
+
+  Map<String, dynamic> _normalizeSectionResult(Object? value, String section) {
+    if (value is! Map) {
+      return {
+        'imported': 0,
+        'skipped': 0,
+        'status': DataOutcomeStatus.failed.name,
+        'errors': ['Target returned no result for section: $section.'],
+      };
+    }
+    final normalized = Map<String, dynamic>.from(value);
+    final status = normalized['status'];
+    if (status is! String ||
+        !DataOutcomeStatus.values.any((value) => value.name == status)) {
+      normalized['status'] = _isCompleteSection(normalized)
+          ? DataOutcomeStatus.complete.name
+          : _isFailedSection(normalized)
+          ? DataOutcomeStatus.failed.name
+          : DataOutcomeStatus.partial.name;
+    }
+    return normalized;
   }
 
   Map<String, dynamic> _errorResult(Object error) {

--- a/lib/src/services/webserver/data_sync_handler.dart
+++ b/lib/src/services/webserver/data_sync_handler.dart
@@ -342,12 +342,8 @@ class DataSyncHandler {
     },
   );
 
-  bool _hasSectionErrors(Object? value) {
+  bool _hasActualSectionErrors(Object? value) {
     if (value is! Map) return false;
-    final status = value['status'];
-    if (status == 'partial' || status == 'failed' || status == 'skipped') {
-      return true;
-    }
     final errors = value['errors'];
     if (errors == null) return false;
     if (errors is! List) return true;
@@ -357,22 +353,23 @@ class DataSyncHandler {
   bool _isCompleteSection(Object? value) {
     if (value is! Map) return false;
     final status = value['status'];
-    if (status is String) return status == DataOutcomeStatus.complete.name;
-    return !_hasSectionErrors(value);
+    return status == DataOutcomeStatus.complete.name &&
+        !_hasActualSectionErrors(value);
   }
 
   bool _isFailedSection(Object? value) {
     if (value is! Map) return true;
+    if (_hasActualSectionErrors(value)) return !_hasSuccessfulRecords(value);
     final status = value['status'];
-    if (status is String) {
-      return status == DataOutcomeStatus.failed.name ||
-          status == DataOutcomeStatus.skipped.name;
-    }
-    if (!_hasSectionErrors(value)) return false;
+    return status == DataOutcomeStatus.failed.name ||
+        status == DataOutcomeStatus.skipped.name;
+  }
+
+  bool _hasSuccessfulRecords(Object? value) {
+    if (value is! Map) return false;
     final imported = value['imported'];
     final skipped = value['skipped'];
-    return !((imported is num && imported > 0) ||
-        (skipped is num && skipped > 0));
+    return (imported is num && imported > 0) || (skipped is num && skipped > 0);
   }
 
   Map<String, dynamic> _normalizeSectionResult(Object? value, String section) {
@@ -386,13 +383,14 @@ class DataSyncHandler {
     }
     final normalized = Map<String, dynamic>.from(value);
     final status = normalized['status'];
-    if (status is! String ||
+    final hasErrors = _hasActualSectionErrors(normalized);
+    if (hasErrors) {
+      normalized['status'] = _hasSuccessfulRecords(normalized)
+          ? DataOutcomeStatus.partial.name
+          : DataOutcomeStatus.failed.name;
+    } else if (status is! String ||
         !DataOutcomeStatus.values.any((value) => value.name == status)) {
-      normalized['status'] = _isCompleteSection(normalized)
-          ? DataOutcomeStatus.complete.name
-          : _isFailedSection(normalized)
-          ? DataOutcomeStatus.failed.name
-          : DataOutcomeStatus.partial.name;
+      normalized['status'] = DataOutcomeStatus.complete.name;
     }
     return normalized;
   }

--- a/lib/src/services/webserver/data_sync_handler.dart
+++ b/lib/src/services/webserver/data_sync_handler.dart
@@ -11,6 +11,15 @@ import 'package:shelf_plus/shelf_plus.dart';
 /// Sync modes for data synchronization between two Decent instances.
 enum SyncMode { pull, push, twoWay }
 
+enum SyncPhaseStatus { complete, partial, fatal }
+
+class SyncPhaseOutcome {
+  final SyncPhaseStatus status;
+  final Map<String, dynamic> result;
+
+  const SyncPhaseOutcome({required this.status, required this.result});
+}
+
 /// Exception thrown when the sync target returns an error.
 class SyncTargetException implements Exception {
   final String message;
@@ -125,48 +134,57 @@ class DataSyncHandler {
 
     // Execute sync
     final results = <String, dynamic>{};
-    bool pullFailed = false;
-    bool pushFailed = false;
+    var fatalPhases = 0;
+    var partialPhase = false;
 
     // Pull phase
     if (mode == SyncMode.pull || mode == SyncMode.twoWay) {
-      try {
-        final pullResult = await _pull(target, strategy, sections);
-        results['pull'] = pullResult;
-      } catch (e) {
-        pullFailed = true;
-        results['pull'] = _errorResult(e);
-      }
+      final pullOutcome = await _runPhase(
+        () => _pull(target, strategy, sections),
+      );
+      results['pull'] = pullOutcome.result;
+      fatalPhases += pullOutcome.status == SyncPhaseStatus.fatal ? 1 : 0;
+      partialPhase |= pullOutcome.status == SyncPhaseStatus.partial;
     }
 
     // Push phase
     if (mode == SyncMode.push || mode == SyncMode.twoWay) {
-      try {
-        final pushResult = await _push(target, strategy, sections);
-        results['push'] = pushResult;
-      } catch (e) {
-        pushFailed = true;
-        results['push'] = _errorResult(e);
-      }
+      final pushOutcome = await _runPhase(
+        () => _push(target, strategy, sections),
+      );
+      results['push'] = pushOutcome.result;
+      fatalPhases += pushOutcome.status == SyncPhaseStatus.fatal ? 1 : 0;
+      partialPhase |= pushOutcome.status == SyncPhaseStatus.partial;
     }
 
-    // Determine response status:
-    // - 200: all phases succeeded
-    // - 207: partial success in two_way mode (one phase failed)
-    // - 502: all phases failed, or single-direction mode failed
-    if (mode == SyncMode.twoWay && (pullFailed != pushFailed)) {
+    if (fatalPhases > 0 && mode == SyncMode.twoWay && fatalPhases < 2) {
       return jsonMultiStatus(results);
     }
 
-    if (pullFailed || pushFailed) {
+    if (fatalPhases > 0) {
       return jsonBadGateway(results);
     }
+
+    if (partialPhase) return jsonMultiStatus(results);
 
     return jsonOk(results);
   }
 
+  Future<SyncPhaseOutcome> _runPhase(
+    Future<SyncPhaseOutcome> Function() phase,
+  ) async {
+    try {
+      return await phase();
+    } catch (e) {
+      return SyncPhaseOutcome(
+        status: SyncPhaseStatus.fatal,
+        result: _errorResult(e),
+      );
+    }
+  }
+
   /// Pull data from the target instance and import it locally.
-  Future<Map<String, dynamic>> _pull(
+  Future<SyncPhaseOutcome> _pull(
     String target,
     ConflictStrategy strategy,
     List<String>? sections,
@@ -184,15 +202,21 @@ class DataSyncHandler {
       );
     }
 
-    return await _exportHandler.importFromBytes(
+    final outcome = await _exportHandler.importFromBytes(
       response.bodyBytes,
       strategy,
       sections: sections,
     );
+    return SyncPhaseOutcome(
+      status: outcome.isPartial
+          ? SyncPhaseStatus.partial
+          : SyncPhaseStatus.complete,
+      result: outcome.toJson(),
+    );
   }
 
   /// Export local data and push it to the target instance.
-  Future<Map<String, dynamic>> _push(
+  Future<SyncPhaseOutcome> _push(
     String target,
     ConflictStrategy strategy,
     List<String>? sections,
@@ -212,7 +236,7 @@ class DataSyncHandler {
         )
         .timeout(_requestTimeout);
 
-    if (response.statusCode != 200) {
+    if (response.statusCode != 200 && response.statusCode != 207) {
       throw SyncTargetException(
         'Target returned status ${response.statusCode}',
         statusCode: response.statusCode,
@@ -220,10 +244,36 @@ class DataSyncHandler {
       );
     }
 
-    return jsonDecode(response.body) as Map<String, dynamic>;
+    final dynamic decoded;
+    try {
+      decoded = jsonDecode(response.body);
+    } catch (e) {
+      throw SyncTargetException(
+        'Target returned invalid JSON',
+        statusCode: response.statusCode,
+        responseBody: response.body,
+      );
+    }
+    if (decoded is! Map) {
+      throw SyncTargetException(
+        'Target returned invalid JSON',
+        statusCode: response.statusCode,
+        responseBody: response.body,
+      );
+    }
+
+    return SyncPhaseOutcome(
+      status: response.statusCode == 207
+          ? SyncPhaseStatus.partial
+          : SyncPhaseStatus.complete,
+      result: Map<String, dynamic>.from(decoded),
+    );
   }
 
   Map<String, dynamic> _errorResult(Object error) {
+    if (error is InvalidBackupException) {
+      return {'error': 'Invalid backup archive', 'message': error.message};
+    }
     if (error is SyncTargetException) {
       return {
         'error': 'Target error',

--- a/lib/src/services/webserver/data_sync_handler.dart
+++ b/lib/src/services/webserver/data_sync_handler.dart
@@ -143,16 +143,14 @@ class DataSyncHandler {
 
     // Execute sync
     final results = <String, dynamic>{};
-    var fatalPhases = 0;
-    var incompletePhase = false;
+    final phaseStatuses = <SyncPhaseStatus>[];
     SyncPhaseOutcome? pullOutcome;
 
     // Pull phase
     if (mode == SyncMode.pull || mode == SyncMode.twoWay) {
       pullOutcome = await _runPhase(() => _pull(target, strategy, sections));
       results['pull'] = pullOutcome.result;
-      fatalPhases += pullOutcome.status == SyncPhaseStatus.fatal ? 1 : 0;
-      incompletePhase |= pullOutcome.status != SyncPhaseStatus.complete;
+      phaseStatuses.add(pullOutcome.status);
     }
 
     // Push phase
@@ -164,21 +162,29 @@ class DataSyncHandler {
           ? _skippedPushOutcome()
           : await _runPhase(() => _push(target, strategy, sections));
       results['push'] = pushOutcome.result;
-      fatalPhases += pushOutcome.status == SyncPhaseStatus.fatal ? 1 : 0;
-      incompletePhase |= pushOutcome.status != SyncPhaseStatus.complete;
+      phaseStatuses.add(pushOutcome.status);
     }
 
-    if (fatalPhases > 0 && mode == SyncMode.twoWay && fatalPhases < 2) {
-      return jsonMultiStatus(results);
+    if (mode != SyncMode.twoWay) {
+      return switch (phaseStatuses.single) {
+        SyncPhaseStatus.complete => jsonOk(results),
+        SyncPhaseStatus.partial => jsonMultiStatus(results),
+        SyncPhaseStatus.failed => jsonBadGateway(results),
+        SyncPhaseStatus.fatal => jsonBadGateway(results),
+        SyncPhaseStatus.skipped => jsonBadGateway(results),
+      };
     }
 
-    if (fatalPhases > 0) {
-      return jsonBadGateway(results);
+    final hasSuccessfulPhase = phaseStatuses.any(
+      (status) =>
+          status == SyncPhaseStatus.complete ||
+          status == SyncPhaseStatus.partial,
+    );
+    if (!hasSuccessfulPhase) return jsonBadGateway(results);
+    if (phaseStatuses.every((status) => status == SyncPhaseStatus.complete)) {
+      return jsonOk(results);
     }
-
-    if (incompletePhase) return jsonMultiStatus(results);
-
-    return jsonOk(results);
+    return jsonMultiStatus(results);
   }
 
   Future<SyncPhaseOutcome> _runPhase(
@@ -217,6 +223,7 @@ class DataSyncHandler {
       response.bodyBytes,
       strategy,
       sections: sections,
+      strictSections: sections != null,
     );
     return SyncPhaseOutcome(
       status: switch (outcome.status) {
@@ -288,15 +295,18 @@ class DataSyncHandler {
       );
     }
     final failedSections = sectionResults
-        .where((entry) => _hasSectionErrors(entry.value))
+        .where((entry) => _isFailedSection(entry.value))
         .length;
+    final allSectionsComplete = sectionResults.every(
+      (entry) => _isCompleteSection(entry.value),
+    );
 
     return SyncPhaseOutcome(
       status: response.statusCode == 207
           ? failedSections == sectionResults.length
                 ? SyncPhaseStatus.failed
                 : SyncPhaseStatus.partial
-          : failedSections == 0
+          : allSectionsComplete
           ? SyncPhaseStatus.complete
           : failedSections == sectionResults.length
           ? SyncPhaseStatus.failed
@@ -316,10 +326,35 @@ class DataSyncHandler {
 
   bool _hasSectionErrors(Object? value) {
     if (value is! Map) return false;
+    final status = value['status'];
+    if (status == 'partial' || status == 'failed' || status == 'skipped') {
+      return true;
+    }
     final errors = value['errors'];
     if (errors == null) return false;
     if (errors is! List) return true;
     return errors.isNotEmpty;
+  }
+
+  bool _isCompleteSection(Object? value) {
+    if (value is! Map) return false;
+    final status = value['status'];
+    if (status is String) return status == DataOutcomeStatus.complete.name;
+    return !_hasSectionErrors(value);
+  }
+
+  bool _isFailedSection(Object? value) {
+    if (value is! Map) return true;
+    final status = value['status'];
+    if (status is String) {
+      return status == DataOutcomeStatus.failed.name ||
+          status == DataOutcomeStatus.skipped.name;
+    }
+    if (!_hasSectionErrors(value)) return false;
+    final imported = value['imported'];
+    final skipped = value['skipped'];
+    return !((imported is num && imported > 0) ||
+        (skipped is num && skipped > 0));
   }
 
   Map<String, dynamic> _errorResult(Object error) {

--- a/lib/src/settings/backup_export_response.dart
+++ b/lib/src/settings/backup_export_response.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+class BackupExportException implements Exception {
+  final String message;
+  final int? statusCode;
+
+  const BackupExportException(this.message, {this.statusCode});
+
+  @override
+  String toString() => 'BackupExportException: $message';
+}
+
+class BackupExportResponse {
+  final Uint8List bytes;
+
+  const BackupExportResponse(this.bytes);
+
+  factory BackupExportResponse.fromHttp({
+    required int statusCode,
+    required String? mimeType,
+    required List<int> bytes,
+  }) {
+    if (statusCode != 200) {
+      throw BackupExportException(
+        _serverMessage(bytes) ?? 'The server returned status $statusCode.',
+        statusCode: statusCode,
+      );
+    }
+    if (mimeType?.toLowerCase() != 'application/zip') {
+      throw const BackupExportException(
+        'The server returned an invalid backup archive.',
+      );
+    }
+    return BackupExportResponse(Uint8List.fromList(bytes));
+  }
+
+  static String? _serverMessage(List<int> bytes) {
+    try {
+      final decoded = jsonDecode(utf8.decode(bytes));
+      final message = decoded is Map ? decoded['message'] : null;
+      return message is String && message.isNotEmpty ? message : null;
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/src/settings/backup_import_response.dart
+++ b/lib/src/settings/backup_import_response.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:reaprime/src/import/import_result.dart';
+
 enum BackupImportStatus { complete, partial }
 
 class BackupImportException implements Exception {
@@ -21,6 +23,8 @@ class BackupImportResponse {
   const BackupImportResponse({required this.status, required this.sections});
 
   bool get shouldNotifyShotsChanged => true;
+
+  ImportResult toImportResult() => ImportResult.fromBackupSections(sections);
 
   factory BackupImportResponse.fromHttp(int statusCode, String body) {
     final dynamic decoded;

--- a/lib/src/settings/backup_import_response.dart
+++ b/lib/src/settings/backup_import_response.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+
+enum BackupImportStatus { complete, partial }
+
+class BackupImportException implements Exception {
+  final String message;
+  final int? statusCode;
+
+  const BackupImportException(this.message, {this.statusCode});
+
+  bool get isInvalidBackup => statusCode == 400;
+
+  @override
+  String toString() => 'BackupImportException: $message';
+}
+
+class BackupImportResponse {
+  final BackupImportStatus status;
+  final Map<String, dynamic> sections;
+
+  const BackupImportResponse({required this.status, required this.sections});
+
+  bool get shouldNotifyShotsChanged => true;
+
+  factory BackupImportResponse.fromHttp(int statusCode, String body) {
+    final dynamic decoded;
+    try {
+      decoded = jsonDecode(body);
+    } catch (_) {
+      throw BackupImportException(
+        'The server returned an invalid response.',
+        statusCode: statusCode,
+      );
+    }
+
+    if (statusCode == 200 || statusCode == 207) {
+      if (decoded is! Map) {
+        throw BackupImportException(
+          'The server returned an invalid import result.',
+          statusCode: statusCode,
+        );
+      }
+      return BackupImportResponse(
+        status: statusCode == 207
+            ? BackupImportStatus.partial
+            : BackupImportStatus.complete,
+        sections: Map<String, dynamic>.from(decoded),
+      );
+    }
+
+    final message = decoded is Map && decoded['message'] is String
+        ? decoded['message'] as String
+        : 'The server returned status $statusCode.';
+    throw BackupImportException(message, statusCode: statusCode);
+  }
+}
+
+String backupImportDialogTitle(BackupImportStatus status) =>
+    status == BackupImportStatus.partial
+    ? 'Import Partially Complete'
+    : 'Import Complete';

--- a/lib/src/settings/data_management_page.dart
+++ b/lib/src/settings/data_management_page.dart
@@ -22,6 +22,7 @@ import 'package:reaprime/src/services/storage/bean_storage_service.dart';
 import 'package:reaprime/src/services/storage/grinder_storage_service.dart';
 import 'package:reaprime/src/services/storage/profile_storage_service.dart';
 import 'package:reaprime/src/settings/backup_import_response.dart';
+import 'package:reaprime/src/settings/backup_export_response.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/util/shot_exporter.dart';
@@ -283,7 +284,7 @@ class _DataManagementPageState extends State<DataManagementPage> {
     if (!mounted) return;
     _showProgressDialog(context, 'Preparing full backup...');
 
-    final Uint8List responseBytes;
+    late final BackupExportResponse exportResponse;
     final client = HttpClient();
     try {
       final request = await client.getUrl(
@@ -294,13 +295,18 @@ class _DataManagementPageState extends State<DataManagementPage> {
       await for (final chunk in response) {
         builder.add(chunk);
       }
-      responseBytes = builder.takeBytes();
+      exportResponse = BackupExportResponse.fromHttp(
+        statusCode: response.statusCode,
+        mimeType: response.headers.contentType?.mimeType,
+        bytes: builder.takeBytes(),
+      );
     } catch (e) {
       _log.severe("Failed to export full backup", e);
       _dismissProgressDialog();
       if (mounted) {
+        final message = e is BackupExportException ? e.message : '$e';
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to export full backup: $e')),
+          SnackBar(content: Text('Failed to export full backup: $message')),
         );
       }
       return;
@@ -322,7 +328,7 @@ class _DataManagementPageState extends State<DataManagementPage> {
       final outputFile = await FilePicker.saveFile(
         fileName: fileName,
         dialogTitle: 'Choose where to save backup',
-        bytes: responseBytes,
+        bytes: exportResponse.bytes,
       );
 
       if (outputFile != null) {

--- a/lib/src/settings/data_management_page.dart
+++ b/lib/src/settings/data_management_page.dart
@@ -21,6 +21,7 @@ import 'package:reaprime/src/import/widgets/import_summary_view.dart';
 import 'package:reaprime/src/services/storage/bean_storage_service.dart';
 import 'package:reaprime/src/services/storage/grinder_storage_service.dart';
 import 'package:reaprime/src/services/storage/profile_storage_service.dart';
+import 'package:reaprime/src/settings/backup_import_response.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/util/shot_exporter.dart';
@@ -536,13 +537,10 @@ class _DataManagementPageState extends State<DataManagementPage> {
         final response = await request.close();
         final responseBody = await response.transform(utf8.decoder).join();
 
-        if (response.statusCode != 200) {
-          throw Exception(
-            'Server returned ${response.statusCode}: $responseBody',
-          );
-        }
-
-        final responseJson = jsonDecode(responseBody) as Map<String, dynamic>;
+        final importResponse = BackupImportResponse.fromHttp(
+          response.statusCode,
+          responseBody,
+        );
 
         if (!mounted) return;
 
@@ -552,12 +550,21 @@ class _DataManagementPageState extends State<DataManagementPage> {
         if (!mounted) return;
 
         // Show result summary
-        await _showImportResultDialog(responseJson);
+        await _showImportResultDialog(importResponse);
 
-        // Notify listeners that shots have changed
-        widget.persistenceController.notifyShotsChanged();
+        if (importResponse.shouldNotifyShotsChanged) {
+          widget.persistenceController.notifyShotsChanged();
+        }
       } finally {
         client.close();
+      }
+    } on BackupImportException catch (e) {
+      _log.severe("Failed to import backup", e);
+      if (mounted) {
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(e.message)));
       }
     } catch (e) {
       _log.severe("Failed to import backup", e);
@@ -896,15 +903,20 @@ class _DataManagementPageState extends State<DataManagementPage> {
     }
   }
 
-  Future<void> _showImportResultDialog(Map<String, dynamic> response) async {
+  Future<void> _showImportResultDialog(BackupImportResponse response) async {
     final sections = <Widget>[];
 
-    for (final entry in response.entries) {
+    for (final entry in response.sections.entries) {
       if (entry.value is Map<String, dynamic>) {
         final data = entry.value as Map<String, dynamic>;
         final imported = data['imported'] ?? 0;
         final skipped = data['skipped'] ?? 0;
-        final errors = data['errors'] as List<dynamic>? ?? [];
+        final errors = data['errors'] is List
+            ? data['errors'] as List<dynamic>
+            : const <dynamic>[];
+        final warnings = data['warnings'] is List
+            ? data['warnings'] as List<dynamic>
+            : const <dynamic>[];
 
         sections.add(
           Text(
@@ -916,12 +928,16 @@ class _DataManagementPageState extends State<DataManagementPage> {
         for (final error in errors) {
           sections.add(
             Text(
-              '  Warning: $error',
+              '  Error: $error',
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 color: Theme.of(context).colorScheme.error,
               ),
             ),
           );
+        }
+
+        for (final warning in warnings) {
+          sections.add(Text('  Warning: $warning'));
         }
       }
     }
@@ -929,7 +945,7 @@ class _DataManagementPageState extends State<DataManagementPage> {
     await showShadDialog(
       context: context,
       builder: (context) => ShadDialog(
-        title: const Text('Import Complete'),
+        title: Text(backupImportDialogTitle(response.status)),
         actions: [
           ShadButton(
             onPressed: () => Navigator.of(context).pop(),

--- a/test/data_export/data_export_handler_test.dart
+++ b/test/data_export/data_export_handler_test.dart
@@ -190,36 +190,30 @@ void main() {
         expect(shotsData['shots'], isList);
       });
 
-      test(
-        'continues exporting other sections when one section fails',
-        () async {
-          final failingSection = FailingExportSection(filename: 'failing.json');
-          final goodSection = MockExportSection(
-            filename: 'good.json',
-            exportData: {'data': 'ok'},
-          );
+      test('returns 500 when a section export fails', () async {
+        final failingSection = FailingExportSection(filename: 'failing.json');
+        final goodSection = MockExportSection(
+          filename: 'good.json',
+          exportData: {'data': 'ok'},
+        );
 
-          final handlerWithFailure = DataExportHandler(
-            sections: [failingSection, goodSection],
-          );
+        final handlerWithFailure = DataExportHandler(
+          sections: [failingSection, goodSection],
+        );
 
-          final app = Router().plus;
-          handlerWithFailure.addRoutes(app);
-          final testHandler = app.call;
+        final app = Router().plus;
+        handlerWithFailure.addRoutes(app);
+        final testHandler = app.call;
 
-          final response = await testHandler(
-            Request('GET', Uri.parse('http://localhost/api/v1/data/export')),
-          );
+        final response = await testHandler(
+          Request('GET', Uri.parse('http://localhost/api/v1/data/export')),
+        );
 
-          expect(response.statusCode, 200);
-          final bytes = await response.read().expand((b) => b).toList();
-          final archive = ZipDecoder().decodeBytes(bytes);
-
-          // Should have metadata + good section (failing section skipped)
-          expect(archive.findFile('good.json'), isNotNull);
-          expect(archive.findFile('failing.json'), isNull);
-        },
-      );
+        expect(response.statusCode, 500);
+        final body = jsonDecode(await response.readAsString());
+        expect(body['error'], 'Export failed');
+        expect(body['sections'], contains('failing'));
+      });
     });
 
     group('POST /api/v1/data/import', () {
@@ -553,6 +547,23 @@ void main() {
         expect(archive.findFile('profiles.json'), isNotNull);
         expect(archive.findFile('shots.json'), isNull);
       });
+
+      test('throws when a requested section cannot be exported', () async {
+        final failingHandler = DataExportHandler(
+          sections: [FailingExportSection(filename: 'profiles.json')],
+        );
+
+        expect(
+          () => failingHandler.exportToBytes(sections: ['profiles']),
+          throwsA(
+            isA<DataExportException>().having(
+              (error) => error.failedSections,
+              'failed sections',
+              contains('profiles'),
+            ),
+          ),
+        );
+      });
     });
 
     group('importFromBytes()', () {
@@ -655,7 +666,10 @@ void main() {
       test('section errors make direct outcomes partial', () async {
         final errorSection = MockExportSection(
           filename: 'profiles.json',
-          importResult: const SectionImportResult(errors: ['bad row']),
+          importResult: const SectionImportResult(
+            imported: 2,
+            errors: ['bad row'],
+          ),
         );
         final outcome = await DataExportHandler(sections: [errorSection])
             .importFromBytes(
@@ -664,6 +678,7 @@ void main() {
             );
         expect(outcome.recognizedSections, 1);
         expect(outcome.isPartial, isTrue);
+        expect(outcome.status, DataOutcomeStatus.partial);
         expect(outcome.failedSections, contains('profiles'));
       });
 
@@ -677,6 +692,7 @@ void main() {
             );
         expect(outcome.recognizedSections, 1);
         expect(outcome.isPartial, isTrue);
+        expect(outcome.status, DataOutcomeStatus.failed);
         expect(outcome.sectionResults['profiles']['errors'], isNotEmpty);
       });
 

--- a/test/data_export/data_export_handler_test.dart
+++ b/test/data_export/data_export_handler_test.dart
@@ -591,6 +591,8 @@ void main() {
         expect(outcome.isPartial, isFalse);
         expect(outcome.sectionResults, contains('profiles'));
         expect(outcome.sectionResults, contains('shots'));
+        expect(outcome.sectionResults['profiles']['status'], 'complete');
+        expect(outcome.sectionResults['shots']['status'], 'complete');
         expect(profileSection.importCalled, isTrue);
         expect(shotsSection.importCalled, isTrue);
       });
@@ -680,6 +682,7 @@ void main() {
         expect(outcome.isPartial, isTrue);
         expect(outcome.status, DataOutcomeStatus.partial);
         expect(outcome.failedSections, contains('profiles'));
+        expect(outcome.sectionResults['profiles']['status'], 'partial');
       });
 
       test('thrown section errors make direct outcomes partial', () async {
@@ -694,6 +697,7 @@ void main() {
         expect(outcome.isPartial, isTrue);
         expect(outcome.status, DataOutcomeStatus.failed);
         expect(outcome.sectionResults['profiles']['errors'], isNotEmpty);
+        expect(outcome.sectionResults['profiles']['status'], 'failed');
       });
 
       test(

--- a/test/data_export/data_export_handler_test.dart
+++ b/test/data_export/data_export_handler_test.dart
@@ -126,6 +126,14 @@ void main() {
     return ZipEncoder().encode(archive);
   }
 
+  List<int> buildZipEntries(Map<String, String> files) {
+    final archive = Archive();
+    for (final entry in files.entries) {
+      archive.addFile(ArchiveFile.string(entry.key, entry.value));
+    }
+    return ZipEncoder().encode(archive);
+  }
+
   group('DataExportHandler', () {
     group('GET /api/v1/data/export', () {
       test(
@@ -286,20 +294,46 @@ void main() {
         expect(body['error'], 'Invalid onConflict value');
       });
 
-      test('returns 200 with empty results for unrecognized data', () async {
-        // The archive library is lenient: unrecognized bytes produce an empty
-        // archive rather than throwing ArchiveException. The handler treats
-        // that as "nothing to import" and returns an empty summary.
-        final response = await sendPost(
-          '/api/v1/data/import',
-          body: [0, 1, 2, 3, 4, 5],
-        );
+      test(
+        'returns 400 when the body is not a recognized backup archive',
+        () async {
+          // The archive library is lenient: unrecognized bytes produce an empty
+          // archive rather than throwing ArchiveException. The handler treats
+          // that as "nothing to import" and returns an empty summary.
+          final response = await sendPost(
+            '/api/v1/data/import',
+            body: [0, 1, 2, 3, 4, 5],
+          );
 
-        expect(response.statusCode, 200);
-        final body = jsonDecode(await response.readAsString());
-        // No sections matched, so results are empty
-        expect(body, isEmpty);
-      });
+          expect(response.statusCode, 400);
+          final body = jsonDecode(await response.readAsString());
+          expect(body['error'], 'Invalid backup archive');
+          expect(body['message'], contains('recognized data sections'));
+        },
+      );
+
+      test(
+        'returns 400 for empty, unknown-only, and metadata-only archives',
+        () async {
+          for (final files in [
+            <String, dynamic>{},
+            {'notes.txt': 'unknown', 'unknown.json': {}},
+            {
+              'metadata.json': {'formatVersion': 1},
+            },
+          ]) {
+            final response = await sendPost(
+              '/api/v1/data/import',
+              body: buildZip(files),
+            );
+            expect(response.statusCode, 400);
+            final body = jsonDecode(await response.readAsString());
+            expect(body['error'], 'Invalid backup archive');
+          }
+          expect(profileSection.importCalled, isFalse);
+          expect(shotsSection.importCalled, isFalse);
+        },
+      );
 
       test('returns 400 when formatVersion is too high', () async {
         final zipBytes = buildZip({
@@ -310,8 +344,32 @@ void main() {
 
         expect(response.statusCode, 400);
         final body = jsonDecode(await response.readAsString());
-        expect(body['error'], 'Unsupported export format');
+        expect(body['error'], 'Invalid backup archive');
         expect(body['message'], contains('999'));
+      });
+
+      test('returns 400 for malformed metadata', () async {
+        for (final zipBytes in [
+          buildZipEntries({
+            'metadata.json': '{not json',
+            'profiles.json': '{}',
+          }),
+          buildZip({
+            'metadata.json': ['not an object'],
+            'profiles.json': {},
+          }),
+          buildZip({
+            'metadata.json': {'formatVersion': '1'},
+            'profiles.json': {},
+          }),
+        ]) {
+          final response = await sendPost(
+            '/api/v1/data/import',
+            body: zipBytes,
+          );
+          expect(response.statusCode, 400);
+          expect(profileSection.importCalled, isFalse);
+        }
       });
 
       test('succeeds when metadata.json is missing from archive', () async {
@@ -341,6 +399,111 @@ void main() {
         expect(shotsSection.importCalled, isFalse);
       });
 
+      test('returns 207 for thrown and returned section errors', () async {
+        final failing = FailingExportSection(filename: 'failing.json');
+        final thrownHandler = DataExportHandler(
+          sections: [profileSection, failing],
+        );
+        final app = Router().plus;
+        thrownHandler.addRoutes(app);
+        final thrownResponse = await app.call(
+          Request(
+            'POST',
+            Uri.parse('http://localhost/api/v1/data/import'),
+            body: buildZip({'profiles.json': {}, 'failing.json': {}}),
+            headers: {'content-type': 'application/octet-stream'},
+          ),
+        );
+        expect(thrownResponse.statusCode, 207);
+        final thrownBody = jsonDecode(await thrownResponse.readAsString());
+        expect(thrownBody['profiles']['imported'], 1);
+        expect(thrownBody['failing']['errors'], isNotEmpty);
+
+        final returned = MockExportSection(
+          filename: 'profiles.json',
+          importResult: const SectionImportResult(
+            imported: 2,
+            errors: ['bad row'],
+          ),
+        );
+        final returnedHandler = DataExportHandler(sections: [returned]);
+        final returnedApp = Router().plus;
+        returnedHandler.addRoutes(returnedApp);
+        final returnedResponse = await returnedApp.call(
+          Request(
+            'POST',
+            Uri.parse('http://localhost/api/v1/data/import'),
+            body: buildZip({'profiles.json': {}}),
+            headers: {'content-type': 'application/octet-stream'},
+          ),
+        );
+        expect(returnedResponse.statusCode, 207);
+        final returnedBody = jsonDecode(await returnedResponse.readAsString());
+        expect(returnedBody['profiles']['imported'], 2);
+        expect(returnedBody['profiles']['errors'], contains('bad row'));
+      });
+
+      test('warnings and skips alone return 200', () async {
+        final warning = MockExportSection(
+          filename: 'profiles.json',
+          importResult: const SectionImportResult(
+            skipped: 2,
+            warnings: ['warning'],
+          ),
+        );
+        final warningHandler = DataExportHandler(sections: [warning]);
+        final app = Router().plus;
+        warningHandler.addRoutes(app);
+        final response = await app.call(
+          Request(
+            'POST',
+            Uri.parse('http://localhost/api/v1/data/import'),
+            body: buildZip({'profiles.json': {}}),
+            headers: {'content-type': 'application/octet-stream'},
+          ),
+        );
+        expect(response.statusCode, 200);
+        final body = jsonDecode(await response.readAsString());
+        expect(body['profiles']['skipped'], 2);
+        expect(body['profiles']['warnings'], isNotEmpty);
+      });
+
+      test('malformed recognized JSON returns 207 and continues', () async {
+        final response = await sendPost(
+          '/api/v1/data/import',
+          body: buildZipEntries({
+            'profiles.json': '{not json',
+            'shots.json': '{}',
+          }),
+        );
+        expect(response.statusCode, 207);
+        final body = jsonDecode(await response.readAsString());
+        expect(body['profiles']['errors'], isNotEmpty);
+        expect(body['shots']['imported'], 2);
+      });
+
+      test('all recognized sections failing return 207', () async {
+        final failingHandler = DataExportHandler(
+          sections: [
+            FailingExportSection(filename: 'profiles.json'),
+            FailingExportSection(filename: 'shots.json'),
+          ],
+        );
+        final app = Router().plus;
+        failingHandler.addRoutes(app);
+        final response = await app.call(
+          Request(
+            'POST',
+            Uri.parse('http://localhost/api/v1/data/import'),
+            body: buildZip({'profiles.json': {}, 'shots.json': {}}),
+            headers: {'content-type': 'application/octet-stream'},
+          ),
+        );
+        expect(response.statusCode, 207);
+        final body = jsonDecode(await response.readAsString());
+        expect(body.keys, containsAll(['profiles', 'shots']));
+      });
+
       test('reports errors when a section import fails', () async {
         final failingSection = FailingExportSection(filename: 'failing.json');
         final handlerWithFailure = DataExportHandler(
@@ -365,7 +528,7 @@ void main() {
           ),
         );
 
-        expect(response.statusCode, 200);
+        expect(response.statusCode, 207);
         final body = jsonDecode(await response.readAsString());
         expect(body['failing']['errors'], isList);
         expect((body['failing']['errors'] as List).first, contains('Failed'));
@@ -408,13 +571,15 @@ void main() {
           },
         });
 
-        final results = await handler.importFromBytes(
+        final outcome = await handler.importFromBytes(
           zipBytes,
           ConflictStrategy.skip,
         );
 
-        expect(results, contains('profiles'));
-        expect(results, contains('shots'));
+        expect(outcome.recognizedSections, 2);
+        expect(outcome.isPartial, isFalse);
+        expect(outcome.sectionResults, contains('profiles'));
+        expect(outcome.sectionResults, contains('shots'));
         expect(profileSection.importCalled, isTrue);
         expect(shotsSection.importCalled, isTrue);
       });
@@ -434,28 +599,106 @@ void main() {
           },
         });
 
-        final results = await handler.importFromBytes(
+        final outcome = await handler.importFromBytes(
           zipBytes,
           ConflictStrategy.skip,
           sections: ['profiles'],
         );
 
-        expect(results, contains('profiles'));
-        expect(results, isNot(contains('shots')));
+        expect(outcome.recognizedSections, 1);
+        expect(outcome.sectionResults, contains('profiles'));
+        expect(outcome.sectionResults, isNot(contains('shots')));
         expect(profileSection.importCalled, isTrue);
         expect(shotsSection.importCalled, isFalse);
       });
 
-      test('throws FormatException for unsupported format version', () async {
-        final zipBytes = buildZip({
-          'metadata.json': {'formatVersion': 99},
-        });
+      test(
+        'throws InvalidBackupException for invalid archives and selections',
+        () async {
+          final zipBytes = buildZip({
+            'metadata.json': {'formatVersion': 99},
+          });
 
-        expect(
-          () => handler.importFromBytes(zipBytes, ConflictStrategy.skip),
-          throwsA(isA<FormatException>()),
+          expect(
+            () => handler.importFromBytes(zipBytes, ConflictStrategy.skip),
+            throwsA(isA<InvalidBackupException>()),
+          );
+
+          expect(
+            () => handler.importFromBytes(
+              buildZip({
+                'metadata.json': {'formatVersion': 1},
+              }),
+              ConflictStrategy.skip,
+            ),
+            throwsA(isA<InvalidBackupException>()),
+          );
+          expect(
+            () => handler.importFromBytes(
+              buildZip({'profiles.json': {}}),
+              ConflictStrategy.skip,
+              sections: ['unknown'],
+            ),
+            throwsA(isA<InvalidBackupException>()),
+          );
+          expect(
+            () => handler.importFromBytes(
+              buildZip({'shots.json': {}}),
+              ConflictStrategy.skip,
+              sections: ['profiles'],
+            ),
+            throwsA(isA<InvalidBackupException>()),
+          );
+        },
+      );
+
+      test('section errors make direct outcomes partial', () async {
+        final errorSection = MockExportSection(
+          filename: 'profiles.json',
+          importResult: const SectionImportResult(errors: ['bad row']),
         );
+        final outcome = await DataExportHandler(sections: [errorSection])
+            .importFromBytes(
+              buildZip({'profiles.json': {}}),
+              ConflictStrategy.skip,
+            );
+        expect(outcome.recognizedSections, 1);
+        expect(outcome.isPartial, isTrue);
+        expect(outcome.failedSections, contains('profiles'));
       });
+
+      test('thrown section errors make direct outcomes partial', () async {
+        final outcome =
+            await DataExportHandler(
+              sections: [FailingExportSection(filename: 'profiles.json')],
+            ).importFromBytes(
+              buildZip({'profiles.json': {}}),
+              ConflictStrategy.skip,
+            );
+        expect(outcome.recognizedSections, 1);
+        expect(outcome.isPartial, isTrue);
+        expect(outcome.sectionResults['profiles']['errors'], isNotEmpty);
+      });
+
+      test(
+        'duplicate selection excludes an unselected failing section',
+        () async {
+          final selectedHandler = DataExportHandler(
+            sections: [
+              profileSection,
+              FailingExportSection(filename: 'shots.json'),
+            ],
+          );
+          final outcome = await selectedHandler.importFromBytes(
+            buildZip({'profiles.json': {}, 'shots.json': {}}),
+            ConflictStrategy.skip,
+            sections: ['profiles', 'profiles'],
+          );
+          expect(outcome.recognizedSections, 1);
+          expect(outcome.isPartial, isFalse);
+          expect(profileSection.importCalled, isTrue);
+        },
+      );
     });
   });
 }

--- a/test/data_export/data_sync_handler_test.dart
+++ b/test/data_export/data_sync_handler_test.dart
@@ -43,6 +43,22 @@ class MockExportSection implements DataExportSection {
   }
 }
 
+class FailingExportSection implements DataExportSection {
+  @override
+  final String filename;
+
+  FailingExportSection({required this.filename});
+
+  @override
+  Future<dynamic> export() async => throw Exception('Export failed');
+
+  @override
+  Future<SectionImportResult> import(
+    dynamic data,
+    ConflictStrategy strategy,
+  ) async => throw Exception('Import failed');
+}
+
 List<int> buildZip(Map<String, dynamic> files) {
   final archive = Archive();
   for (final entry in files.entries) {
@@ -425,6 +441,42 @@ void main() {
         expect(body['push']['shots']['errors'], contains('bad row'));
       });
 
+      test(
+        'push returns 207 for a remote 200 response with section errors',
+        () async {
+          final client = http_testing.MockClient(
+            (_) async =>
+                http.Response('{"profiles":{"errors":["bad row"]}}', 200),
+          );
+          final handler = buildSyncHandler(client);
+          final response = await sendSync(handler, {
+            'target': 'http://192.168.1.50:8080',
+            'mode': 'push',
+          });
+          expect(response.statusCode, 207);
+          final body = jsonDecode(await response.readAsString());
+          expect(body['push']['phaseStatus'], 'failed');
+          expect(body['push']['profiles']['errors'], contains('bad row'));
+        },
+      );
+
+      test('push returns 207 when every remote section fails', () async {
+        final client = http_testing.MockClient(
+          (_) async => http.Response(
+            '{"profiles":{"errors":["bad profile"]},"shots":{"errors":["bad shot"]}}',
+            200,
+          ),
+        );
+        final handler = buildSyncHandler(client);
+        final response = await sendSync(handler, {
+          'target': 'http://192.168.1.50:8080',
+          'mode': 'push',
+        });
+        expect(response.statusCode, 207);
+        final body = jsonDecode(await response.readAsString());
+        expect(body['push']['phaseStatus'], 'failed');
+      });
+
       test('push returns 502 for a remote 400 response', () async {
         final client = http_testing.MockClient(
           (_) async => http.Response('{"message":"Invalid backup"}', 400),
@@ -454,6 +506,34 @@ void main() {
         final body = jsonDecode(await response.readAsString());
         expect(body['push']['error'], 'Target unreachable');
       });
+
+      test(
+        'push returns 502 when a requested local section cannot be exported',
+        () async {
+          var postCalled = false;
+          final client = http_testing.MockClient((request) async {
+            postCalled = true;
+            return http.Response('', 200);
+          });
+          final handler = buildSyncHandler(
+            client,
+            exportHandler: DataExportHandler(
+              sections: [FailingExportSection(filename: 'profiles.json')],
+            ),
+          );
+
+          final response = await sendSync(handler, {
+            'target': 'http://192.168.1.50:8080',
+            'mode': 'push',
+            'sections': ['profiles'],
+          });
+
+          expect(response.statusCode, 502);
+          expect(postCalled, isFalse);
+          final body = jsonDecode(await response.readAsString());
+          expect(body['push']['error'], 'Local export failed');
+        },
+      );
     });
 
     group('two_way mode', () {
@@ -510,8 +590,10 @@ void main() {
         expect(body['push']['error'], 'Target error');
       });
 
-      test('returns 207 when push succeeds but pull fails', () async {
+      test('skips push after a failed pull by default', () async {
+        var requestCount = 0;
         final client = http_testing.MockClient((request) async {
+          requestCount++;
           if (request.method == 'GET') {
             return http.Response('Server Error', 500);
           }
@@ -527,7 +609,40 @@ void main() {
         expect(response.statusCode, 207);
         final body = jsonDecode(await response.readAsString());
         expect(body['pull']['error'], 'Target error');
-        expect(body['push'], isNotNull);
+        expect(body['push']['phaseStatus'], 'skipped');
+        expect(requestCount, 1);
+      });
+
+      test('skips push after a partial pull by default', () async {
+        var requestCount = 0;
+        final partialSection = MockExportSection(
+          filename: 'profiles.json',
+          importResult: const SectionImportResult(
+            imported: 1,
+            errors: ['bad row'],
+          ),
+        );
+        final client = http_testing.MockClient((request) async {
+          requestCount++;
+          if (request.method == 'GET') {
+            return http.Response.bytes(buildZip({'profiles.json': {}}), 200);
+          }
+          return http.Response('{"profiles":{"imported":1}}', 200);
+        });
+        final handler = buildSyncHandler(
+          client,
+          exportHandler: DataExportHandler(sections: [partialSection]),
+        );
+
+        final response = await sendSync(handler, {
+          'target': 'http://192.168.1.50:8080',
+          'mode': 'two_way',
+        });
+
+        expect(response.statusCode, 207);
+        expect(requestCount, 1);
+        final body = jsonDecode(await response.readAsString());
+        expect(body['push']['phaseStatus'], 'skipped');
       });
 
       test(
@@ -550,6 +665,7 @@ void main() {
           final response = await sendSync(handler, {
             'target': 'http://192.168.1.50:8080',
             'mode': 'two_way',
+            'bestEffort': true,
           });
           expect(response.statusCode, 207);
           final body = jsonDecode(await response.readAsString());
@@ -578,6 +694,7 @@ void main() {
           final response = await sendSync(handler, {
             'target': 'http://192.168.1.50:8080',
             'mode': 'two_way',
+            'bestEffort': true,
           });
           expect(response.statusCode, 207);
           final body = jsonDecode(await response.readAsString());
@@ -595,6 +712,7 @@ void main() {
         final response = await sendSync(handler, {
           'target': 'http://192.168.1.50:8080',
           'mode': 'two_way',
+          'bestEffort': true,
         });
 
         expect(response.statusCode, 502);

--- a/test/data_export/data_sync_handler_test.dart
+++ b/test/data_export/data_sync_handler_test.dart
@@ -338,22 +338,20 @@ void main() {
         expect(body['pull']['profiles']['errors'], contains('bad row'));
       });
 
-      test(
-        'pull returns 502 for an archive with no recognized sections',
-        () async {
-          final client = http_testing.MockClient(
-            (_) async => http.Response.bytes(buildZip({}), 200),
-          );
-          final handler = buildSyncHandler(client);
-          final response = await sendSync(handler, {
-            'target': 'http://192.168.1.50:8080',
-            'mode': 'pull',
-          });
-          expect(response.statusCode, 502);
-          final body = jsonDecode(await response.readAsString());
-          expect(body['pull']['error'], 'Invalid backup archive');
-        },
-      );
+      test('pull reports missing sections for an empty archive', () async {
+        final client = http_testing.MockClient(
+          (_) async => http.Response.bytes(buildZip({}), 200),
+        );
+        final handler = buildSyncHandler(client);
+        final response = await sendSync(handler, {
+          'target': 'http://192.168.1.50:8080',
+          'mode': 'pull',
+        });
+        expect(response.statusCode, 502);
+        final body = jsonDecode(await response.readAsString());
+        expect(body['pull']['phaseStatus'], 'failed');
+        expect(body['pull']['profiles']['status'], 'failed');
+      });
     });
 
     group('push mode', () {
@@ -457,8 +455,56 @@ void main() {
           final body = jsonDecode(await response.readAsString());
           expect(body['push']['phaseStatus'], 'failed');
           expect(body['push']['profiles']['errors'], contains('bad row'));
+          expect(body['push']['profiles']['status'], 'failed');
         },
       );
+
+      test('push accounts for a missing explicit section result', () async {
+        final client = http_testing.MockClient(
+          (_) async => http.Response('{"profiles":{"imported":1}}', 200),
+        );
+        final handler = buildSyncHandler(
+          client,
+          exportHandler: DataExportHandler(
+            sections: [
+              MockExportSection(filename: 'profiles.json'),
+              MockExportSection(filename: 'shots.json'),
+            ],
+          ),
+        );
+        final response = await sendSync(handler, {
+          'target': 'http://192.168.1.50:8080',
+          'mode': 'push',
+          'sections': ['profiles', 'shots'],
+        });
+        expect(response.statusCode, 207);
+        final body = jsonDecode(await response.readAsString());
+        expect(body['push']['profiles']['status'], 'complete');
+        expect(body['push']['shots']['status'], 'failed');
+      });
+
+      test('push accounts for a missing default section result', () async {
+        final client = http_testing.MockClient(
+          (_) async => http.Response('{"profiles":{"imported":1}}', 200),
+        );
+        final handler = buildSyncHandler(
+          client,
+          exportHandler: DataExportHandler(
+            sections: [
+              MockExportSection(filename: 'profiles.json'),
+              MockExportSection(filename: 'shots.json'),
+            ],
+          ),
+        );
+        final response = await sendSync(handler, {
+          'target': 'http://192.168.1.50:8080',
+          'mode': 'push',
+        });
+        expect(response.statusCode, 207);
+        final body = jsonDecode(await response.readAsString());
+        expect(body['push']['profiles']['status'], 'complete');
+        expect(body['push']['shots']['status'], 'failed');
+      });
 
       test('push preserves a remote partial section status', () async {
         final client = http_testing.MockClient(
@@ -666,6 +712,42 @@ void main() {
           expect(requestCount, 1);
         },
       );
+
+      test('missing default section blocks the default two-way push', () async {
+        final methods = <String>[];
+        final sections = [
+          MockExportSection(filename: 'profiles.json'),
+          MockExportSection(filename: 'shots.json'),
+        ];
+        final client = http_testing.MockClient((request) async {
+          methods.add(request.method);
+          return http.Response.bytes(
+            buildZip({
+              'profiles.json': {'profiles': []},
+            }),
+            200,
+          );
+        });
+        final handler = buildSyncHandler(
+          client,
+          exportHandler: DataExportHandler(sections: sections),
+        );
+
+        final response = await sendSync(handler, {
+          'target': 'http://192.168.1.50:8080',
+          'mode': 'two_way',
+        });
+
+        expect(response.statusCode, 207);
+        final body = jsonDecode(await response.readAsString());
+        expect(body['pull']['shots']['status'], 'failed');
+        expect(
+          body['pull']['shots']['errors'],
+          contains(contains('Missing requested section')),
+        );
+        expect(body['push']['phaseStatus'], 'skipped');
+        expect(methods, ['GET']);
+      });
 
       test('skips push after a partial pull by default', () async {
         var requestCount = 0;

--- a/test/data_export/data_sync_handler_test.dart
+++ b/test/data_export/data_sync_handler_test.dart
@@ -523,6 +523,42 @@ void main() {
         expect(body['push']['profiles']['status'], 'partial');
       });
 
+      test('push normalizes complete status with successful errors', () async {
+        final client = http_testing.MockClient(
+          (_) async => http.Response(
+            '{"profiles":{"status":"complete","imported":1,"errors":["bad row"]}}',
+            200,
+          ),
+        );
+        final handler = buildSyncHandler(client);
+        final response = await sendSync(handler, {
+          'target': 'http://192.168.1.50:8080',
+          'mode': 'push',
+        });
+        expect(response.statusCode, 207);
+        final body = jsonDecode(await response.readAsString());
+        expect(body['push']['phaseStatus'], 'partial');
+        expect(body['push']['profiles']['status'], 'partial');
+      });
+
+      test('push normalizes complete status with only errors', () async {
+        final client = http_testing.MockClient(
+          (_) async => http.Response(
+            '{"profiles":{"status":"complete","errors":["bad row"]}}',
+            200,
+          ),
+        );
+        final handler = buildSyncHandler(client);
+        final response = await sendSync(handler, {
+          'target': 'http://192.168.1.50:8080',
+          'mode': 'push',
+        });
+        expect(response.statusCode, 502);
+        final body = jsonDecode(await response.readAsString());
+        expect(body['push']['phaseStatus'], 'failed');
+        expect(body['push']['profiles']['status'], 'failed');
+      });
+
       test('push returns 502 when every remote section fails', () async {
         final client = http_testing.MockClient(
           (_) async => http.Response(

--- a/test/data_export/data_sync_handler_test.dart
+++ b/test/data_export/data_sync_handler_test.dart
@@ -442,7 +442,7 @@ void main() {
       });
 
       test(
-        'push returns 207 for a remote 200 response with section errors',
+        'push returns 502 for a remote 200 response with every section failing',
         () async {
           final client = http_testing.MockClient(
             (_) async =>
@@ -453,14 +453,31 @@ void main() {
             'target': 'http://192.168.1.50:8080',
             'mode': 'push',
           });
-          expect(response.statusCode, 207);
+          expect(response.statusCode, 502);
           final body = jsonDecode(await response.readAsString());
           expect(body['push']['phaseStatus'], 'failed');
           expect(body['push']['profiles']['errors'], contains('bad row'));
         },
       );
 
-      test('push returns 207 when every remote section fails', () async {
+      test('push preserves a remote partial section status', () async {
+        final client = http_testing.MockClient(
+          (_) async => http.Response(
+            '{"profiles":{"status":"partial","imported":1,"errors":["bad row"]}}',
+            200,
+          ),
+        );
+        final handler = buildSyncHandler(client);
+        final response = await sendSync(handler, {
+          'target': 'http://192.168.1.50:8080',
+          'mode': 'push',
+        });
+        expect(response.statusCode, 207);
+        final body = jsonDecode(await response.readAsString());
+        expect(body['push']['profiles']['status'], 'partial');
+      });
+
+      test('push returns 502 when every remote section fails', () async {
         final client = http_testing.MockClient(
           (_) async => http.Response(
             '{"profiles":{"errors":["bad profile"]},"shots":{"errors":["bad shot"]}}',
@@ -472,7 +489,7 @@ void main() {
           'target': 'http://192.168.1.50:8080',
           'mode': 'push',
         });
-        expect(response.statusCode, 207);
+        expect(response.statusCode, 502);
         final body = jsonDecode(await response.readAsString());
         expect(body['push']['phaseStatus'], 'failed');
       });
@@ -606,12 +623,49 @@ void main() {
           'mode': 'two_way',
         });
 
-        expect(response.statusCode, 207);
+        expect(response.statusCode, 502);
         final body = jsonDecode(await response.readAsString());
         expect(body['pull']['error'], 'Target error');
         expect(body['push']['phaseStatus'], 'skipped');
         expect(requestCount, 1);
       });
+
+      test(
+        'missing selected section blocks the default two-way push',
+        () async {
+          var requestCount = 0;
+          final sections = [
+            MockExportSection(filename: 'profiles.json'),
+            MockExportSection(filename: 'shots.json'),
+          ];
+          final client = http_testing.MockClient((request) async {
+            requestCount++;
+            expect(request.method, 'GET');
+            return http.Response.bytes(
+              buildZip({
+                'profiles.json': {'profiles': []},
+              }),
+              200,
+            );
+          });
+          final handler = buildSyncHandler(
+            client,
+            exportHandler: DataExportHandler(sections: sections),
+          );
+
+          final response = await sendSync(handler, {
+            'target': 'http://192.168.1.50:8080',
+            'mode': 'two_way',
+            'sections': ['profiles', 'shots'],
+          });
+
+          expect(response.statusCode, 207);
+          final body = jsonDecode(await response.readAsString());
+          expect(body['pull']['shots']['status'], 'failed');
+          expect(body['push']['phaseStatus'], 'skipped');
+          expect(requestCount, 1);
+        },
+      );
 
       test('skips push after a partial pull by default', () async {
         var requestCount = 0;
@@ -650,7 +704,10 @@ void main() {
         () async {
           final partialSection = MockExportSection(
             filename: 'profiles.json',
-            importResult: const SectionImportResult(errors: ['bad row']),
+            importResult: const SectionImportResult(
+              imported: 1,
+              errors: ['bad row'],
+            ),
           );
           final client = http_testing.MockClient((request) async {
             if (request.method == 'GET') {
@@ -679,7 +736,10 @@ void main() {
         () async {
           final partialSection = MockExportSection(
             filename: 'profiles.json',
-            importResult: const SectionImportResult(errors: ['bad row']),
+            importResult: const SectionImportResult(
+              imported: 1,
+              errors: ['bad row'],
+            ),
           );
           final client = http_testing.MockClient((request) async {
             if (request.method == 'GET') {

--- a/test/data_export/data_sync_handler_test.dart
+++ b/test/data_export/data_sync_handler_test.dart
@@ -62,8 +62,11 @@ void main() {
     );
   });
 
-  Handler buildSyncHandler(http.Client client) {
-    final exportHandler = DataExportHandler(sections: [profileSection]);
+  Handler buildSyncHandler(
+    http.Client client, {
+    DataExportHandler? exportHandler,
+  }) {
+    exportHandler ??= DataExportHandler(sections: [profileSection]);
     final syncHandler = DataSyncHandler(
       exportHandler: exportHandler,
       httpClient: client,
@@ -293,6 +296,48 @@ void main() {
         final body = jsonDecode(await response.readAsString());
         expect(body['pull']['error'], 'Target unreachable');
       });
+
+      test('pull returns 207 for a partial local import', () async {
+        final partialSection = MockExportSection(
+          filename: 'profiles.json',
+          importResult: const SectionImportResult(
+            imported: 2,
+            errors: ['bad row'],
+          ),
+        );
+        final client = http_testing.MockClient(
+          (_) async =>
+              http.Response.bytes(buildZip({'profiles.json': {}}), 200),
+        );
+        final handler = buildSyncHandler(
+          client,
+          exportHandler: DataExportHandler(sections: [partialSection]),
+        );
+        final response = await sendSync(handler, {
+          'target': 'http://192.168.1.50:8080',
+          'mode': 'pull',
+        });
+        expect(response.statusCode, 207);
+        final body = jsonDecode(await response.readAsString());
+        expect(body['pull']['profiles']['errors'], contains('bad row'));
+      });
+
+      test(
+        'pull returns 502 for an archive with no recognized sections',
+        () async {
+          final client = http_testing.MockClient(
+            (_) async => http.Response.bytes(buildZip({}), 200),
+          );
+          final handler = buildSyncHandler(client);
+          final response = await sendSync(handler, {
+            'target': 'http://192.168.1.50:8080',
+            'mode': 'pull',
+          });
+          expect(response.statusCode, 502);
+          final body = jsonDecode(await response.readAsString());
+          expect(body['pull']['error'], 'Invalid backup archive');
+        },
+      );
     });
 
     group('push mode', () {
@@ -360,6 +405,38 @@ void main() {
         final body = jsonDecode(await response.readAsString());
         expect(body['push']['error'], 'Target error');
         expect(body['push']['status'], 500);
+      });
+
+      test('push returns 207 and preserves a remote partial result', () async {
+        final client = http_testing.MockClient(
+          (_) async => http.Response(
+            '{"profiles":{"imported":2},"shots":{"errors":["bad row"]}}',
+            207,
+          ),
+        );
+        final handler = buildSyncHandler(client);
+        final response = await sendSync(handler, {
+          'target': 'http://192.168.1.50:8080',
+          'mode': 'push',
+        });
+        expect(response.statusCode, 207);
+        final body = jsonDecode(await response.readAsString());
+        expect(body['push']['profiles']['imported'], 2);
+        expect(body['push']['shots']['errors'], contains('bad row'));
+      });
+
+      test('push returns 502 for a remote 400 response', () async {
+        final client = http_testing.MockClient(
+          (_) async => http.Response('{"message":"Invalid backup"}', 400),
+        );
+        final handler = buildSyncHandler(client);
+        final response = await sendSync(handler, {
+          'target': 'http://192.168.1.50:8080',
+          'mode': 'push',
+        });
+        expect(response.statusCode, 502);
+        final body = jsonDecode(await response.readAsString());
+        expect(body['push']['status'], 400);
       });
 
       test('push returns 502 when target is unreachable', () async {
@@ -452,6 +529,62 @@ void main() {
         expect(body['pull']['error'], 'Target error');
         expect(body['push'], isNotNull);
       });
+
+      test(
+        'returns 207 when one phase is partial and the other completes',
+        () async {
+          final partialSection = MockExportSection(
+            filename: 'profiles.json',
+            importResult: const SectionImportResult(errors: ['bad row']),
+          );
+          final client = http_testing.MockClient((request) async {
+            if (request.method == 'GET') {
+              return http.Response.bytes(buildZip({'profiles.json': {}}), 200);
+            }
+            return http.Response('{"profiles":{"imported":1}}', 200);
+          });
+          final handler = buildSyncHandler(
+            client,
+            exportHandler: DataExportHandler(sections: [partialSection]),
+          );
+          final response = await sendSync(handler, {
+            'target': 'http://192.168.1.50:8080',
+            'mode': 'two_way',
+          });
+          expect(response.statusCode, 207);
+          final body = jsonDecode(await response.readAsString());
+          expect(body['pull']['profiles']['errors'], contains('bad row'));
+          expect(body['push']['profiles']['imported'], 1);
+        },
+      );
+
+      test(
+        'returns 207 when one phase is partial and the other fails',
+        () async {
+          final partialSection = MockExportSection(
+            filename: 'profiles.json',
+            importResult: const SectionImportResult(errors: ['bad row']),
+          );
+          final client = http_testing.MockClient((request) async {
+            if (request.method == 'GET') {
+              return http.Response.bytes(buildZip({'profiles.json': {}}), 200);
+            }
+            return http.Response('Server Error', 500);
+          });
+          final handler = buildSyncHandler(
+            client,
+            exportHandler: DataExportHandler(sections: [partialSection]),
+          );
+          final response = await sendSync(handler, {
+            'target': 'http://192.168.1.50:8080',
+            'mode': 'two_way',
+          });
+          expect(response.statusCode, 207);
+          final body = jsonDecode(await response.readAsString());
+          expect(body['pull']['profiles']['errors'], contains('bad row'));
+          expect(body['push']['error'], 'Target error');
+        },
+      );
 
       test('returns 502 when both pull and push fail', () async {
         final client = http_testing.MockClient(

--- a/test/import/import_result_test.dart
+++ b/test/import/import_result_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/import/import_result.dart';
+
+void main() {
+  test(
+    'converts partial backup sections into onboarding counts and errors',
+    () {
+      final result = ImportResult.fromBackupSections({
+        'profiles': {'imported': 3, 'skipped': 1},
+        'shots': {
+          'imported': 2,
+          'errors': ['bad shot'],
+        },
+      });
+
+      expect(result.profilesImported, 3);
+      expect(result.profilesSkipped, 1);
+      expect(result.shotsImported, 2);
+      expect(result.errors.single.filename, 'shots');
+      expect(result.errors.single.reason, 'bad shot');
+    },
+  );
+}

--- a/test/settings/backup_export_response_test.dart
+++ b/test/settings/backup_export_response_test.dart
@@ -1,0 +1,49 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/settings/backup_export_response.dart';
+
+void main() {
+  test('rejects an export error before returning backup bytes', () {
+    expect(
+      () => BackupExportResponse.fromHttp(
+        statusCode: 500,
+        mimeType: 'application/json',
+        bytes: Uint8List.fromList(
+          '{"message":"Failed to export profiles."}'.codeUnits,
+        ),
+      ),
+      throwsA(
+        isA<BackupExportException>()
+            .having((error) => error.statusCode, 'status code', 500)
+            .having(
+              (error) => error.message,
+              'message',
+              'Failed to export profiles.',
+            ),
+      ),
+    );
+  });
+
+  test('rejects a successful response with a non-ZIP content type', () {
+    expect(
+      () => BackupExportResponse.fromHttp(
+        statusCode: 200,
+        mimeType: 'application/json',
+        bytes: Uint8List.fromList('{}'.codeUnits),
+      ),
+      throwsA(isA<BackupExportException>()),
+    );
+  });
+
+  test('accepts a successful ZIP response', () {
+    final bytes = Uint8List.fromList([1, 2, 3]);
+    final response = BackupExportResponse.fromHttp(
+      statusCode: 200,
+      mimeType: 'application/zip',
+      bytes: bytes,
+    );
+
+    expect(response.bytes, orderedEquals(bytes));
+  });
+}

--- a/test/settings/backup_import_response_test.dart
+++ b/test/settings/backup_import_response_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/settings/backup_import_response.dart';
+
+void main() {
+  test('200 parses as complete', () {
+    final response = BackupImportResponse.fromHttp(
+      200,
+      '{"profiles":{"imported":4,"skipped":1}}',
+    );
+    expect(response.status, BackupImportStatus.complete);
+    expect(response.sections['profiles']['imported'], 4);
+  });
+
+  test('207 parses as partial and preserves section details', () {
+    final response = BackupImportResponse.fromHttp(
+      207,
+      '{"profiles":{"imported":4},"shots":{"errors":["bad row"]}}',
+    );
+    expect(response.status, BackupImportStatus.partial);
+    expect(response.sections['profiles']['imported'], 4);
+    expect(response.sections['shots']['errors'], contains('bad row'));
+  });
+
+  test('partial UI state does not use complete wording', () {
+    expect(
+      backupImportDialogTitle(BackupImportStatus.partial),
+      'Import Partially Complete',
+    );
+    expect(
+      backupImportDialogTitle(BackupImportStatus.partial),
+      isNot('Import Complete'),
+    );
+  });
+
+  test('partial response can notify changed data', () {
+    final response = BackupImportResponse.fromHttp(207, '{}');
+    expect(response.shouldNotifyShotsChanged, isTrue);
+  });
+
+  test('400 preserves the invalid-backup server message', () {
+    expect(
+      () => BackupImportResponse.fromHttp(
+        400,
+        '{"error":"Invalid backup archive","message":"No recognized data sections."}',
+      ),
+      throwsA(
+        isA<BackupImportException>()
+            .having((error) => error.isInvalidBackup, 'invalid backup', isTrue)
+            .having(
+              (error) => error.message,
+              'message',
+              contains('recognized'),
+            ),
+      ),
+    );
+  });
+
+  test('archive-level failure does not produce a refresh response', () {
+    expect(
+      () => BackupImportResponse.fromHttp(400, '{"message":"invalid"}'),
+      throwsA(isA<BackupImportException>()),
+    );
+  });
+}

--- a/test/settings/backup_import_response_test.dart
+++ b/test/settings/backup_import_response_test.dart
@@ -19,6 +19,9 @@ void main() {
     expect(response.status, BackupImportStatus.partial);
     expect(response.sections['profiles']['imported'], 4);
     expect(response.sections['shots']['errors'], contains('bad row'));
+    final result = response.toImportResult();
+    expect(result.profilesImported, 4);
+    expect(result.errors.single.reason, 'bad row');
   });
 
   test('partial UI state does not use complete wording', () {


### PR DESCRIPTION
## Summary

- Problem: Mixed-version backup peers could omit requested sections or report contradictory section statuses, allowing an incomplete sync to be treated as complete.
- Why it matters: A false-complete pull can permit the default two-way sync to push stale local data back to the peer.
- What changed: Strict expected-section accounting, normalized remote results, canonical section/phase statuses, fail-closed native export handling, and documented result schemas.
- What did NOT change (scope boundary): No new endpoint, WebSocket topic, BLE/USB behavior, database migration, or configuration change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all)

- [ ] BLE transport / device comms
- [x] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [x] WebUI skins
- [ ] Plugins / JS runtime
- [x] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #
- Related #

## Root Cause (if bug fix)

- Root cause: Backup import treated missing files permissively and trusted a remote `status: complete` even when the same section contained errors.
- Missing detection or guardrail: Sync did not always compare responses against the expected section set, and section status was not canonicalized from both status and result errors.
- Contributing context (if known): Older peers may omit failed export sections or return legacy result shapes without section statuses.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/data_export/data_sync_handler_test.dart`, `test/data_export/data_export_handler_test.dart`, and `test/import/import_result_test.dart`.
- Scenario the test should lock in: Missing expected pull/push sections block two-way push; legacy errors are normalized; contradictory complete statuses become partial or failed with matching HTTP status; native export rejects non-200 and non-ZIP responses before opening the file picker.
- If no new test added, why not: N/A

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [x] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A - no docs affected

## Security Impact (required)

This app runs a local web server (port 8080) and connects to BLE/USB hardware.

- New or changed REST endpoints? (Yes/No): No
- New or changed WebSocket topics? (Yes/No): No
- New or changed network calls? (Yes/No): No new network calls; existing sync/export responses are validated more strictly.
- BLE/USB surface changed? (Yes/No): No
- File system access changed? (Yes/No): No
- Plugin sandbox boundary changed? (Yes/No): No
- If any Yes, explain risk and mitigation: Existing backup sync and export paths now fail closed on incomplete or contradictory results, preventing stale data from being pushed and preventing JSON errors from being saved as ZIP backups.

## User-Visible Changes

- Backup sync reports partial or failed results instead of false success when sections are missing or contradictory.
- Failed full-backup exports show the server error and do not open the save dialog.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` - no remaining changes
- [x] `flutter analyze` - clean (no new warnings)
- [ ] `flutter test` - all pass
- [ ] `(cd packages/dye2-plugin && npm run build)` - plugin builds

### Manual verification (if applicable)

- OS / platform tested: Windows development environment
- Simulated devices? (`simulate=1`): No
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: Ran the focused backup export/import/sync tests and static analysis.
- Edge cases checked: 73 focused backup/export/import/sync tests passed, including missing sections, legacy responses, contradictory statuses, and non-ZIP export errors.
- What you did **not** verify: Full `flutter test` has 2,597 passing tests and 14 unrelated pre-existing failures; no real hardware or simulated-device smoke test was run.

### Evidence

Attach at least one:

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? (Yes/No): Yes
- Config / env changes needed? (Yes/No): No
- Database migration needed? (Yes/No): No
- If any No or Yes, explain exact steps: No migration or configuration changes are required. Legacy peer responses are normalized safely; incomplete results now correctly prevent two-way pushes.

## Risks & Mitigations

- Risk: Older peers may now receive a non-success response for incomplete backup exchanges.
  - Mitigation: This is intentional fail-closed behavior; normalized per-section results identify the missing or failed sections for recovery.