### PR TITLE
fix: relax App Store skin and plugin gates

### DIFF
--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -15,6 +15,8 @@ A Decaid plugin consists of two required files:
 
 ### 1. `manifest.json` - Plugin metadata and configuration
 
+> **`id` restrictions:** The plugin id becomes a directory name under the app's `plugins/` folder, so it must be a single safe filesystem path component: no `/` or `\` separators, no `.` or `..`, no leading drive letter or NUL byte, and no Windows-reserved characters. Unsafe ids are rejected with a clear error and the plugin is not installed.
+
 ```json
 {
   "id": "unique.plugin.id",

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -2929,6 +2929,8 @@ ApplicationDocuments/
     └── .rea_metadata.json    # Version tracking (managed by REA)
 ```
 
+> **Skin id restrictions:** A skin's id (from `skin-manifest.json`, `manifest.json`, or the install folder name) becomes a directory name under `web-ui/`, so it must be a single safe filesystem path component: no `/` or `\` separators, no `.` or `..`, no leading drive letter or NUL byte, and no Windows-reserved characters. Unsafe ids are rejected with a clear error and the skin is not installed.
+
 ### Cross-Skin Asset Sharing
 
 A skin can fetch files from any other installed skin via:

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -3283,13 +3283,11 @@ Live-edit validates that the selected folder contains an `index.html`.
 
 | Feature | Android | iOS | macOS | Linux | Windows | App Store |
 |---------|---------|-----|-------|-------|---------|-----------|
-| Install from ZIP | yes | yes | yes | yes | yes | no |
+| Install from ZIP | yes | yes | yes | yes | yes | yes |
 | Live-edit folder | yes* | no | yes | yes | yes | no |
-| Delete skins | yes | yes | yes | yes | yes | no |
+| Delete skins | yes | yes | yes | yes | yes | yes |
 
 \* Android requires the **Manage External Storage** permission for live-edit. A permission button appears in Settings when needed.
-
-**App Store Restrictions:** When running as an App Store build, custom skin installation, deletion, and update checks are disabled. Only bundled skins are available.
 
 ### Settings Plugin (Web-Based Management)
 

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -11,7 +11,6 @@ import 'package:reaprime/src/plugins/plugin_manager.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
 import 'package:reaprime/src/plugins/plugin_runtime.dart';
 import 'package:reaprime/src/services/account/decent_proxy_service.dart';
