### PR TITLE
feat(sleep): auto-sleep from needsWater on FW >= 1357

### DIFF
--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -170,6 +170,12 @@ A queue can produce only one wrapper timeout per faulted generation; followers a
 - `ScanStateGuardian` guards against overlapping scans and tracks adapter state.
 - `ScanOrchestrator` manages single-scan lifecycle.
 
+## Sleep From NeedsWater (Refill State)
+
+DE1 firmware build 1357 (commit `eb21a1d`, `CTopTouchSM::S_Refill`) honors a BLE sleep request while the machine is in refill/needsWater state when no refill kit is present. The app sends sleep from `needsWater` only on FW >= 1357 (`PresenceController._kSleepOnRefillMinFwBuild` / `_canSleepFromState`); idle/schedIdle are always eligible.
+
+**Why the build gate exists:** older firmware ignores the sleep request *while in refill* but keeps it latched in `BLERequestedState`. The machine honors it once it exits refill (e.g. right after the user refills the tank), so sending sleep from needsWater on old FW would put the machine straight back to sleep after a refill. With a refill kit present, the FW ignores the request (kit refill in progress) — the FW owns that guard, the app just sends the request.
+
 ## Comms-Layer Patterns
 
 An awake Decent Scale connection requires a recognised FFF4 status or weight frame after subscription and a status request. Two seconds of silence triggers one immediate re-subscribe and status request; a second silent window tears down the transport without sending the physical power-off command so ConnectionManager owns the next reconnect. A deliberately sleeping reconnect only restores the subscription while remaining dark and defers the same readiness probe until wake.

--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -172,9 +172,9 @@ A queue can produce only one wrapper timeout per faulted generation; followers a
 
 ## Sleep From NeedsWater (Refill State)
 
-DE1 firmware build 1357 (commit `eb21a1d`, `CTopTouchSM::S_Refill`) honors a BLE sleep request while the machine is in refill/needsWater state when no refill kit is present. The app sends sleep from `needsWater` only on FW >= 1357 (`PresenceController._kSleepOnRefillMinFwBuild` / `_canSleepFromState`); idle/schedIdle are always eligible.
+DE1 firmware build 1357+ honors a BLE sleep request while the machine is in refill/needsWater state when no refill kit is present. The app sends sleep from `needsWater` only for DE1 (not Bengle) on FW >= 1357 (`PresenceController._kSleepOnRefillMinFwBuild` / `_canSleepFromState`); idle/schedIdle are always eligible.
 
-**Why the build gate exists:** older firmware ignores the sleep request *while in refill* but keeps it latched in `BLERequestedState`. The machine honors it once it exits refill (e.g. right after the user refills the tank), so sending sleep from needsWater on old FW would put the machine straight back to sleep after a refill. With a refill kit present, the FW ignores the request (kit refill in progress) — the FW owns that guard, the app just sends the request.
+**Why the build gate exists:** older firmware ignores the sleep request *while in refill* but keeps it latched, honoring it once the machine exits refill (e.g. right after the user refills the tank), so sending sleep from needsWater on old FW would put the machine straight back to sleep after a refill. With a refill kit present, the FW ignores the request (kit refill in progress) — the FW owns that guard, the app just sends the request.
 
 ## Comms-Layer Patterns
 

--- a/lib/src/controllers/presence_controller.dart
+++ b/lib/src/controllers/presence_controller.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/keep_awake_occurrence.dart';
 import 'package:reaprime/src/models/wake_schedule.dart';
@@ -351,7 +352,12 @@ class PresenceController {
       return true;
     }
     if (state == MachineState.needsWater) {
-      final fwBuild = int.tryParse(_de1?.machineInfo.version ?? '') ?? 0;
+      final de1 = _de1;
+      if (de1 == null ||
+          de1.implementation != DeviceImplementation.unifiedDe1) {
+        return false;
+      }
+      final fwBuild = int.tryParse(de1.machineInfo.version) ?? 0;
       return fwBuild >= _kSleepOnRefillMinFwBuild;
     }
     return false;

--- a/lib/src/controllers/presence_controller.dart
+++ b/lib/src/controllers/presence_controller.dart
@@ -318,15 +318,24 @@ class PresenceController {
       return;
     }
 
