### PR TITLE
feat(serial): connect an attached Android USB machine immediately

### DIFF
--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -210,13 +210,35 @@ capability. Attach events are non-replaying hints and may carry incomplete
 metadata; serial scanning and detection remain the support filter. Android can
 broadcast attach before the CDC interface is usable, so
 `AttachReconnectCoordinator` coalesces bursts and waits a configurable 500 ms
-before invoking the normal connection policy.
+before acting.
 
-Only a missing preferred machine enables this path. The attempt therefore uses
-remembered-device quick-connect first, retains scan fallback, and cannot open a
-picker when no preference exists. If the immediate attempt finds nothing or
-fails, the coordinator explicitly re-arms normal machine recovery. BLE, Wi-Fi,
-simulated-device, and scale-only behavior do not expose attach events.
+A second optional capability, `UsbAttachProbe`, lets the originating serial
+service positively identify and connect the specifically attached USB device.
+`SerialServiceAndroid.connectAttachedMachine` correlates the event with a
+newly listed USB device (stable-ID match when Android supplied one, otherwise
+only devices not already connected), runs the existing serial admission and
+`_detectDevice` logic, and connects only supported `De1Interface` machines.
+Scales, sensors, debug ports, and arbitrary USB devices are rejected with
+full transport cleanup. The typed result distinguishes connected / nothing
+supported / detected-but-failed.
+
+The central distinction: preferred-machine policy controls passive automatic
+discovery; physically attaching a supported USB machine is explicit connection
+intent. On a probe-capable scanner, `ConnectionManager` runs the probe ahead of
+any preferred-machine scan — no preference, a stale BLE preference, another
+USB preference, or a simulated preference are all overridden by the attached
+machine, and the machine's USB ID becomes the preferred machine only after a
+successful connection and adoption. Unsupported attachments change nothing;
+failed attachments preserve the previous preference and return control to the
+existing preferred-machine recovery policy (or surface the normal connection
+failure). A connected machine is never replaced.
+
+Attach attempts never run in parallel with another connect. An attach arriving
+while an automatic/recovery connect is in flight supersedes that scan via the
+existing generation mechanism and runs one coalesced probe as soon as the
+ownership releases; explicit user scans and scale-only connects are waited
+out. No BLE, Wi-Fi, simulated-device, or scale-only behavior exposes attach
+events.
 
 ## Quick Connect
 

--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -220,7 +220,9 @@ only devices not already connected), runs the existing serial admission and
 `_detectDevice` logic, and connects only supported `De1Interface` machines.
 Scales, sensors, debug ports, and arbitrary USB devices are rejected with
 full transport cleanup. The typed result distinguishes connected / nothing
-supported / detected-but-failed.
+supported / detected-but-failed, plus "probe unavailable" when the
+originating service lacks the capability — which falls back to the legacy
+preferred-machine connect policy.
 
 The central distinction: preferred-machine policy controls passive automatic
 discovery; physically attaching a supported USB machine is explicit connection

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -176,16 +176,49 @@ the required `DeviceScanner` interface. A scanner exposes attach hints only when
 it also implements `DeviceAttachNotifier`, so BLE, Wi-Fi, and simulated scanners
 remain unchanged.
 
-`AttachReconnectCoordinator` owns the subscription, configurable 500 ms settle
-timer, burst coalescing, in-flight guard, and disposal. Disposal waits for an
-in-flight attempt before `ConnectionManager` tears down its dependencies. The
-delay lets Android's CDC interface become usable after the earlier attach
-broadcast. If a preferred
-machine is absent, it invokes the normal `ConnectionManager.connect()` policy,
-including remembered-device quick-connect and scan fallback. An unsuccessful
-attempt explicitly re-arms machine recovery. It ignores hints when a machine is
-already connected or no preferred machine exists; this prevents an unrelated USB
-attach from connecting another device or opening a picker.
+`AttachReconnectCoordinator` owns the attach subscription, configurable 500 ms
+settle timer, burst coalescing, in-flight guard, and disposal. Disposal waits
+for an in-flight attempt before `ConnectionManager` tears down its
+dependencies. The delay lets Android's CDC interface become usable after the
+earlier attach broadcast.
+
+`UsbAttachProbe` is a second optional capability for the originating serial
+service. `SerialServiceAndroid.connectAttachedMachine` correlates the attach
+event with a newly listed USB device (by stable ID when Android supplied one,
+otherwise only devices not already connected), runs the normal serial admission
+and detection, and connects the device only when it is a supported machine
+(`De1Interface`). Scales, sensors, debug ports, keyboards, and other USB
+devices are rejected and their transports disposed. The typed result
+distinguishes a connected machine from "no supported machine attached" from
+"machine detected but connection or identity initialization failed".
+
+When the scanner implements `UsbAttachProbe`, a physical USB attachment is
+explicit connection intent and wins over passive preferred-machine policy:
+`ConnectionManager` runs the probe ahead of any preferred-machine scan,
+adopts the connected machine, and persists its USB device id as the preferred
+machine. A stale BLE preference, a different preferred USB machine, a
+simulated preference, or no preference at all are all overridden by the
+physically attached machine; no BLE scan runs and no machine picker opens.
+An attached machine that fails to connect preserves the previous preference
+and returns control to the existing preferred-machine recovery policy (or
+surfaces the normal machine-connection failure when no preference exists).
+Unsupported or uncorrelated attachments change nothing — no scan, no picker,
+no preference update, and an already scheduled recovery attempt is left
+alone. A machine that is already connected is never replaced; the attach
+attempt re-checks before executing.
+
+When the scanner implements only `DeviceAttachNotifier` (no probe), the
+original behavior applies: a preferred machine must exist, and the normal
+`ConnectionManager.connect()` policy (remembered-device quick-connect and
+scan fallback) runs, with machine recovery explicitly re-armed after an
+unsuccessful attempt.
+
+An attach event arriving while another connection operation owns the connect
+guard is queued as one coalesced probe; in-flight automatic/recovery scanning
+is superseded through the existing scan-generation mechanism, while explicit
+user scans and scale-only connects are waited out. The queued probe runs
+before other drained work, re-checks that no machine connected meanwhile, and
+never runs in parallel with another connect.
 
 The original incident showed 20.3 seconds between USB enumeration and connection
 because recovery was waiting for its backoff timer; the existing backoff can
@@ -532,9 +565,11 @@ Device preferences are stored via `SettingsController`:
 Identity remains per transport. BLE and USB IDs for the same physical machine
 are not aliased. If the BLE ID is preferred while Bluetooth is unavailable, a
 discovered USB identity is offered for selection; selecting it persists that USB
-ID. Later automatic startup and Android USB-attach recovery can quick-connect
+ID. Later automatic startup and recovery scans can quick-connect
 through the remembered USB record, with normal implementation validation and
-scan fallback on failure.
+scan fallback on failure. A physically attached Android USB machine bypasses
+preference entirely (see "Android USB attach recovery") and persists its USB
+ID as the preferred machine after a successful connection.
 
 ---
 
@@ -709,8 +744,10 @@ scale discovery:
 - **No preferred scale:** `_armPostQuickConnectScaleScan()` (single deferred
   scale-only scan after ~3s, same delay as the post-wake reconnect)
 
