### PR TITLE
fix: skin selector update button refreshes user-installed skins

### DIFF
--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -3407,11 +3407,27 @@ Decaid tracks skin metadata in `.rea_metadata.json`:
 }
 ```
 
+`sourceUrl` records where a skin came from so it can be refreshed later:
+
+- `github_branch:owner/repo@branch` — GitHub branch installs
+- `github_release:owner/repo@tag` — GitHub release installs. `releaseAssetName`
+  (the specifically selected asset) and `includePrerelease` (prerelease
+  tracking) are stored alongside and re-applied on every update.
+- A plain `http(s)://` URL — raw URL installs, tracked via `etag` /
+  `lastModified` headers
+
 **Update Detection:**
-- Remote skins are checked for updates when `downloadRemoteSkins()` is called
-- Uses HTTP `ETag` and `Last-Modified` headers for efficient version checking
+- User-installed skins are checked for updates via `updateAllSkins()`, which
+  runs on the app's periodic update check, from `POST /api/v1/webui/skins/update`,
+  from the web settings plugin's "Check for Skin Updates", and from the native
+  skin selector's "Check for updates" button.
+- Raw-URL and GitHub-release skins are compared against their recorded source
+  on every check: URL skins via HTTP `ETag` / `Last-Modified` headers,
+  release skins by re-resolving the latest release (honoring the recorded
+  `releaseAssetName` and `includePrerelease`).
 - Only downloads if remote version differs from installed version
-- Updates are automatic for remote bundled skins and user-installed GitHub branch skins
+- Updates are automatic for remote bundled skins and all user-installed skins
+  (GitHub branch, GitHub release, or raw URL)
 
 ---
 

--- a/lib/src/skin_selector/skin_selector_page.dart
+++ b/lib/src/skin_selector/skin_selector_page.dart
@@ -657,11 +657,13 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
         const SnackBar(content: Text('Checking for skin updates...')),
       );
 
-      await widget.webUIStorage.downloadRemoteSkins();
+      // Updates both remote-bundled skins and user-installed skins with a
+      // sourceUrl (github branch/release or raw URL), then re-scans the
+      // registry so installedSkins reflects any new versions (#503).
+      await widget.webUIStorage.updateAllSkins();
 
-      // downloadRemoteSkins() re-scans the registry, so installedSkins now
-      // reflects any newly downloaded versions. Rebuild so the dropdown shows
-      // them without the user having to leave and re-enter the page (#370).
+      // Rebuild so the dropdown shows newly downloaded versions without the
+      // user having to leave and re-enter the page (#370).
       if (mounted) setState(() {});
 
       if (!context.mounted) return;

--- a/lib/src/skin_selector/skin_selector_page.dart
+++ b/lib/src/skin_selector/skin_selector_page.dart
@@ -657,9 +657,6 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
         const SnackBar(content: Text('Checking for skin updates...')),
       );
 
-      // Updates both remote-bundled skins and user-installed skins with a
-      // sourceUrl (github branch/release or raw URL), then re-scans the
-      // registry so installedSkins reflects any new versions (#503).
       await widget.webUIStorage.updateAllSkins();
 
       // Rebuild so the dropdown shows newly downloaded versions without the

--- a/lib/src/webui_support/webui_storage.dart
+++ b/lib/src/webui_support/webui_storage.dart
@@ -19,6 +19,8 @@ class WebUIReaMetadata {
   final String? lastModified;
   final String? etag;
   final String? commitHash;
+  final String? releaseAssetName;
+  final bool? includePrerelease;
   final DateTime installedAt;
   final DateTime? lastChecked;
 
@@ -28,6 +30,8 @@ class WebUIReaMetadata {
     this.lastModified,
     this.etag,
     this.commitHash,
+    this.releaseAssetName,
+    this.includePrerelease,
     required this.installedAt,
     this.lastChecked,
   });