-    // If machine is in idle or schedIdle, put it to sleep
-    if (_currentMachineState == MachineState.idle ||
-        _currentMachineState == MachineState.schedIdle) {
+    // If machine is in a state we can sleep from (idle/schedIdle, or
+    // needsWater on FW >= 1357), put it to sleep
+    final state = _currentMachineState;
+    if (state != null && _canSleepFromState(state)) {
       _log.info('Sleep timeout fired, putting machine to sleep');
       _de1!.requestState(MachineState.sleeping).catchError((Object e) {
         _log.warning('Failed to request sleep', e);
       });
     }
   }
+
+  /// First DE1 firmware build that honors a BLE sleep request while the
+  /// machine is in refill/needsWater state (with no refill kit present).
+  /// See DE1Firmware `CTopTouchSM::S_Refill` (commit eb21a1d, build 1357).
+  /// Older firmware ignores the request while in refill but keeps it latched,
+  /// honoring it once the machine exits refill (e.g. after the user refills
+  /// the tank) — so we must not send sleep from needsWater below this build.
+  static const int _kSleepOnRefillMinFwBuild = 1357;
 
   /// Returns true for machine states where we should NOT auto-sleep.
   bool _isActiveState(MachineState? state) {
@@ -343,6 +352,22 @@ class PresenceController {
       default:
         return false;
     }
+  }
+
+  /// True when the machine is in a state we may put to sleep from the idle
+  /// timer. `needsWater` (refill) is only included on firmware that honors a
+  /// sleep request while refilling (build >= [_kSleepOnRefillMinFwBuild]);
+  /// older builds latch the request and would sleep the machine right after
+  /// the user refills the tank.
+  bool _canSleepFromState(MachineState state) {
+    if (state == MachineState.idle || state == MachineState.schedIdle) {
+      return true;
+    }
+    if (state == MachineState.needsWater) {
+      final fwBuild = int.tryParse(_de1?.machineInfo.version ?? '') ?? 0;
+      return fwBuild >= _kSleepOnRefillMinFwBuild;
+    }
+    return false;
   }
 
   int _secondsRemaining() {

--- a/lib/src/controllers/presence_controller.dart
+++ b/lib/src/controllers/presence_controller.dart
@@ -318,8 +318,6 @@ class PresenceController {
       return;
     }
 
-    // If machine is in a state we can sleep from (idle/schedIdle, or
-    // needsWater on FW >= 1357), put it to sleep
     final state = _currentMachineState;
     if (state != null && _canSleepFromState(state)) {
       _log.info('Sleep timeout fired, putting machine to sleep');
@@ -329,12 +327,6 @@ class PresenceController {
     }
   }
 
-  /// First DE1 firmware build that honors a BLE sleep request while the
-  /// machine is in refill/needsWater state (with no refill kit present).
-  /// See DE1Firmware `CTopTouchSM::S_Refill` (commit eb21a1d, build 1357).
-  /// Older firmware ignores the request while in refill but keeps it latched,
-  /// honoring it once the machine exits refill (e.g. after the user refills
-  /// the tank) — so we must not send sleep from needsWater below this build.
   static const int _kSleepOnRefillMinFwBuild = 1357;
 
   /// Returns true for machine states where we should NOT auto-sleep.
@@ -354,11 +346,6 @@ class PresenceController {
     }
   }
 