-import 'package:reaprime/build_info.dart';
 
 class PluginSettingsValidationException implements Exception {
   final String message;
@@ -27,7 +26,6 @@ class PluginLoaderService {
   static const _loadingPluginKey = 'plugin.watchdog.loading';
 
   final PluginManager pluginManager;
-  final bool _appStoreMode;
   final _log = Logger('PluginLoaderService');
 
   late Directory _pluginsDir;
@@ -38,12 +36,10 @@ class PluginLoaderService {
   PluginLoaderService({
     required KeyValueStoreService kvStore,
     DecentProxyService? decentProxyService,
-    bool? appStoreMode,
   }) : pluginManager = PluginManager(
          kvStore: kvStore,
          decentProxyService: decentProxyService,
-       ),
-       _appStoreMode = appStoreMode ?? BuildInfo.appStore;
+       );
 
   bool _initialized = false;
 
@@ -84,12 +80,6 @@ class PluginLoaderService {
   /// user will provide filesystem path and permissions, REA should copy the contents over to
   /// the plugins folder
   Future<void> addPlugin(String sourcePath) async {
-    if (_appStoreMode) {
-      throw UnsupportedError(
-        'Plugin installation is not available on this platform',
-      );
-    }
-
     final source = File(sourcePath);
     final sourceDir = Directory(sourcePath);
 

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -11,6 +11,7 @@ import 'package:reaprime/src/plugins/plugin_manager.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
 import 'package:reaprime/src/plugins/plugin_runtime.dart';
 import 'package:reaprime/src/services/account/decent_proxy_service.dart';
+import 'package:reaprime/src/util/safe_path.dart';
 
 class PluginSettingsValidationException implements Exception {
   final String message;
@@ -107,6 +108,14 @@ class PluginLoaderService {
     final manifestJson = jsonDecode(await manifestFile.readAsString());
     final manifest = PluginManifest.fromJson(manifestJson);
 
+    // The id becomes a directory name under the plugins root; reject anything
+    // that is not exactly one safe path component before creating it.
+    if (!isSafePathComponent(manifest.id)) {
+      throw FormatException(
+        'Unsafe plugin id "${manifest.id}": must be a single safe path component',
+      );
+    }
+
     // Create plugin directory in plugins folder
     final pluginDir = Directory('${_pluginsDir.path}/${manifest.id}');
     if (pluginDir.existsSync()) {
@@ -127,6 +136,14 @@ class PluginLoaderService {
   /// Remove/uninstall a plugin
   /// This will unload the plugin if it's loaded and delete its files
   Future<void> removePlugin(String pluginId) async {
+    // The id would be joined into a filesystem path; reject unsafe ids
+    // before any unload, cache, or directory operation.
+    if (!isSafePathComponent(pluginId)) {
+      throw FormatException(
+        'Unsafe plugin id "$pluginId": must be a single safe path component',
+      );
+    }
+
     // Unload plugin if it's loaded
     if (isPluginLoaded(pluginId)) {
       await unloadPlugin(pluginId);
@@ -295,6 +312,11 @@ class PluginLoaderService {
 
   /// Get the directory path for a specific plugin
   String getPluginDirectory(String pluginId) {
+    if (!isSafePathComponent(pluginId)) {
+      throw FormatException(
+        'Unsafe plugin id "$pluginId": must be a single safe path component',
+      );
+    }
     if (!_availablePluginsCache.containsKey(pluginId)) {
       throw Exception('Plugin not found: $pluginId');
     }
@@ -470,6 +492,15 @@ class PluginLoaderService {
 
         final manifestJson = jsonDecode(await manifestFile.readAsString());
         final manifest = PluginManifest.fromJson(manifestJson);
+
+        // An unsafe id must not enter the cache, where it could later drive
+        // filesystem paths (issue #547 follow-up).
+        if (!isSafePathComponent(manifest.id)) {
+          _log.warning(
+            'Skipping plugin with unsafe id "${manifest.id}" at ${dir.path}',
+          );
+          continue;
+        }
 
         _availablePluginsCache[manifest.id] = manifest;
         _log.fine('Found plugin: ${manifest.id}');

--- a/lib/src/services/webserver/plugins_handler.dart
+++ b/lib/src/services/webserver/plugins_handler.dart
@@ -3,17 +3,12 @@ part of '../webserver_service.dart';
 final class PluginsHandler {
   final PluginManager pluginManager;
   final PluginLoaderService pluginService;
-  final bool _appStoreMode;
 
   final Logger _log = Logger("PluginsHandler");
 
   final Random _random = Random();
 
-  PluginsHandler({
-    required this.pluginManager,
-    required this.pluginService,
-    bool? appStoreMode,
-  }) : _appStoreMode = appStoreMode ?? BuildInfo.appStore;
+  PluginsHandler({required this.pluginManager, required this.pluginService});
 
   void addRoutes(RouterPlus app) {
     app.get('/api/v1/plugins', (Request req) async {
@@ -28,11 +23,6 @@ final class PluginsHandler {
     });
 
     app.post('/api/v1/plugins/install', (Request request) async {
-      if (_appStoreMode) {
-        return jsonForbidden({
-          'error': 'Plugin installation is not available on this platform',
-        });
-      }
       try {
         final payload = await request.readAsString();
         final json = jsonDecode(payload) as Map<String, dynamic>;
@@ -86,11 +76,6 @@ final class PluginsHandler {
     });
 
     app.delete('/api/v1/plugins/<id>', (Request request, String id) async {
-      if (_appStoreMode) {
-        return jsonForbidden({
-          'error': 'Plugin removal is not available on this platform',
-        });
-      }
       try {
         if (pluginService.getPluginManifest(id) == null) {
           return jsonNotFound({'error': 'Plugin not found: $id'});

--- a/lib/src/services/webserver/webui_handler.dart
+++ b/lib/src/services/webserver/webui_handler.dart
@@ -4,15 +4,10 @@ part of '../webserver_service.dart';
 class WebUIHandler {
   final WebUIStorage _storage;
   final WebUIService _service;
-  final bool _appStoreMode;
 
-  WebUIHandler({
-    required WebUIStorage storage,
-    required WebUIService service,
-    bool? appStoreMode,
-  }) : _storage = storage,
-       _service = service,
-       _appStoreMode = appStoreMode ?? BuildInfo.appStore;
+  WebUIHandler({required WebUIStorage storage, required WebUIService service})
+    : _storage = storage,
+      _service = service;
 
   void addRoutes(RouterPlus app) {
     // List all installed skins
@@ -143,11 +138,6 @@ class WebUIHandler {
   ///   "prerelease": false         // optional
   /// }
   Future<Response> _handleInstallFromGitHubRelease(Request request) async {
-    if (_appStoreMode) {
-      return jsonForbidden({
-        'error': 'Skin installation is not available on this platform',
-      });
-    }
     try {
       final body =
           jsonDecode(await request.readAsString()) as Map<String, dynamic>;
@@ -188,11 +178,6 @@ class WebUIHandler {
   ///   "branch": "main"            // optional, defaults to "main"
   /// }
   Future<Response> _handleInstallFromGitHubBranch(Request request) async {
-    if (_appStoreMode) {
-      return jsonForbidden({
-        'error': 'Skin installation is not available on this platform',
-      });
-    }
     try {
       final body =
           jsonDecode(await request.readAsString()) as Map<String, dynamic>;
@@ -228,11 +213,6 @@ class WebUIHandler {
   ///   "url": "https://example.com/skin.zip"
   /// }
   Future<Response> _handleInstallFromUrl(Request request) async {
-    if (_appStoreMode) {
-      return jsonForbidden({
-        'error': 'Skin installation is not available on this platform',
-      });
-    }
     try {
       final body =
           jsonDecode(await request.readAsString()) as Map<String, dynamic>;

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -80,7 +80,6 @@ import 'package:reaprime/src/controllers/presence_controller.dart';
 import 'package:reaprime/src/settings/charging_mode.dart';
 import 'package:reaprime/src/models/wake_schedule.dart';
 import 'package:reaprime/src/services/webview_log_service.dart';
-import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/services/update_check_service.dart';
 import 'package:reaprime/src/services/app_update_state.dart';
 import 'package:reaprime/src/services/webserver/info_handler.dart';

--- a/lib/src/settings/plugins_settings_view.dart
+++ b/lib/src/settings/plugins_settings_view.dart
@@ -5,7 +5,6 @@ import 'package:logging/logging.dart';
 import 'package:saf_stream/saf_stream.dart';
 import 'package:saf_util/saf_util.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
-import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
 
@@ -80,7 +79,7 @@ class PluginsSettingsView extends StatefulWidget {
   const PluginsSettingsView({
     super.key,
     required this.pluginLoaderService,
-    this.allowInstall = !BuildInfo.appStore,
+    this.allowInstall = true,
   });
 
   static const routeName = '/plugins';

--- a/lib/src/skin_selector/skin_selector_page.dart
+++ b/lib/src/skin_selector/skin_selector_page.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
-import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/skin_feature/skin_view.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
@@ -60,7 +59,7 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
   }
 
   Future<void> _checkStoragePermission() async {
-    if (!Platform.isAndroid || BuildInfo.appStore) return;
+    if (!Platform.isAndroid) return;
     final status = await Permission.manageExternalStorage.status;
     if (mounted && status.isGranted != _storagePermissionGranted) {
       setState(() => _storagePermissionGranted = status.isGranted);
@@ -70,7 +69,7 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
   @override
   Widget build(BuildContext context) {
     // The storage-permission affordance only exists for Android sideload builds.
-    final showStorageRow = Platform.isAndroid && !BuildInfo.appStore;
+    final showStorageRow = Platform.isAndroid;
 
     return Scaffold(
       appBar: AppBar(title: const Text('Web Interface')),
@@ -145,15 +144,13 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
             ],
           ),
         ),
-        if (!BuildInfo.appStore) ...[
-          const SizedBox(width: 8),
-          _ActionButton.outline(
-            label: 'Check for updates',
-            icon: Icons.refresh,
-            size: ShadButtonSize.sm,
-            onPressed: () => _checkForSkinUpdates(context),
-          ),
-        ],
+        const SizedBox(width: 8),
+        _ActionButton.outline(
+          label: 'Check for updates',
+          icon: Icons.refresh,
+          size: ShadButtonSize.sm,
+          onPressed: () => _checkForSkinUpdates(context),
+        ),
       ],
     );
   }
@@ -296,7 +293,7 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
                           ),
                         ),
                       ],
-                      if (!skin.isBundled && !BuildInfo.appStore) ...[
+                      if (!skin.isBundled) ...[
                         const SizedBox(width: 8),
                         SizedBox(
                           width: 24,
@@ -365,24 +362,22 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
                   ),
                 );
               }),
-              if (!BuildInfo.appStore)
-                const DropdownMenuItem(
-                  value: _customSkinId,
-                  child: Row(
-                    children: [
-                      Icon(Icons.archive_outlined, size: 16),
-                      SizedBox(width: 8),
-                      Text('Install from .zip...'),
-                    ],
-                  ),
+              const DropdownMenuItem(
+                value: _customSkinId,
+                child: Row(
+                  children: [
+                    Icon(Icons.archive_outlined, size: 16),
+                    SizedBox(width: 8),
+                    Text('Install from .zip...'),
+                  ],
                 ),
-              if (!BuildInfo.appStore &&
-                  (Platform.isMacOS ||
-                      Platform.isLinux ||
-                      Platform.isWindows ||
-                      (Platform.isAndroid &&
-                          (_storagePermissionGranted ||
-                              _selectedSkinId == _liveEditSkinId))))
+              ),
+              if (Platform.isMacOS ||
+                  Platform.isLinux ||
+                  Platform.isWindows ||
+                  (Platform.isAndroid &&
+                      (_storagePermissionGranted ||
+                          _selectedSkinId == _liveEditSkinId)))
                 const DropdownMenuItem(
                   value: _liveEditSkinId,
                   child: Row(
@@ -401,7 +396,7 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
   }
 
   Widget _buildStoragePermissionRow() {
-    if (!Platform.isAndroid || BuildInfo.appStore) {
+    if (!Platform.isAndroid) {
       return const SizedBox.shrink();
     }
 

--- a/lib/src/util/safe_path.dart
+++ b/lib/src/util/safe_path.dart
@@ -1,0 +1,46 @@
+/// Rules for turning untrusted strings into single filesystem path
+/// components (skin ids, plugin ids).
+///
+/// Both skin and plugin ids come from untrusted manifests and are used
+/// directly as directory names under an app-owned root (web-ui/ or
+/// plugins/). An id that is not exactly one safe component could resolve
+/// outside that root when joined with it, so the same rules apply in both
+/// places.
+library;
+
+/// Win32 forbids these characters in path components: `<>:"|?*`.
+final RegExp _win32ReservedChars = RegExp(r'[<>:"|?*]');
+
+/// Returns true when [component] is exactly one safe filesystem path
+/// component under both POSIX and Windows path rules:
+///
+///   - non-empty
+///   - not `.` or `..`
+///   - no `/` or `\` separators (rejects nested and absolute paths)
+///   - no NUL byte
+///   - not a Windows drive path (`C:...`)
+///   - not a Windows reserved-character name (`<>:"|?*`)
+///   - no trailing dot or space (Win32 silently strips these from path
+///     components, so what we write would not be what we read)
+///
+/// An id that passes can be used as exactly one directory name under a
+/// parent directory without escaping it.
+bool isSafePathComponent(String component) {
+  if (component.isEmpty) return false;
+  if (component == '.' || component == '..') return false;
+  if (component.contains('/') || component.contains('\\')) return false;
+  if (component.contains('\x00')) return false;
+
+  // Drive-letter prefix (`C:...`): rooted on Windows.
+  if (component.length >= 2 && component.codeUnitAt(1) == 0x3A /* : */ ) {
+    final first = component.codeUnitAt(0);
+    final isLetter =
+        (first >= 0x41 && first <= 0x5A) || (first >= 0x61 && first <= 0x7A);
+    if (isLetter) return false;
+  }
+
+  if (_win32ReservedChars.hasMatch(component)) return false;
+  if (component.endsWith('.') || component.endsWith(' ')) return false;
+
+  return true;
+}

--- a/lib/src/webui_support/webui_storage.dart
+++ b/lib/src/webui_support/webui_storage.dart
@@ -9,6 +9,7 @@ import 'package:http/http.dart' as http;
 import 'package:archive/archive_io.dart';
 import 'package:path/path.dart' as p;
 import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/util/safe_path.dart';
 import 'package:reaprime/src/webui_support/webui_zip_support.dart';
 
 /// REA metadata for tracking WebUI skin source and version
@@ -1198,6 +1199,15 @@ class WebUIStorage {
           );
         }
 
+        // An unsafe id (e.g. from a tampered manifest) must not enter the
+        // in-memory registry, where it could later drive filesystem paths.
+        if (!isSafePathComponent(skin.id)) {
+          _log.warning(
+            'Skipping skin with unsafe id "${skin.id}" at ${dir.path}',
+          );
+          continue;
+        }
+
         _installedSkins[skin.id] = skin;
         _log.fine('Found skin: ${skin.id} at ${skin.path}');
       } catch (e) {
@@ -1313,6 +1323,15 @@ class WebUIStorage {
       skinId = manifestJson['id'] as String? ?? p.basename(sourceDir.path);
     } else {
       skinId = p.basename(sourceDir.path);
+    }
+
+    // The id becomes a directory name under the web-ui root; reject anything
+    // that is not exactly one safe path component before constructing or
+    // deleting the destination (issue #547 follow-up).
+    if (!isSafePathComponent(skinId)) {
+      throw FormatException(
+        'Unsafe skin id "$skinId": must be a single safe path component',
+      );
     }
 
     // Check if skin already exists

--- a/lib/src/webui_support/webui_storage.dart
+++ b/lib/src/webui_support/webui_storage.dart
@@ -8,7 +8,6 @@ import 'package:path_provider/path_provider.dart';
 import 'package:http/http.dart' as http;
 import 'package:archive/archive_io.dart';
 import 'package:path/path.dart' as p;
-import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/webui_support/webui_zip_support.dart';
 
@@ -146,15 +145,13 @@ class WebUISkin {
 class WebUIStorage {
   final _log = Logger('WebUIStorage');
   final SettingsController _settingsController;
-  final bool _appStoreMode;
 
   late Directory _webUIDir;
   final Map<String, WebUISkin> _installedSkins = {};
   final Map<String, WebUIReaMetadata> _skinMetadata = {};
   bool _initialized = false;
 
-  WebUIStorage(this._settingsController, {bool? appStoreMode})
-    : _appStoreMode = appStoreMode ?? BuildInfo.appStore;
+  WebUIStorage(this._settingsController);
 
   /// Test seam: point storage at a specific web-ui directory and mark it
   /// initialized, bypassing the asset/network [initialize] flow so install
@@ -229,11 +226,10 @@ class WebUIStorage {
     // Copy bundled skins from assets
     await _copyBundledSkins();
 
-    // Download and install remote bundled skins (includes version checking)
-    // Skip on App Store builds — bundled skins from assets are the only source.
+    // Download and install remote bundled skins (includes version checking).
     // Skip when downloadRemote is false (cold-boot critical path) — the caller
     // runs downloadRemoteSkinsAndRescan() in the background instead.
-    if (downloadRemote && !_appStoreMode) {
+    if (downloadRemote) {
       await downloadRemoteSkins();
     }
 
@@ -569,7 +565,6 @@ class WebUIStorage {
   /// `initialize(downloadRemote: false)` — [downloadRemoteSkins] does not
   /// rescan on its own, so the explicit [_scanInstalledSkins] is required.
   Future<void> downloadRemoteSkinsAndRescan() async {
-    if (_appStoreMode) return;
     await downloadRemoteSkins();
     await _scanInstalledSkins();
   }
@@ -580,8 +575,6 @@ class WebUIStorage {
   /// to keep all skins up to date. Each skin update is independent — one failure
   /// does not prevent others from updating.
   Future<void> updateAllSkins() async {
-    if (_appStoreMode) return;
-
     _log.info('Starting update check for all skins');
 
     // 1. Update remote-bundled skins

--- a/lib/src/webui_support/webui_zip_support.dart
+++ b/lib/src/webui_support/webui_zip_support.dart
@@ -57,8 +57,47 @@ class ExtractionResult {
   const ExtractionResult({required this.extracted, required this.skipped});
 }
 
+/// Returns true when [entryName] is safe to write under a destination
+/// directory. Archive entry names are untrusted input, so this rejects
+/// anything that could resolve outside the extraction root:
+///
+///   - NUL bytes
+///   - absolute paths (leading `/` or `\`, Windows drive prefixes, UNC)
+///   - `..` path components, using `/` or `\` separators (so Windows-style
+///     traversal like `..\escape` is caught on every host)
+///
+/// Win32-reserved characters (`<>:"|?*`) are NOT rejected here — they are
+/// handled by [sanitizeZipEntryPath] so otherwise-valid POSIX filenames
+/// survive on non-Windows hosts.
+bool isSafeZipEntryPath(String entryName) {
+  if (entryName.contains('\x00')) return false;
+  if (entryName.startsWith('/') || entryName.startsWith('\\')) return false;
+  if (entryName.startsWith('\\\\') || entryName.startsWith('//')) return false;
+
+  // Windows drive prefix (`C:...`): rooted on Windows.
+  if (entryName.length >= 2 && entryName.codeUnitAt(1) == 0x3A /* : */ ) {
+    final first = entryName.codeUnitAt(0);
+    final isLetter =
+        (first >= 0x41 && first <= 0x5A) || (first >= 0x61 && first <= 0x7A);
+    if (isLetter) return false;
+  }
+
+  // Normalise Windows separators so `..\escape` is caught on every host.
+  final normalized = entryName.replaceAll('\\', '/');
+  for (final segment in normalized.split('/')) {
+    if (segment == '..') return false;
+  }
+  return true;
+}
+
 /// Extracts every entry of [archive] under [destDir], isolating per-entry
 /// failures so a single bad entry cannot abort the whole extraction.
+///
+/// Archive entry names are treated as untrusted. Every entry is validated
+/// against path-traversal before anything is written: if any entry is
+/// absolute, contains `..` components, or would resolve outside [destDir],
+/// the whole archive is rejected with a [FormatException] and nothing is
+/// written — traversal is never silently sanitised away.
 ///
 /// When [sanitize] is true, each entry path is run through
 /// [sanitizeZipEntryPath] first — callers set this on Windows, where the
@@ -76,6 +115,23 @@ ExtractionResult extractArchiveToDirectory(
   required bool sanitize,
   Logger? log,
 }) {
+  // Pass 1: validate every entry before writing any files. A single unsafe
+  // entry rejects the whole archive so nothing can land outside destDir.
+  for (final entry in archive) {
+    final originalName = entry.name;
+    final safeName = sanitize
+        ? sanitizeZipEntryPath(originalName)
+        : originalName;
+    final outPath = p.normalize(p.join(destDir.path, safeName));
+    if (!isSafeZipEntryPath(originalName) ||
+        (outPath != destDir.path && !p.isWithin(destDir.path, outPath))) {
+      throw FormatException(
+        'Rejecting zip archive: entry "$originalName" resolves outside the '
+        'extraction directory',
+      );
+    }
+  }
+
   var extracted = 0;
   var skipped = 0;
 

--- a/test/plugin_loader_service_appstore_test.dart
+++ b/test/plugin_loader_service_appstore_test.dart
@@ -49,34 +49,13 @@ class FakeKvStore implements KeyValueStoreService {
 
 void main() {
   group('PluginLoaderService App Store mode', () {
-    test('addPlugin throws UnsupportedError when appStoreMode is true', () {
-      final service = PluginLoaderService(
-        kvStore: FakeKvStore(),
-        appStoreMode: true,
-      );
+    test('addPlugin is available in App Store builds', () {
+      final service = PluginLoaderService(kvStore: FakeKvStore());
 
       expect(
         () => service.addPlugin('/some/path'),
-        throwsA(isA<UnsupportedError>()),
+        throwsA(isNot(isA<UnsupportedError>())),
       );
     });
-
-    test(
-      'addPlugin does not throw UnsupportedError when appStoreMode is false',
-      () {
-        final service = PluginLoaderService(
-          kvStore: FakeKvStore(),
-          appStoreMode: false,
-        );
-
-        // Should not throw UnsupportedError — will throw a different error
-        // because the path doesn't exist and the service isn't initialized,
-        // but it should NOT be an UnsupportedError.
-        expect(
-          () => service.addPlugin('/nonexistent/path'),
-          throwsA(isNot(isA<UnsupportedError>())),
-        );
-      },
-    );
   });
 }

--- a/test/plugin_loader_service_appstore_test.dart
+++ b/test/plugin_loader_service_appstore_test.dart
@@ -1,6 +1,11 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
 import 'package:reaprime/src/services/storage/kv_store_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class FakeKvStore implements KeyValueStoreService {
   final Map<String, Map<String, Object>> _store = {};
@@ -48,13 +53,212 @@ class FakeKvStore implements KeyValueStoreService {
 }
 
 void main() {
-  group('PluginLoaderService App Store mode', () {
-    test('addPlugin is available in App Store builds', () {
-      final service = PluginLoaderService(kvStore: FakeKvStore());
+  TestWidgetsFlutterBinding.ensureInitialized();
 
+  group('PluginLoaderService App Store mode', () {
+    late Directory tempDir;
+    late PluginLoaderService service;
+    var sourceCounter = 0;
+
+    Directory makePluginSource(String id) {
+      final dir = Directory('${tempDir.path}/source_${sourceCounter++}')
+        ..createSync();
+      File('${dir.path}/manifest.json').writeAsStringSync(
+        jsonEncode({
+          'id': id,
+          'author': 'Test',
+          'name': 'Test plugin',
+          'description': 'Test plugin',
+          'version': '1.0.0',
+          'apiVersion': 1,
+          'permissions': <String>[],
+          'settings': <String, Object>{},
+          'api': <Object>[],
+        }),
+      );
+      File('${dir.path}/plugin.js').writeAsStringSync('''
+function createPlugin() {
+  return { id: "x", onLoad() {} };
+}
+''');
+      return dir;
+    }
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      tempDir = Directory.systemTemp.createTempSync('plugin_appstore_test');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            (_) async => tempDir.path,
+          );
+      service = PluginLoaderService(kvStore: FakeKvStore());
+      await service.initialize();
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            null,
+          );
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    test('addPlugin installs a plugin from a real source directory', () async {
+      const id = 'installed.reaplugin';
+      final source = makePluginSource(id);
+
+      await service.addPlugin(source.path);
+
+      final pluginDir = Directory('${tempDir.path}/plugins/$id');
+      expect(pluginDir.existsSync(), isTrue);
+      expect(File('${pluginDir.path}/manifest.json').existsSync(), isTrue);
+      expect(File('${pluginDir.path}/plugin.js').existsSync(), isTrue);
+      expect(service.getPluginManifest(id), isNotNull);
+      expect(service.availablePlugins.any((m) => m.id == id), isTrue);
+    });
+
+    test('removePlugin deletes the installed plugin directory', () async {
+      const id = 'removable.reaplugin';
+      await service.addPlugin(makePluginSource(id).path);
+
+      final pluginDir = Directory('${tempDir.path}/plugins/$id');
+      expect(pluginDir.existsSync(), isTrue);
+
+      await service.removePlugin(id);
+
+      expect(pluginDir.existsSync(), isFalse);
+      expect(service.getPluginManifest(id), isNull);
+    });
+
+    const unsafeIds = [
+      '',
+      '.',
+      '..',
+      '../escape',
+      'a/b',
+      r'a\b',
+      '/abs',
+      r'\abs',
+      'C:evil',
+      r'\\server\share',
+      'a?b',
+      'trailing.',
+      'trailing ',
+    ];
+
+    for (final id in unsafeIds) {
+      test(
+        'addPlugin rejects unsafe plugin id ${id.isEmpty ? '(empty)' : '"$id"'}',
+        () async {
+          final source = makePluginSource(id);
+
+          await expectLater(
+            service.addPlugin(source.path),
+            throwsFormatException,
+          );
+          expect(
+            service.availablePlugins.any((m) => m.id == id),
+            isFalse,
+            reason: 'unsafe id must not enter the registry',
+          );
+        },
+      );
+    }
+
+    test(
+      'rejected installs never create or delete directories outside plugins root',
+      () async {
+        final pluginsDir = Directory('${tempDir.path}/plugins');
+
+        // ../escape resolves outside the plugins root.
+        final escapeDir = Directory('${tempDir.path}/escape');
+        if (escapeDir.existsSync()) escapeDir.deleteSync(recursive: true);
+        await expectLater(
+          service.addPlugin(makePluginSource('../escape').path),
+          throwsFormatException,
+        );
+        expect(escapeDir.existsSync(), isFalse);
+
+        // Nested ids must not create nested directories.
+        final nested = Directory('${pluginsDir.path}/a/b');
+        await expectLater(
+          service.addPlugin(makePluginSource('a/b').path),
+          throwsFormatException,
+        );
+        expect(nested.existsSync(), isFalse);
+
+        // Absolute ids must not resolve under the plugins root.
+        final absDir = Directory('${pluginsDir.path}/abs');
+        if (absDir.existsSync()) absDir.deleteSync(recursive: true);
+        await expectLater(
+          service.addPlugin(makePluginSource('/abs').path),
+          throwsFormatException,
+        );
+        expect(absDir.existsSync(), isFalse);
+
+        // Windows-style separators are literal on POSIX hosts, but the id is
+        // still rejected so nothing is created.
+        final winSep = Directory('${pluginsDir.path}/a\\b');
+        await expectLater(
+          service.addPlugin(makePluginSource(r'a\b').path),
+          throwsFormatException,
+        );
+        expect(winSep.existsSync(), isFalse);
+      },
+    );
+
+    test(
+      'removePlugin rejects an unsafe id before touching the filesystem',
+      () async {
+        await expectLater(
+          service.removePlugin('../escape'),
+          throwsFormatException,
+        );
+        expect(
+          Directory('${tempDir.path}/escape').existsSync(),
+          isFalse,
+          reason: 'removePlugin must not resolve an unsafe id into a path',
+        );
+      },
+    );
+
+    test('getPluginDirectory rejects an unsafe id', () {
       expect(
-        () => service.addPlugin('/some/path'),
-        throwsA(isNot(isA<UnsupportedError>())),
+        () => service.getPluginDirectory('../escape'),
+        throwsFormatException,
+      );
+    });
+
+    test('an unsafe manifest cannot enter the registry via scan', () async {
+      final evilDir = Directory('${tempDir.path}/plugins/evil-dir')
+        ..createSync(recursive: true);
+      File('${evilDir.path}/manifest.json').writeAsStringSync(
+        jsonEncode({
+          'id': '../escape',
+          'author': 'Test',
+          'name': 'Evil',
+          'description': 'Test plugin',
+          'version': '1.0.0',
+          'apiVersion': 1,
+          'permissions': <String>[],
+          'settings': <String, Object>{},
+          'api': <Object>[],
+        }),
+      );
+      File(
+        '${evilDir.path}/plugin.js',
+      ).writeAsStringSync('function createPlugin() {}');
+
+      final fresh = PluginLoaderService(kvStore: FakeKvStore());
+      await fresh.initialize();
+
+      expect(fresh.getPluginManifest('../escape'), isNull);
+      expect(
+        fresh.availablePlugins.any((m) => m.id == '../escape'),
+        isFalse,
+        reason: 'an unsafe manifest id must not enter the registry',
       );
     });
   });

--- a/test/plugin_loader_service_watchdog_test.dart
+++ b/test/plugin_loader_service_watchdog_test.dart
@@ -9,8 +9,7 @@ import 'package:reaprime/src/services/storage/kv_store_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _ControllablePluginLoaderService extends PluginLoaderService {
-  _ControllablePluginLoaderService({required super.kvStore})
-    : super(appStoreMode: false);
+  _ControllablePluginLoaderService({required super.kvStore});
 
   String? _pausedPluginId;
   Completer<void>? _pauseEntered;
@@ -238,10 +237,7 @@ function createPlugin() {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString('plugin.watchdog.loading', pluginId);
 
-    final nextLaunch = PluginLoaderService(
-      kvStore: _FakeKvStore(),
-      appStoreMode: false,
-    );
+    final nextLaunch = PluginLoaderService(kvStore: _FakeKvStore());
     await nextLaunch.initialize();
 
     expect(await nextLaunch.shouldAutoLoad(pluginId), isFalse);

--- a/test/plugins_settings_view_appstore_test.dart
+++ b/test/plugins_settings_view_appstore_test.dart
@@ -28,14 +28,11 @@ void main() {
   });
 
   group('PluginsSettingsView install button visibility', () {
-    testWidgets('shows install button when allowInstall is true', (
-      tester,
-    ) async {
+    testWidgets('shows install button by default', (tester) async {
       await tester.pumpWidget(
         ShadApp(
           home: PluginsSettingsView(
             pluginLoaderService: fakePluginLoaderService,
-            allowInstall: true,
           ),
         ),
       );

--- a/test/services/webserver/plugins_handler_watchdog_test.dart
+++ b/test/services/webserver/plugins_handler_watchdog_test.dart
@@ -46,7 +46,6 @@ void main() {
     PluginsHandler(
       pluginManager: _FakePluginManager(),
       pluginService: pluginService,
-      appStoreMode: false,
     ).addRoutes(app);
 
     final response = await app.call(

--- a/test/webui_handler_appstore_test.dart
+++ b/test/webui_handler_appstore_test.dart
@@ -44,11 +44,10 @@ void main() {
     fakeStorage = FakeWebUIStorage();
   });
 
-  Handler buildHandler({required bool appStoreMode}) {
+  Handler buildHandler() {
     final webUIHandler = WebUIHandler(
       storage: fakeStorage,
       service: WebUIService(),
-      appStoreMode: appStoreMode,
     );
     final app = Router().plus;
     webUIHandler.addRoutes(app);
@@ -70,66 +69,16 @@ void main() {
     );
   }
 
-  group('WebUIHandler App Store mode', () {
-    group('when appStoreMode is true', () {
+  group('WebUIHandler skin installation', () {
+    group('installation endpoints', () {
       late Handler handler;
 
       setUp(() {
-        handler = buildHandler(appStoreMode: true);
+        handler = buildHandler();
       });
 
       test(
-        'POST /api/v1/webui/skins/install/github-release returns 403',
-        () async {
-          final response = await sendPost(
-            handler,
-            '/api/v1/webui/skins/install/github-release',
-            {'repo': 'user/repo'},
-          );
-          expect(response.statusCode, 403);
-          final body = jsonDecode(await response.readAsString());
-          expect(body['error'], contains('not available'));
-          expect(fakeStorage.installFromGitHubReleaseCalled, isFalse);
-        },
-      );
-
-      test(
-        'POST /api/v1/webui/skins/install/github-branch returns 403',
-        () async {
-          final response = await sendPost(
-            handler,
-            '/api/v1/webui/skins/install/github-branch',
-            {'repo': 'user/repo'},
-          );
-          expect(response.statusCode, 403);
-          final body = jsonDecode(await response.readAsString());
-          expect(body['error'], contains('not available'));
-          expect(fakeStorage.installFromGitHubCalled, isFalse);
-        },
-      );
-
-      test('POST /api/v1/webui/skins/install/url returns 403', () async {
-        final response = await sendPost(
-          handler,
-          '/api/v1/webui/skins/install/url',
-          {'url': 'https://example.com/skin.zip'},
-        );
-        expect(response.statusCode, 403);
-        final body = jsonDecode(await response.readAsString());
-        expect(body['error'], contains('not available'));
-        expect(fakeStorage.installFromUrlCalled, isFalse);
-      });
-    });
-
-    group('when appStoreMode is false', () {
-      late Handler handler;
-
-      setUp(() {
-        handler = buildHandler(appStoreMode: false);
-      });
-
-      test(
-        'POST /api/v1/webui/skins/install/github-release calls storage method',
+        'POST /api/v1/webui/skins/install/github-release calls storage',
         () async {
           final response = await sendPost(
             handler,
@@ -142,7 +91,7 @@ void main() {
       );
 
       test(
-        'POST /api/v1/webui/skins/install/github-branch calls storage method',
+        'POST /api/v1/webui/skins/install/github-branch calls storage',
         () async {
           final response = await sendPost(
             handler,
@@ -154,18 +103,15 @@ void main() {
         },
       );
 
-      test(
-        'POST /api/v1/webui/skins/install/url calls storage method',
-        () async {
-          final response = await sendPost(
-            handler,
-            '/api/v1/webui/skins/install/url',
-            {'url': 'https://example.com/skin.zip'},
-          );
-          expect(response.statusCode, isNot(403));
-          expect(fakeStorage.installFromUrlCalled, isTrue);
-        },
-      );
+      test('POST /api/v1/webui/skins/install/url calls storage', () async {
+        final response = await sendPost(
+          handler,
+          '/api/v1/webui/skins/install/url',
+          {'url': 'https://example.com/skin.zip'},
+        );
+        expect(response.statusCode, isNot(403));
+        expect(fakeStorage.installFromUrlCalled, isTrue);
+      });
     });
   });
 }

--- a/test/webui_handler_appstore_test.dart
+++ b/test/webui_handler_appstore_test.dart
@@ -85,7 +85,7 @@ void main() {
             '/api/v1/webui/skins/install/github-release',
             {'repo': 'user/repo'},
           );
-          expect(response.statusCode, isNot(403));
+          expect(response.statusCode, 200);
           expect(fakeStorage.installFromGitHubReleaseCalled, isTrue);
         },
       );
@@ -98,7 +98,7 @@ void main() {
             '/api/v1/webui/skins/install/github-branch',
             {'repo': 'user/repo'},
           );
-          expect(response.statusCode, isNot(403));
+          expect(response.statusCode, 200);
           expect(fakeStorage.installFromGitHubCalled, isTrue);
         },
       );
@@ -109,7 +109,7 @@ void main() {
           '/api/v1/webui/skins/install/url',
           {'url': 'https://example.com/skin.zip'},
         );
-        expect(response.statusCode, isNot(403));
+        expect(response.statusCode, 200);
         expect(fakeStorage.installFromUrlCalled, isTrue);
       });
     });

--- a/test/webui_storage_bundled_test.dart
+++ b/test/webui_storage_bundled_test.dart
@@ -2,10 +2,6 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:reaprime/src/webui_support/webui_storage.dart';
-import 'package:reaprime/src/settings/settings_controller.dart';
-
-import 'helpers/mock_settings_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -24,34 +20,6 @@ void main() {
         expect(source, contains('type'));
         expect(source['type'], anyOf('github_release', 'github_branch', 'url'));
       }
-    });
-  });
-
-  group('WebUIStorage appStoreMode', () {
-    late SettingsController settingsController;
-
-    setUp(() async {
-      final settingsService = MockSettingsService();
-      settingsController = SettingsController(settingsService);
-      await settingsController.loadSettings();
-    });
-
-    test('constructor accepts appStoreMode parameter', () {
-      // Should not throw
-      final storage = WebUIStorage(settingsController, appStoreMode: true);
-      expect(storage, isNotNull);
-    });
-
-    test('constructor defaults appStoreMode without parameter', () {
-      // Should not throw — defaults to BuildInfo.appStore (false in tests)
-      final storage = WebUIStorage(settingsController);
-      expect(storage, isNotNull);
-    });
-
-    test('updateAllSkins returns early when appStoreMode is true', () async {
-      final storage = WebUIStorage(settingsController, appStoreMode: true);
-      // Should complete without error and without making any HTTP requests
-      await storage.updateAllSkins();
     });
   });
 

--- a/test/webui_storage_install_test.dart
+++ b/test/webui_storage_install_test.dart
@@ -25,7 +25,7 @@ void main() {
 
       final settingsController = SettingsController(MockSettingsService());
       await settingsController.loadSettings();
-      storage = WebUIStorage(settingsController, appStoreMode: false);
+      storage = WebUIStorage(settingsController);
       storage.debugInitWithWebUIDir(webUIDir);
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(

--- a/test/webui_storage_safe_ids_test.dart
+++ b/test/webui_storage_safe_ids_test.dart
@@ -1,0 +1,139 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/webui_support/webui_storage.dart';
+
+import 'helpers/mock_settings_service.dart';
+
+/// Regression tests for safe skin ID handling.
+///
+/// Skin IDs come from untrusted manifests and are used directly as directory
+/// names under the web-ui root, so an unsafe id must be rejected before any
+/// directory is created or deleted (see issue #547 follow-up — App Store
+/// builds expose the install path, which makes escape-proofing mandatory).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('WebUIStorage safe skin ids', () {
+    late Directory tmpRoot;
+    late Directory webUIDir;
+    late WebUIStorage storage;
+    var sourceCounter = 0;
+
+    setUp(() async {
+      tmpRoot = Directory.systemTemp.createTempSync('webui_safe_ids_test');
+      webUIDir = Directory('${tmpRoot.path}/web-ui');
+
+      final settingsController = SettingsController(MockSettingsService());
+      await settingsController.loadSettings();
+      storage = WebUIStorage(settingsController);
+      storage.debugInitWithWebUIDir(webUIDir);
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            (_) async => tmpRoot.path,
+          );
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            null,
+          );
+      if (tmpRoot.existsSync()) tmpRoot.deleteSync(recursive: true);
+    });
+
+    /// Builds a source skin directory whose skin-manifest.json declares [id].
+    Directory makeSource(String id) {
+      final dir = Directory('${tmpRoot.path}/src_${sourceCounter++}')
+        ..createSync();
+      File('${dir.path}/skin-manifest.json').writeAsStringSync(
+        jsonEncode({'id': id, 'name': 'Test Skin', 'version': '1.0.0'}),
+      );
+      File('${dir.path}/index.html').writeAsStringSync('<html></html>');
+      return dir;
+    }
+
+    const unsafeIds = [
+      '',
+      '.',
+      '..',
+      '../escape',
+      'a/b',
+      r'a\b',
+      '/abs',
+      r'\abs',
+      'C:evil',
+      r'\\server\share',
+      'a?b',
+      'trailing.',
+      'trailing ',
+    ];
+
+    for (final id in unsafeIds) {
+      test('rejects skin id ${id.isEmpty ? '(empty)' : '"$id"'}', () async {
+        final source = makeSource(id);
+
+        await expectLater(
+          storage.installFromPath(source.path),
+          throwsFormatException,
+        );
+
+        // Nothing may be created or deleted under web-ui for an unsafe id.
+        expect(
+          webUIDir.listSync().whereType<Directory>(),
+          isEmpty,
+          reason: 'no skin directory may be created for unsafe id "$id"',
+        );
+        expect(storage.installedSkins, isEmpty);
+      });
+    }
+
+    test('valid ids with dots, hyphens and underscores install fine', () async {
+      for (final id in ['streamline.js', 'my-skin_v2.3', 'passione-dist']) {
+        final source = makeSource(id);
+
+        final installedId = await storage.installFromPath(source.path);
+
+        expect(installedId, id);
+        expect(Directory('${webUIDir.path}/$id').existsSync(), isTrue);
+        expect(storage.getSkin(id), isNotNull);
+      }
+    });
+
+    test(
+      'unsafe manifest ids cannot enter the in-memory registry on scan',
+      () async {
+        final goodSource = makeSource('good.skin');
+        await storage.installFromPath(goodSource.path);
+        expect(storage.getSkin('good.skin'), isNotNull);
+
+        // Drop a malicious skin dir whose manifest declares an unsafe id
+        // directly into the web-ui root, then re-trigger the scan via another
+        // install.
+        final evilDir = Directory('${webUIDir.path}/evil-dir')..createSync();
+        File(
+          '${evilDir.path}/skin-manifest.json',
+        ).writeAsStringSync(jsonEncode({'id': '../escape', 'name': 'Evil'}));
+        File('${evilDir.path}/index.html').writeAsStringSync('<html></html>');
+
+        final anotherSource = makeSource('another.skin');
+        await storage.installFromPath(anotherSource.path);
+
+        expect(storage.getSkin('../escape'), isNull);
+        expect(
+          storage.installedSkins.any((s) => s.id == '../escape'),
+          isFalse,
+          reason: 'an unsafe manifest id must not enter the registry',
+        );
+        // Valid skins must still be present.
+        expect(storage.getSkin('good.skin'), isNotNull);
+        expect(storage.getSkin('another.skin'), isNotNull);
+      },
+    );
+  });
+}

--- a/test/webui_zip_support_test.dart
+++ b/test/webui_zip_support_test.dart
@@ -222,6 +222,123 @@ void main() {
     );
   });
 
+  group('extractArchiveToDirectory rejects unsafe entry paths', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync(
+        'reaprime_zip_unsafe_test_',
+      );
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    void expectArchiveRejected(Archive archive, String reason) {
+      expect(
+        () => extractArchiveToDirectory(archive, tempDir, sanitize: true),
+        throwsFormatException,
+        reason: reason,
+      );
+    }
+
+    Archive archiveWith(String name) =>
+        Archive()..addFile(ArchiveFile.string(name, 'boom'));
+
+    test('rejects POSIX traversal components', () {
+      for (final name in [
+        '../escape.txt',
+        'a/../../escape.txt',
+        'a/../b.txt',
+      ]) {
+        expectArchiveRejected(archiveWith(name), 'entry "$name"');
+      }
+    });
+
+    test('rejects Windows-style traversal with backslashes', () {
+      for (final name in [
+        r'..\escape.txt',
+        r'a\..\escape.txt',
+        r'..\..\etc\passwd',
+      ]) {
+        expectArchiveRejected(archiveWith(name), 'entry "$name"');
+      }
+    });
+
+    test('rejects absolute POSIX paths', () {
+      for (final name in ['/etc/passwd', '/tmp/escape.txt']) {
+        expectArchiveRejected(archiveWith(name), 'entry "$name"');
+      }
+    });
+
+    test('rejects Windows drive paths', () {
+      for (final name in ['C:\\evil.txt', 'C:/evil.txt']) {
+        expectArchiveRejected(archiveWith(name), 'entry "$name"');
+      }
+    });
+
+    test('rejects UNC-style paths', () {
+      for (final name in [
+        r'\\server\share\evil.txt',
+        '//server/share/evil.txt',
+      ]) {
+        expectArchiveRejected(archiveWith(name), 'entry "$name"');
+      }
+    });
+
+    test('rejects NUL bytes in entry names', () {
+      expectArchiveRejected(archiveWith('bad\x00name.txt'), 'NUL byte');
+    });
+
+    test('rejects the archive before writing anything', () {
+      final sibling = File(
+        p.join(tempDir.parent.path, 'escape_${p.basename(tempDir.path)}.txt'),
+      );
+      if (sibling.existsSync()) sibling.deleteSync();
+
+      final archive = Archive()
+        ..addFile(ArchiveFile.string('good.txt', 'fine'))
+        ..addFile(ArchiveFile.string('../escape.txt', 'boom'));
+
+      expectArchiveRejected(archive, 'traversal entry after a valid entry');
+
+      // Pre-validation must reject the whole archive before any entry is
+      // written — not even the innocent first entry may land.
+      expect(
+        tempDir.listSync(),
+        isEmpty,
+        reason: 'no entries may be written when the archive is rejected',
+      );
+      expect(
+        sibling.existsSync(),
+        isFalse,
+        reason: 'nothing may land outside the extraction directory',
+      );
+      if (sibling.existsSync()) sibling.deleteSync();
+    });
+
+    test(
+      'still extracts a sanitiseable entry (reserved chars are not unsafe)',
+      () {
+        final archive = Archive()
+          ..addFile(ArchiveFile.string('shots/2025:bad.json', 'ok'));
+
+        final result = extractArchiveToDirectory(
+          archive,
+          tempDir,
+          sanitize: true,
+        );
+
+        expect(result.extracted, 1);
+        expect(
+          File(p.join(tempDir.path, 'shots', '2025_bad.json')).existsSync(),
+          isTrue,
+        );
+      },
+    );
+  });
+
   group('installBundledSkinList', () {
     late Logger testLog;
     late List<LogRecord> logged;


### PR DESCRIPTION
## Summary

- Problem: App Store builds hid or blocked skin and plugin management.
- Why it matters: iOS users could not update installed skins; the update endpoint returned success after doing nothing.
- What changed: removed the blanket App Store gates from skin/plugin UI, storage, and handlers, and hardened the newly exposed filesystem paths (ZIP extraction containment + safe id validation for skins and plugins).
- What did NOT change: App Store build reporting, the Exit Decaid gate, and platform-only live-edit restrictions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [x] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [x] WebUI skins
- [x] Plugins / JS runtime
- [x] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #547
- Related #503

## Root Cause (if bug fix)

- Root cause: App Store readiness used one blanket flag for unrelated skin and plugin capabilities.
- Missing detection or guardrail: tests asserted the restrictions rather than the desired App Store behavior.
- Contributing context: the original restrictions predated successful App Store beta reviews.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [x] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/webui_handler_appstore_test.dart`, `test/webui_storage_install_test.dart`, `test/plugin_loader_service_appstore_test.dart`, `test/plugins_settings_view_appstore_test.dart`, `test/skin_selector_update_refresh_test.dart`
- Scenario the test should lock in: App Store builds expose skin/plugin management and perform skin updates.
- If no new test added, why not: Existing regression tests were inverted to assert the corrected behavior.

## Documentation Obligations (required)

- [x] API spec reviewed: no response shape changed; the removed distribution gate was undocumented.
- [x] API docs reviewed: no endpoint shape changed.
- [x] Plugin docs reviewed: no event or API shape changed.
- [x] Skin docs updated: `doc/Skins.md`
- [x] Profile docs N/A
- [x] Device docs N/A

## Security Impact (required)

- New or changed REST endpoints? `Yes` — existing handlers are now reachable in App Store builds.
- New or changed WebSocket topics? `No`
- New or changed network calls? `Yes` — App Store builds can download and update skins.
- BLE/USB surface changed? `No`
- File system access changed? `Yes` — existing install/remove paths are enabled.
- Plugin sandbox boundary changed? `No`
- If any `Yes`, explain risk and mitigation: The newly exposed paths are contained:
  - ZIP extraction (`webui_zip_support.dart`) now pre-validates every archive entry before writing anything and rejects the whole archive with a `FormatException` on traversal (`../`, `..\`, absolute, drive/UNC paths); Win32-reserved-character sanitisation for otherwise-valid names is unchanged.
  - Skin ids (from `skin-manifest.json` / `manifest.json` / folder name) must be exactly one safe filesystem component and are validated before any directory is created or deleted; unsafe ids are rejected at install time and skipped at scan time so they cannot enter the in-memory registry.
  - Plugin ids are validated with the same shared single-component rule in `addPlugin()`, `_scanAvailablePlugins()`, `removePlugin()`, and `getPluginDirectory()` before any path is formed.
  - Download/update traffic is unchanged from the pre-existing non-App-Store behavior. Live-edit remains platform-gated.

## User-Visible Changes

- iOS users can install, remove, and update skins.
- Plugin installation and removal are no longer hidden or rejected solely because of App Store distribution.
- Skin/plugin installs with unsafe ids (path separators, `..`, absolute paths, etc.) now fail with a clear error instead of writing outside the storage root.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — no remaining changes
- [x] `flutter analyze` — clean
- [x] `flutter test` — all pass
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds

### Manual verification (if applicable)

- OS / platform tested: macOS
- Simulated devices? `Yes`
- Real hardware? `No`
- What you personally verified and how: Started with `APP_STORE=true` and MockDe1; `/api/v1/info` reported App Store mode; skin/plugin install handlers returned validation errors rather than 403 before and after hot reload.
- Edge cases checked: normal and App Store compile modes; remote skin update metadata; plugin watchdog behavior.
- What you did **not** verify: physical iOS device or App Store review.

### Evidence

- [x] Test output (failing before + passing after)
- [x] Log snippets
- [ ] Screenshot / recording (UI changes)
- [x] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`
- No migration steps required.

## Risks & Mitigations

- Risk: App Store builds can install archives/manifests whose names are attacker-controlled.
  - Mitigation: every newly exposed filesystem installation path stays inside its assigned storage directory — zip entries are pre-validated for traversal, and skin/plugin ids must be a single safe path component under both POSIX and Windows rules. Live-edit remains unavailable on iOS.

