### PR TITLE
fix(de1): await the DE1 refill-level transport write

### DIFF
--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -538,7 +538,7 @@ class UnifiedDe1 implements De1Interface {
     try {
       value.setUint16(0, 0, Endian.big);
       value.setUint16(2, newRefillLevel * 256, Endian.big);
-      _transport.writeWithResponse(
+      await _transport.writeWithResponse(
         Endpoint.waterLevels,
         value.buffer.asUint8List(),
       );

--- a/test/unit/models/device/impl/de1/unified_de1/refill_level_await_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/refill_level_await_test.dart
@@ -30,8 +30,6 @@ void main() {
       unawaited(de1.setRefillLevel(50).then(completed.complete));
       await writeArrived;
 
-      // The write reached the transport but is blocked on the barrier, so
-      // setRefillLevel must still be in flight.
       expect(completed.isCompleted, isFalse);
 
       barrier.complete();

--- a/test/unit/models/device/impl/de1/unified_de1/refill_level_await_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/refill_level_await_test.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+
+import '../../../../../../helpers/barrier_ble_transport.dart';
+
+void main() {
+  late BarrierBleTransport transport;
+  late UnifiedDe1 de1;
+
+  setUp(() async {
+    transport = BarrierBleTransport();
+    addTearDown(transport.dispose);
+    transport.queueOnConnectResponses();
+    de1 = UnifiedDe1(transport: transport);
+    await de1.onConnect();
+    transport.writes.clear();
+  });
+
+  test(
+    'setRefillLevel stays pending until the transport write completes',
+    () async {
+      final writeArrived = transport.nextWrite(Endpoint.waterLevels.uuid);
+      final barrier = Completer<void>();
+      transport.pauseNextWrite(Endpoint.waterLevels.uuid, barrier);
+
+      final completed = Completer<void>();
+      unawaited(de1.setRefillLevel(50).then(completed.complete));
+      await writeArrived;
+
+      // The write reached the transport but is blocked on the barrier, so
+      // setRefillLevel must still be in flight.
+      expect(completed.isCompleted, isFalse);
+
+      barrier.complete();
+      await completed.future;
+    },
+  );
+
+  test(
+    'transport error from setRefillLevel propagates to the caller',
+    () async {
+      final writeArrived = transport.nextWrite(Endpoint.waterLevels.uuid);
+      final barrier = Completer<void>();
+      transport.pauseNextWrite(Endpoint.waterLevels.uuid, barrier);
+
+      final write = de1.setRefillLevel(50);
+      await writeArrived;
+
+      barrier.completeError(StateError('transport boom'));
+      await expectLater(write, throwsA(isA<StateError>()));
+    },
+  );
+}

--- a/test/webserver/water_levels_handler_test.dart
+++ b/test/webserver/water_levels_handler_test.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+import '../helpers/barrier_ble_transport.dart';
+import '../helpers/mock_device_discovery_service.dart';
+import '../helpers/mock_settings_service.dart';
+
+/// Locks the end-to-end contract for `POST /api/v1/machine/waterLevels`:
+/// the response and the shared device-write queue stay pending until the
+/// DE1 transport write completes, and transport failures come back
+/// through the REST error mapping instead of as unhandled async errors.
+void main() {
+  late BarrierBleTransport transport;
+  late Handler handler;
+
+  setUp(() async {
+    transport = BarrierBleTransport();
+    addTearDown(transport.dispose);
+    transport.queueOnConnectResponses();
+
+    final de1 = UnifiedDe1(transport: transport);
+
+    final deviceController = DeviceController([MockDeviceDiscoveryService()]);
+    await deviceController.initialize();
+    final de1Controller = De1Controller(controller: deviceController);
+    await de1Controller.connectToDe1(de1);
+
+    final settingsController = SettingsController(MockSettingsService());
+    await settingsController.loadSettings();
+
+    final de1Handler = De1Handler(
+      controller: de1Controller,
+      settingsController: settingsController,
+      scaleController: ScaleController(),
+      workflowController: WorkflowController(),
+    );
+
+    final app = Router().plus;
+    de1Handler.addRoutes(app);
+    handler = app.call;
+  });
+
+  Future<Response> postWaterLevels(int refillLevel) async {
+    return await handler(
+      Request(
+        'POST',
+        Uri.parse('http://localhost/api/v1/machine/waterLevels'),
+        body: jsonEncode({'refillLevel': refillLevel}),
+        headers: {'content-type': 'application/json'},
+      ),
+    );
+  }
+
+  test('waterLevels POST and queued writes stay pending until the write '
+      'completes', () async {
+    final writeArrived = transport.nextWrite(Endpoint.waterLevels.uuid);
+    final barrier = Completer<void>();
+    transport.pauseNextWrite(Endpoint.waterLevels.uuid, barrier);
+
+    final first = postWaterLevels(50);
+    await writeArrived;
+
+    var secondWriteArrived = false;
+    transport.nextWrite(Endpoint.waterLevels.uuid).then((_) {
+      secondWriteArrived = true;
+    });
+    var secondResponseArrived = false;
+    final second = postWaterLevels(60).then((r) {
+      secondResponseArrived = true;
+      return r;
+    });
+    await _settle();
+
+    expect(secondWriteArrived, isFalse);
+    expect(secondResponseArrived, isFalse);
+
+    barrier.complete();
+
+    final firstResponse = await first;
+    expect(firstResponse.statusCode, 202);
+    final secondResponse = await second;
+    expect(secondResponse.statusCode, 202);
+    expect(secondWriteArrived, isTrue);
+  });
+
+  test('transport failure surfaces through REST error handling', () async {
+    final writeArrived = transport.nextWrite(Endpoint.waterLevels.uuid);
+    final barrier = Completer<void>();
+    transport.pauseNextWrite(Endpoint.waterLevels.uuid, barrier);
+
+    final response = postWaterLevels(50);
+    await writeArrived;
+
+    barrier.completeError(StateError('transport boom'));
+    final res = await response;
+    expect(res.statusCode, 500);
+  });
+}
+
+Future<void> _settle([int turns = 10]) async {
+  for (var i = 0; i < turns; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}

--- a/test/webserver/water_levels_handler_test.dart
+++ b/test/webserver/water_levels_handler_test.dart
@@ -16,39 +16,44 @@ import '../helpers/barrier_ble_transport.dart';
 import '../helpers/mock_device_discovery_service.dart';
 import '../helpers/mock_settings_service.dart';
 
-/// Locks the end-to-end contract for `POST /api/v1/machine/waterLevels`:
-/// the response and the shared device-write queue stay pending until the
-/// DE1 transport write completes, and transport failures come back
-/// through the REST error mapping instead of as unhandled async errors.
 void main() {
   late BarrierBleTransport transport;
+  late De1Controller de1Controller;
+  late DeviceController deviceController;
+  late ScaleController scaleController;
   late Handler handler;
 
   setUp(() async {
     transport = BarrierBleTransport();
-    addTearDown(transport.dispose);
     transport.queueOnConnectResponses();
 
     final de1 = UnifiedDe1(transport: transport);
 
-    final deviceController = DeviceController([MockDeviceDiscoveryService()]);
+    deviceController = DeviceController([MockDeviceDiscoveryService()]);
     await deviceController.initialize();
-    final de1Controller = De1Controller(controller: deviceController);
+    de1Controller = De1Controller(controller: deviceController);
     await de1Controller.connectToDe1(de1);
 
     final settingsController = SettingsController(MockSettingsService());
     await settingsController.loadSettings();
 
+    scaleController = ScaleController();
     final de1Handler = De1Handler(
       controller: de1Controller,
       settingsController: settingsController,
-      scaleController: ScaleController(),
+      scaleController: scaleController,
       workflowController: WorkflowController(),
     );
 
     final app = Router().plus;
     de1Handler.addRoutes(app);
     handler = app.call;
+  });
+
+  tearDown(() async {
+    await de1Controller.dispose();
+    deviceController.dispose();
+    scaleController.dispose();
   });
 
   Future<Response> postWaterLevels(int refillLevel) async {


### PR DESCRIPTION
## Summary

- **Problem:** `UnifiedDe1.setRefillLevel()` dispatched the `waterLevels` transport write without awaiting it, so the queued REST operation could report acceptance before the DE1 acknowledged the write, and transport failures escaped the method's `try/catch` as unhandled asynchronous errors.
- **Why it matters:** The route-side `await` in `de1handler.dart` could not provide its intended guarantee — the machine-operation queue was released before the write completed and failures were silently dropped.
- **What changed:** Added the missing `await` on `_transport.writeWithResponse(Endpoint.waterLevels, ...)`. Transport failures now propagate through the existing `try/catch`/`rethrow` and the queued REST error handling. Added regression tests at both the device and handler level.
- **What did NOT change (scope boundary):** No API contract changes (endpoint and request shape untouched). The pre-existing `newRefillLevel * 256` uint16 overflow for inputs > 255 is out of scope. Mock DE1's no-op stub unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [x] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs

## Linked Issues

- Closes #552
- Related #552

## Root Cause (if bug fix)

- Root cause: `setRefillLevel()` was the only transport-write method on the DE1 surface that fired `writeWithResponse` without `await`. Every sibling write method (`setSteamFlow`, `setTankTempThreshold`, `setUsbChargerMode`, etc.) awaits its transport call; this one predated the `writeWithResponse` consolidation and was left fire-and-forget.
- Missing detection or guardrail: No regression test held the method to the same pending-until-write-completes contract as its siblings, and no handler-level test pinned the end-to-end pending behavior.
- Contributing context (if known): The REST handler already awaited the method correctly (`withQueuedDe1`), so the failure was invisible until a transport error surfaced as an unhandled async error or the queue released early.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/unit/models/device/impl/de1/unified_de1/refill_level_await_test.dart` (device-level unit test) and `test/webserver/water_levels_handler_test.dart` (handler-level integration test — real UnifiedDe1 + controllers wired, only the transport edge mocked)
- Scenario the test should lock in: device level — `setRefillLevel()` stays pending while the transport write is pending, completes on success, and a transport error propagates to the caller instead of becoming an unhandled async error. Handler level — a real `UnifiedDe1` behind the webserver: the waterLevels POST and a subsequent queued write both stay pending while the write is blocked, release to 202s, and a transport failure returns 500 through the REST error mapping.
- If no new test added, why not: N/A. Both test files were verified red before the fix (early completion + unhandled async error at device level; pending-assertion and 500-mapping failures at handler level) and green after.

## Documentation Obligations (required)

These are **not optional**. Stale specs mislead clients and agents.

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A — no docs affected: the REST/WS contract is unchanged (same endpoint, same request/response shape); the fix is internal await semantics.

## Security Impact (required)

This app runs a local web server (port 8080) and connects to BLE/USB hardware.

- New or changed REST endpoints? (`No`)
- New or changed WebSocket topics? (`No`)
- New or changed network calls? (`No`)
- BLE/USB surface changed? (`Yes` — the existing waterLevels BLE write now blocks until acknowledged; same characteristic, same payload)
- File system access changed? (`No`)
- Plugin sandbox boundary changed? (`No`)
- If any `Yes`, explain risk and mitigation: The write is unchanged on the wire; the only difference is the caller now observes its completion/errors. No new attack surface.

## User-Visible Changes

The endpoint previously returned `202 accepted` as soon as the request was queued, before the DE1 had acknowledged the water-level write. It now waits for the transport write to complete before responding, so a failed write surfaces as a `500` error instead of an unhandled async error. The request/response shape and documented semantics are unchanged — this restores the behavior the route was written to guarantee.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — no remaining changes
- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass (2762 tests)
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds (untouched)

### Manual verification (if applicable)

- OS / platform tested: macOS (unit tests only)
- Simulated devices? (`simulate=1`): `No` — no end-to-end behavior change to smoke-test; transport semantics covered by unit + handler tests
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: both new test files red before the fix (early completion + unhandled async error; pending assertions and 500 mapping), green after; full suite green.
- Edge cases checked: pending-while-write-pending (device + queue), success completion, transport error propagation (device + REST 500).
- What you did **not** verify: real DE1 write acknowledgement timing.

### Evidence

Attach at least one:

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? (`Yes`)
- Config / env changes needed? (`No`)
- Database migration needed? (`No`)
- If any `No` or `Yes`, explain exact steps: N/A

## Risks & Mitigations

List only real risks for this PR. If none, write `None`.

- Risk: the waterLevels write now delays the REST response until the transport write completes (previously returned immediately). Mitigation: this is exactly the documented contract of the route (`await de1.setRefillLevel` inside `withQueuedDe1`); transport timeout handling in `UnifiedDe1Transport.writeWithResponse` bounds the wait and surfaces failures as errors instead of hanging.