@@ -39,6 +43,8 @@ class WebUIReaMetadata {
       lastModified: json['lastModified'] as String?,
       etag: json['etag'] as String?,
       commitHash: json['commitHash'] as String?,
+      releaseAssetName: json['releaseAssetName'] as String?,
+      includePrerelease: json['includePrerelease'] as bool?,
       installedAt: DateTime.parse(json['installedAt'] as String),
       lastChecked: json['lastChecked'] != null
           ? DateTime.parse(json['lastChecked'] as String)
@@ -53,6 +59,8 @@ class WebUIReaMetadata {
       'lastModified': lastModified,
       'etag': etag,
       'commitHash': commitHash,
+      'releaseAssetName': releaseAssetName,
+      'includePrerelease': includePrerelease,
       'installedAt': installedAt.toIso8601String(),
       'lastChecked': lastChecked?.toIso8601String(),
     };
@@ -63,6 +71,8 @@ class WebUIReaMetadata {
     String? lastModified,
     String? etag,
     String? commitHash,
+    String? releaseAssetName,
+    bool? includePrerelease,
     DateTime? installedAt,
     DateTime? lastChecked,
   }) {
@@ -72,6 +82,8 @@ class WebUIReaMetadata {
       lastModified: lastModified ?? this.lastModified,
       etag: etag ?? this.etag,
       commitHash: commitHash ?? this.commitHash,
+      releaseAssetName: releaseAssetName ?? this.releaseAssetName,
+      includePrerelease: includePrerelease ?? this.includePrerelease,
       installedAt: installedAt ?? this.installedAt,
       lastChecked: lastChecked ?? this.lastChecked,
     );
@@ -325,7 +337,12 @@ class WebUIStorage {
   /// [sourceIdentifier] is stored as the skin's metadata sourceUrl so that
   /// [updateAllSkins] can find and refresh this skin later (raw URLs default
   /// to the URL itself, ETag/Last-Modified tracked).
-  Future<void> installFromUrl(String url, {String? sourceIdentifier}) async {
+  Future<void> installFromUrl(
+    String url, {
+    String? sourceIdentifier,
+    String? releaseAssetName,
+    bool? includePrerelease,
+  }) async {
     _log.info('Downloading WebUI from URL: $url');
 
     try {
@@ -357,6 +374,8 @@ class WebUIStorage {
       _skinMetadata[installedSkinId] = WebUIReaMetadata(
         skinId: installedSkinId,
         sourceUrl: sourceIdentifier ?? url,
+        releaseAssetName: releaseAssetName,
+        includePrerelease: includePrerelease,
         etag: etag,
         lastModified: lastModified,
         installedAt: DateTime.now(),
@@ -473,10 +492,14 @@ class WebUIStorage {
       _log.info('Downloading asset: ${targetAsset['name']}');
 
       // Download and install, tracking the release so updateAllSkins()
-      // can detect newer releases via the GitHub API.
+      // can detect newer releases via the GitHub API. The requested asset
+      // name and prerelease flag ride along so updates keep the same
+      // selection semantics.
       await installFromUrl(
         downloadUrl,
         sourceIdentifier: 'github_release:$repo@$releaseTag',
+        releaseAssetName: assetName,
+        includePrerelease: includePrerelease,
       );
 
       _log.info(
@@ -595,8 +618,8 @@ class WebUIStorage {
           );
           await _installFromGitHubRelease(
             repo,
-            null,
-            false,
+            entry.value.releaseAssetName,
+            entry.value.includePrerelease ?? false,
             markAsRemoteBundled: false,
           );
         } else if (sourceUrl.startsWith('github_branch:')) {
@@ -751,11 +774,14 @@ class WebUIStorage {
         await _saveRemoteBundledSkinIds();
       }
 
-      // Store REA metadata with release information
+      // Store REA metadata with release information, preserving the
+      // selection options so later updateAllSkins() runs keep them.
       _skinMetadata[installedSkinId] = WebUIReaMetadata(
         skinId: installedSkinId,
         sourceUrl: sourceIdentifier,
         commitHash: releaseTag,
+        releaseAssetName: assetName,
+        includePrerelease: includePrerelease,
         etag: null, // GitHub releases don't use ETags for versioning
         lastModified: publishedAt,
         installedAt: DateTime.now(),

--- a/lib/src/webui_support/webui_storage.dart
+++ b/lib/src/webui_support/webui_storage.dart
@@ -321,7 +321,11 @@ class WebUIStorage {
 
   /// Install a WebUI skin from a URL
   /// The URL should point to a zip file
-  Future<void> installFromUrl(String url) async {
+  ///
+  /// [sourceIdentifier] is stored as the skin's metadata sourceUrl so that
+  /// [updateAllSkins] can find and refresh this skin later (raw URLs default
+  /// to the URL itself, ETag/Last-Modified tracked).
+  Future<void> installFromUrl(String url, {String? sourceIdentifier}) async {
     _log.info('Downloading WebUI from URL: $url');
 
     try {
@@ -330,21 +334,35 @@ class WebUIStorage {
       if (response.statusCode != 200) {
         throw Exception('Failed to download: ${response.statusCode}');
       }
+      final etag = response.headers['etag'];
+      final lastModified = response.headers['last-modified'];
 
       // Create temp file for the downloaded zip
       final appDocDir = await getApplicationDocumentsDirectory();
       final tempFile = File('${appDocDir.path}/temp_webui.zip');
       await tempFile.writeAsBytes(response.bodyBytes);
 
+      String installedSkinId;
       try {
         // Install from the downloaded zip
-        await _installFromZip(tempFile.path);
+        installedSkinId = await _installFromZip(tempFile.path);
       } finally {
         // Clean up temp file
         if (tempFile.existsSync()) {
           await tempFile.delete();
         }
       }
+
+      // Persist source metadata so updateAllSkins() can refresh this skin.
+      _skinMetadata[installedSkinId] = WebUIReaMetadata(
+        skinId: installedSkinId,
+        sourceUrl: sourceIdentifier ?? url,
+        etag: etag,
+        lastModified: lastModified,
+        installedAt: DateTime.now(),
+        lastChecked: DateTime.now(),
+      );
+      await _saveSkinMetadata();
 
       // Rescan installed skins
       await _scanInstalledSkins();
@@ -454,8 +472,12 @@ class WebUIStorage {
 
       _log.info('Downloading asset: ${targetAsset['name']}');
 
-      // Download and install
-      await installFromUrl(downloadUrl);
+      // Download and install, tracking the release so updateAllSkins()
+      // can detect newer releases via the GitHub API.
+      await installFromUrl(
+        downloadUrl,
+        sourceIdentifier: 'github_release:$repo@$releaseTag',
+      );
 
       _log.info(
         'Successfully installed WebUI from GitHub release: $releaseTag',
@@ -571,7 +593,12 @@ class WebUIStorage {
           _log.info(
             'Updating user-installed skin "$skinId" from GitHub release: $repo',
           );
-          await _installFromGitHubRelease(repo, null, false);
+          await _installFromGitHubRelease(
+            repo,
+            null,
+            false,
+            markAsRemoteBundled: false,
+          );
         } else if (sourceUrl.startsWith('github_branch:')) {
           final withoutPrefix = sourceUrl.substring('github_branch:'.length);
           final atIndex = withoutPrefix.indexOf('@');
@@ -614,8 +641,9 @@ class WebUIStorage {
   Future<void> _installFromGitHubRelease(
     String repo,
     String? assetName,
-    bool includePrerelease,
-  ) async {
+    bool includePrerelease, {
+    bool markAsRemoteBundled = true,
+  }) async {
     try {
       // Fetch latest release from GitHub API
       final apiUrl = includePrerelease
@@ -716,9 +744,12 @@ class WebUIStorage {
         }
       }
 
-      // Mark this skin as remote bundled
-      _remoteBundledSkinIds.add(installedSkinId);
-      await _saveRemoteBundledSkinIds();
+      // Mark this skin as remote bundled (skip for user-installed skins
+      // being updated, so they stay removable).
+      if (markAsRemoteBundled) {
+        _remoteBundledSkinIds.add(installedSkinId);
+        await _saveRemoteBundledSkinIds();
+      }
 
       // Store REA metadata with release information
       _skinMetadata[installedSkinId] = WebUIReaMetadata(

--- a/test/skin_selector_update_refresh_test.dart
+++ b/test/skin_selector_update_refresh_test.dart
@@ -22,14 +22,14 @@ class _FakeWebUIStorage extends Fake implements WebUIStorage {
   _FakeWebUIStorage(this._version);
 
   String _version;
-  int downloadCount = 0;
+  int updateCount = 0;
 
   WebUISkin get _skin => WebUISkin(
     id: 'streamline.js',
     name: 'Streamline',
     path: '/tmp/streamline.js',
     version: _version,
-    isBundled: true,
+    isBundled: false,
   );
 
   @override
@@ -43,7 +43,7 @@ class _FakeWebUIStorage extends Fake implements WebUIStorage {
 
   @override
   Future<void> updateAllSkins() async {
-    downloadCount++;
+    updateCount++;
     _version = '0.2.3';
   }
 }
@@ -51,7 +51,7 @@ class _FakeWebUIStorage extends Fake implements WebUIStorage {
 void main() {
   testWidgets(
     'skins list refreshes to the new version after "Check for updates" '
-    '(issue #370)',
+    '(issues #370, #503)',
     (tester) async {
       final storage = _FakeWebUIStorage('0.2.2');
 
@@ -81,7 +81,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 300)); // settle snackbar
 
       // Storage actually ran the update...
-      expect(storage.downloadCount, 1);
+      expect(storage.updateCount, 1);
       // ...and the list now reflects the new version without leaving the page.
       expect(find.textContaining('0.2.3'), findsOneWidget);
       expect(find.textContaining('0.2.2'), findsNothing);

--- a/test/skin_selector_update_refresh_test.dart
+++ b/test/skin_selector_update_refresh_test.dart
@@ -16,7 +16,7 @@ class _FakeWebUIService extends Fake implements WebUIService {
 }
 
 /// Stand-in storage whose single installed skin reports a newer version after
-/// [downloadRemoteSkins] runs — mirroring a real update check that bumps the
+/// [updateAllSkins] runs — mirroring a real update check that bumps the
 /// on-disk skin from 0.2.2 to 0.2.3 and re-scans the registry.
 class _FakeWebUIStorage extends Fake implements WebUIStorage {
   _FakeWebUIStorage(this._version);
@@ -42,7 +42,7 @@ class _FakeWebUIStorage extends Fake implements WebUIStorage {
   WebUISkin? getSkin(String id) => id == _skin.id ? _skin : null;
 
   @override
-  Future<void> downloadRemoteSkins() async {
+  Future<void> updateAllSkins() async {
     downloadCount++;
     _version = '0.2.3';
   }

--- a/test/webui_handler_appstore_test.dart
+++ b/test/webui_handler_appstore_test.dart
@@ -27,7 +27,12 @@ class FakeWebUIStorage extends Fake implements WebUIStorage {
   }
 
   @override
-  Future<void> installFromUrl(String url, {String? sourceIdentifier}) async {
+  Future<void> installFromUrl(
+    String url, {
+    String? sourceIdentifier,
+    String? releaseAssetName,
+    bool? includePrerelease,
+  }) async {
     installFromUrlCalled = true;
   }
 }

--- a/test/webui_handler_appstore_test.dart
+++ b/test/webui_handler_appstore_test.dart
@@ -27,7 +27,7 @@ class FakeWebUIStorage extends Fake implements WebUIStorage {
   }
 
   @override
-  Future<void> installFromUrl(String url) async {
+  Future<void> installFromUrl(String url, {String? sourceIdentifier}) async {
     installFromUrlCalled = true;
   }
 }

--- a/test/webui_storage_install_test.dart
+++ b/test/webui_storage_install_test.dart
@@ -132,6 +132,125 @@ void main() {
       expect(DateTime.parse(persisted['passione-dist']['lastChecked']), after);
     });
 
+    test('URL install persists source metadata; updateAllSkins refreshes on '
+        'ETag change', () async {
+      final archive = makeGitHubArchive();
+      var urlHeadRequests = 0;
+      var urlGetRequests = 0;
+      var etag = 'url-etag-v1';
+
+      await http.runWithClient(
+        () async {
+          await storage.installFromUrl('https://example.com/skin.zip');
+
+          final metadata = storage.getSkin('passione-dist')!.reaMetadata!;
+          expect(metadata.sourceUrl, 'https://example.com/skin.zip');
+          expect(metadata.etag, 'url-etag-v1');
+          expect(storage.getSkin('passione-dist')!.isBundled, isFalse);
+          expect(urlGetRequests, 1);
+
+          // Unchanged ETag: updateAllSkins skips the re-download.
+          await storage.updateAllSkins();
+          expect(urlGetRequests, 1);
+
+          // Changed ETag: updateAllSkins re-downloads and refreshes metadata.
+          etag = 'url-etag-v2';
+          await storage.updateAllSkins();
+          expect(urlGetRequests, 2);
+          expect(
+            storage.getSkin('passione-dist')!.reaMetadata!.etag,
+            'url-etag-v2',
+          );
+        },
+        () => MockClient((request) async {
+          final url = request.url.toString();
+          if (url != 'https://example.com/skin.zip') {
+            return http.Response('', 404);
+          }
+          if (request.method == 'HEAD') {
+            urlHeadRequests++;
+            return http.Response('', 200, headers: {'etag': etag});
+          }
+          urlGetRequests++;
+          return http.Response.bytes(archive, 200, headers: {'etag': etag});
+        }),
+      );
+
+      expect(urlHeadRequests, greaterThanOrEqualTo(2));
+      final persisted =
+          jsonDecode(
+                File('${webUIDir.path}/.rea_metadata.json').readAsStringSync(),
+              )
+              as Map<String, dynamic>;
+      expect(
+        persisted['passione-dist']['sourceUrl'],
+        'https://example.com/skin.zip',
+      );
+    });
+
+    test('GitHub release install tracks release; updateAllSkins picks up new '
+        'releases and keeps the skin removable', () async {
+      final archive = makeGitHubArchive();
+      var apiGets = 0;
+      var assetGets = 0;
+      var releaseTag = 'v1.0.0';
+      Map<String, dynamic> releaseBody() => {
+        'tag_name': releaseTag,
+        'name': 'Custom Skin $releaseTag',
+        'published_at': '2026-01-01T00:00:00Z',
+        'assets': [
+          {
+            'name': 'custom-skin.zip',
+            'browser_download_url':
+                'https://github.com/acme/custom-skin/releases/download/'
+                '$releaseTag/custom-skin.zip',
+            'size': 1234,
+          },
+        ],
+      };
+
+      await http.runWithClient(
+        () async {
+          await storage.installFromGitHubRelease('acme/custom-skin');
+
+          var metadata = storage.getSkin('passione-dist')!.reaMetadata!;
+          expect(metadata.sourceUrl, 'github_release:acme/custom-skin@v1.0.0');
+          expect(storage.getSkin('passione-dist')!.isBundled, isFalse);
+          expect(assetGets, 1);
+
+          // Same tag: updateAllSkins skips the asset download.
+          await storage.updateAllSkins();
+          expect(assetGets, 1);
+
+          // New release: updateAllSkins re-downloads and retargets metadata.
+          releaseTag = 'v1.1.0';
+          await storage.updateAllSkins();
+          expect(assetGets, 2);
+          metadata = storage.getSkin('passione-dist')!.reaMetadata!;
+          expect(metadata.sourceUrl, 'github_release:acme/custom-skin@v1.1.0');
+          // User-installed skin stays removable after an update.
+          expect(storage.getSkin('passione-dist')!.isBundled, isFalse);
+        },
+        () => MockClient((request) async {
+          final url = request.url.toString();
+          if (url ==
+              'https://api.github.com/repos/acme/custom-skin/releases/latest') {
+            apiGets++;
+            return http.Response(jsonEncode(releaseBody()), 200);
+          }
+          if (url.startsWith(
+            'https://github.com/acme/custom-skin/releases/download/',
+          )) {
+            assetGets++;
+            return http.Response.bytes(archive, 200);
+          }
+          return http.Response('', 404);
+        }),
+      );
+
+      expect(apiGets, greaterThanOrEqualTo(2));
+    });
+
     test('overwriteIfExists:false leaves an existing skin untouched', () async {
       // Newer copy installed first (e.g. from a GitHub release).
       await storage.installFromPath(makeSkinSource('0.1.33').path);

--- a/test/webui_storage_install_test.dart
+++ b/test/webui_storage_install_test.dart
@@ -251,6 +251,154 @@ void main() {
       expect(apiGets, greaterThanOrEqualTo(2));
     });
 
+    test(
+      'GitHub release update preserves a specifically selected asset',
+      () async {
+        final archive = makeGitHubArchive();
+        final requestedAssets = <String>[];
+        var releaseTag = 'v1.0.0';
+        Map<String, dynamic> releaseBody() => {
+          'tag_name': releaseTag,
+          'name': 'Custom Skin $releaseTag',
+          'published_at': '2026-01-01T00:00:00Z',
+          'assets': [
+            {
+              'name': 'first.zip',
+              'browser_download_url':
+                  'https://github.com/acme/custom-skin/releases/download/'
+                  '$releaseTag/first.zip',
+              'size': 100,
+            },
+            {
+              'name': 'second.zip',
+              'browser_download_url':
+                  'https://github.com/acme/custom-skin/releases/download/'
+                  '$releaseTag/second.zip',
+              'size': 200,
+            },
+          ],
+        };
+
+        await http.runWithClient(
+          () async {
+            await storage.installFromGitHubRelease(
+              'acme/custom-skin',
+              assetName: 'second.zip',
+            );
+            expect(requestedAssets, [
+              'https://github.com/acme/custom-skin/releases/download/'
+                  'v1.0.0/second.zip',
+            ]);
+            expect(
+              storage.getSkin('passione-dist')!.reaMetadata!.releaseAssetName,
+              'second.zip',
+            );
+
+            // New release: the update re-selects second.zip, not first.zip.
+            releaseTag = 'v1.1.0';
+            await storage.updateAllSkins();
+            expect(requestedAssets, [
+              'https://github.com/acme/custom-skin/releases/download/'
+                  'v1.0.0/second.zip',
+              'https://github.com/acme/custom-skin/releases/download/'
+                  'v1.1.0/second.zip',
+            ]);
+            expect(
+              storage.getSkin('passione-dist')!.reaMetadata!.releaseAssetName,
+              'second.zip',
+            );
+          },
+          () => MockClient((request) async {
+            final url = request.url.toString();
+            if (url ==
+                'https://api.github.com/repos/acme/custom-skin/releases/latest') {
+              return http.Response(jsonEncode(releaseBody()), 200);
+            }
+            if (url.startsWith(
+              'https://github.com/acme/custom-skin/releases/download/',
+            )) {
+              requestedAssets.add(url);
+              return http.Response.bytes(archive, 200);
+            }
+            return http.Response('', 404);
+          }),
+        );
+      },
+    );
+
+    test('GitHub release update preserves prerelease tracking', () async {
+      final archive = makeGitHubArchive();
+      final latestApiGets = <String>[];
+      var releaseTag = 'v1.0.0-rc.1';
+      Map<String, dynamic> releaseBody() => {
+        'tag_name': releaseTag,
+        'name': 'Custom Skin $releaseTag',
+        'prerelease': true,
+        'published_at': '2026-01-01T00:00:00Z',
+        'assets': [
+          {
+            'name': 'custom-skin.zip',
+            'browser_download_url':
+                'https://github.com/acme/custom-skin/releases/download/'
+                '$releaseTag/custom-skin.zip',
+            'size': 1234,
+          },
+        ],
+      };
+
+      await http.runWithClient(
+        () async {
+          await storage.installFromGitHubRelease(
+            'acme/custom-skin',
+            includePrerelease: true,
+          );
+          expect(
+            storage.getSkin('passione-dist')!.reaMetadata!.includePrerelease,
+            isTrue,
+          );
+
+          // New prerelease: the update hits the /releases list endpoint
+          // (not /releases/latest) and re-selects a prerelease.
+          releaseTag = 'v1.1.0-rc.1';
+          await storage.updateAllSkins();
+          expect(
+            latestApiGets.every((u) => u.endsWith('/releases')),
+            isTrue,
+            reason: 'prerelease updates must use the /releases endpoint',
+          );
+          expect(
+            storage.getSkin('passione-dist')!.reaMetadata!.sourceUrl,
+            'github_release:acme/custom-skin@v1.1.0-rc.1',
+          );
+          expect(
+            storage.getSkin('passione-dist')!.reaMetadata!.includePrerelease,
+            isTrue,
+          );
+        },
+        () => MockClient((request) async {
+          final url = request.url.toString();
+          if (url == 'https://api.github.com/repos/acme/custom-skin/releases' ||
+              url ==
+                  'https://api.github.com/repos/acme/custom-skin/releases/latest') {
+            latestApiGets.add(url);
+            // The /releases list endpoint returns an array.
+            return http.Response(
+              url.endsWith('/releases')
+                  ? jsonEncode([releaseBody()])
+                  : jsonEncode(releaseBody()),
+              200,
+            );
+          }
+          if (url.startsWith(
+            'https://github.com/acme/custom-skin/releases/download/',
+          )) {
+            return http.Response.bytes(archive, 200);
+          }
+          return http.Response('', 404);
+        }),
+      );
+    });
+
     test('overwriteIfExists:false leaves an existing skin untouched', () async {
       // Newer copy installed first (e.g. from a GitHub release).
       await storage.installFromPath(makeSkinSource('0.1.33').path);


### PR DESCRIPTION
## Summary

- **Problem:** The skin selector's "Check for updates" button called `downloadRemoteSkins()`, which only refreshes the hardcoded remote-bundled skin list. User-installed skins were never refreshed — the button always reported success while doing nothing for them.
- **Why it matters:** A user relying on the native button sees "Skin updates completed" with nothing actually updated. The REST endpoint and web settings plugin already used the correct path (`updateAllSkins()`).
- **What changed:** (1) The button now calls `updateAllSkins()`. (2) `installFromUrl()` persists `sourceUrl` + ETag/Last-Modified metadata so raw-URL installs are updatable. (3) `installFromGitHubRelease()` persists `github_release:owner/repo@tag` plus `releaseAssetName` / `includePrerelease`, and `updateAllSkins()` passes them back, so asset selection and prerelease tracking survive updates. (4) User-installed release skins stay removable after an update (`markAsRemoteBundled: false`).
- **What did NOT change:** No REST/WebSocket endpoints added or changed. No behavior for bundled/remote skins changed. Metadata file is additive (new optional keys), old entries parse fine.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [x] WebUI skins
- [ ] Plugins / JS runtime
- [x] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #503
- Related #

## Root Cause (if bug fix)

- **Root cause:** Two independent gaps. First, the button wired to `downloadRemoteSkins()`, which only iterates the hardcoded `skin_sources.json` list. Second, `updateAllSkins()` can only refresh skins whose metadata records a `sourceUrl` — `installFromUrl()` and the public `installFromGitHubRelease()` (which delegates to it) never wrote metadata, so URL and release installs were invisible to update checks. Release installs also lost their `assetName` / `includePrerelease` selection because the stored source identifier dropped both.
- **Missing detection or guardrail:** No test exercised the "Check for updates" button against a user-installed (non-bundled) skin; install tests only covered the branch path.
- **Contributing context:** `updateAllSkins()` was introduced for the periodic check service and already handled `http` and `github_release:` sources — the missing half was metadata persistence at install time.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/webui_storage_install_test.dart` (URL ETag refresh; release update; asset selection; prerelease tracking), `test/skin_selector_update_refresh_test.dart` (button calls updateAllSkins, list refreshes).
- Scenario the test should lock in: user-installed skins of all three kinds (URL, release, branch) are refreshed by `updateAllSkins()`; release updates keep the selected asset and prerelease flag.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [x] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A — no docs affected

## Security Impact (required)

- New or changed REST endpoints? (`No`)
- New or changed WebSocket topics? (`No`)
- New or changed network calls? (`Yes`) — raw-URL and GitHub-release skins are now compared against their recorded source on periodic update checks. This is same-origin-to-recorded-source traffic only, on the same schedule as the existing bundled-skin checks; the recorded source is the URL the user already installed from.
- BLE/USB surface changed? (`No`)
- File system access changed? (`No`)
- Plugin sandbox boundary changed? (`No`)

## User-Visible Changes

- "Check for updates" in the skin selector now actually updates user-installed skins (GitHub branch, GitHub release, or raw URL), not just bundled ones.
- Previously release-installed skins keep their selected asset and prerelease preference across updates.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — no remaining changes
- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass (2694)
- [ ] `(cd packages/dye2-plugin && npm run build)` — plugin builds (not touched)

### Manual verification (if applicable)

- OS / platform tested: not manually verified (no hardware session)
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: unit/widget test suite only
- Edge cases checked: unchanged ETag skips re-download; new release re-resolves via GitHub API; selected asset preserved; prerelease flag preserved; user skin stays removable
- What you did **not** verify: live install/update against a real GitHub repo

### Evidence

Attach at least one:

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? (`Yes`)
- Config / env changes needed? (`No`)
- Database migration needed? (`No`) — `.rea_metadata.json` gains optional `releaseAssetName` / `includePrerelease` keys; existing entries parse with them null, which is the old behavior.
- If any `No` or `Yes`, explain exact steps: none needed.

## Risks & Mitigations

- Risk: `updateAllSkins()` now touches user-installed URL skins whose servers may lack ETag/Last-Modified headers — each check would re-download (no way to tell if changed). Mitigation: download is skipped only when headers exist; this matches the pre-existing behavior for URL-based remote sources, and update checks are periodic, not on every launch.
- Risk: a prerelease-tracked skin could update to a newer prerelease automatically. Mitigation: prerelease tracking is opt-in at install time and the user-visible check runs from an explicit button, periodic service, or REST call — same trigger surface as bundled skins.