### PR TITLE
fix: point feedback and update services to decentespresso/decaid

### DIFF
--- a/lib/src/services/feedback_service.dart
+++ b/lib/src/services/feedback_service.dart
@@ -23,7 +23,7 @@ class FeedbackService {
 
   FeedbackService({
     required String githubToken,
-    String repo = 'tadelv/reaprime',
+    String repo = 'decentespresso/decaid',
   }) : _githubToken = githubToken,
        _repo = repo;
 

--- a/lib/src/services/update_check_service.dart
+++ b/lib/src/services/update_check_service.dart
@@ -236,14 +236,14 @@ class UpdateCheckService {
 
   /// Get the GitHub releases page URL
   String getReleasesUrl() {
-    return 'https://github.com/tadelv/reaprime/releases';
+    return 'https://github.com/decentespresso/decaid/releases';
   }
 
   /// Get the specific release URL if an update is available
   String? getReleaseUrl([UpdateInfo? update]) {
     final release = update ?? _availableUpdate;
     if (release == null) return null;
-    return 'https://github.com/tadelv/reaprime/releases/tag/${release.tagName}';
+    return 'https://github.com/decentespresso/decaid/releases/tag/${release.tagName}';
   }
 
   /// Enable automatic update checks
@@ -275,7 +275,7 @@ class UpdateCheckService {
       version: version,
       downloadUrl:
           downloadUrl ??
-          'https://github.com/tadelv/reaprime/releases/download/v0.7.7/decent-android-0.7.7.apk',
+          'https://github.com/decentespresso/decaid/releases/download/v0.7.7/decent-android-0.7.7.apk',
       releaseNotes: 'Forced update for testing the update API.',
       isPrerelease: false,
       tagName: 'v$version',

--- a/lib/src/webui_support/webui_zip_support.dart
+++ b/lib/src/webui_support/webui_zip_support.dart
@@ -11,9 +11,9 @@ import 'package:path/path.dart' as p;
 /// standing up the full storage + asset bundle stack.
 ///
 /// Issues this file addresses:
-///   - https://github.com/tadelv/reaprime/issues/147
+///   - https://github.com/decentespresso/decaid/issues/147
 ///     `_installFromZip` crashed on Windows-reserved filename chars.
-///   - https://github.com/tadelv/reaprime/issues/148
+///   - https://github.com/decentespresso/decaid/issues/148
 ///     `_copyBundledSkins` silently skipped every later bundled skin if any
 ///     earlier one threw.
 

--- a/test/app_update_state_test.dart
+++ b/test/app_update_state_test.dart
@@ -9,7 +9,8 @@ void main() {
         currentVersion: '0.6.1',
         latestVersion: '0.6.2',
         releaseNotes: 'notes',
-        releaseUrl: 'https://github.com/decentespresso/decaid/releases/tag/v0.6.2',
+        releaseUrl:
+            'https://github.com/decentespresso/decaid/releases/tag/v0.6.2',
         installable: true,
         progress: null,
         error: null,
@@ -20,7 +21,8 @@ void main() {
         'currentVersion': '0.6.1',
         'latestVersion': '0.6.2',
         'releaseNotes': 'notes',
-        'releaseUrl': 'https://github.com/decentespresso/decaid/releases/tag/v0.6.2',
+        'releaseUrl':
+            'https://github.com/decentespresso/decaid/releases/tag/v0.6.2',
         'installable': true,
         'progress': null,
         'error': null,

--- a/test/app_update_state_test.dart
+++ b/test/app_update_state_test.dart
@@ -9,7 +9,7 @@ void main() {
         currentVersion: '0.6.1',
         latestVersion: '0.6.2',
         releaseNotes: 'notes',
-        releaseUrl: 'https://github.com/tadelv/reaprime/releases/tag/v0.6.2',
+        releaseUrl: 'https://github.com/decentespresso/decaid/releases/tag/v0.6.2',
         installable: true,
         progress: null,
         error: null,
@@ -20,7 +20,7 @@ void main() {
         'currentVersion': '0.6.1',
         'latestVersion': '0.6.2',
         'releaseNotes': 'notes',
-        'releaseUrl': 'https://github.com/tadelv/reaprime/releases/tag/v0.6.2',
+        'releaseUrl': 'https://github.com/decentespresso/decaid/releases/tag/v0.6.2',
         'installable': true,
         'progress': null,
         'error': null,
@@ -31,7 +31,7 @@ void main() {
       const state = AppUpdateState(
         phase: AppUpdatePhase.idle,
         currentVersion: '0.6.1',
-        releaseUrl: 'https://github.com/tadelv/reaprime/releases',
+        releaseUrl: 'https://github.com/decentespresso/decaid/releases',
         installable: false,
       );
 

--- a/test/services/webserver/feedback_handler_test.dart
+++ b/test/services/webserver/feedback_handler_test.dart
@@ -22,7 +22,7 @@ class _StubFeedbackService implements FeedbackService {
   ) async {
     if (onSubmitted != null) return onSubmitted!(request);
     return FeedbackSubmissionResult.succeeded(
-      issueUrl: 'https://github.com/tadelv/reaprime/issues/999',
+      issueUrl: 'https://github.com/decentespresso/decaid/issues/999',
       issueNumber: 999,
     );
   }
@@ -71,7 +71,7 @@ void main() {
       expect(res.statusCode, 201);
       final body = jsonDecode(await res.readAsString()) as Map<String, dynamic>;
       expect(body['success'], true);
-      expect(body['issueUrl'], 'https://github.com/tadelv/reaprime/issues/999');
+      expect(body['issueUrl'], 'https://github.com/decentespresso/decaid/issues/999');
       expect(body['issueNumber'], 999);
     });
 

--- a/test/services/webserver/feedback_handler_test.dart
+++ b/test/services/webserver/feedback_handler_test.dart
@@ -71,7 +71,10 @@ void main() {
       expect(res.statusCode, 201);
       final body = jsonDecode(await res.readAsString()) as Map<String, dynamic>;
       expect(body['success'], true);
-      expect(body['issueUrl'], 'https://github.com/decentespresso/decaid/issues/999');
+      expect(
+        body['issueUrl'],
+        'https://github.com/decentespresso/decaid/issues/999',
+      );
       expect(body['issueNumber'], 999);
     });
 

--- a/test/update_check_service_test.dart
+++ b/test/update_check_service_test.dart
@@ -131,7 +131,7 @@ void main() {
 
       expect(
         svc.getReleaseUrl(_update(version: '1.2.3')),
-        'https://github.com/tadelv/reaprime/releases/tag/v1.2.3',
+        'https://github.com/decentespresso/decaid/releases/tag/v1.2.3',
       );
       svc.dispose();
     });


### PR DESCRIPTION
## Summary

- Problem: feedback and update services still pointed at the old `tadelv/reaprime` repo; issues and release URLs 404'd or opened the wrong repo.
- Why it matters: feedback submissions and update links need to land in the new `decentespresso/decaid` home.
- What changed: repo references updated in `FeedbackService`, `UpdateCheckService`, `webui_zip_support.dart`, and matching tests.
- What did NOT change (scope boundary): no logic changes, no API surface changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- closes: #540 

## Root Cause (if bug fix)

- Root cause: repo renamed/moved; hardcoded `tadelv/reaprime` URLs not updated.
- Missing detection or guardrail: `N/A`
- Contributing context (if known): `N/A`

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/services/webserver/feedback_handler_test.dart`, `test/update_check_service_test.dart`, `test/app_update_state_test.dart`
- Scenario the test should lock in: expected URLs contain `decentespresso/decaid`.
- If no new test added, why not: existing tests updated to assert the new URLs.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A — no docs affected

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `No`
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`
- If any `Yes`, explain risk and mitigation: `N/A`

## User-Visible Changes

Feedback submission and update links now point to the `decentespresso/decaid` repo instead of `tadelv/reaprime`.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — no remaining changes
- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass
- [ ] `(cd packages/dye2-plugin && npm run build)` — plugin builds (not affected)

### Manual verification (if applicable)

- OS / platform tested: `N/A`
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: URL assertions in unit tests updated and passing.
- Edge cases checked: `N/A`
- What you did **not** verify: live feedback submission / release download.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`
- If any `No` or `Yes`, explain exact steps: `N/A`

## Risks & Mitigations

- Risk: none.
  - Mitigation: `N/A`