-  /// True when the machine is in a state we may put to sleep from the idle
-  /// timer. `needsWater` (refill) is only included on firmware that honors a
-  /// sleep request while refilling (build >= [_kSleepOnRefillMinFwBuild]);
-  /// older builds latch the request and would sleep the machine right after
-  /// the user refills the tank.
   bool _canSleepFromState(MachineState state) {
     if (state == MachineState.idle || state == MachineState.schedIdle) {
       return true;

--- a/test/controllers/presence_controller_test.dart
+++ b/test/controllers/presence_controller_test.dart
@@ -118,8 +118,6 @@ class _TestDe1 implements De1Interface {
   @override
   Stream<bool> get ready => Stream.value(true);
 
-  /// Overridable firmware build reported via [machineInfo]. Default '1' so
-  /// existing tests behave as before (pre-1357, needsWater sleep disabled).
   String fwBuild = '1';
 
   @override

--- a/test/controllers/presence_controller_test.dart
+++ b/test/controllers/presence_controller_test.dart
@@ -117,9 +117,13 @@ class _TestDe1 implements De1Interface {
       BehaviorSubject.seeded(ConnectionState.connected).stream;
   @override
   Stream<bool> get ready => Stream.value(true);
+  /// Overridable firmware build reported via [machineInfo]. Default '1' so
+  /// existing tests behave as before (pre-1357, needsWater sleep disabled).
+  String fwBuild = '1';
+
   @override
   MachineInfo get machineInfo => MachineInfo(
-    version: '1',
+    version: fwBuild,
     model: '1',
     serialNumber: '1',
     groupHeadControllerPresent: false,
@@ -486,6 +490,87 @@ void main() {
         });
       },
     );
+
+    test(
+      'needsWater on FW >= 1357 sleeps after timeout',
+      () {
+        fakeAsync((async) {
+          settingsController.setSleepTimeoutMinutes(5);
+          async.flushMicrotasks();
+
+          testDe1.fwBuild = '1357';
+          final controller = PresenceController(
+            de1Controller: de1Controller,
+            settingsController: settingsController,
+            clock: () => clock.now(),
+          );
+          controller.initialize();
+          de1Controller.setDe1(testDe1);
+          async.flushMicrotasks();
+
+          controller.heartbeat();
+          async.flushMicrotasks();
+
+          // Machine runs dry while idle.
+          testDe1.emitState(MachineState.needsWater);
+          async.flushMicrotasks();
+
+          // Advance past the timeout while in needsWater.
+          async.elapse(const Duration(minutes: 5, seconds: 1));
+
+          expect(
+            testDe1.requestedStates,
+            contains(MachineState.sleeping),
+            reason: 'FW >= 1357 honors sleep while in refill',
+          );
+
+          controller.dispose();
+        });
+      },
+    );
+
+    test('needsWater on FW < 1357 does NOT sleep after timeout', () {
+      fakeAsync((async) {
+        settingsController.setSleepTimeoutMinutes(5);
+        async.flushMicrotasks();
+
+        // Default fwBuild is '1' (< 1357).
+        final controller = PresenceController(
+          de1Controller: de1Controller,
+          settingsController: settingsController,
+          clock: () => clock.now(),
+        );
+        controller.initialize();
+        de1Controller.setDe1(testDe1);
+        async.flushMicrotasks();
+
+        controller.heartbeat();
+        async.flushMicrotasks();
+
+        testDe1.emitState(MachineState.needsWater);
+        async.flushMicrotasks();
+
+        // Advance well past the timeout while in needsWater.
+        async.elapse(const Duration(minutes: 5, seconds: 1));
+
+        expect(
+          testDe1.requestedStates.where((s) => s == MachineState.sleeping),
+          isEmpty,
+          reason: 'FW < 1357 latches the request; must not send sleep from needsWater',
+        );
+
+        // User refills the tank (heartbeat re-arms the timer) and the machine
+        // returns to idle: sleep works there as before.
+        controller.heartbeat();
+        async.flushMicrotasks();
+        testDe1.emitState(MachineState.idle);
+        async.flushMicrotasks();
+        async.elapse(const Duration(minutes: 5, seconds: 1));
+        expect(testDe1.requestedStates, contains(MachineState.sleeping));
+
+        controller.dispose();
+      });
+    });
   });
 
   group('scheduled wake', () {

--- a/test/controllers/presence_controller_test.dart
+++ b/test/controllers/presence_controller_test.dart
@@ -104,7 +104,7 @@ class _TestDe1 implements De1Interface {
   DeviceType get type => DeviceType.machine;
 
   @override
-  DeviceImplementation get implementation => DeviceImplementation.unifiedDe1;
+  DeviceImplementation get implementation => deviceImplementation;
 
   @override
   TransportType get transportType => TransportType.unknown;
@@ -119,6 +119,7 @@ class _TestDe1 implements De1Interface {
   Stream<bool> get ready => Stream.value(true);
 
   String fwBuild = '1';
+  DeviceImplementation deviceImplementation = DeviceImplementation.unifiedDe1;
 
   @override
   MachineInfo get machineInfo => MachineInfo(
@@ -564,6 +565,41 @@ void main() {
         async.flushMicrotasks();
         async.elapse(const Duration(minutes: 5, seconds: 1));
         expect(testDe1.requestedStates, contains(MachineState.sleeping));
+
+        controller.dispose();
+      });
+    });
+
+    test('needsWater on Bengle does NOT sleep even on FW >= 1357', () {
+      fakeAsync((async) {
+        settingsController.setSleepTimeoutMinutes(5);
+        async.flushMicrotasks();
+
+        testDe1.fwBuild = '1357';
+        testDe1.deviceImplementation = DeviceImplementation.bengle;
+        final controller = PresenceController(
+          de1Controller: de1Controller,
+          settingsController: settingsController,
+          clock: () => clock.now(),
+        );
+        controller.initialize();
+        de1Controller.setDe1(testDe1);
+        async.flushMicrotasks();
+
+        controller.heartbeat();
+        async.flushMicrotasks();
+
+        testDe1.emitState(MachineState.needsWater);
+        async.flushMicrotasks();
+
+        // Advance well past the timeout while in needsWater.
+        async.elapse(const Duration(minutes: 5, seconds: 1));
+
+        expect(
+          testDe1.requestedStates.where((s) => s == MachineState.sleeping),
+          isEmpty,
+          reason: 'sleep-from-needsWater is DE1-only',
+        );
 
         controller.dispose();
       });

--- a/test/controllers/presence_controller_test.dart
+++ b/test/controllers/presence_controller_test.dart
@@ -117,6 +117,7 @@ class _TestDe1 implements De1Interface {
       BehaviorSubject.seeded(ConnectionState.connected).stream;
   @override
   Stream<bool> get ready => Stream.value(true);
+
   /// Overridable firmware build reported via [machineInfo]. Default '1' so
   /// existing tests behave as before (pre-1357, needsWater sleep disabled).
   String fwBuild = '1';
@@ -491,43 +492,40 @@ void main() {
       },
     );
 
-    test(
-      'needsWater on FW >= 1357 sleeps after timeout',
-      () {
-        fakeAsync((async) {
-          settingsController.setSleepTimeoutMinutes(5);
-          async.flushMicrotasks();
+    test('needsWater on FW >= 1357 sleeps after timeout', () {
+      fakeAsync((async) {
+        settingsController.setSleepTimeoutMinutes(5);
+        async.flushMicrotasks();
 
-          testDe1.fwBuild = '1357';
-          final controller = PresenceController(
-            de1Controller: de1Controller,
-            settingsController: settingsController,
-            clock: () => clock.now(),
-          );
-          controller.initialize();
-          de1Controller.setDe1(testDe1);
-          async.flushMicrotasks();
+        testDe1.fwBuild = '1357';
+        final controller = PresenceController(
+          de1Controller: de1Controller,
+          settingsController: settingsController,
+          clock: () => clock.now(),
+        );
+        controller.initialize();
+        de1Controller.setDe1(testDe1);
+        async.flushMicrotasks();
 
-          controller.heartbeat();
-          async.flushMicrotasks();
+        controller.heartbeat();
+        async.flushMicrotasks();
 
-          // Machine runs dry while idle.
-          testDe1.emitState(MachineState.needsWater);
-          async.flushMicrotasks();
+        // Machine runs dry while idle.
+        testDe1.emitState(MachineState.needsWater);
+        async.flushMicrotasks();
 
-          // Advance past the timeout while in needsWater.
-          async.elapse(const Duration(minutes: 5, seconds: 1));
+        // Advance past the timeout while in needsWater.
+        async.elapse(const Duration(minutes: 5, seconds: 1));
 
-          expect(
-            testDe1.requestedStates,
-            contains(MachineState.sleeping),
-            reason: 'FW >= 1357 honors sleep while in refill',
-          );
+        expect(
+          testDe1.requestedStates,
+          contains(MachineState.sleeping),
+          reason: 'FW >= 1357 honors sleep while in refill',
+        );
 
-          controller.dispose();
-        });
-      },
-    );
+        controller.dispose();
+      });
+    });
 
     test('needsWater on FW < 1357 does NOT sleep after timeout', () {
       fakeAsync((async) {
@@ -556,7 +554,8 @@ void main() {
         expect(
           testDe1.requestedStates.where((s) => s == MachineState.sleeping),
           isEmpty,
-          reason: 'FW < 1357 latches the request; must not send sleep from needsWater',
+          reason:
+              'FW < 1357 latches the request; must not send sleep from needsWater',
         );
 
         // User refills the tank (heartbeat re-arms the timer) and the machine


### PR DESCRIPTION
## Summary

- Problem: DE1 firmware build 1357 (commit `eb21a1d`) now honors a BLE sleep request while the machine is in refill/needsWater state (when no refill kit is present), but the app's idle timer only sent the sleep request from `idle`/`schedIdle` — so a machine left in needsWater never auto-slept.
- Why it matters: without this, the new FW capability is unreachable via auto-sleep; the machine stays awake in refill indefinitely.
- What changed: `PresenceController._onSleepTimeout` now also sleeps from `needsWater`, gated on firmware build >= 1357 (`_kSleepOnRefillMinFwBuild`).
- What did NOT change (scope boundary): no change to heartbeat/presence logic, no change to the FW. Old-FW behavior (idle/schedIdle only) is preserved.

## Change Type (select all)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] Machine state / shot logic
- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs

## Linked Issues

- Closes #
- Related #357 (descale cooling; refill-state sleep unblocks Phase 2 on-machine test), DE1Firmware `eb21a1d`

## Root Cause (if bug fix)

- Root cause: N/A (feature)
- The gating exists because older FW (< 1357) does **not** discard a sleep request received while refilling — it latches `BLERequestedState` and honors it once the machine exits refill (e.g. right after the user refills the tank). Sending sleep from needsWater unconditionally would put the machine straight back to sleep after a refill on old FW.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/controllers/presence_controller_test.dart` (sleep timeout group)
- Scenario the test should lock in: needsWater + FW >= 1357 → sleep after timeout; needsWater + FW < 1357 → no sleep from needsWater, but idle still sleeps.
- If no new test added, why not: N/A

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A — no docs affected

## Security Impact (required)

This app runs a local web server (port 8080) and connects to BLE/USB hardware.

- New or changed REST endpoints? (`No`)
- New or changed WebSocket topics? (`No`)
- New or changed network calls? (`No`)
- BLE/USB surface changed? (`No`)
- File system access changed? (`No`)
- Plugin sandbox boundary changed? (`No`)
- If any `Yes`, explain risk and mitigation: N/A

## User-Visible Changes

On DE1 firmware >= 1357, a machine left in needsWater (tank empty, no refill kit) now auto-sleeps after the idle timeout instead of staying awake indefinitely. On older firmware, behavior is unchanged.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — no remaining changes
- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass (26/26 in presence_controller_test.dart)
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds (unchanged; not run — no plugin changes)

### Manual verification (if applicable)

- OS / platform tested: None (logic verified via unit tests)
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `No` — FW side being flashed/tested separately (build 1357)
- What you personally verified and how: unit tests; code trace of FW `S_Refill` exit path (refill → heating consumes latched request on old FW)
- Edge cases checked: FW < 1357 latch behavior, needsWater → idle after heartbeat, active-state pause
- What you did **not** verify: on-device refill → sleep transition

### Evidence

Attach at least one:

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? (`Yes`) — old FW behavior preserved via build gate; needsWater sleep is additive on FW >= 1357
- Config / env changes needed? (`No`)
- Database migration needed? (`No`)
- If any `No` or `Yes`, explain exact steps: N/A

## Risks & Mitigations

- Risk: on FW >= 1357 with a refill kit **present**, the machine stays in refill and the FW ignores the sleep request (kit refill in progress) — same as today, no regression.
  - Mitigation: FW owns the refill-kit guard (`S_Refill` checks `isRefillKitPresent()`); app sends the request unconditionally on >= 1357 and the FW decides.