-Quick-connect is reserved for automatic startup and recovery, including
-Android USB-attach recovery. Explicit native, REST, and WebSocket scans call
+Quick-connect is reserved for automatic startup and recovery. Android
+USB-attach recovery probes the attached device directly instead of
+quick-connecting when the scanner supports `UsbAttachProbe` (see "Android USB
+attach recovery"). Explicit native, REST, and WebSocket scans call
 `scanAndConnect()` and always scan before applying policy. The phase stream shows
 `idle → connectingMachine → ready` on success. On failure:
 `connectingMachine` is published before the attempt, then phase falls

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -190,7 +190,10 @@ and detection, and connects the device only when it is a supported machine
 (`De1Interface`). Scales, sensors, debug ports, keyboards, and other USB
 devices are rejected and their transports disposed. The typed result
 distinguishes a connected machine from "no supported machine attached" from
-"machine detected but connection or identity initialization failed".
+"machine detected but connection or identity initialization failed". When
+the originating service only implements the notifier (no probe capability),
+the result is "probe unavailable" and the legacy preferred-machine policy
+runs instead.
 
 When the scanner implements `UsbAttachProbe`, a physical USB attachment is
 explicit connection intent and wins over passive preferred-machine policy:
@@ -207,8 +210,9 @@ no preference update, and an already scheduled recovery attempt is left
 alone. A machine that is already connected is never replaced; the attach
 attempt re-checks before executing.
 
-When the scanner implements only `DeviceAttachNotifier` (no probe), the
-original behavior applies: a preferred machine must exist, and the normal
+When the probe capability is unavailable (a notifier-only scanner, or a
+`DeviceController` whose originating service cannot probe), the original
+behavior applies: a preferred machine must exist, and the normal
 `ConnectionManager.connect()` policy (remembered-device quick-connect and
 scan fallback) runs, with machine recovery explicitly re-armed after an
 unsuccessful attempt.

--- a/doc/plans/archive/android-usb-attach-machine-adoption/2026-07-18-design.md
+++ b/doc/plans/archive/android-usb-attach-machine-adoption/2026-07-18-design.md
@@ -1,0 +1,124 @@
+# Adopt an attached Android USB machine immediately (issue #473)
+
+## Problem
+
+PR #455 added Android USB attach-triggered recovery, but the attach path only
+invokes the normal preferred-machine connection policy. When the stored
+preferred machine is a BLE device (or another USB machine, or a simulated
+device), the app scans for that preference before adopting the physically
+attached serial machine. A physical USB attachment is explicit user intent and
+must win over passive automatic preference policy.
+
+## Rule
+
+When Android reports a USB attachment and the serial service positively
+identifies and successfully connects a supported machine, Decaid adopts that
+machine immediately, provided no machine is currently connected. The
+preferred-machine setting never gates this behavior. The preference is updated
+to the attached machine's USB ID only after successful connection and
+adoption.
+
+## Design
+
+### Optional probe capability
+
+New transport-neutral capability `UsbAttachProbe` in
+`lib/src/models/device/usb_attach_probe.dart`:
+
+- `connectAttachedMachine(DeviceAttachedEvent)` → typed `AttachProbeResult`:
+  - `AttachProbeConnected(machine)` — supported machine connected, identity
+    init complete;
+  - `AttachProbeUnsupported` — no supported machine correlates with the
+    attachment (uncorrelated, unsupported, or already known);
+  - `AttachProbeFailed(deviceId, deviceName)` — supported machine detected but
+    connection/identity init failed; resources cleaned up.
+
+### SerialServiceAndroid
+
+Implements `UsbAttachProbe`:
+
+1. Correlate: when `event.deviceId` is present, probe only the listed USB
+   device whose stable ID matches. When absent, probe only devices not already
+   in the service's connected-device list — so an unrelated keyboard attach
+   (null metadata) cannot re-adopt an already-present serial DE1.
+2. Skip devices already known/connected (duplicate attach broadcasts).
+3. Run the existing serial admission and `_detectDevice` logic (product-name
+   gate, VID:PID shortcuts, probe heuristics).
+4. Accept only `De1Interface` machines; scales, sensors, and debug ports are
+   rejected and their transports disposed.
+5. `onConnect()` (transport connect + v13Model identity init) with the same
+   10s timeout as quick-connect; failure cleans up port, transport, and device
+   and reports `AttachProbeFailed`.
+6. Success registers the device like quick-connect (devices list, disconnect
+   listener, subject emission).
+
+Constructor seam: optional `detectDevice` injection for tests, probe path only.
+
+### DeviceController
+
+Implements `UsbAttachProbe`. Records the originating service per attach event
+instance while aggregating notifier streams, and routes
+`connectAttachedMachine(event)` only to that service when it is capable.
+Non-originating services are never probed.
+
+### AttachReconnectCoordinator
+
+Attempt callback now receives the attach event (the latest of a coalesced
+burst). Settle, burst coalescing, in-flight absorption, cancellation, and
+disposal ownership unchanged.
+
+### ConnectionManager
+
+- `shouldAttempt` = machine not connected AND (probe capability exists OR a
+  preferred machine exists). Legacy scanners (attach hint without probe) keep
+  the old preference-gated behavior; probe-capable scanners attempt on any
+  attach.
+- Attempt: machine already connected → ignore. Probe-capable and a connect is
+  in flight → queue one coalesced attach attempt; supersede in-flight
+  automatic/adapter-recovery scanning via the existing generation bump +
+  `stopScan()` (explicit user scans and scale-only connects are queued, not
+  superseded). The `_runConnect` drain loop runs the queued probe first,
+  re-checking machine-connected before executing.
+- The probe runs under the `_isConnecting` guard so no competing connection
+  operation can start in parallel.
+- Connected machine → adopt via `de1Controller.adoptDevice`, persist
+  `preferredMachineId` = USB device id, settle scale state exactly like the
+  quick-connect path (Bengle virtual scale, scale reacquisition or deferred
+  scale scan), publish ready.
+- Unsupported → do nothing; preferences, scans, picker, and any already
+  scheduled recovery stay untouched.
+- Failed → preserve previous preference. With a preferred machine, hand back
+  to the existing preferred-machine recovery policy (recovery loop already
+  re-arms itself; queued path arms it explicitly). Without one, surface a
+  normal machine-connect failure and remain disconnected.
+
+## Concurrency
+
+- Attach attempts never run in parallel with any other connect (probe holds
+  `_isConnecting`).
+- Attach during in-flight automatic/recovery connect: superseded scan bails on
+  generation mismatch, then the queued probe runs in the drain.
+- Attach during explicit scan or scale-only connect: queued, runs after the
+  owner releases.
+- Machine-connected re-checked at every execution point; a machine that
+  connected before the attach attempt ran is never replaced.
+
+## Tests
+
+- Coordinator: existing settle/burst/in-flight/disposal tests updated for the
+  event-passing attempt signature.
+- Serial service: correlation (id match, no-id new-device-only, already-known
+  skip, no match), keyboard attach with a present DE1, scale/sensor/debug
+  rejection, connect failure cleanup + typed result, success registration.
+- DeviceController: probe routes only to the originating capable service.
+- ConnectionManager: no-preference adoption, BLE preference overridden, other
+  USB preference overridden, same-machine cross-transport equals different
+  machine, unsupported does nothing, failed preserves preference and resumes
+  recovery, connected machine ignores attach, attach during recovery scanning
+  not dropped and no parallel attempts, legacy no-probe behavior unchanged.
+
+## Scope
+
+No REST, WebSocket, database, skin, or plugin API changes. BLE, Wi-Fi,
+simulated-device, scale-only, explicit-scan, and non-Android behavior
+unchanged. Android hardware timing not verified — unit-tested only.

--- a/doc/plans/archive/android-usb-attach-machine-adoption/2026-07-18-design.md
+++ b/doc/plans/archive/android-usb-attach-machine-adoption/2026-07-18-design.md
@@ -31,7 +31,9 @@ New transport-neutral capability `UsbAttachProbe` in
   - `AttachProbeUnsupported` — no supported machine correlates with the
     attachment (uncorrelated, unsupported, or already known);
   - `AttachProbeFailed(deviceId, deviceName)` — supported machine detected but
-    connection/identity init failed; resources cleaned up.
+    connection/identity init failed; resources cleaned up;
+  - `AttachProbeUnavailable` — the originating service lacks the capability;
+    the legacy preferred-machine connect policy runs instead.
 
 ### SerialServiceAndroid
 
@@ -52,7 +54,8 @@ Implements `UsbAttachProbe`:
 6. Success registers the device like quick-connect (devices list, disconnect
    listener, subject emission).
 
-Constructor seam: optional `detectDevice` injection for tests, probe path only.
+Constructor seam: optional `detectDevice` injection for tests, replacing the
+real detector across the scan, quick-connect, and probe paths.
 
 ### DeviceController
 

--- a/lib/src/controllers/connection/attach_reconnect_coordinator.dart
+++ b/lib/src/controllers/connection/attach_reconnect_coordinator.dart
@@ -5,7 +5,7 @@ import 'package:reaprime/src/models/device/device_attach_notifier.dart';
 class AttachReconnectCoordinator {
   final Duration settleDelay;
   final bool Function() shouldAttempt;
-  final Future<bool> Function() attempt;
+  final Future<bool> Function(DeviceAttachedEvent event) attempt;
   final FutureOr<void> Function() recover;
 
   late final StreamSubscription<DeviceAttachedEvent> _subscription;
@@ -13,6 +13,7 @@ class AttachReconnectCoordinator {
   Future<void>? _inFlightAttempt;
   bool _inFlight = false;
   bool _disposed = false;
+  DeviceAttachedEvent? _pendingEvent;
 
   AttachReconnectCoordinator({
     required Stream<DeviceAttachedEvent> attachEvents,
@@ -24,31 +25,34 @@ class AttachReconnectCoordinator {
     _subscription = attachEvents.listen(_onAttach);
   }
 
-  void _onAttach(DeviceAttachedEvent _) {
-    if (_disposed || _inFlight || _settleTimer != null || !shouldAttempt()) {
-      return;
-    }
+  void _onAttach(DeviceAttachedEvent event) {
+    if (_disposed || _inFlight) return;
+    _pendingEvent = event;
+    if (_settleTimer != null) return;
+    if (!shouldAttempt()) return;
     _settleTimer = Timer(settleDelay, () {
       _settleTimer = null;
       if (_disposed || _inFlight || !shouldAttempt()) return;
+      final event = _pendingEvent;
+      if (event == null) return;
       _inFlight = true;
-      _inFlightAttempt = _startAttempt();
+      _inFlightAttempt = _startAttempt(event);
       unawaited(_inFlightAttempt);
     });
   }
 
-  Future<void> _startAttempt() async {
+  Future<void> _startAttempt(DeviceAttachedEvent event) async {
     try {
-      await _runAttempt();
+      await _runAttempt(event);
     } finally {
       _inFlightAttempt = null;
     }
   }
 
-  Future<void> _runAttempt() async {
+  Future<void> _runAttempt(DeviceAttachedEvent event) async {
     var succeeded = false;
     try {
-      succeeded = await attempt();
+      succeeded = await attempt(event);
     } catch (_) {
       succeeded = false;
     } finally {

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -367,8 +367,6 @@ class ConnectionManager {
   UsbAttachProbe? get _attachProbe =>
       deviceScanner is UsbAttachProbe ? deviceScanner as UsbAttachProbe : null;
 
-  /// One coalesced attach probe queued while another connect owned the
-  /// connection guard. Drained first in [_runConnect]'s drain loop.
   bool _pendingAttachAttempt = false;
   DeviceAttachedEvent? _pendingAttachEvent;
 
@@ -378,11 +376,6 @@ class ConnectionManager {
     if (_isConnecting) {
       _pendingAttachEvent = event;
       _pendingAttachAttempt = true;
-      // Prioritize the attached machine over automatic/recovery scanning:
-      // supersede the in-flight automatic connect via the existing
-      // generation mechanism so the queued probe runs as soon as the
-      // current owner releases. Explicit user scans and scale-only
-      // connects are left alone and the probe simply waits its turn.
       final intent = currentStatus.intent;
       if (intent == ConnectionIntent.automatic ||
           intent == ConnectionIntent.adapterRecovery) {
@@ -391,7 +384,14 @@ class ConnectionManager {
       }
       return true;
     }
-    await _executeAttachProbe(event);
+    final handled = await _runConnect(
+      scaleOnly: false,
+      policy: ConnectionAttemptPolicy.automatic,
+      attachEvent: event,
+    );
+    if (!handled && settingsController.preferredMachineId != null) {
+      return _attemptAutomaticConnect();
+    }
     return true;
   }
 
@@ -407,72 +407,62 @@ class ConnectionManager {
     return _machineConnected;
   }
 
-  /// Runs the attach probe under the connection guard so no competing
-  /// connection operation can start in parallel, then settles outcome:
-  /// connected → adopted; failed with a preferred machine → hand back to
-  /// the existing recovery policy; failed without one → failure surfaced.
-  Future<void> _executeAttachProbe(DeviceAttachedEvent event) async {
-    if (_machineConnected) return;
+  Future<bool> _executeAttachProbe(DeviceAttachedEvent event) async {
+    if (_machineConnected) return true;
     _isConnecting = true;
     try {
-      final succeeded = await _runAttachProbe(event);
-      if (!succeeded &&
-          !_machineConnected &&
-          settingsController.preferredMachineId != null) {
-        _ensureMachineRecoveryArmed();
+      final probe = _attachProbe;
+      if (probe == null) return false;
+      final result = await probe.connectAttachedMachine(event);
+      switch (result) {
+        case AttachProbeConnected(machine: final machine):
+          _log.info(
+            'Attach probe: machine ${machine.name} (${machine.deviceId}) '
+            'connected, adopting',
+          );
+          await _adoptAttachedMachine(machine);
+          return true;
+        case AttachProbeUnsupported():
+          _log.fine(
+            'Attach probe: no supported machine on the attached device',
+          );
+          return true;
+        case AttachProbeUnavailable():
+          return false;
+        case AttachProbeFailed(deviceId: final id, deviceName: final name):
+          if (settingsController.preferredMachineId != null) {
+            _log.info(
+              'Attach probe: attached machine ${name ?? id} failed to '
+              'connect; returning to preferred-machine recovery',
+            );
+            _ensureMachineRecoveryArmed();
+            return true;
+          }
+          _log.info(
+            'Attach probe: attached machine ${name ?? id} failed to connect',
+          );
+          _emit(
+            ConnectionError(
+              kind: ConnectionErrorKind.machineConnectFailed,
+              severity: ConnectionErrorSeverity.error,
+              timestamp: DateTime.now().toUtc(),
+              deviceId: id,
+              deviceName: name,
+              message:
+                  'Attached machine ${name ?? id ?? 'device'} failed to '
+                  'connect.',
+              suggestion:
+                  'Make sure the machine is powered on and the USB '
+                  'cable is seated, then try again.',
+            ),
+          );
+          return true;
       }
     } finally {
       _isConnecting = false;
     }
   }
 
-  Future<bool> _runAttachProbe(DeviceAttachedEvent event) async {
-    final probe = _attachProbe;
-    if (probe == null) return false;
-    final result = await probe.connectAttachedMachine(event);
-    switch (result) {
-      case AttachProbeConnected(machine: final machine):
-        _log.info(
-          'Attach probe: machine ${machine.name} (${machine.deviceId}) '
-          'connected, adopting',
-        );
-        await _adoptAttachedMachine(machine);
-        return true;
-      case AttachProbeUnsupported():
-        _log.fine('Attach probe: no supported machine on the attached device');
-        return true;
-      case AttachProbeFailed(deviceId: final id, deviceName: final name):
-        if (settingsController.preferredMachineId != null) {
-          _log.info(
-            'Attach probe: attached machine ${name ?? id} failed to connect; '
-            'returning to preferred-machine recovery',
-          );
-          return false;
-        }
-        _log.info(
-          'Attach probe: attached machine ${name ?? id} failed to connect',
-        );
-        _emit(
-          ConnectionError(
-            kind: ConnectionErrorKind.machineConnectFailed,
-            severity: ConnectionErrorSeverity.error,
-            timestamp: DateTime.now().toUtc(),
-            deviceId: id,
-            deviceName: name,
-            message:
-                'Attached machine ${name ?? id ?? 'device'} failed to '
-                'connect.',
-            suggestion:
-                'Make sure the machine is powered on and the USB '
-                'cable is seated, then try again.',
-          ),
-        );
-        return true;
-    }
-  }
-
-  /// Adopt an already-connected attached machine and settle connection
-  /// and scale state consistently with a successful machine quick-connect.
   Future<void> _adoptAttachedMachine(De1Interface machine) async {
     _publishStatus(
       currentStatus.copyWith(
@@ -758,30 +748,33 @@ class ConnectionManager {
       return _queuedExplicitScan!.future;
     }
     _explicitScanGeneration++;
-    return _runConnect(
+    await _runConnect(
       scaleOnly: false,
       policy: ConnectionAttemptPolicy.explicitScan,
     );
   }
 
-  Future<void> _runConnect({
+  Future<bool> _runConnect({
     required bool scaleOnly,
     required ConnectionAttemptPolicy policy,
     bool adapterRecovery = false,
+    DeviceAttachedEvent? attachEvent,
   }) async {
     if (_isConnecting) {
-      if (adapterRecovery) return;
+      if (adapterRecovery) return true;
       if (scaleOnly) {
         final completer = _queuedScaleOnly ??= Completer<void>();
-        return completer.future;
+        return completer.future.then((_) => true);
       }
-      return;
+      return true;
     }
 
     try {
       if (adapterRecovery) {
         _adapterRecoveryQueued = false;
         await _executeAdapterRecovery();
+      } else if (attachEvent != null) {
+        return await _executeAttachProbe(attachEvent);
       } else {
         await _executeConnect(scaleOnly, policy: policy);
       }
@@ -789,8 +782,7 @@ class ConnectionManager {
       // Single priority-aware drain loop: explicit always evaluated
       // first at each scheduling boundary. An explicit request arriving
       // during a queued scale-only drain is picked up immediately. A
-      // queued attach probe runs before everything else — it is a
-      // targeted connection of a physically attached machine.
+      // queued attach probe runs first.
       while (_pendingAttachAttempt ||
           _queuedExplicitScan != null ||
           _adapterRecoveryQueued ||
@@ -799,10 +791,11 @@ class ConnectionManager {
           _pendingAttachAttempt = false;
           final event = _pendingAttachEvent;
           _pendingAttachEvent = null;
-          // Re-check before executing queued work: a machine that
-          // completed connection while we waited is never replaced.
           if (event != null && !_machineConnected) {
-            await _executeAttachProbe(event);
+            final handled = await _executeAttachProbe(event);
+            if (!handled && settingsController.preferredMachineId != null) {
+              await _attemptAutomaticConnect();
+            }
           }
           continue;
         }
@@ -841,6 +834,7 @@ class ConnectionManager {
         }
       }
     }
+    return true;
   }
 
   Future<void> _executeConnect(

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -30,6 +30,7 @@ import 'package:reaprime/src/models/device/device_scanner.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
+import 'package:reaprime/src/models/device/usb_attach_probe.dart';
 import 'package:reaprime/src/models/scan_report.dart';
 import 'package:reaprime/src/settings/scale_power_mode.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
@@ -357,13 +358,44 @@ class ConnectionManager {
   }
 
   bool _shouldAttemptAttachReconnect() {
+    if (_machineConnected) return false;
+    if (_attachProbe != null) return true;
     final preferredMachineId = settingsController.preferredMachineId;
-    return !_machineConnected &&
-        preferredMachineId != null &&
-        preferredMachineId.isNotEmpty;
+    return preferredMachineId != null && preferredMachineId.isNotEmpty;
   }
 
-  Future<bool> _attemptAttachReconnect() async {
+  UsbAttachProbe? get _attachProbe =>
+      deviceScanner is UsbAttachProbe ? deviceScanner as UsbAttachProbe : null;
+
+  /// One coalesced attach probe queued while another connect owned the
+  /// connection guard. Drained first in [_runConnect]'s drain loop.
+  bool _pendingAttachAttempt = false;
+  DeviceAttachedEvent? _pendingAttachEvent;
+
+  Future<bool> _attemptAttachReconnect(DeviceAttachedEvent event) async {
+    if (_machineConnected) return true;
+    if (_attachProbe == null) return _attemptAutomaticConnect();
+    if (_isConnecting) {
+      _pendingAttachEvent = event;
+      _pendingAttachAttempt = true;
+      // Prioritize the attached machine over automatic/recovery scanning:
+      // supersede the in-flight automatic connect via the existing
+      // generation mechanism so the queued probe runs as soon as the
+      // current owner releases. Explicit user scans and scale-only
+      // connects are left alone and the probe simply waits its turn.
+      final intent = currentStatus.intent;
+      if (intent == ConnectionIntent.automatic ||
+          intent == ConnectionIntent.adapterRecovery) {
+        _explicitScanGeneration++;
+        deviceScanner.stopScan();
+      }
+      return true;
+    }
+    await _executeAttachProbe(event);
+    return true;
+  }
+
+  Future<bool> _attemptAutomaticConnect() async {
     _machineReconnect?.cancel();
     _machineReconnect = null;
     _machineReconnectFailures = 0;
@@ -373,6 +405,94 @@ class ConnectionManager {
       _log.fine('Attach-triggered connect failed', e, st);
     }
     return _machineConnected;
+  }
+
+  /// Runs the attach probe under the connection guard so no competing
+  /// connection operation can start in parallel, then settles outcome:
+  /// connected → adopted; failed with a preferred machine → hand back to
+  /// the existing recovery policy; failed without one → failure surfaced.
+  Future<void> _executeAttachProbe(DeviceAttachedEvent event) async {
+    if (_machineConnected) return;
+    _isConnecting = true;
+    try {
+      final succeeded = await _runAttachProbe(event);
+      if (!succeeded &&
+          !_machineConnected &&
+          settingsController.preferredMachineId != null) {
+        _ensureMachineRecoveryArmed();
+      }
+    } finally {
+      _isConnecting = false;
+    }
+  }
+
+  Future<bool> _runAttachProbe(DeviceAttachedEvent event) async {
+    final probe = _attachProbe;
+    if (probe == null) return false;
+    final result = await probe.connectAttachedMachine(event);
+    switch (result) {
+      case AttachProbeConnected(machine: final machine):
+        _log.info(
+          'Attach probe: machine ${machine.name} (${machine.deviceId}) '
+          'connected, adopting',
+        );
+        await _adoptAttachedMachine(machine);
+        return true;
+      case AttachProbeUnsupported():
+        _log.fine('Attach probe: no supported machine on the attached device');
+        return true;
+      case AttachProbeFailed(deviceId: final id, deviceName: final name):
+        if (settingsController.preferredMachineId != null) {
+          _log.info(
+            'Attach probe: attached machine ${name ?? id} failed to connect; '
+            'returning to preferred-machine recovery',
+          );
+          return false;
+        }
+        _log.info(
+          'Attach probe: attached machine ${name ?? id} failed to connect',
+        );
+        _emit(
+          ConnectionError(
+            kind: ConnectionErrorKind.machineConnectFailed,
+            severity: ConnectionErrorSeverity.error,
+            timestamp: DateTime.now().toUtc(),
+            deviceId: id,
+            deviceName: name,
+            message:
+                'Attached machine ${name ?? id ?? 'device'} failed to '
+                'connect.',
+            suggestion:
+                'Make sure the machine is powered on and the USB '
+                'cable is seated, then try again.',
+          ),
+        );
+        return true;
+    }
+  }
+
+  /// Adopt an already-connected attached machine and settle connection
+  /// and scale state consistently with a successful machine quick-connect.
+  Future<void> _adoptAttachedMachine(De1Interface machine) async {
+    _publishStatus(
+      currentStatus.copyWith(
+        phase: ConnectionPhase.connectingMachine,
+        activeTargetTransport: () => machine.transportType,
+      ),
+    );
+    de1Controller.adoptDevice(machine);
+    await settingsController.setPreferredMachineId(machine.deviceId);
+    _log.info('Attach probe: machine adopted (${machine.deviceId})');
+    if (machine is BengleInterface) {
+      await _attachBengleVirtualScale(machine);
+    } else if (!_scaleConnected) {
+      if (settingsController.preferredScaleId != null) {
+        _ensureScaleReacquisition();
+      } else {
+        _armPostQuickConnectScaleScan();
+      }
+    }
+    _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.ready));
   }
 
   void _ensureMachineRecoveryArmed() {
@@ -668,10 +788,25 @@ class ConnectionManager {
     } finally {
       // Single priority-aware drain loop: explicit always evaluated
       // first at each scheduling boundary. An explicit request arriving
-      // during a queued scale-only drain is picked up immediately.
-      while (_queuedExplicitScan != null ||
+      // during a queued scale-only drain is picked up immediately. A
+      // queued attach probe runs before everything else — it is a
+      // targeted connection of a physically attached machine.
+      while (_pendingAttachAttempt ||
+          _queuedExplicitScan != null ||
           _adapterRecoveryQueued ||
           _queuedScaleOnly != null) {
+        if (_pendingAttachAttempt) {
+          _pendingAttachAttempt = false;
+          final event = _pendingAttachEvent;
+          _pendingAttachEvent = null;
+          // Re-check before executing queued work: a machine that
+          // completed connection while we waited is never replaced.
+          if (event != null && !_machineConnected) {
+            await _executeAttachProbe(event);
+          }
+          continue;
+        }
+
         if (_queuedExplicitScan != null) {
           final drain = _queuedExplicitScan!;
           _queuedExplicitScan = null;

--- a/lib/src/controllers/device_controller.dart
+++ b/lib/src/controllers/device_controller.dart
@@ -9,12 +9,14 @@ import 'package:reaprime/src/models/device/device_scanner.dart';
 import 'package:reaprime/src/models/device/device_watch.dart';
 import 'package:reaprime/src/models/device/remembered_device.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
+import 'package:reaprime/src/models/device/usb_attach_probe.dart';
 import 'package:reaprime/src/models/device/watch_filter.dart';
 import 'package:reaprime/src/services/ble/ble_discovery_service.dart';
 import 'package:reaprime/src/services/telemetry/telemetry_service.dart';
 import 'package:rxdart/rxdart.dart';
 
-class DeviceController implements DeviceScanner, DeviceAttachNotifier {
+class DeviceController
+    implements DeviceScanner, DeviceAttachNotifier, UsbAttachProbe {
   final List<DeviceDiscoveryService> _services;
 
   late Map<DeviceDiscoveryService, List<Device>> _devices;
@@ -52,6 +54,12 @@ class DeviceController implements DeviceScanner, DeviceAttachNotifier {
   @override
   Stream<DeviceAttachedEvent> get deviceAttached =>
       _deviceAttachedStream.stream;
+
+  /// Originating service per attach event instance, recorded while
+  /// aggregating notifier streams so [connectAttachedMachine] can route
+  /// the probe back to the service that saw the attachment. Events are
+  /// non-replaying edges, so instance identity is stable.
+  final Map<DeviceAttachedEvent, DeviceDiscoveryService> _attachOrigins = {};
 
   final List<StreamSubscription> _serviceSubscriptions = [];
 
@@ -142,6 +150,7 @@ class DeviceController implements DeviceScanner, DeviceAttachNotifier {
         }
         if (service case final DeviceAttachNotifier notifier) {
           final attachSub = notifier.deviceAttached.listen((event) {
+            _attachOrigins[event] = service;
             _log.info("device attached on $service: $event");
             if (!_deviceAttachedStream.isClosed) {
               _deviceAttachedStream.add(event);
@@ -272,6 +281,17 @@ class DeviceController implements DeviceScanner, DeviceAttachNotifier {
       }
     }
     return null;
+  }
+
+  @override
+  Future<AttachProbeResult> connectAttachedMachine(
+    DeviceAttachedEvent event,
+  ) async {
+    final origin = _attachOrigins[event];
+    if (origin case final UsbAttachProbe probe) {
+      return probe.connectAttachedMachine(event);
+    }
+    return const AttachProbeUnsupported();
   }
 
   Iterable<DeviceWatchCapable> get _watchCapableServices => _services
@@ -425,6 +445,7 @@ class DeviceController implements DeviceScanner, DeviceAttachNotifier {
       subscription.cancel();
     }
     _serviceSubscriptions.clear();
+    _attachOrigins.clear();
     _deviceStream.close();
     _scanningStream.close();
     _adapterStateStream.close();

--- a/lib/src/controllers/device_controller.dart
+++ b/lib/src/controllers/device_controller.dart
@@ -55,11 +55,8 @@ class DeviceController
   Stream<DeviceAttachedEvent> get deviceAttached =>
       _deviceAttachedStream.stream;
 
-  /// Originating service per attach event instance, recorded while
-  /// aggregating notifier streams so [connectAttachedMachine] can route
-  /// the probe back to the service that saw the attachment. Events are
-  /// non-replaying edges, so instance identity is stable.
-  final Map<DeviceAttachedEvent, DeviceDiscoveryService> _attachOrigins = {};
+  /// Weak origin association for attach-probe routing.
+  final Expando<DeviceDiscoveryService> _attachOrigins = Expando();
 
   final List<StreamSubscription> _serviceSubscriptions = [];
 
@@ -291,7 +288,7 @@ class DeviceController
     if (origin case final UsbAttachProbe probe) {
       return probe.connectAttachedMachine(event);
     }
-    return const AttachProbeUnsupported();
+    return const AttachProbeUnavailable();
   }
 
   Iterable<DeviceWatchCapable> get _watchCapableServices => _services
@@ -445,7 +442,6 @@ class DeviceController
       subscription.cancel();
     }
     _serviceSubscriptions.clear();
-    _attachOrigins.clear();
     _deviceStream.close();
     _scanningStream.close();
     _adapterStateStream.close();

--- a/lib/src/models/device/usb_attach_probe.dart
+++ b/lib/src/models/device/usb_attach_probe.dart
@@ -1,0 +1,38 @@
+import 'de1_interface.dart';
+import 'device_attach_notifier.dart';
+
+/// Outcome of probing a specifically attached USB device for a supported
+/// machine.
+sealed class AttachProbeResult {
+  const AttachProbeResult();
+}
+
+/// A supported machine was positively identified, connected, and its
+/// identity initialization completed.
+class AttachProbeConnected extends AttachProbeResult {
+  const AttachProbeConnected(this.machine);
+
+  final De1Interface machine;
+}
+
+/// No supported machine corresponds to the attachment: uncorrelated,
+/// unsupported, or already known. Nothing was changed.
+class AttachProbeUnsupported extends AttachProbeResult {
+  const AttachProbeUnsupported();
+}
+
+/// A supported machine was detected but connection or identity
+/// initialization failed. All resources were cleaned up.
+class AttachProbeFailed extends AttachProbeResult {
+  const AttachProbeFailed({this.deviceId, this.deviceName});
+
+  final String? deviceId;
+  final String? deviceName;
+}
+
+/// Optional capability for the discovery service that originated a
+/// [DeviceAttachedEvent]: positively identify and connect the machine on the
+/// specifically attached USB device, bypassing preferred-machine policy.
+abstract class UsbAttachProbe {
+  Future<AttachProbeResult> connectAttachedMachine(DeviceAttachedEvent event);
+}

--- a/lib/src/models/device/usb_attach_probe.dart
+++ b/lib/src/models/device/usb_attach_probe.dart
@@ -21,6 +21,13 @@ class AttachProbeUnsupported extends AttachProbeResult {
   const AttachProbeUnsupported();
 }
 
+/// The originating discovery service does not implement the probe
+/// capability. Callers should fall back to the legacy preferred-machine
+/// connection policy.
+class AttachProbeUnavailable extends AttachProbeResult {
+  const AttachProbeUnavailable();
+}
+
 /// A supported machine was detected but connection or identity
 /// initialization failed. All resources were cleaned up.
 class AttachProbeFailed extends AttachProbeResult {

--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_attach_notifier.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
@@ -17,6 +18,7 @@ import 'package:reaprime/src/models/device/impl/sensor/sensor_basket.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/remembered_device.dart';
+import 'package:reaprime/src/models/device/usb_attach_probe.dart';
 import 'mmr_codec.dart';
 import 'usb_ids.dart';
 import 'utils.dart';
@@ -27,10 +29,11 @@ import 'package:rxdart/subjects.dart';
 import 'package:usb_serial/usb_serial.dart';
 
 class SerialServiceAndroid
-    implements DeviceDiscoveryService, DeviceAttachNotifier {
+    implements DeviceDiscoveryService, DeviceAttachNotifier, UsbAttachProbe {
   final _log = Logger("Android Serial service");
   final Future<List<UsbDevice>> Function() _listDevices;
   final Stream<UsbEvent>? Function() _usbEventStream;
+  final Future<Device?> Function(UsbDevice device)? _detectOverride;
 
   final List<Device> _devices = [];
   StreamSubscription<UsbEvent>? _usbEventSubscription;
@@ -39,8 +42,10 @@ class SerialServiceAndroid
   SerialServiceAndroid({
     Future<List<UsbDevice>> Function()? listDevices,
     Stream<UsbEvent>? Function()? usbEventStream,
+    Future<Device?> Function(UsbDevice device)? detectDevice,
   }) : _listDevices = listDevices ?? UsbSerial.listDevices,
-       _usbEventStream = usbEventStream ?? (() => UsbSerial.usbEventStream);
+       _usbEventStream = usbEventStream ?? (() => UsbSerial.usbEventStream),
+       _detectOverride = detectDevice;
 
   /// Tracks transports created by [_detectDevice] so quick-connect cleanup
   /// can dispose them. Keyed by [Device.deviceId] (== [AndroidSerialPort.id]).
@@ -167,6 +172,120 @@ class SerialServiceAndroid
   }
 
   @override
+  Future<AttachProbeResult> connectAttachedMachine(
+    DeviceAttachedEvent event,
+  ) async {
+    if (_disposed) return const AttachProbeUnsupported();
+    final devices = await _listDevices();
+    final candidates = _attachedCandidates(event, devices);
+    if (candidates.isEmpty) {
+      _log.fine('Attach probe: no USB device correlates with $event');
+      return const AttachProbeUnsupported();
+    }
+    AttachProbeFailed? failure;
+    for (final device in candidates) {
+      final result = await _connectAttachedMachine(device);
+      if (result is AttachProbeConnected) return result;
+      if (result is AttachProbeFailed) failure = result;
+    }
+    return failure ?? const AttachProbeUnsupported();
+  }
+
+  List<UsbDevice> _attachedCandidates(
+    DeviceAttachedEvent event,
+    List<UsbDevice> devices,
+  ) {
+    final id = event.deviceId;
+    if (id != null && id.isNotEmpty) {
+      return devices.where((d) => _stableIdOf(d) == id).toList();
+    }
+    final known = _devices.map((d) => d.deviceId).toSet();
+    return devices.where((d) => !known.contains(_stableIdOf(d))).toList();
+  }
+
+  String _stableIdOf(UsbDevice device) =>
+      computeUsbStableId(
+        vid: device.vid,
+        pid: device.pid,
+        serial: device.serial,
+      ) ??
+      '${device.deviceId}';
+
+  Future<AttachProbeResult> _connectAttachedMachine(UsbDevice device) async {
+    final stableId = _stableIdOf(device);
+    if (_devices.any((d) => d.deviceId == stableId)) {
+      _log.fine('Attach probe: $stableId already known, skipping');
+      return const AttachProbeUnsupported();
+    }
+    if (!serialProbeAllowsProductName(device.productName)) {
+      _log.fine(
+        'Attach probe: ${device.productName} is not a supported product',
+      );
+      return const AttachProbeUnsupported();
+    }
+    Device? detected;
+    try {
+      detected = await _runDetection(device);
+    } catch (e, st) {
+      _log.warning('Attach probe: detection failed for $stableId', e, st);
+      return const AttachProbeUnsupported();
+    }
+    if (detected == null) {
+      _log.fine('Attach probe: no supported device on $stableId');
+      return const AttachProbeUnsupported();
+    }
+    final machine = detected;
+    if (machine is! De1Interface) {
+      _log.info('Attach probe: ${machine.name} is not a machine, rejecting');
+      await _rejectAttachedDevice(machine);
+      return const AttachProbeUnsupported();
+    }
+    try {
+      await machine.onConnect().timeout(const Duration(seconds: 10));
+    } catch (e, st) {
+      _log.warning(
+        'Attach probe: connect failed for ${machine.deviceId}',
+        e,
+        st,
+      );
+      await _rejectAttachedDevice(machine);
+      return AttachProbeFailed(
+        deviceId: machine.deviceId,
+        deviceName: machine.name,
+      );
+    }
+    _devices.add(machine);
+    machine.connectionState.listen((state) {
+      if (state == ConnectionState.disconnected) {
+        _devices.remove(machine);
+        _machineSubject.add(_devices);
+        final t = _transportForDeviceId.remove(machine.deviceId);
+        try {
+          t?.dispose();
+        } catch (_) {}
+      }
+    });
+    _machineSubject.add(_devices);
+    _log.info('Attach probe: connected ${machine.name} (${machine.deviceId})');
+    return AttachProbeConnected(machine);
+  }
+
+  Future<void> _rejectAttachedDevice(Device detected) async {
+    try {
+      await detected.disconnect();
+    } catch (e, st) {
+      _log.fine('Attach probe: rejected device disconnect failed', e, st);
+    }
+    final t = _transportForDeviceId.remove(detected.deviceId);
+    try {
+      await t?.dispose();
+    } catch (_) {}
+  }
+
+  Future<Device?> _runDetection(UsbDevice device) =>
+      (_detectOverride ?? _detectDevice)(device);
+
+  @override
   void stopScan() {}
 
   @override
@@ -189,7 +308,7 @@ class SerialServiceAndroid
       );
       Device? device;
       try {
-        device = await _detectDevice(d);
+        device = await _runDetection(d);
       } catch (e, st) {
         _log.warning('Quick-connect: _detectDevice failed', e, st);
         continue;
@@ -334,7 +453,7 @@ class SerialServiceAndroid
     final results = await Future.wait(
       devices.map((d) async {
         try {
-          final device = await _detectDevice(d);
+          final device = await _runDetection(d);
           _log.info("Port $d -> ${device ?? 'no device'}");
           return device;
         } catch (e, st) {

--- a/test/controllers/connection/attach_reconnect_coordinator_test.dart
+++ b/test/controllers/connection/attach_reconnect_coordinator_test.dart
@@ -18,7 +18,7 @@ void main() {
         attachEvents: events.stream,
         settleDelay: settleDelay,
         shouldAttempt: () => true,
-        attempt: () async {
+        attempt: (_) async {
           attempts++;
           return true;
         },
@@ -48,7 +48,7 @@ void main() {
         attachEvents: events.stream,
         settleDelay: settleDelay,
         shouldAttempt: () => true,
-        attempt: () async {
+        attempt: (_) async {
           attempts++;
           return true;
         },
@@ -79,7 +79,7 @@ void main() {
         attachEvents: events.stream,
         settleDelay: settleDelay,
         shouldAttempt: () => true,
-        attempt: () {
+        attempt: (_) {
           attempts++;
           return attemptCompletion.future;
         },
@@ -111,7 +111,7 @@ void main() {
         attachEvents: events.stream,
         settleDelay: settleDelay,
         shouldAttempt: () => false,
-        attempt: () async {
+        attempt: (_) async {
           attempts++;
           return true;
         },
@@ -137,7 +137,7 @@ void main() {
         attachEvents: events.stream,
         settleDelay: settleDelay,
         shouldAttempt: () => true,
-        attempt: () async => false,
+        attempt: (_) async => false,
         recover: () => recoveries++,
       );
 
@@ -160,7 +160,7 @@ void main() {
       attachEvents: events.stream,
       settleDelay: Duration.zero,
       shouldAttempt: () => true,
-      attempt: () {
+      attempt: (_) {
         attemptStarted.complete();
         return attemptCompletion.future;
       },
@@ -192,7 +192,7 @@ void main() {
         attachEvents: events.stream,
         settleDelay: settleDelay,
         shouldAttempt: () => true,
-        attempt: () async {
+        attempt: (_) async {
           attempts++;
           return true;
         },
@@ -204,6 +204,35 @@ void main() {
       async.elapse(settleDelay);
       expect(attempts, 0);
 
+      events.close();
+    });
+  });
+
+  test('attempt receives the latest event of a coalesced burst', () {
+    fakeAsync((async) {
+      final events = StreamController<DeviceAttachedEvent>.broadcast(
+        sync: true,
+      );
+      DeviceAttachedEvent? attemptedEvent;
+      final coordinator = AttachReconnectCoordinator(
+        attachEvents: events.stream,
+        settleDelay: settleDelay,
+        shouldAttempt: () => true,
+        attempt: (event) async {
+          attemptedEvent = event;
+          return true;
+        },
+        recover: () {},
+      );
+
+      events.add(const DeviceAttachedEvent(deviceId: 'first'));
+      events.add(const DeviceAttachedEvent(deviceId: 'second'));
+      events.add(const DeviceAttachedEvent(deviceId: 'third'));
+      async.elapse(settleDelay);
+      async.flushMicrotasks();
+
+      expect(attemptedEvent?.deviceId, 'third');
+      coordinator.dispose();
       events.close();
     });
   });

--- a/test/controllers/connection_manager_usb_attach_test.dart
+++ b/test/controllers/connection_manager_usb_attach_test.dart
@@ -45,12 +45,19 @@ class _ProbeScanner extends _AttachScanner implements UsbAttachProbe {
   int probeCallCount = 0;
   final List<DeviceAttachedEvent> probeEvents = [];
 
+  /// When set, [connectAttachedMachine] waits for this before returning.
+  Completer<void>? probeGate;
+  final Completer<void> probeStarted = Completer<void>();
+
   @override
   Future<AttachProbeResult> connectAttachedMachine(
     DeviceAttachedEvent event,
   ) async {
     probeCallCount++;
     probeEvents.add(event);
+    if (!probeStarted.isCompleted) probeStarted.complete();
+    final gate = probeGate;
+    if (gate != null) await gate.future;
     return probeResult;
   }
 }
@@ -529,5 +536,69 @@ void main() {
         expect(manager.currentStatus.phase, ConnectionPhase.ready);
       },
     );
+
+    test(
+      'explicit scan arriving during an attach probe drains afterwards',
+      () async {
+        probeScanner.probeResult = AttachProbeConnected(
+          _FakeDe1(deviceId: 'usb-machine-id'),
+        );
+        probeScanner.probeGate = Completer<void>();
+        probeScanner.attach();
+        await probeScanner.probeStarted.future;
+
+        final scanning = manager.scanAndConnect();
+        probeScanner.probeGate!.complete();
+        await scanning.timeout(const Duration(seconds: 5));
+
+        expect(probeScanner.probeCallCount, 1);
+        expect(probeScanner.scanCallCount, 1);
+        expect(settings.preferredMachineId, 'usb-machine-id');
+        expect(manager.currentStatus.phase, ConnectionPhase.ready);
+      },
+    );
+
+    test(
+      'scale-only connect arriving during an attach probe drains afterwards',
+      () async {
+        probeScanner.probeResult = AttachProbeConnected(
+          _FakeDe1(deviceId: 'usb-machine-id'),
+        );
+        probeScanner.probeGate = Completer<void>();
+        probeScanner.attach();
+        await probeScanner.probeStarted.future;
+
+        final scaleOnly = manager.connect(scaleOnly: true);
+        probeScanner.probeGate!.complete();
+        await scaleOnly.timeout(const Duration(seconds: 5));
+
+        expect(probeScanner.probeCallCount, 1);
+        expect(probeScanner.scanCallCount, 1);
+        expect(settings.preferredMachineId, 'usb-machine-id');
+        expect(manager.currentStatus.phase, ConnectionPhase.ready);
+      },
+    );
+
+    test('unavailable probe falls back to preferred-machine policy', () async {
+      await settings.setPreferredMachineId('ble-machine-id');
+      probeScanner.probeResult = const AttachProbeUnavailable();
+
+      await attachAndSettle();
+
+      expect(probeScanner.probeCallCount, 1);
+      expect(probeScanner.scanCallCount, 1);
+      expect(settings.preferredMachineId, 'ble-machine-id');
+    });
+
+    test('unavailable probe without preference changes nothing', () async {
+      probeScanner.probeResult = const AttachProbeUnavailable();
+
+      await attachAndSettle();
+
+      expect(probeScanner.probeCallCount, 1);
+      expect(probeScanner.scanCallCount, 0);
+      expect(settings.preferredMachineId, isNull);
+      expect(manager.currentStatus.pendingAmbiguity, isNull);
+    });
   });
 }

--- a/test/controllers/connection_manager_usb_attach_test.dart
+++ b/test/controllers/connection_manager_usb_attach_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/controllers/connection_error.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/remembered_devices_controller.dart';
@@ -13,6 +14,7 @@ import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/device/remembered_device.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:reaprime/src/models/device/usb_attach_probe.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 
 import '../helpers/mock_de1_controller.dart';
@@ -35,6 +37,21 @@ class _AttachScanner extends MockDeviceScanner implements DeviceAttachNotifier {
   void dispose() {
     _attachEvents.close();
     super.dispose();
+  }
+}
+
+class _ProbeScanner extends _AttachScanner implements UsbAttachProbe {
+  AttachProbeResult probeResult = const AttachProbeUnsupported();
+  int probeCallCount = 0;
+  final List<DeviceAttachedEvent> probeEvents = [];
+
+  @override
+  Future<AttachProbeResult> connectAttachedMachine(
+    DeviceAttachedEvent event,
+  ) async {
+    probeCallCount++;
+    probeEvents.add(event);
+    return probeResult;
   }
 }
 
@@ -67,6 +84,9 @@ class _FakeDe1 implements De1Interface {
 
   @override
   Stream<bool> get ready => const Stream.empty();
+
+  @override
+  Future<void> onConnect() async {}
 
   @override
   Future<void> disconnect() async {}
@@ -312,4 +332,202 @@ void main() {
       scannerWithoutNotifier.dispose();
     },
   );
+
+  group('probe-capable attach', () {
+    late _ProbeScanner probeScanner;
+    late De1Controller realDe1Controller;
+
+    setUp(() {
+      probeScanner = _ProbeScanner();
+      realDe1Controller = De1Controller(
+        controller: DeviceController([discovery]),
+      );
+      manager = ConnectionManager(
+        deviceScanner: probeScanner,
+        de1Controller: realDe1Controller,
+        scaleController: scaleController,
+        settingsController: settings,
+        deviceAttachSettleDelay: Duration.zero,
+      );
+      manager.machineReconnectBaseDelay = const Duration(days: 1);
+    });
+
+    tearDown(() {
+      probeScanner.dispose();
+    });
+
+    Future<void> attachAndSettle() async {
+      probeScanner.attach();
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    test(
+      'no preferred machine adopts a supported attached USB machine',
+      () async {
+        probeScanner.probeResult = AttachProbeConnected(
+          _FakeDe1(deviceId: 'usb-machine-id'),
+        );
+
+        await attachAndSettle();
+
+        expect(probeScanner.probeCallCount, 1);
+        expect(probeScanner.scanCallCount, 0);
+        expect(probeScanner.quickConnectCallCount, 0);
+        expect(manager.currentStatus.pendingAmbiguity, isNull);
+        expect(settings.preferredMachineId, 'usb-machine-id');
+        expect(manager.currentStatus.phase, ConnectionPhase.ready);
+      },
+    );
+
+    test('BLE preference loses to a supported attached USB machine', () async {
+      await settings.setPreferredMachineId('ble-machine-id');
+      probeScanner.probeResult = AttachProbeConnected(
+        _FakeDe1(deviceId: 'usb-machine-id'),
+      );
+
+      await attachAndSettle();
+
+      expect(probeScanner.scanCallCount, 0);
+      expect(probeScanner.quickConnectCallCount, 0);
+      expect(settings.preferredMachineId, 'usb-machine-id');
+      expect(manager.currentStatus.phase, ConnectionPhase.ready);
+    });
+
+    test(
+      'a different preferred USB machine loses to the attached machine',
+      () async {
+        await settings.setPreferredMachineId('usb-other-machine-id');
+        probeScanner.probeResult = AttachProbeConnected(
+          _FakeDe1(deviceId: 'usb-machine-id'),
+        );
+
+        await attachAndSettle();
+
+        expect(settings.preferredMachineId, 'usb-machine-id');
+        expect(manager.currentStatus.phase, ConnectionPhase.ready);
+      },
+    );
+
+    test(
+      'same-machine cross-transport preference produces the same outcome',
+      () async {
+        await settings.setPreferredMachineId('ble-1a86-55d3');
+        probeScanner.probeResult = AttachProbeConnected(
+          _FakeDe1(deviceId: 'usb-1a86-55d3'),
+        );
+
+        await attachAndSettle();
+
+        expect(settings.preferredMachineId, 'usb-1a86-55d3');
+        expect(manager.currentStatus.phase, ConnectionPhase.ready);
+      },
+    );
+
+    test('unsupported USB device changes nothing', () async {
+      await settings.setPreferredMachineId('ble-machine-id');
+      probeScanner.probeResult = const AttachProbeUnsupported();
+
+      await attachAndSettle();
+
+      expect(probeScanner.probeCallCount, 1);
+      expect(probeScanner.scanCallCount, 0);
+      expect(settings.preferredMachineId, 'ble-machine-id');
+      expect(manager.currentStatus.pendingAmbiguity, isNull);
+      expect(manager.currentStatus.phase, ConnectionPhase.idle);
+    });
+
+    test(
+      'failed attached machine resumes recovery and keeps preference',
+      () async {
+        await settings.setPreferredMachineId('ble-machine-id');
+        probeScanner.probeResult = const AttachProbeFailed(
+          deviceId: 'usb-machine-id',
+          deviceName: 'DE1',
+        );
+
+        await attachAndSettle();
+
+        expect(settings.preferredMachineId, 'ble-machine-id');
+        expect(manager.machineRecoveryActive, isTrue);
+        expect(manager.currentStatus.phase, ConnectionPhase.idle);
+      },
+    );
+
+    test(
+      'failed attached machine without preference surfaces the failure',
+      () async {
+        probeScanner.probeResult = const AttachProbeFailed(
+          deviceId: 'usb-machine-id',
+          deviceName: 'DE1',
+        );
+
+        await attachAndSettle();
+
+        expect(settings.preferredMachineId, isNull);
+        expect(manager.machineRecoveryActive, isFalse);
+        expect(
+          manager.currentStatus.error?.kind,
+          ConnectionErrorKind.machineConnectFailed,
+        );
+        expect(manager.currentStatus.phase, ConnectionPhase.idle);
+      },
+    );
+
+    test('connected machine ignores attach', () async {
+      await settings.setPreferredMachineId('ble-machine-id');
+      await realDe1Controller.connectToDe1(_FakeDe1());
+      await realDe1Controller.de1.firstWhere((machine) => machine != null);
+
+      await attachAndSettle();
+
+      expect(probeScanner.probeCallCount, 0);
+    });
+
+    test(
+      'attach during automatic scanning is queued, not dropped or parallel',
+      () async {
+        await settings.setPreferredMachineId('ble-machine-id');
+        probeScanner.probeResult = AttachProbeConnected(
+          _FakeDe1(deviceId: 'usb-machine-id'),
+        );
+        probeScanner.scanCompleter = Completer<void>();
+
+        final connecting = manager.connect();
+        await probeScanner.scanningStream.firstWhere((scanning) => scanning);
+        probeScanner.attach();
+        await Future<void>.delayed(Duration.zero);
+
+        probeScanner.completeScan();
+        await connecting;
+
+        expect(probeScanner.probeCallCount, 1);
+        expect(probeScanner.scanCallCount, 1);
+        expect(settings.preferredMachineId, 'usb-machine-id');
+        expect(manager.currentStatus.phase, ConnectionPhase.ready);
+      },
+    );
+
+    test(
+      'attach during an explicit scan waits for the scan to finish',
+      () async {
+        probeScanner.probeResult = AttachProbeConnected(
+          _FakeDe1(deviceId: 'usb-machine-id'),
+        );
+        probeScanner.scanCompleter = Completer<void>();
+
+        final scanning = manager.scanAndConnect();
+        await probeScanner.scanningStream.firstWhere((scanning) => scanning);
+        probeScanner.attach();
+        await Future<void>.delayed(Duration.zero);
+
+        probeScanner.completeScan();
+        await scanning;
+
+        expect(probeScanner.probeCallCount, 1);
+        expect(probeScanner.scanCallCount, 1);
+        expect(settings.preferredMachineId, 'usb-machine-id');
+        expect(manager.currentStatus.phase, ConnectionPhase.ready);
+      },
+    );
+  });
 }

--- a/test/controllers/device_controller_test.dart
+++ b/test/controllers/device_controller_test.dart
@@ -573,7 +573,7 @@ void main() {
       controller.dispose();
     });
 
-    test('events not seen by the controller are unsupported', () async {
+    test('events not seen by the controller are unavailable', () async {
       final origin = _AttachProbeService();
       final controller = DeviceController([origin]);
       await controller.initialize();
@@ -582,8 +582,25 @@ void main() {
         const DeviceAttachedEvent(deviceId: 'usb-unknown'),
       );
 
-      expect(result, isA<AttachProbeUnsupported>());
+      expect(result, isA<AttachProbeUnavailable>());
       expect(origin.probeCalls, 0);
+      controller.dispose();
+    });
+
+    test('events from a notifier-only service are unavailable', () async {
+      final notifierOnly = _AttachNotifierOnlyService();
+      final capable = _AttachProbeService();
+      final controller = DeviceController([notifierOnly, capable]);
+      await controller.initialize();
+
+      final event = const DeviceAttachedEvent(deviceId: 'usb-2e8a-a-1234');
+      notifierOnly.emitAttach(event);
+      await Future<void>.delayed(Duration.zero);
+
+      final result = await controller.connectAttachedMachine(event);
+
+      expect(result, isA<AttachProbeUnavailable>());
+      expect(capable.probeCalls, 0);
       controller.dispose();
     });
   });
@@ -666,4 +683,16 @@ class _AttachProbeService extends _ManualDiscoveryService
     probeCalls++;
     return AttachProbeConnected(_FakeMachine(event.deviceId ?? 'usb'));
   }
+}
+
+class _AttachNotifierOnlyService extends _ManualDiscoveryService
+    implements DeviceAttachNotifier {
+  final _attachEvents = StreamController<DeviceAttachedEvent>.broadcast(
+    sync: true,
+  );
+
+  @override
+  Stream<DeviceAttachedEvent> get deviceAttached => _attachEvents.stream;
+
+  void emitAttach(DeviceAttachedEvent event) => _attachEvents.add(event);
 }

--- a/test/controllers/device_controller_test.dart
+++ b/test/controllers/device_controller_test.dart
@@ -2,13 +2,16 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_attach_notifier.dart';
+import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/device/scan_result.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/remembered_device.dart';
+import 'package:reaprime/src/models/device/usb_attach_probe.dart';
 import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/services/telemetry/telemetry_service.dart';
 import 'package:rxdart/rxdart.dart';
@@ -549,6 +552,41 @@ void main() {
       expect(result, same(device));
     });
   });
+
+  group('attach probe routing', () {
+    test('routes only to the originating capable service', () async {
+      final origin = _AttachProbeService();
+      final other = _AttachProbeService();
+      final plain = _ManualDiscoveryService();
+      final controller = DeviceController([origin, other, plain]);
+      await controller.initialize();
+
+      final event = const DeviceAttachedEvent(deviceId: 'usb-2e8a-a-1234');
+      origin.emitAttach(event);
+      await Future<void>.delayed(Duration.zero);
+
+      final result = await controller.connectAttachedMachine(event);
+
+      expect(result, isA<AttachProbeConnected>());
+      expect(origin.probeCalls, 1);
+      expect(other.probeCalls, 0);
+      controller.dispose();
+    });
+
+    test('events not seen by the controller are unsupported', () async {
+      final origin = _AttachProbeService();
+      final controller = DeviceController([origin]);
+      await controller.initialize();
+
+      final result = await controller.connectAttachedMachine(
+        const DeviceAttachedEvent(deviceId: 'usb-unknown'),
+      );
+
+      expect(result, isA<AttachProbeUnsupported>());
+      expect(origin.probeCalls, 0);
+      controller.dispose();
+    });
+  });
 }
 
 class _QuickConnectService extends _ManualDiscoveryService {
@@ -568,5 +606,64 @@ class _ThrowingQuickConnectService extends _ManualDiscoveryService {
   @override
   Future<Device?> tryQuickConnect(RememberedDevice remembered) async {
     throw StateError('quick-connect failed');
+  }
+}
+
+class _FakeMachine implements De1Interface {
+  @override
+  final String deviceId;
+
+  _FakeMachine(this.deviceId);
+
+  @override
+  String get name => 'DE1';
+
+  @override
+  DeviceType get type => DeviceType.machine;
+
+  @override
+  DeviceImplementation get implementation => DeviceImplementation.unifiedDe1;
+
+  @override
+  TransportType get transportType => TransportType.serial;
+
+  @override
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.connected);
+
+  @override
+  Stream<MachineSnapshot> get currentSnapshot => const Stream.empty();
+
+  @override
+  Stream<bool> get ready => const Stream.empty();
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _AttachProbeService extends _ManualDiscoveryService
+    implements DeviceAttachNotifier, UsbAttachProbe {
+  final _attachEvents = StreamController<DeviceAttachedEvent>.broadcast(
+    sync: true,
+  );
+  int probeCalls = 0;
+
+  @override
+  Stream<DeviceAttachedEvent> get deviceAttached => _attachEvents.stream;
+
+  void emitAttach(DeviceAttachedEvent event) => _attachEvents.add(event);
+
+  @override
+  Future<AttachProbeResult> connectAttachedMachine(
+    DeviceAttachedEvent event,
+  ) async {
+    probeCalls++;
+    return AttachProbeConnected(_FakeMachine(event.deviceId ?? 'usb'));
   }
 }

--- a/test/services/serial/usb_attach_probe_test.dart
+++ b/test/services/serial/usb_attach_probe_test.dart
@@ -1,0 +1,330 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/device_attach_notifier.dart';
+import 'package:reaprime/src/models/device/device_implementation.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:reaprime/src/models/device/usb_attach_probe.dart';
+import 'package:reaprime/src/services/serial/serial_service_android.dart';
+import 'package:rxdart/subjects.dart';
+
+// ignore: depend_on_referenced_packages
+import 'package:usb_serial/usb_serial.dart';
+
+UsbDevice _device({
+  int? vid = 0x2E8A,
+  int? pid = 0x000A,
+  String? serial = '8549628789ABCDEF',
+  String productName = 'DE1',
+}) {
+  return UsbDevice(
+    '/dev/bus/usb/001/002',
+    vid,
+    pid,
+    productName,
+    'Decent Espresso',
+    1002,
+    serial,
+    1,
+  );
+}
+
+class _FakeMachine implements De1Interface {
+  @override
+  String get deviceId => 'usb-2e8a-a-8549628789ABCDEF';
+
+  @override
+  String get name => 'DE1';
+
+  @override
+  DeviceType get type => DeviceType.machine;
+
+  @override
+  DeviceImplementation get implementation => DeviceImplementation.unifiedDe1;
+
+  @override
+  TransportType get transportType => TransportType.serial;
+
+  int onConnectCalls = 0;
+  int disconnectCalls = 0;
+  bool failConnect = false;
+
+  final BehaviorSubject<ConnectionState> _connectionState =
+      BehaviorSubject.seeded(ConnectionState.connected);
+
+  @override
+  Stream<ConnectionState> get connectionState => _connectionState.stream;
+
+  @override
+  Stream<MachineSnapshot> get currentSnapshot => const Stream.empty();
+
+  @override
+  Stream<bool> get ready => const Stream.empty();
+
+  @override
+  Future<void> onConnect() async {
+    onConnectCalls++;
+    if (failConnect) throw Exception('simulated connect failure');
+  }
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCalls++;
+  }
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeScale implements Device {
+  @override
+  String get deviceId => 'usb-2e8a-a-8549628789ABCDEF-scale';
+
+  @override
+  String get name => 'Half Decent Scale';
+
+  @override
+  DeviceType get type => DeviceType.scale;
+
+  @override
+  DeviceImplementation get implementation => DeviceImplementation.hdsSerial;
+
+  @override
+  TransportType get transportType => TransportType.serial;
+
+  int disconnectCalls = 0;
+
+  @override
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.connected);
+
+  @override
+  Future<void> onConnect() async {}
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCalls++;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeSensor implements Device {
+  @override
+  String get deviceId => 'usb-2e8a-a-8549628789ABCDEF-sensor';
+
+  @override
+  String get name => 'Sensor Basket';
+
+  @override
+  DeviceType get type => DeviceType.sensor;
+
+  @override
+  DeviceImplementation get implementation => DeviceImplementation.sensorBasket;
+
+  @override
+  TransportType get transportType => TransportType.serial;
+
+  int disconnectCalls = 0;
+
+  @override
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.connected);
+
+  @override
+  Future<void> onConnect() async {}
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCalls++;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  late SerialServiceAndroid service;
+  late List<UsbDevice> listed;
+  late Future<Device?> Function(UsbDevice) detection;
+
+  SerialServiceAndroid build() => SerialServiceAndroid(
+    listDevices: () async => listed,
+    usbEventStream: () => null,
+    detectDevice: detection,
+  );
+
+  setUp(() {
+    listed = [];
+    detection = (_) async => null;
+    service = build();
+  });
+
+  tearDown(() async {
+    await service.dispose();
+  });
+
+  test('correlated attach connects the matching supported machine', () async {
+    final machine = _FakeMachine();
+    listed = [_device()];
+    detection = (_) async => machine;
+    service = build();
+
+    final result = await service.connectAttachedMachine(
+      const DeviceAttachedEvent(deviceId: 'usb-2e8a-a-8549628789ABCDEF'),
+    );
+
+    expect(result, isA<AttachProbeConnected>());
+    expect((result as AttachProbeConnected).machine, same(machine));
+    expect(machine.onConnectCalls, 1);
+    expect(await service.devices.first, contains(machine));
+  });
+
+  test('attach id matching no listed device is unsupported', () async {
+    listed = [_device()];
+    detection = (_) async => fail('must not be probed');
+    service = build();
+
+    final result = await service.connectAttachedMachine(
+      const DeviceAttachedEvent(deviceId: 'usb-ffff-ffff-OTHER'),
+    );
+
+    expect(result, isA<AttachProbeUnsupported>());
+  });
+
+  test('attach without id probes only devices not already known', () async {
+    final machine = _FakeMachine();
+    listed = [_device(), _device(serial: 'OTHER-SERIAL')];
+    detection = (d) async => d.serial == '8549628789ABCDEF' ? machine : null;
+    service = build();
+    await service.scanForDevices();
+    expect(await service.devices.first, contains(machine));
+
+    final result = await service.connectAttachedMachine(
+      const DeviceAttachedEvent(),
+    );
+
+    expect(result, isA<AttachProbeUnsupported>());
+    expect(machine.onConnectCalls, 0);
+  });
+
+  test('duplicate attach for an already-known device is unsupported', () async {
+    final machine = _FakeMachine();
+    listed = [_device()];
+    detection = (_) async => machine;
+    service = build();
+    await service.scanForDevices();
+    expect(await service.devices.first, contains(machine));
+
+    final result = await service.connectAttachedMachine(
+      const DeviceAttachedEvent(deviceId: 'usb-2e8a-a-8549628789ABCDEF'),
+    );
+
+    expect(result, isA<AttachProbeUnsupported>());
+    expect(machine.onConnectCalls, 0);
+  });
+
+  test(
+    'unrelated USB device does not adopt an already-present serial machine',
+    () async {
+      final machine = _FakeMachine();
+      listed = [_device()];
+      detection = (_) async => machine;
+      service = build();
+      await service.scanForDevices();
+      expect(await service.devices.first, contains(machine));
+
+      var keyboardProbed = false;
+      listed = [
+        _device(),
+        _device(
+          vid: 0x046D,
+          pid: 0xC31C,
+          serial: 'kbd-1',
+          productName: 'USB Keyboard',
+        ),
+      ];
+      detection = (d) {
+        if (d.productName == 'USB Keyboard') keyboardProbed = true;
+        return Future.value(machine);
+      };
+      final result = await service.connectAttachedMachine(
+        const DeviceAttachedEvent(
+          deviceId: 'usb-46d-c31c-kbd-1',
+          name: 'USB Keyboard',
+        ),
+      );
+
+      expect(keyboardProbed, isFalse);
+      expect(result, isA<AttachProbeUnsupported>());
+      expect(machine.onConnectCalls, 0);
+      expect(await service.devices.first, contains(machine));
+    },
+  );
+
+  test('scale devices are rejected as attached machine candidates', () async {
+    final scale = _FakeScale();
+    listed = [_device()];
+    detection = (_) async => scale;
+    service = build();
+
+    final result = await service.connectAttachedMachine(
+      const DeviceAttachedEvent(deviceId: 'usb-2e8a-a-8549628789ABCDEF'),
+    );
+
+    expect(result, isA<AttachProbeUnsupported>());
+    expect(scale.disconnectCalls, 1);
+    expect(await service.devices.first, isEmpty);
+  });
+
+  test('sensor devices are rejected as attached machine candidates', () async {
+    final sensor = _FakeSensor();
+    listed = [_device()];
+    detection = (_) async => sensor;
+    service = build();
+
+    final result = await service.connectAttachedMachine(
+      const DeviceAttachedEvent(deviceId: 'usb-2e8a-a-8549628789ABCDEF'),
+    );
+
+    expect(result, isA<AttachProbeUnsupported>());
+    expect(sensor.disconnectCalls, 1);
+    expect(await service.devices.first, isEmpty);
+  });
+
+  test('machine whose connect fails reports failed and cleans up', () async {
+    final machine = _FakeMachine()..failConnect = true;
+    listed = [_device()];
+    detection = (_) async => machine;
+    service = build();
+
+    final result = await service.connectAttachedMachine(
+      const DeviceAttachedEvent(deviceId: 'usb-2e8a-a-8549628789ABCDEF'),
+    );
+
+    expect(result, isA<AttachProbeFailed>());
+    expect((result as AttachProbeFailed).deviceId, machine.deviceId);
+    expect(machine.disconnectCalls, 1);
+    expect(await service.devices.first, isEmpty);
+  });
+
+  test('detection failure is unsupported and leaves no residue', () async {
+    listed = [_device()];
+    detection = (_) async => throw Exception('probe error');
+    service = build();
+
+    final result = await service.connectAttachedMachine(
+      const DeviceAttachedEvent(deviceId: 'usb-2e8a-a-8549628789ABCDEF'),
+    );
+
+    expect(result, isA<AttachProbeUnsupported>());
+    expect(await service.devices.first, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary

- Problem: the Android USB attach path (PR #455) only invoked the normal preferred-machine connection policy. With a BLE machine stored as preferred, the app scanned for that BLE machine before adopting the physically attached serial machine (#473 observed this on real hardware — the log shows the serial machine connecting only after the stale BLE preference path completed).
- Why it matters: a physical USB attachment is explicit user intent and should win over passive automatic preference policy; waiting out a stale BLE scan delays machine availability by seconds.
- What changed: `SerialServiceAndroid` implements a new optional `UsbAttachProbe` capability that correlates the attach event with the newly listed USB device, runs the existing serial admission and `_detectDevice` logic, and connects only supported `De1Interface` machines. `DeviceController` routes the probe to the originating capable service. `ConnectionManager` runs the probe ahead of any preferred-machine scan, adopts the connected machine, and persists its USB ID as `preferredMachineId` — but only after successful connection and adoption.
- What did NOT change (scope boundary): no BLE/USB identity aliasing; the attach event never selects a machine by name/VID/PID; scales, sensors, debug ports, and arbitrary USB devices are never adopted; no REST, WebSocket, database, skin, or plugin API changes; BLE, Wi-Fi, simulated-device, scale-only, explicit-scan, and non-Android behavior unchanged. A notifier-only service (no probe capability) reports "probe unavailable" and the legacy preference-gated policy runs instead.

Review iteration (post-review fixes on this branch): standalone attach probes now run through the shared `_runConnect` scheduler so explicit scans and scale-only connects queued during an in-flight probe are drained instead of hanging; `AttachProbeUnavailable` restores the genuinely optional probe capability; attach-origin tracking uses an `Expando` so events are not retained; verbose implementation comments removed (rationale lives in the docs).

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

The device-comms change is Android USB serial, not BLE.

## Linked Issues

- Closes #473
- Related #455

## Root Cause (if bug fix)

- Root cause: the attach-triggered path from #455 invoked the normal `ConnectionManager.connect()` policy, which honors `preferredMachineId` (quick-connect the preferred device, then scan). A stored BLE preference therefore won over the physically attached serial machine.
- Missing detection or guardrail: no way for the originating serial service to positively identify and connect the specifically attached USB device, and no connection intent stronger than passive preference policy.
- Contributing context (if known): observed on real Android hardware on 2026-07-17 during PR #455 testing; the device log showed the serial machine connecting only after the BLE preference path completed.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/services/serial/usb_attach_probe_test.dart`, `test/controllers/connection_manager_usb_attach_test.dart` (probe-capable group), `test/controllers/device_controller_test.dart` (attach probe routing), `test/controllers/connection/attach_reconnect_coordinator_test.dart`.
- Scenario the test should lock in: no-preference and BLE/other-USB preference overridden by a supported attached machine with no scan and no picker; unsupported or uncorrelated attach changes nothing; failed attach preserves preference and resumes recovery (or surfaces the failure without one); connected machine ignores attach; attach during automatic/recovery scanning is queued and never runs in parallel; explicit scan and scale-only connect arriving during an in-flight attach probe drain and complete (regression for the queued-work deadlock — confirmed failing without the fix); unavailable probe falls back to the legacy policy (with preference) or does nothing (without): correlation, already-known skip, scale/sensor/debug rejection, and cleanup at the serial service; DeviceController routes only to the originating capable service and reports unavailable for notifier-only origins.
- If no new test added, why not: N/A — 30 new tests added; red (compile + assertion failures) confirmed before implementation.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [x] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A — no docs affected

Design rationale archived at `doc/plans/archive/android-usb-attach-machine-adoption/2026-07-18-design.md`; `doc/AI_BLE_NOTES.md` updated with the central distinction (preferred-machine policy = passive automatic discovery; physical USB attachment = explicit connection intent).

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `Yes`
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`
- If any `Yes`, explain risk and mitigation: any Android USB attach can trigger one targeted probe of the specifically attached USB device. The event cannot select or admit a device — the existing product-name gate, `_detectDevice` admission, `De1Interface` check, and full connection/identity initialization remain authoritative; uncorrelated and unsupported attachments are no-ops; only a positively identified and successfully connected machine is adopted; a connected machine is never replaced; the probe holds the connect guard so it never runs in parallel with another connection operation.

## User-Visible Changes

On Android, physically attaching a supported USB machine (DE1/Bengle) now connects and is adopted immediately — no wait for a stale BLE scan, no machine picker, and the attached machine's USB ID becomes the preferred machine. Behavior is unchanged on non-Android platforms and for BLE-only discovery.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — changed/new files formatted; `dart format --output=none --set-exit-if-changed` clean on all touched files (no unrelated repository-wide reformatting)
- [x] `flutter analyze` — clean (`flutter analyze --no-pub`: `No issues found!`)
- [x] `flutter test` — 2758 tests pass (full suite; run twice)
- [x] `(cd packages/dye2-plugin && npm run build)` — Vite build passes (16 modules)

Focused evidence:

- `flutter test test/controllers/connection/ test/controllers/connection_manager_usb_attach_test.dart test/controllers/device_controller_test.dart test/services/serial/` — 126 tests pass.
- `flutter test test/controllers/connection_manager_test.dart test/unit/services/ble_quick_connect_test.dart` — 146 tests pass.
- TDD red first: the new tests failed (missing capability implementation and event-passing coordinator signature) before implementation, then passed.

### Manual verification (if applicable)

- OS / platform tested: macOS host tests only.
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: serial probe correlation/rejection/cleanup, DeviceController origin routing, ConnectionManager adoption/preference/recovery/queuing behavior, coordinator coalescing, existing connection/quick-connect/recovery suites, analyzer, plugin build, full Flutter suite.
- Edge cases checked: no preference; BLE / other-USB / simulated preference; same-machine and different-machine cross-transport (identical outcome, no aliasing); unsupported and uncorrelated attach; already-known device (duplicate broadcast); scale/sensor rejection; connect-failure cleanup; failed attach with and without preference; connected-machine ignore; attach during automatic and explicit scanning; burst coalescing; legacy no-probe path unchanged.
- What you did **not** verify: **Android hardware timing is unverified — no real hardware was tested.** CDC settle timing, real USB re-enumeration latency, duplicate-broadcast behavior, and the end-to-end log sequence from #473 were not measured on an Android device.

Manual verification recipe (on an Android tablet with USB OTG, `simulate=1` off):

1. Build and install: `flutter run` (or `./flutter_with_commit.sh run`) on the Android tablet.
2. Connect a DE1 via USB OTG and grant USB permission when prompted.
3. Confirm the device log shows `Attach probe: connected <name> (<usb-… id>)`, then `Attach probe: machine adopted (<usb-… id>)`, and that `ConnectionManager` reaches `ready` without any BLE scan (`BLE scanning`/`Quick-connect` logs absent).
4. Verify Settings → Device Management now shows the USB ID as the preferred machine.
5. Repeat with a BLE machine stored as preferred (or with no preference) — the USB machine must still connect immediately.
6. Attach a keyboard or other non-Decent USB device: nothing should connect, scan, or open a picker.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`
- If any `No` or `Yes`, explain exact steps: `UsbAttachProbe` is an optional sibling capability, exactly like `DeviceAttachNotifier` — scanners and out-of-tree implementations that do not implement it keep their previous behavior. The remembered-device registry is untouched (the adopted machine is recorded through the existing machine-connection stream, retaining previous records).

## Risks & Mitigations

- Risk: Android announces attach before descriptors/CDC are ready, or emits several edges for one physical arrival.
  - Mitigation: unchanged 500 ms settle, burst coalescing, already-known-device skip, and one in-flight probe; uncorrelated events fall back to new-device-only correlation.
- Risk: the probe connects a machine the user did not intend (e.g. a second DE1 attached while another machine is connected).
  - Mitigation: a connected machine is never replaced; the attach attempt re-checks machine-connected before executing.
- Risk: probing an attached device interferes with an in-flight connection.
  - Mitigation: the probe holds the `_isConnecting` guard, supersedes only automatic/recovery scans via the existing generation mechanism, and queues behind explicit user scans and scale-only connects.
- Risk: real-hardware timing differs from expectations.
  - Mitigation: explicitly stated — no hardware timing is claimed; the path reuses the existing serial admission/detection/connect code that shipped in #455/#482.
