### PR TITLE
feat(macos): add Sparkle 2 auto-update with signed GitHub Pages appcast

### DIFF
--- a/.github/workflows/develop-builds.yml
+++ b/.github/workflows/develop-builds.yml
@@ -175,14 +175,17 @@ jobs:
         env:
           FEEDBACK_TOKEN: ${{ secrets.FEEDBACK_TOKEN }}
 
-      - name: Codesign app (hardened runtime)
+      - name: Codesign app (Developer ID, deepest-first)
         run: |
-          APP="build/macos/Build/Products/Release/Decaid.app"
-          codesign --deep --force \
-            --options runtime \
-            --entitlements macos/Runner/Release.entitlements \
-            --sign "Developer ID Application" \
-            "$APP"
+          # Never codesign --deep: it rewrites Sparkle's nested helpers with
+          # the host entitlements, breaking the sandboxed Installer XPC.
+          scripts/sign_macos_deepest_first.sh \
+            build/macos/Build/Products/Release/Decaid.app
+
+      - name: Verify signing gates (pre-notarization)
+        run: |
+          scripts/verify_macos_signature.sh \
+            build/macos/Build/Products/Release/Decaid.app
 
       # ---- Notarize ----
       - name: Zip app for notarization
@@ -224,6 +227,11 @@ jobs:
           done
           echo "Stapling failed after 5 attempts"
           exit 1
+
+      - name: Verify signed + notarized app (spctl + stapler)
+        run: |
+          scripts/verify_macos_signature.sh \
+            build/macos/Build/Products/Release/Decaid.app XLS3XF57J8 1
 
       # ---- Upload ----
       - name: Create development ZIP

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -715,7 +715,6 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#v}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           # Match the prerelease detection in create-release: any beta/alpha/rc
           # tag publishes to the Sparkle beta channel.
           if [[ "$VERSION" == *beta* || "$VERSION" == *alpha* || "$VERSION" == *rc* ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - 'v*'  # Triggers on tags like v1.0.0, v2.1.3, etc.
 
+# Two tags pushed close together must not race the appcast feed.
+concurrency:
+  group: sparkle-appcast
+  cancel-in-progress: false
+
 # bundle_skins.sh (invoked by flutter_with_commit.sh) hits api.github.com.
 # Without auth, all jobs share the runner IP's 60 req/hr limit and silently
 # get empty manifests. Expose GITHUB_TOKEN to every job so curl gets 5000/hr.
@@ -158,14 +163,17 @@ jobs:
         env:
           FEEDBACK_TOKEN: ${{ secrets.FEEDBACK_TOKEN }}
 
-      - name: Codesign app (hardened runtime)
+      - name: Codesign app (Developer ID, deepest-first)
         run: |
-          APP="build/macos/Build/Products/Release/Decaid.app"
-          codesign --deep --force \
-            --options runtime \
-            --entitlements macos/Runner/Release.entitlements \
-            --sign "Developer ID Application" \
-            "$APP"
+          # Never codesign --deep: it rewrites Sparkle's nested helpers with
+          # the host entitlements, breaking the sandboxed Installer XPC.
+          scripts/sign_macos_deepest_first.sh \
+            build/macos/Build/Products/Release/Decaid.app
+
+      - name: Verify signing gates (pre-notarization)
+        run: |
+          scripts/verify_macos_signature.sh \
+            build/macos/Build/Products/Release/Decaid.app
 
       # ---- Notarize ----
       - name: Zip app for notarization
@@ -207,6 +215,11 @@ jobs:
           done
           echo "Stapling failed after 5 attempts"
           exit 1
+
+      - name: Verify signed + notarized app (spctl + stapler)
+        run: |
+          scripts/verify_macos_signature.sh \
+            build/macos/Build/Products/Release/Decaid.app XLS3XF57J8 1
 
       # ---- Final ZIP ----
       - name: Get version
@@ -681,6 +694,88 @@ jobs:
           body_path: release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-appcast:
+    name: Publish Sparkle appcast
+    needs: [create-release]
+    runs-on: macos-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve tag and channel
+        id: version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # Match the prerelease detection in create-release: any beta/alpha/rc
+          # tag publishes to the Sparkle beta channel.
+          if [[ "$VERSION" == *beta* || "$VERSION" == *alpha* || "$VERSION" == *rc* ]]; then
+            echo "channel=beta" >> "$GITHUB_OUTPUT"
+          else
+            echo "channel=stable" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download the release ZIP asset
+        run: |
+          gh release download "${{ steps.version.outputs.tag }}" \
+            --pattern 'decaid-macos-*.zip' \
+            --dir "$RUNNER_TEMP/appcast-staging"
+          ls -la "$RUNNER_TEMP/appcast-staging"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch generated release notes
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${{ steps.version.outputs.tag }}" \
+            --jq .body > "$RUNNER_TEMP/appcast-staging/release-notes.md"
+          test -s "$RUNNER_TEMP/appcast-staging/release-notes.md"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Sparkle 2.9.5 release tools
+        run: |
+          curl -sL -o "$RUNNER_TEMP/sparkle.tar.xz" \
+            https://github.com/sparkle-project/Sparkle/releases/download/2.9.5/Sparkle-2.9.5.tar.xz
+          tar -xJf "$RUNNER_TEMP/sparkle.tar.xz" -C "$RUNNER_TEMP" bin
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          generate_appcast --help >/dev/null
+
+      - name: Run appcast helper tests
+        run: scripts/test_appcast_helpers.sh
+
+      - name: Generate and validate appcast
+        run: |
+          ZIP="$(ls "$RUNNER_TEMP/appcast-staging"/decaid-macos-*.zip | head -1)"
+          # Deploy dir holds only the feed (and any future static assets); the
+          # ZIP stays in staging, which generate_appcast uses as its source.
+          mkdir -p "$RUNNER_TEMP/pages"
+          scripts/publish_appcast.sh \
+            "$ZIP" \
+            "$RUNNER_TEMP/appcast-staging/release-notes.md" \
+            "https://github.com/decentespresso/decaid/releases/download/${{ steps.version.outputs.tag }}/" \
+            "${{ steps.version.outputs.channel }}" \
+            - \
+            "$RUNNER_TEMP/pages/appcast.xml" <<< "${{ secrets.SPARKLE_ED_PRIVATE_KEY }}"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "$RUNNER_TEMP/pages"
+          name: sparkle-appcast
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+        with:
+          artifact_name: sparkle-appcast
 
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -700,9 +700,7 @@ jobs:
     needs: [create-release]
     runs-on: macos-latest
     permissions:
-      contents: read
-      pages: write
-      id-token: write
+      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -723,6 +721,32 @@ jobs:
             echo "channel=stable" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Fetch previous appcast from gh-pages branch
+        id: feed
+        run: |
+          # The gh-pages branch is the durable source of truth, read through
+          # git (not the Pages CDN) so a transient Pages/TLS failure can never
+          # be mistaken for a first publication.
+          if git fetch origin gh-pages 2>/dev/null && git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
+            git show origin/gh-pages:appcast.xml > "$RUNNER_TEMP/previous-appcast.xml"
+            test -s "$RUNNER_TEMP/previous-appcast.xml"
+            echo "feed-present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "feed-present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enforce one-time bootstrap
+        if: steps.feed.outputs.feed-present == 'false'
+        run: |
+          if [ "${{ vars.SPARKLE_APPCAST_BOOTSTRAP }}" != "true" ]; then
+            echo "No appcast.xml exists on the gh-pages branch."
+            echo "For the FIRST Sparkle release only, set the repo variable"
+            echo "SPARKLE_APPCAST_BOOTSTRAP=true, re-run this workflow on the"
+            echo "release tag, then delete the variable."
+            exit 1
+          fi
+          echo "Bootstrap authorized via SPARKLE_APPCAST_BOOTSTRAP"
+
       - name: Download the release ZIP asset
         run: |
           gh release download "${{ steps.version.outputs.tag }}" \
@@ -740,10 +764,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download Sparkle 2.9.5 release tools
+      - name: Download Sparkle 2.9.5 release tools (pinned checksum)
         run: |
-          curl -sL -o "$RUNNER_TEMP/sparkle.tar.xz" \
+          curl -fSL -o "$RUNNER_TEMP/sparkle.tar.xz" \
             https://github.com/sparkle-project/Sparkle/releases/download/2.9.5/Sparkle-2.9.5.tar.xz
+          echo "015336b601493e05c237964954bff6191370003d94edefe663724c88840d73cc  $RUNNER_TEMP/sparkle.tar.xz" \
+            | shasum -a 256 -c -
           tar -xJf "$RUNNER_TEMP/sparkle.tar.xz" -C "$RUNNER_TEMP" bin
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
           generate_appcast --help >/dev/null
@@ -754,27 +780,38 @@ jobs:
       - name: Generate and validate appcast
         run: |
           ZIP="$(ls "$RUNNER_TEMP/appcast-staging"/decaid-macos-*.zip | head -1)"
-          # Deploy dir holds only the feed (and any future static assets); the
-          # ZIP stays in staging, which generate_appcast uses as its source.
           mkdir -p "$RUNNER_TEMP/pages"
+          PREV=""
+          if [ -f "$RUNNER_TEMP/previous-appcast.xml" ]; then
+            PREV="$RUNNER_TEMP/previous-appcast.xml"
+          fi
           scripts/publish_appcast.sh \
             "$ZIP" \
             "$RUNNER_TEMP/appcast-staging/release-notes.md" \
             "https://github.com/decentespresso/decaid/releases/download/${{ steps.version.outputs.tag }}/" \
             "${{ steps.version.outputs.channel }}" \
             - \
-            "$RUNNER_TEMP/pages/appcast.xml" <<< "${{ secrets.SPARKLE_ED_PRIVATE_KEY }}"
+            "$RUNNER_TEMP/pages/appcast.xml" \
+            "$PREV" <<< "${{ secrets.SPARKLE_ED_PRIVATE_KEY }}"
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: "$RUNNER_TEMP/pages"
-          name: sparkle-appcast
-
-      - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v4
-        with:
-          artifact_name: sparkle-appcast
+      - name: Publish appcast to gh-pages branch
+        run: |
+          if git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
+            git switch -c gh-pages origin/gh-pages
+          else
+            git switch --orphan gh-pages
+          fi
+          cp "$RUNNER_TEMP/pages/appcast.xml" appcast.xml
+          touch .nojekyll
+          git add appcast.xml .nojekyll
+          if git diff --cached --quiet; then
+            echo "appcast.xml unchanged; nothing to commit"
+          else
+            git -c user.name="github-actions[bot]" \
+                -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+                commit -m "appcast: update for ${{ steps.version.outputs.tag }}"
+            git push origin gh-pages
+          fi
 
 
 

--- a/doc/AI_BUILD_NOTES.md
+++ b/doc/AI_BUILD_NOTES.md
@@ -81,6 +81,24 @@ temporary real-hardware tuning builds where debug endpoints must be reachable.
 
 **Fix:** Finite 500ms per-chunk write timeout + bail on zero-progress, `drainWithTimeout` polling `bytesToWrite`.
 
+## Footgun #3: `codesign --deep` destroys Sparkle's Installer XPC
+
+**Symptom:** After a signed/notarized update, Sparkle's "Update failed" alert or a silent failure to relaunch. The app builds and notarizes fine.
+
+**Root cause:** `codesign --deep --force --entitlements <host.plist>` re-signs every nested binary (Sparkle.framework, Installer.xpc, Updater.app, Autoupdate) with the HOST's entitlements. The sandboxed Installer XPC service needs its own embedded entitlements; clobbering them breaks the sandbox escape that replaces the app in `/Applications`. Sparkle explicitly warns against `--deep`.
+
+**Fix:** `scripts/sign_macos_deepest_first.sh` signs Sparkle's nested helpers deepest-first (`Installer.xpc` → `Downloader.xpc` → `Updater.app` → `Autoupdate` → framework → host), each without `--entitlements` so existing embedded entitlements survive; only the host app gets `Release.entitlements`. Gates in `scripts/verify_macos_signature.sh` (Team ID, Hardened Runtime, mach-lookup names, no `get-task-allow`) run before and after notarization.
+
+## Footgun #4: `codesign` does not expand `$(PRODUCT_BUNDLE_IDENTIFIER)`
+
+**Symptom:** The signed app's entitlements contain the literal string `$(PRODUCT_BUNDLE_IDENTIFIER)-spks`, so Sparkle's XPC lookup fails (the XPC registers as `net.tadel.reaprime-spks`).
+
+**Root cause:** `codesign --entitlements` takes the file as-is; Xcode build-variable expansion happens only in Xcode's own signing step. The signing script sed-expands the bundle id before signing (see `scripts/sign_macos_deepest_first.sh`).
+
+**Fix:** Never hand `Release.entitlements` to `codesign` unexpanded. The verification script also greps for the unexpanded variable.
+
+**Note (App Store):** `com.apple.security.temporary-exception.mach-lookup.global-name` is not permitted in Mac App Store builds. Any future `APP_STORE=true` macOS build must drop the Sparkle keys/entitlements and keep self-update disabled.
+
 ## CLI Parameters
 
 The app supports several command-line flags for headless/calibration-station use. See PR #349 and #352 for full details.

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -91,8 +91,14 @@ the feed.
    ```
    (A keychain permission prompt appears once.) The appcast job fails fast until the secret and
    `SUPublicEDKey` match.
-4. Enable GitHub Pages for `decentespresso/decaid`: Settings > Pages > Source: **GitHub Actions**.
-5. Verify `https://decentespresso.github.io/decaid/appcast.xml` is publicly reachable.
+4. Enable GitHub Pages for `decentespresso/decaid`: Settings > Pages > Source: **Deploy from a
+   branch** > branch `gh-pages` > folder `/ (root)`. The `publish-appcast` job maintains that
+   branch.
+5. First release only — bootstrap the feed by setting the repo variable
+   `SPARKLE_APPCAST_BOOTSTRAP=true` (Settings > Secrets and variables > Actions > Variables),
+   push the first Sparkle-enabled tag, then delete the variable. The publish job fails fast with
+   instructions until the feed exists; the variable is the explicit one-time escape hatch.
+6. Verify `https://decentespresso.github.io/decaid/appcast.xml` is publicly reachable.
 
 ### What a tag push publishes
 
@@ -100,13 +106,18 @@ the feed.
    nested helpers deepest-first (never `codesign --deep` — see `scripts/sign_macos_deepest_first.sh`)
    and runs `scripts/verify_macos_signature.sh` before and after notarization.
 2. `create-release` attaches the artifacts, then `publish-appcast` (macOS runner):
+   - reads the currently deployed feed from the **`gh-pages` branch through git** (not the Pages
+     CDN), so a transient Pages/TLS failure is never mistaken for a first publication;
    - downloads `decaid-macos-<version>.zip` from the release;
+   - downloads Sparkle 2.9.5's tools with a pinned SHA-256 check;
    - reads `CFBundleVersion` from the ZIP and refuses to publish unless it is strictly greater than
      every item already in the feed (see the version policy below);
    - runs `generate_appcast` with the `SPARKLE_ED_PRIVATE_KEY` secret, embedding the GitHub release
      notes;
+   - asserts total and default-channel item counts never decrease (a beta publication can never
+     erase stable or historical items);
    - validates the feed with `xmllint` + `scripts/appcast_helpers.sh` assertions;
-   - deploys `appcast.xml` to GitHub Pages.
+   - commits `appcast.xml` to the `gh-pages` branch, which Pages serves.
 
 Beta/alpha/rc tags publish feed items with `<sparkle:channel>beta</sparkle:channel>`; stable tags
 publish un-channelled (default) items. A Beta user sees Beta and Stable items; a Stable user sees

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -114,8 +114,9 @@ the feed.
      every item already in the feed (see the version policy below);
    - runs `generate_appcast` with the `SPARKLE_ED_PRIVATE_KEY` secret, embedding the GitHub release
      notes;
-   - asserts total and default-channel item counts never decrease (a beta publication can never
-     erase stable or historical items);
+   - asserts the feed grows by exactly one item (one more default-channel item for a
+     stable publication) and that every old (version, channel) pair survives — a beta
+     publication can never erase stable or historical items;
    - validates the feed with `xmllint` + `scripts/appcast_helpers.sh` assertions;
    - commits `appcast.xml` to the `gh-pages` branch, which Pages serves.
 

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -147,8 +147,26 @@ archive in place under the same appcast version; publish a corrected release wit
 2. Install the older build in `/Applications`, launch once, then check Settings > Check for updates.
 3. Confirm data/settings survive the relaunch and the bundle ID is unchanged.
 
-The first public Sparkle-enabled release is a baseline: older Decaid builds cannot self-update into
-it.
+### Acceptance gate: notarized two-build update (required before the first public Sparkle release)
+
+The full procedure lives in `doc/plans/archive/521-macos-auto-update-sparkle/` (Phase 4). Use two
+Developer-ID-signed, notarized builds with increasing `CFBundleVersion` values and a temporary
+signed feed:
+
+1. Install the older build in `/Applications` and launch it once.
+2. Stable channel: publish a Beta item only; a manual check must report no Stable update.
+3. Switch to Beta; a manual check must offer the Beta update.
+4. Accept it; verify download, sandboxed XPC installation, relaunch, the new build number, the
+   same bundle ID, the same application data, and retained settings.
+5. Publish a newer Stable item; both channels must offer it.
+6. Tamper with one byte of the ZIP; Sparkle must reject it before extraction.
+7. Sign an archive with a different EdDSA key or app-signing identity; Sparkle must reject it.
+8. Disable automatic checks, relaunch, and confirm no scheduled check occurs; a manual check must
+   still work.
+
+Do not close #521 until the baseline-to-newer-build update has been demonstrated with
+production-equivalent signatures. The first public Sparkle-enabled release is a baseline: older
+Decaid builds cannot self-update into it.
 
 ## Editing Release Notes
 

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -65,6 +65,79 @@ Pre-releases are automatically detected by:
 - Version suffix (beta, alpha, rc)
 - GitHub's pre-release flag
 
+## macOS Auto-Update (Sparkle)
+
+macOS builds check for updates through [Sparkle](https://sparkle-project.org) against a signed
+appcast at `https://decentespresso.github.io/decaid/appcast.xml`. The feed is generated from the
+same GitHub release ZIPs the manual flow publishes, so a tag push publishes both the release and
+the feed.
+
+### One-time setup (required before the first Sparkle-enabled release)
+
+1. On a trusted Mac, generate the EdDSA keypair with Sparkle 2.9.5's `generate_keys`:
+   ```bash
+   curl -sL -o /tmp/Sparkle.tar.xz https://github.com/sparkle-project/Sparkle/releases/download/2.9.5/Sparkle-2.9.5.tar.xz
+   tar -xJf /tmp/Sparkle.tar.xz -C /tmp bin
+   /tmp/bin/generate_keys
+   ```
+   It prints the `SUPublicEDKey` value; the private key is stored in the login keychain.
+2. Put the printed value in `SUPublicEDKey` in `macos/Runner/Info.plist` (keep it in sync with the
+   private key below).
+3. Export the private key from the keychain and store it as the GitHub Actions secret
+   `SPARKLE_ED_PRIVATE_KEY`:
+   ```bash
+   security find-generic-password -s "https://sparkle-project.org" -a ed25519 -w \
+     | gh secret set SPARKLE_ED_PRIVATE_KEY
+   ```
+   (A keychain permission prompt appears once.) The appcast job fails fast until the secret and
+   `SUPublicEDKey` match.
+4. Enable GitHub Pages for `decentespresso/decaid`: Settings > Pages > Source: **GitHub Actions**.
+5. Verify `https://decentespresso.github.io/decaid/appcast.xml` is publicly reachable.
+
+### What a tag push publishes
+
+1. All platform builds, signed + notarized as before. macOS uses Developer ID signing of Sparkle's
+   nested helpers deepest-first (never `codesign --deep` — see `scripts/sign_macos_deepest_first.sh`)
+   and runs `scripts/verify_macos_signature.sh` before and after notarization.
+2. `create-release` attaches the artifacts, then `publish-appcast` (macOS runner):
+   - downloads `decaid-macos-<version>.zip` from the release;
+   - reads `CFBundleVersion` from the ZIP and refuses to publish unless it is strictly greater than
+     every item already in the feed (see the version policy below);
+   - runs `generate_appcast` with the `SPARKLE_ED_PRIVATE_KEY` secret, embedding the GitHub release
+     notes;
+   - validates the feed with `xmllint` + `scripts/appcast_helpers.sh` assertions;
+   - deploys `appcast.xml` to GitHub Pages.
+
+Beta/alpha/rc tags publish feed items with `<sparkle:channel>beta</sparkle:channel>`; stable tags
+publish un-channelled (default) items. A Beta user sees Beta and Stable items; a Stable user sees
+only default-channel items.
+
+### Version policy for macOS
+
+Sparkle compares `CFBundleVersion`, which `flutter_with_commit.sh` derives from the commit count of
+`origin/main`. Every published macOS release must therefore have a strictly greater commit count
+than the previously published macOS item — including beta-to-stable tags cut from the same commit.
+The appcast job rejects equal or lower values rather than publishing an update Sparkle cannot
+select. Keep `CFBundleShortVersionString` as `MAJOR.MINOR.PATCH` (no `-beta.N` suffix); prerelease
+identity lives in the Beta channel and release title.
+
+### Rollback
+
+To stop offering an update: remove or fix the latest appcast item (the feed redeploys without
+rebuilding the app). Keep the GitHub ZIP available for manual installation. Never replace a signed
+archive in place under the same appcast version; publish a corrected release with a strictly higher
+`CFBundleVersion`. Do not rotate the EdDSA key and the Developer ID identity in the same update.
+
+### Testing a macOS update locally
+
+1. Build a release ZIP and generate a feed with `scripts/publish_appcast.sh` (see its usage); a
+   temporary keypair works for local testing as long as `SUPublicEDKey` matches.
+2. Install the older build in `/Applications`, launch once, then check Settings > Check for updates.
+3. Confirm data/settings survive the relaunch and the bundle ID is unchanged.
+
+The first public Sparkle-enabled release is a baseline: older Decaid builds cannot self-update into
+it.
+
 ## Editing Release Notes
 
 The workflow publishes GitHub's generated release notes. After the release is created, review them and edit the release when a shorter summary, screenshots, upgrade instructions, or corrections are needed.

--- a/doc/plans/archive/521-macos-auto-update-sparkle/521-macos-auto-update-sparkle.md
+++ b/doc/plans/archive/521-macos-auto-update-sparkle/521-macos-auto-update-sparkle.md
@@ -1,0 +1,349 @@
+# Issue #521 — macOS auto-update with Sparkle 2
+
+> **Status:** Architecture approved; implemented in PR #563
+> **Issue:** [#521 — Add auto-update to macOS](https://github.com/decentespresso/decaid/issues/521)
+> **Priority:** P2, required for Decaid 1.0
+> **Decision:** Keep App Sandbox and use Sparkle 2's Installer XPC service. Do not port SideStep's shell-based bundle replacement.
+
+> **Amendment (review of PR #563):** the appcast is stored on the `gh-pages`
+> branch (Pages deploys from that branch) and the publish job reads it through
+> git, not the Pages CDN — a transient Pages/TLS failure can never be mistaken
+> for a first publication. Missing feeds are only allowed through an explicit
+> `SPARKLE_APPCAST_BOOTSTRAP` repo variable, and the job asserts item counts
+> never decrease. The plan's original deploy-pages flow and the Sparkle tools
+> download now also pin a SHA-256 checksum.
+
+## Goal
+
+A signed GitHub-distributed macOS build checks for Stable or Beta updates, presents Sparkle's native update UI, securely downloads the existing notarized ZIP release asset, replaces `Decaid.app` outside the host sandbox through Sparkle's Installer XPC service, and relaunches.
+
+## Why Sparkle instead of a direct SideStep port
+
+The pinned [SideStep updater](https://github.com/johnbuckman/SideStep/blob/8f297608373c95dfbf380f8b4bdbf8cad66f5de9/InstallerApp/UpdateChecker.swift) establishes the desired product and security behavior:
+
+- check a hosted release feed on a schedule;
+- accept ZIP/DMG application releases;
+- prompt before updating;
+- validate downloaded code before replacing the app;
+- quit, atomically replace, and relaunch.
+
+SideStep performs replacement through an unsandboxed shell process. Decaid's Release build has `com.apple.security.app-sandbox=true`; a child process inherits that restriction and cannot safely replace an app in `/Applications`. Removing App Sandbox would also change current data-container behavior and pull #508 into this feature.
+
+Sparkle 2 supplies the missing sandbox escape as a signed Installer XPC service and provides atomic replacement, relaunch, permission handling, archive-signature verification, and Apple code-signing validation. Decaid retains its sandbox and existing data locations.
+
+## Current state
+
+- `UpdateCheckService` schedules checks every 12 hours and owns the Flutter/API update state.
+- `AndroidUpdater` reads GitHub Releases, but only accepts `.apk` assets and only installs through `ApkInstaller`.
+- Settings already expose:
+  - Automatic update checks, default on;
+  - Stable/Beta channel;
+  - Check for updates.
+- macOS releases already publish `decaid-macos-<version>.zip` containing `Decaid.app`.
+- The macOS app is already signed with Developer ID Team `XLS3XF57J8`, notarized, and stapled.
+- The release workflow currently re-signs with `codesign --deep`; Sparkle explicitly warns against this for sandboxed XPC services.
+- There is no GitHub Pages site or `gh-pages` branch yet.
+
+## Scope
+
+### In scope
+
+- Sparkle 2.9.5 through Swift Package Manager.
+- Sandboxed Installer XPC integration.
+- Stable and Beta update channels.
+- Existing Flutter update settings as the user-facing controls.
+- A signed appcast hosted by GitHub Pages.
+- Correct signing, notarization, stapling, and verification of Sparkle's nested helpers.
+- Production-like update smoke tests.
+
+### Out of scope
+
+- Silent forced updates or critical-update policy.
+- A custom update dialog or download progress UI.
+- Delta updates in the first version.
+- DMG creation; #507 owns native installer packaging and the existing ZIP is supported by Sparkle.
+- Mac App Store builds; the store owns updates there and self-update must remain disabled for any future `APP_STORE=true` macOS build.
+- Changing REST/WebSocket update contracts. Their in-app install capability remains Android-only in this change.
+- Removing App Sandbox or migrating application data (#508).
+- Refactoring the Android updater or correcting unrelated legacy repository strings.
+
+## Design
+
+### 1. Native Sparkle integration
+
+Add the `Sparkle` SPM product from `https://github.com/sparkle-project/Sparkle`, pinned to 2.9.5 in `macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved`, and link/embed it in the Runner target.
+
+Add these production defaults to `macos/Runner/Info.plist`:
+
+| Key | Value | Reason |
+|---|---|---|
+| `SUFeedURL` | `https://decentespresso.github.io/decaid/appcast.xml` | Stable feed location independent of a release tag |
+| `SUPublicEDKey` | generated public Ed25519 key | Verify every update archive |
+| `SUEnableInstallerLauncherService` | `true` | Required to update a sandboxed app |
+| `SUEnableAutomaticChecks` | `true` | Preserve Decaid's existing default without Sparkle's second-launch permission prompt |
+| `SUScheduledCheckInterval` | `43200` | Preserve the existing 12-hour interval |
+| `SUAutomaticallyUpdate` | `false` | Check automatically, but ask before download/install like SideStep |
+| `SUVerifyUpdateBeforeExtraction` | `true` | Reject a bad archive before extraction |
+| `SURequireSignedFeed` | `true` | Prevent a compromised feed from spoofing update metadata or links |
+
+Add Sparkle's required Mach lookup exceptions to both `Release.entitlements` and `DebugProfile.entitlements`:
+
+```xml
+<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+<array>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
+</array>
+```
+
+Keep `com.apple.security.app-sandbox` and `com.apple.security.network.client`. Do not enable `SUEnableDownloaderService`; Decaid already has outbound network permission.
+
+Add `macos/Runner/MacOSUpdater.swift`:
+
+- `@MainActor final class MacOSUpdater: NSObject, SPUUpdaterDelegate`.
+- Own one `SPUStandardUpdaterController(startingUpdater: false, updaterDelegate: self, userDriverDelegate: nil)`.
+- Start once after Flutter supplies the persisted Decaid settings.
+- Map Stable to an empty allowed-channel set and Beta to `Set(["beta"])`; Sparkle always includes the default Stable channel.
+- On a channel change, update the delegate state and call `resetUpdateCycleAfterShortDelay()`.
+- Forward manual checks to `updater.checkForUpdates()` so Sparkle owns all UI and error presentation.
+- Forward automatic-check changes to `updater.automaticallyChecksForUpdates` only in response to initial migration or a user setting change.
+- Return structured `FlutterError`s for configuration/start failures; never expose downloaded paths or implement replacement code in Dart.
+
+Register one method channel after creating the macOS `FlutterViewController`:
+
+```text
+net.tadel.reaprime/macos_updater
+```
+
+Methods:
+
+| Method | Arguments |
+|---|---|
+| `configure` | `{automaticChecks: bool, channel: "stable" | "beta"}` |
+| `setAutomaticChecks` | `{enabled: bool}` |
+| `setChannel` | `{channel: "stable" | "beta"}` |
+| `checkForUpdates` | none |
+
+`configure` is idempotent. Use a native migration marker so the existing Flutter `automaticUpdateCheck` value is copied into Sparkle only once; afterwards both settings surfaces are updated together when the user changes the Flutter switch.
+
+Do not add another custom dialog or menu item in the first pass. Settings already provides the manual check, while Sparkle supplies the native update window.
+
+### 2. Flutter bridge and settings
+
+Add `lib/src/services/macos_updater.dart` as a thin, injectable MethodChannel wrapper. It must be a no-op off macOS and expose the four commands above.
+
+Wire it by constructor injection:
+
+1. Construct it in `main.dart` on macOS.
+2. After `SettingsController.loadSettings()`, call `configure` immediately with `automaticUpdateCheck` and `updateChannel`; do not wait for the current 10-minute Dart update timer.
+3. Thread it through `AppRoot` and `MyApp` to `SettingsView`.
+4. In `SettingsView`:
+   - automatic-check changes update the existing setting, then Sparkle on macOS and `UpdateCheckService` elsewhere;
+   - channel changes update the existing setting, then Sparkle on macOS and perform the existing Dart re-check elsewhere;
+   - manual macOS checks call Sparkle and do not show the current misleading immediate “latest version” Snackbar;
+   - Android behavior remains unchanged.
+
+Prevent duplicate app checks on macOS:
+
+- Add an injectable macOS-platform flag to `UpdateCheckService`.
+- On macOS, periodic initialization may continue scheduling skin updates, but must skip the APK-based `checkForUpdate()` call.
+- `requestCheck()`/`checkForUpdate()` from the existing REST/WS update API remain non-installing on macOS; do not claim `installable=true` or mirror partial Sparkle state into `AppUpdateState`.
+- Preserve Windows/Linux behavior in this issue.
+
+This keeps a single macOS updater scheduler—Sparkle—without splitting or rewriting the existing skin-update scheduling.
+
+### 3. Release signing
+
+Update both `.github/workflows/release.yml` and `.github/workflows/develop-builds.yml`.
+
+Replace top-level `codesign --deep` signing with Xcode archive/export using Developer ID wherever practical. Sparkle recommends `xcodebuild archive` + `xcodebuild -exportArchive` because Xcode correctly signs its Installer XPC service and helper tools while preserving their entitlements.
+
+The exported app must then pass these gates before notarization:
+
+1. `codesign --verify --deep --strict --verbose=4 Decaid.app`.
+2. Host signature has Team ID `XLS3XF57J8` and Hardened Runtime.
+3. Host entitlements still contain App Sandbox, network client, and expanded `net.tadel.reaprime-spks`/`net.tadel.reaprime-spki` names.
+4. `Sparkle.framework`, `Installer.xpc`, `Autoupdate`, and `Updater.app` are present and signed by the same Team ID.
+5. No Sparkle helper retains `com.apple.security.get-task-allow` in a distribution build.
+6. `spctl --assess --type execute --verbose Decaid.app` succeeds after notarization.
+7. `xcrun stapler validate Decaid.app` succeeds.
+
+If Flutter's generated project prevents archive/export, explicitly sign Sparkle's nested components deepest-first using Sparkle's documented commands, preserve Downloader entitlements if that unused service remains embedded, sign the framework, then sign the host app last. Do not restore `--deep` as a signing operation.
+
+Keep the existing release ZIP name and `ditto --keepParent` packaging. Preserve framework symlinks and executable bits.
+
+### 4. Sparkle key and appcast publishing
+
+One-time maintainer setup:
+
+1. Run Sparkle 2.9.5 `generate_keys` on a trusted Mac.
+2. Put the public value in `SUPublicEDKey`.
+3. Export the private key and store it as the GitHub Actions secret `SPARKLE_ED_PRIVATE_KEY`.
+4. Enable GitHub Pages for `decentespresso/decaid` with GitHub Actions as its source.
+5. Verify `https://decentespresso.github.io/decaid/appcast.xml` is publicly reachable before shipping the first Sparkle-enabled build.
+
+Add a serialized `publish-appcast` job after `create-release`, running on macOS so the GitHub release asset exists before the feed advertises it.
+
+The job should:
+
+1. Download pinned Sparkle 2.9.5 release tools.
+2. Create a staging directory and fetch the currently deployed `appcast.xml` when present.
+3. Download/copy the current `decaid-macos-<version>.zip` into staging.
+4. Save generated GitHub release notes beside it with the same basename and `.md` extension.
+5. Read `CFBundleVersion` from the ZIP and fail unless it is greater than every existing appcast item. This catches beta→stable tags made from the same commit because `flutter_with_commit.sh` uses commit count as the machine version.
+6. Run `generate_appcast` with:
+   - private key through standard input via `--ed-key-file -`;
+   - `--download-url-prefix https://github.com/decentespresso/decaid/releases/download/<tag>/`;
+   - `--embed-release-notes`;
+   - `--versions <current CFBundleVersion>`;
+   - `--maximum-deltas 0` for the first version;
+   - `--maximum-versions 0` so existing items remain in the feed;
+   - `--channel beta` only when the GitHub release is a prerelease.
+7. Validate the output with `xmllint` and assert the current item has the expected build number, GitHub asset URL, EdDSA signature, and Beta channel when applicable.
+8. Deploy only the feed/static page through `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages`.
+
+Use workflow concurrency with cancellation disabled so two tags cannot race and overwrite the feed.
+
+Stable appcast items have no channel. Beta items use `<sparkle:channel>beta</sparkle:channel>`. The native delegate allows Beta users to see both Beta and default Stable items, preserving issue #82 semantics.
+
+### 5. Version policy
+
+Sparkle compares `CFBundleVersion`, not Dart's prerelease semantic version. Decaid currently sets it from the `origin/main` commit count.
+
+Therefore every published macOS release, including beta→beta and beta→stable, must have a strictly greater commit count than the previously published macOS item. The appcast job must reject equal or lower values rather than publishing an update Sparkle cannot select.
+
+`CFBundleShortVersionString` remains Apple's numeric `MAJOR.MINOR.PATCH`; prerelease identity is represented by the appcast Beta channel and GitHub release title. Do not put `-beta.N` into the bundle short version.
+
+## Test-first implementation order
+
+### Phase 1 — Feed and signing proof
+
+1. Add a CI-only fixture or script test that inspects a minimal existing appcast, appends Stable/Beta items, and rejects a non-increasing build number.
+2. Integrate Sparkle through SPM and make archive/export signing pass locally or in a branch workflow.
+3. Add entitlements and Info.plist configuration.
+4. Verify the exported artifact before touching Flutter settings.
+
+**Exit:** a signed/notarized sandboxed Decaid artifact contains correctly signed Sparkle helpers and a generated, validated appcast item.
+
+### Phase 2 — Native coordinator
+
+1. Replace the placeholder `RunnerTests.swift` test with focused tests for Stable/Beta allowed-channel mapping and idempotent configuration/start behavior where it can be tested without launching an installer.
+2. Add `MacOSUpdater.swift` and the MethodChannel registration.
+3. Run Runner XCTest on macOS.
+
+**Exit:** native manual checks open Sparkle's standard UI against a test feed; Stable excludes Beta and Beta includes both.
+
+### Phase 3 — Flutter integration
+
+1. Add MethodChannel wrapper tests using a mocked binary messenger.
+2. Add/update Settings widget tests proving:
+   - macOS manual check delegates to Sparkle without the false “latest” Snackbar;
+   - toggle and channel changes send the expected native calls;
+   - Android keeps the existing dialog/install flow.
+3. Add `UpdateCheckService` tests proving macOS skips APK checks while skin scheduling remains available.
+4. Wire the bridge through `main.dart`, `AppRoot`, `MyApp`, and `SettingsView`.
+
+**Exit:** one scheduler owns macOS app updates and existing Android behavior remains green.
+
+### Phase 4 — End-to-end update
+
+Use two Developer-ID-signed, notarized test builds with increasing `CFBundleVersion` values and a temporary signed feed:
+
+1. Install the older build in `/Applications` and launch it once.
+2. Stable channel: publish a Beta item only; manual check must report no Stable update.
+3. Switch to Beta; manual check must offer the Beta update.
+4. Accept; verify download, sandboxed XPC installation, relaunch, new build number, same bundle ID, same application data, and retained settings.
+5. Publish a newer Stable item; both channels must offer it.
+6. Tamper with one byte of the ZIP; Sparkle must reject it before extraction.
+7. Sign an archive with a different EdDSA key or app signing identity; Sparkle must reject it.
+8. Disable automatic checks, relaunch, and confirm no scheduled check occurs; manual check must still work.
+
+The first public Sparkle-enabled release is a baseline: older Decaid builds cannot self-update into it. Do not close #521 until baseline→newer-build updating has been demonstrated with production-equivalent signatures.
+
+## Verification commands/gates
+
+```bash
+dart format lib test
+flutter analyze
+flutter test
+flutter build macos --release
+
+xcodebuild test \
+  -workspace macos/Runner.xcworkspace \
+  -scheme Runner \
+  -destination 'platform=macOS'
+
+codesign --verify --deep --strict --verbose=4 Decaid.app
+codesign -d --entitlements :- Decaid.app
+spctl --assess --type execute --verbose=4 Decaid.app
+xcrun stapler validate Decaid.app
+xmllint --noout appcast.xml
+```
+
+Also run the full tagged-release workflow in a safe prerelease before claiming completion.
+
+## Expected files
+
+### New
+
+- `macos/Runner/MacOSUpdater.swift`
+- `lib/src/services/macos_updater.dart`
+- focused Dart tests for the bridge/settings behavior
+- focused Runner XCTest coverage
+- appcast validation helper/test only if shell assertions become unreadable in workflow YAML
+
+### Modified
+
+- `macos/Runner.xcodeproj/project.pbxproj`
+- `macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved`
+- `macos/Runner/AppDelegate.swift` or `MainFlutterWindow.swift` for channel registration
+- `macos/Runner/Info.plist`
+- `macos/Runner/Release.entitlements`
+- `macos/Runner/DebugProfile.entitlements`
+- `macos/RunnerTests/RunnerTests.swift`
+- `lib/main.dart`
+- `lib/src/app.dart`
+- `lib/src/settings/settings_view.dart`
+- `lib/src/services/update_check_service.dart`
+- `.github/workflows/release.yml`
+- `.github/workflows/develop-builds.yml`
+- `doc/RELEASE.md`
+- `doc/AI_BUILD_NOTES.md` if signing/XPC diagnostics reveal a reusable footgun
+
+No REST or WebSocket spec changes are expected.
+
+## Acceptance criteria
+
+- [ ] App Sandbox remains enabled.
+- [ ] A signed/notarized ZIP update installs from `/Applications` and relaunches through Sparkle's Installer XPC service.
+- [ ] Every archive and the appcast are EdDSA-signed; tampering is rejected.
+- [ ] Apple code-signing continuity resolves to Team ID `XLS3XF57J8`.
+- [ ] Automatic checks default on and run every 12 hours without a duplicate Dart app-update check.
+- [ ] The existing switch enables/disables Sparkle scheduling.
+- [ ] Stable sees only default-channel releases.
+- [ ] Beta sees Beta and Stable releases.
+- [ ] Manual checks use Sparkle's native UI.
+- [ ] Android update behavior and tests remain unchanged.
+- [ ] REST/WS still report macOS in-app installation as unsupported rather than presenting inaccurate Sparkle state.
+- [ ] Release CI refuses non-increasing macOS bundle versions.
+- [ ] Appcast deployment occurs only after the GitHub ZIP asset exists.
+- [ ] Existing application data and settings survive update/relaunch.
+
+## Rollback
+
+If the updater fails after release:
+
+1. Remove or fix the latest appcast item; existing builds stop offering it without changing binaries.
+2. Keep the GitHub ZIP available for manual installation.
+3. Publish a corrected release with a strictly higher `CFBundleVersion`; never replace a signed archive in place under the same appcast version.
+4. Do not rotate the EdDSA key and Developer ID identity in the same update.
+
+## References
+
+- [SideStep `UpdateChecker.swift` at the issue-pinned commit](https://github.com/johnbuckman/SideStep/blob/8f297608373c95dfbf380f8b4bdbf8cad66f5de9/InstallerApp/UpdateChecker.swift)
+- [Sparkle basic setup and security](https://sparkle-project.org/documentation/)
+- [Sparkle sandboxing/XPC setup](https://sparkle-project.org/documentation/sandboxing/)
+- [Sparkle programmatic setup](https://sparkle-project.org/documentation/programmatic-setup/)
+- [Sparkle appcast publishing and channels](https://sparkle-project.org/documentation/publishing/)
+- [Sparkle settings behavior](https://sparkle-project.org/documentation/preferences-ui/)
+- [GitHub Pages custom workflows](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -535,10 +535,18 @@ void main(List<String> args) async {
   });
   await settingsController.loadSettings();
   if (macosUpdater != null) {
-    await macosUpdater.configure(
-      automaticChecks: settingsController.automaticUpdateCheck,
-      channel: settingsController.updateChannel,
-    );
+    try {
+      await macosUpdater.configure(
+        automaticChecks: settingsController.automaticUpdateCheck,
+        channel: settingsController.updateChannel,
+      );
+    } catch (e, st) {
+      log.warning(
+        'Sparkle configuration failed; continuing without macOS auto-update',
+        e,
+        st,
+      );
+    }
   }
   bleDiscoveryService.requestLargeMtuNonAndroid = () =>
       settingsController.isFeatureFlagEnabled(.largeBleMtuNonAndroid);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,6 +57,7 @@ import 'package:reaprime/src/services/storage/hive_store_service.dart';
 import 'package:reaprime/src/services/universal_ble_discovery_service.dart';
 import 'package:reaprime/src/services/simulated_device_service.dart';
 import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:reaprime/src/services/macos_updater.dart';
 import 'package:reaprime/src/services/update_check_service.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
 import 'package:reaprime/src/cli/cli_args.dart';
@@ -485,6 +486,11 @@ void main(List<String> args) async {
     webUIStorage: webUIStorage,
   );
 
+  // macOS only: the native Sparkle coordinator. Constructed here (after the
+  // Flutter engine is up) so the method channel exists before the first
+  // configure() call; a no-op on every other platform.
+  final macosUpdater = Platform.isMacOS ? MacOSUpdater() : null;
+
   try {
     await startWebServer(
       deviceController,
@@ -531,6 +537,15 @@ void main(List<String> args) async {
     };
   });
   await settingsController.loadSettings();
+  // Push the persisted settings into Sparkle right after load, before the
+  // 10-minute Dart timer defers any work. Idempotent; the native side migrates
+  // the Flutter default into Sparkle exactly once.
+  if (macosUpdater != null) {
+    await macosUpdater.configure(
+      automaticChecks: settingsController.automaticUpdateCheck,
+      channel: settingsController.updateChannel,
+    );
+  }
   bleDiscoveryService.requestLargeMtuNonAndroid = () =>
       settingsController.isFeatureFlagEnabled(.largeBleMtuNonAndroid);
 
@@ -603,6 +618,7 @@ void main(List<String> args) async {
         webUIService: webUIService,
         webUIStorage: webUIStorage,
         updateCheckService: updateCheckService,
+        macosUpdater: macosUpdater,
         webViewLogService: webViewLogService,
         presenceController: presenceController,
         beanStorage: beanStorage,
@@ -784,6 +800,7 @@ class AppRoot extends StatefulWidget {
   final WebUIService webUIService;
   final WebUIStorage webUIStorage;
   final UpdateCheckService? updateCheckService;
+  final MacOSUpdater? macosUpdater;
   final WebViewLogService webViewLogService;
   final PresenceController presenceController;
   final BeanStorageService? beanStorage;
@@ -812,6 +829,7 @@ class AppRoot extends StatefulWidget {
     required this.connectionManager,
     required this.scanStateGuardian,
     this.updateCheckService,
+    this.macosUpdater,
     this.beanStorage,
     this.grinderStorage,
     this.profileStorageService,
@@ -875,6 +893,7 @@ class _AppRootState extends State<AppRoot> {
         webUIService: widget.webUIService,
         webUIStorage: widget.webUIStorage,
         updateCheckService: widget.updateCheckService,
+        macosUpdater: widget.macosUpdater,
         webViewLogService: widget.webViewLogService,
         presenceController: widget.presenceController,
         beanStorage: widget.beanStorage,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -486,9 +486,6 @@ void main(List<String> args) async {
     webUIStorage: webUIStorage,
   );
 
-  // macOS only: the native Sparkle coordinator. Constructed here (after the
-  // Flutter engine is up) so the method channel exists before the first
-  // configure() call; a no-op on every other platform.
   final macosUpdater = Platform.isMacOS ? MacOSUpdater() : null;
 
   try {
@@ -537,9 +534,6 @@ void main(List<String> args) async {
     };
   });
   await settingsController.loadSettings();
-  // Push the persisted settings into Sparkle right after load, before the
-  // 10-minute Dart timer defers any work. Idempotent; the native side migrates
-  // the Flutter default into Sparkle exactly once.
   if (macosUpdater != null) {
     await macosUpdater.configure(
       automaticChecks: settingsController.automaticUpdateCheck,

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -48,6 +48,7 @@ import 'package:reaprime/src/debug_feature/scale_debug_view.dart';
 import 'package:reaprime/src/services/storage/bean_storage_service.dart';
 import 'package:reaprime/src/services/storage/grinder_storage_service.dart';
 import 'package:reaprime/src/services/storage/profile_storage_service.dart';
+import 'package:reaprime/src/services/macos_updater.dart';
 import 'package:reaprime/src/services/update_check_service.dart';
 import 'package:reaprime/src/services/webview_log_service.dart';
 import 'package:reaprime/src/account/account_page.dart';
@@ -92,6 +93,7 @@ class MyApp extends StatefulWidget {
     required this.connectionManager,
     required this.scanStateGuardian,
     this.updateCheckService,
+    this.macosUpdater,
     this.beanStorage,
     this.grinderStorage,
     this.profileStorageService,
@@ -115,6 +117,7 @@ class MyApp extends StatefulWidget {
   final ConnectionManager connectionManager;
   final ScanStateGuardian scanStateGuardian;
   final UpdateCheckService? updateCheckService;
+  final MacOSUpdater? macosUpdater;
   final BeanStorageService? beanStorage;
   final GrinderStorageService? grinderStorage;
   final ProfileStorageService? profileStorageService;
@@ -370,6 +373,7 @@ class _MyAppState extends State<MyApp> {
                       return SettingsView(
                         controller: widget.settingsController,
                         updateCheckService: widget.updateCheckService,
+                        macosUpdater: widget.macosUpdater,
                         presenceController: widget.presenceController,
                         webUIStorage: widget.webUIStorage,
                       );

--- a/lib/src/services/macos_updater.dart
+++ b/lib/src/services/macos_updater.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:reaprime/src/services/android_updater.dart' show UpdateChannel;
+
+/// Thin MethodChannel wrapper for the native Sparkle updater on macOS.
+///
+/// No-op off macOS. All update logic lives in `MacOSUpdater.swift`; Dart never
+/// downloads, validates, or replaces application code.
+class MacOSUpdater {
+  static const MethodChannel _channel = MethodChannel(
+    'net.tadel.reaprime/macos_updater',
+  );
+
+  final bool _supported;
+
+  MacOSUpdater({bool? supported}) : _supported = supported ?? Platform.isMacOS;
+
+  /// Whether the native Sparkle updater exists on this platform.
+  bool get isSupported => _supported;
+
+  /// Starts the native updater and applies the persisted settings.
+  /// Idempotent on the native side; safe to call on every launch.
+  Future<void> configure({
+    required bool automaticChecks,
+    required UpdateChannel channel,
+  }) async {
+    if (!isSupported) return;
+    await _channel.invokeMethod<void>('configure', {
+      'automaticChecks': automaticChecks,
+      'channel': channel.name,
+    });
+  }
+
+  /// Enables/disables Sparkle's automatic checks. Only meaningful after
+  /// [configure]; ignored before the one-time migration happens natively.
+  Future<void> setAutomaticChecks(bool enabled) async {
+    if (!isSupported) return;
+    await _channel.invokeMethod<void>('setAutomaticChecks', {
+      'enabled': enabled,
+    });
+  }
+
+  /// Switches the Sparkle update channel. No-op when unchanged.
+  Future<void> setChannel(UpdateChannel channel) async {
+    if (!isSupported) return;
+    await _channel.invokeMethod<void>('setChannel', {'channel': channel.name});
+  }
+
+  /// Asks Sparkle to check for updates now and present its native UI.
+  /// No-op until the native side has been configured.
+  Future<void> checkForUpdates() async {
+    if (!isSupported) return;
+    await _channel.invokeMethod<void>('checkForUpdates');
+  }
+}

--- a/lib/src/services/macos_updater.dart
+++ b/lib/src/services/macos_updater.dart
@@ -13,14 +13,21 @@ class MacOSUpdater {
   );
 
   final bool _supported;
+  bool _available = false;
 
   MacOSUpdater({bool? supported}) : _supported = supported ?? Platform.isMacOS;
 
   /// Whether the native Sparkle updater exists on this platform.
   bool get isSupported => _supported;
 
+  /// Whether the native updater is configured and usable. Stays false after a
+  /// failed [configure], so callers stop routing controls to Sparkle and fall
+  /// back to the Dart-side schedule instead of silently no-op'ing.
+  bool get isAvailable => _supported && _available;
+
   /// Starts the native updater and applies the persisted settings.
-  /// Idempotent on the native side; safe to call on every launch.
+  /// Idempotent on the native side; safe to call on every launch. Marks the
+  /// updater available only on success.
   Future<void> configure({
     required bool automaticChecks,
     required UpdateChannel channel,
@@ -30,12 +37,13 @@ class MacOSUpdater {
       'automaticChecks': automaticChecks,
       'channel': channel.name,
     });
+    _available = true;
   }
 
   /// Enables/disables Sparkle's automatic checks. Only meaningful after
   /// [configure]; ignored before the one-time migration happens natively.
   Future<void> setAutomaticChecks(bool enabled) async {
-    if (!isSupported) return;
+    if (!isAvailable) return;
     await _channel.invokeMethod<void>('setAutomaticChecks', {
       'enabled': enabled,
     });
@@ -43,14 +51,14 @@ class MacOSUpdater {
 
   /// Switches the Sparkle update channel. No-op when unchanged.
   Future<void> setChannel(UpdateChannel channel) async {
-    if (!isSupported) return;
+    if (!isAvailable) return;
     await _channel.invokeMethod<void>('setChannel', {'channel': channel.name});
   }
 
   /// Asks Sparkle to check for updates now and present its native UI.
   /// No-op until the native side has been configured.
   Future<void> checkForUpdates() async {
-    if (!isSupported) return;
+    if (!isAvailable) return;
     await _channel.invokeMethod<void>('checkForUpdates');
   }
 }

--- a/lib/src/services/update_check_service.dart
+++ b/lib/src/services/update_check_service.dart
@@ -20,6 +20,10 @@ class UpdateCheckService {
   /// Injectable so the state machine is testable off-device.
   final bool _isAndroid;
 
+  /// Whether Sparkle owns app updates on this platform (macOS only).
+  /// Injectable so scheduling behavior is testable off-device.
+  final bool _isMacOS;
+
   Timer? _periodicTimer;
   UpdateInfo? _availableUpdate;
 
@@ -37,10 +41,12 @@ class UpdateCheckService {
     AndroidUpdater? updater,
     required WebUIStorage webUIStorage,
     bool? platformIsAndroid,
+    bool? platformIsMacOS,
   }) : _settingsService = settingsService,
        _updater = updater ?? AndroidUpdater(owner: 'tadelv', repo: 'reaprime'),
        _webUIStorage = webUIStorage,
-       _isAndroid = platformIsAndroid ?? Platform.isAndroid {
+       _isAndroid = platformIsAndroid ?? Platform.isAndroid,
+       _isMacOS = platformIsMacOS ?? Platform.isMacOS {
     _state = BehaviorSubject.seeded(_snapshot(AppUpdatePhase.idle));
   }
 
@@ -151,24 +157,33 @@ class UpdateCheckService {
     }
   }
 
-  /// Start periodic update checks
+  /// Start periodic update checks. On macOS Sparkle owns app updates, so the
+  /// timer only refreshes skins; the APK-based check never runs.
   Future<void> _startPeriodicChecks() async {
     _log.info(
-      'Starting periodic update checks (every ${_checkInterval.inHours} hours)',
+      'Starting periodic update checks (every ${_checkInterval.inHours} hours)'
+      '${_isMacOS ? ' [skins only — Sparkle owns macOS app updates]' : ''}',
     );
 
-    // Check immediately if we haven't checked recently
-    final lastCheck = await _settingsService.lastUpdateCheckTime();
-    if (lastCheck == null ||
-        DateTime.now().difference(lastCheck) > _checkInterval) {
-      await checkForUpdate();
+    if (_isMacOS) {
+      // Sparkle owns app updates; the periodic timer only refreshes skins.
       await _updateSkins();
+    } else {
+      // Check immediately if we haven't checked recently
+      final lastCheck = await _settingsService.lastUpdateCheckTime();
+      if (lastCheck == null ||
+          DateTime.now().difference(lastCheck) > _checkInterval) {
+        await checkForUpdate();
+        await _updateSkins();
+      }
     }
 
     // Schedule periodic checks
     _periodicTimer?.cancel();
     _periodicTimer = Timer.periodic(_checkInterval, (_) async {
-      await checkForUpdate();
+      if (!_isMacOS) {
+        await checkForUpdate();
+      }
       await _updateSkins();
     });
   }
@@ -191,8 +206,14 @@ class UpdateCheckService {
     }
   }
 
-  /// Manually check for updates
+  /// Manually check for updates. No-op on macOS: Sparkle owns app updates and
+  /// presents its own UI; the REST/WS API must not mirror partial Sparkle
+  /// state into [AppUpdateState].
   Future<UpdateInfo?> checkForUpdate() async {
+    if (_isMacOS) {
+      _log.info('macOS app updates are owned by Sparkle; skipping APK check');
+      return null;
+    }
     try {
       _emit(AppUpdatePhase.checking);
       _log.info('Checking for updates (current: ${BuildInfo.version})');

--- a/lib/src/services/update_check_service.dart
+++ b/lib/src/services/update_check_service.dart
@@ -166,7 +166,6 @@ class UpdateCheckService {
     );
 
     if (_isMacOS) {
-      // Sparkle owns app updates; the periodic timer only refreshes skins.
       await _updateSkins();
     } else {
       // Check immediately if we haven't checked recently

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -387,12 +387,51 @@ class SettingsView extends StatelessWidget {
   }
 
   Future<void> _checkForUpdates(BuildContext context) async {
-    if (macosUpdater?.isAvailable == true) {
-      try {
-        await macosUpdater?.checkForUpdates();
-      } catch (e, st) {
-        Logger('Settings View').warning('Sparkle manual check failed', e, st);
+    final updater = macosUpdater;
+    if (updater != null && updater.isSupported) {
+      // macOS: Sparkle owns app updates.
+      if (updater.isAvailable) {
+        try {
+          await updater.checkForUpdates();
+        } catch (e, st) {
+          Logger('Settings View').warning('Sparkle manual check failed', e, st);
+          if (!context.mounted) return;
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text('Update check failed: $e')));
+        }
+        return;
       }
+      // Sparkle could not be configured: no functional app-update path exists
+      // on macOS, so never claim a Dart "latest version" result.
+      if (!context.mounted) return;
+      showDialog(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('Auto-update unavailable'),
+          content: const Text(
+            'The built-in updater could not be configured on this Mac. '
+            'Download the latest Decaid build from GitHub Releases.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('Later'),
+            ),
+            ElevatedButton(
+              onPressed: () async {
+                Navigator.of(dialogContext).pop();
+                await launchUrl(
+                  Uri.parse(
+                    'https://github.com/decentespresso/decaid/releases',
+                  ),
+                );
+              },
+              child: const Text('Open Releases'),
+            ),
+          ],
+        ),
+      );
       return;
     }
     final log = Logger('Settings View');

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -95,8 +95,6 @@ class SettingsView extends StatelessWidget {
                   onChanged: (v) async {
                     await controller.setAutomaticUpdateCheck(v);
                     if (Platform.isMacOS) {
-                      // Sparkle owns the macOS scheduler; the Flutter switch is
-                      // just the control surface.
                       await macosUpdater?.setAutomaticChecks(v);
                     } else if (v) {
                       await updateCheckService?.enableAutomaticChecks();
@@ -311,7 +309,6 @@ class SettingsView extends StatelessWidget {
     await controller.setUpdateChannel(channel);
     if (dialogContext.mounted) Navigator.of(dialogContext).pop();
     if (Platform.isMacOS) {
-      // Sparkle re-resolves the feed; the Dart APK check never runs on macOS.
       await macosUpdater?.setChannel(channel);
     } else {
       await updateCheckService?.requestCheck();
@@ -378,8 +375,6 @@ class SettingsView extends StatelessWidget {
 
   Future<void> _checkForUpdates(BuildContext context) async {
     if (Platform.isMacOS) {
-      // Sparkle presents its own native UI and error handling; the Dart
-      // "checking..." / "latest version" Snackbars would be misleading here.
       await macosUpdater?.checkForUpdates();
       return;
     }

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -94,9 +94,10 @@ class SettingsView extends StatelessWidget {
                   value: controller.automaticUpdateCheck,
                   onChanged: (v) async {
                     await controller.setAutomaticUpdateCheck(v);
-                    if (Platform.isMacOS) {
+                    if (macosUpdater?.isSupported == true) {
                       await macosUpdater?.setAutomaticChecks(v);
-                    } else if (v) {
+                    }
+                    if (v) {
                       await updateCheckService?.enableAutomaticChecks();
                     } else {
                       await updateCheckService?.disableAutomaticChecks();
@@ -308,7 +309,7 @@ class SettingsView extends StatelessWidget {
   ) async {
     await controller.setUpdateChannel(channel);
     if (dialogContext.mounted) Navigator.of(dialogContext).pop();
-    if (Platform.isMacOS) {
+    if (macosUpdater?.isSupported == true) {
       await macosUpdater?.setChannel(channel);
     } else {
       await updateCheckService?.requestCheck();
@@ -374,7 +375,7 @@ class SettingsView extends StatelessWidget {
   }
 
   Future<void> _checkForUpdates(BuildContext context) async {
-    if (Platform.isMacOS) {
+    if (macosUpdater?.isSupported == true) {
       await macosUpdater?.checkForUpdates();
       return;
     }

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -94,13 +94,21 @@ class SettingsView extends StatelessWidget {
                   value: controller.automaticUpdateCheck,
                   onChanged: (v) async {
                     await controller.setAutomaticUpdateCheck(v);
-                    if (macosUpdater?.isSupported == true) {
-                      await macosUpdater?.setAutomaticChecks(v);
-                    }
                     if (v) {
                       await updateCheckService?.enableAutomaticChecks();
                     } else {
                       await updateCheckService?.disableAutomaticChecks();
+                    }
+                    if (macosUpdater?.isAvailable == true) {
+                      try {
+                        await macosUpdater?.setAutomaticChecks(v);
+                      } catch (e, st) {
+                        Logger('Settings View').warning(
+                          'Sparkle automatic-check toggle failed',
+                          e,
+                          st,
+                        );
+                      }
                     }
                   },
                   label: const Text('Automatic update checks'),
@@ -309,8 +317,12 @@ class SettingsView extends StatelessWidget {
   ) async {
     await controller.setUpdateChannel(channel);
     if (dialogContext.mounted) Navigator.of(dialogContext).pop();
-    if (macosUpdater?.isSupported == true) {
-      await macosUpdater?.setChannel(channel);
+    if (macosUpdater?.isAvailable == true) {
+      try {
+        await macosUpdater?.setChannel(channel);
+      } catch (e, st) {
+        Logger('Settings View').warning('Sparkle channel change failed', e, st);
+      }
     } else {
       await updateCheckService?.requestCheck();
     }
@@ -375,8 +387,12 @@ class SettingsView extends StatelessWidget {
   }
 
   Future<void> _checkForUpdates(BuildContext context) async {
-    if (macosUpdater?.isSupported == true) {
-      await macosUpdater?.checkForUpdates();
+    if (macosUpdater?.isAvailable == true) {
+      try {
+        await macosUpdater?.checkForUpdates();
+      } catch (e, st) {
+        Logger('Settings View').warning('Sparkle manual check failed', e, st);
+      }
       return;
     }
     final log = Logger('Settings View');

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -5,6 +5,7 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/controllers/presence_controller.dart';
 import 'package:reaprime/src/services/android_updater.dart';
+import 'package:reaprime/src/services/macos_updater.dart';
 import 'package:reaprime/src/services/update_check_service.dart';
 import 'package:reaprime/src/settings/battery_charging_settings_page.dart';
 import 'package:reaprime/src/settings/common.dart';
@@ -24,6 +25,7 @@ class SettingsView extends StatelessWidget {
     super.key,
     required this.controller,
     this.updateCheckService,
+    this.macosUpdater,
     required this.presenceController,
     this.webUIStorage,
   });
@@ -33,6 +35,7 @@ class SettingsView extends StatelessWidget {
   final SettingsController controller;
   final PresenceController presenceController;
   final UpdateCheckService? updateCheckService;
+  final MacOSUpdater? macosUpdater;
   final WebUIStorage? webUIStorage;
 
   @override
@@ -91,7 +94,11 @@ class SettingsView extends StatelessWidget {
                   value: controller.automaticUpdateCheck,
                   onChanged: (v) async {
                     await controller.setAutomaticUpdateCheck(v);
-                    if (v) {
+                    if (Platform.isMacOS) {
+                      // Sparkle owns the macOS scheduler; the Flutter switch is
+                      // just the control surface.
+                      await macosUpdater?.setAutomaticChecks(v);
+                    } else if (v) {
                       await updateCheckService?.enableAutomaticChecks();
                     } else {
                       await updateCheckService?.disableAutomaticChecks();
@@ -303,7 +310,12 @@ class SettingsView extends StatelessWidget {
   ) async {
     await controller.setUpdateChannel(channel);
     if (dialogContext.mounted) Navigator.of(dialogContext).pop();
-    await updateCheckService?.requestCheck();
+    if (Platform.isMacOS) {
+      // Sparkle re-resolves the feed; the Dart APK check never runs on macOS.
+      await macosUpdater?.setChannel(channel);
+    } else {
+      await updateCheckService?.requestCheck();
+    }
   }
 
   void _showAboutSection(BuildContext context) {
@@ -365,6 +377,12 @@ class SettingsView extends StatelessWidget {
   }
 
   Future<void> _checkForUpdates(BuildContext context) async {
+    if (Platform.isMacOS) {
+      // Sparkle presents its own native UI and error handling; the Dart
+      // "checking..." / "latest version" Snackbars would be misleading here.
+      await macosUpdater?.checkForUpdates();
+      return;
+    }
     final log = Logger('Settings View');
     try {
       if (!context.mounted) return;

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -27,10 +27,14 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		8A5C1B4E2F3D4A5B6C7D8E9F /* MacOSUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOSUpdater.swift; sourceTree = "<group>"; };
 		4C9BF2F4B2EA1104A9614C84 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E43F08B2060B01440E6FFA82 /* GoogleService-Info.plist */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		F18EA8F69B058B5E6E5B3D2B /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 68B0D9FE1D5946CBCF03D32B /* Pods_Runner.framework */; };
 		FEE9A0CB61232AB0202B94FE /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97F92C13CE4680B10445DC37 /* Pods_RunnerTests.framework */; };
+		1B2C3D4E5F6A7B8C9D0E1F2A /* MacOSUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5C1B4E2F3D4A5B6C7D8E9F /* MacOSUpdater.swift */; };
+		3A4B5C6D7E8F9A0B1C2D3E4F /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 9F8E7D6C5B4A39281706F5E4 /* Sparkle */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy); }; };
+		5E6F7A8B9C0D1E2F3A4B5C6D /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 9F8E7D6C5B4A39281706F5E4 /* Sparkle */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -100,6 +104,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FEE9A0CB61232AB0202B94FE /* Pods_RunnerTests.framework in Frameworks */,
+				5E6F7A8B9C0D1E2F3A4B5C6D /* Sparkle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -109,6 +114,7 @@
 			files = (
 				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				F18EA8F69B058B5E6E5B3D2B /* Pods_Runner.framework in Frameworks */,
+				3A4B5C6D7E8F9A0B1C2D3E4F /* Sparkle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -184,6 +190,7 @@
 			children = (
 				33CC10F02044A3C60003C045 /* AppDelegate.swift */,
 				33CC11122044BFA00003C045 /* MainFlutterWindow.swift */,
+				8A5C1B4E2F3D4A5B6C7D8E9F /* MacOSUpdater.swift */,
 				33E51913231747F40026EE4D /* DebugProfile.entitlements */,
 				33E51914231749380026EE4D /* Release.entitlements */,
 				33CC11242044D66E0003C045 /* Resources */,
@@ -232,6 +239,9 @@
 				331C80DA294CF71000263BE5 /* PBXTargetDependency */,
 			);
 			name = RunnerTests;
+			packageProductDependencies = (
+				9F8E7D6C5B4A39281706F5E4 /* Sparkle */,
+			);
 			productName = RunnerTests;
 			productReference = 331C80D5294CF71000263BE5 /* RunnerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -256,6 +266,7 @@
 			name = Runner;
 			packageProductDependencies = (
 				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+				9F8E7D6C5B4A39281706F5E4 /* Sparkle */,
 			);
 			productName = Runner;
 			productReference = 33CC10ED2044A3C60003C045 /* Streamline.app */;
@@ -303,6 +314,7 @@
 			mainGroup = 33CC10E42044A3C60003C045;
 			packageReferences = (
 				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+				7C8D9E0F1A2B3C4D5E6F7A8B /* XCRemoteSwiftPackageReference "Sparkle" */,
 			);
 			productRefGroup = 33CC10EE2044A3C60003C045 /* Products */;
 			projectDirPath = "";
@@ -453,6 +465,7 @@
 			files = (
 				33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */,
 				33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */,
+				1B2C3D4E5F6A7B8C9D0E1F2A /* MacOSUpdater.swift in Sources */,
 				335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -830,10 +843,26 @@
 		};
 /* End XCLocalSwiftPackageReference section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		7C8D9E0F1A2B3C4D5E6F7A8B /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = exactVersion;
+				version = 2.9.5;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+		9F8E7D6C5B4A39281706F5E4 /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7C8D9E0F1A2B3C4D5E6F7A8B /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -118,6 +118,15 @@
       }
     },
     {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
+        "version" : "2.9.5"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",

--- a/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -118,6 +118,15 @@
       }
     },
     {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
+        "version" : "2.9.5"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -3,6 +3,9 @@ import FlutterMacOS
 
 @main
 class AppDelegate: FlutterAppDelegate {
+  /// Retains the Sparkle coordinator registered by MainFlutterWindow.
+  var macosUpdater: MacOSUpdater?
+
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true
   }

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -16,5 +16,10 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
+	</array>
 </dict>
 </plist>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -22,6 +22,22 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>SUFeedURL</key>
+	<string>https://decentespresso.github.io/decaid/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>QbJSraY4tjmHW7tReRFC0GC0pYxIRl48RcIwOR8oNkQ=</string>
+	<key>SUEnableInstallerLauncherService</key>
+	<true/>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUScheduledCheckInterval</key>
+	<integer>43200</integer>
+	<key>SUAutomaticallyUpdate</key>
+	<false/>
+	<key>SUVerifyUpdateBeforeExtraction</key>
+	<true/>
+	<key>SURequireSignedFeed</key>
+	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/macos/Runner/MacOSUpdater.swift
+++ b/macos/Runner/MacOSUpdater.swift
@@ -118,9 +118,6 @@ final class MacOSUpdater: NSObject, SPUUpdaterDelegate {
       controller.startUpdater()
       configured = true
     }
-    // Copy the pre-Sparkle Flutter default into Sparkle exactly once. After
-    // migration, only setAutomaticChecks(_:) writes to Sparkle so the two
-    // settings surfaces cannot drift.
     if !UserDefaults.standard.bool(forKey: Self.automaticChecksMigrationKey) {
       controller.automaticallyChecksForUpdates = automaticChecks
       UserDefaults.standard.set(true, forKey: Self.automaticChecksMigrationKey)

--- a/macos/Runner/MacOSUpdater.swift
+++ b/macos/Runner/MacOSUpdater.swift
@@ -1,0 +1,199 @@
+import Cocoa
+import FlutterMacOS
+import Sparkle
+
+/// Minimal surface MacOSUpdater needs from Sparkle's updater controller.
+/// Protocol so RunnerTests can drive MacOSUpdater without launching Sparkle's
+/// installer machinery.
+@MainActor
+protocol SPUUpdaterControlling: AnyObject {
+  /// Pre-flight check that the host bundle is configured for Sparkle.
+  /// Defaults to a no-op; the production controller validates Info.plist keys.
+  func validateConfiguration() throws
+  func startUpdater()
+  func checkForUpdates()
+  var automaticallyChecksForUpdates: Bool { get set }
+  func resetUpdateCycleAfterShortDelay()
+}
+
+extension SPUUpdaterControlling {
+  func validateConfiguration() throws {}
+}
+
+/// Production controller wrapping Sparkle's standard updater controller.
+@MainActor
+final class SparkleUpdaterController: SPUUpdaterControlling {
+  private let standard: SPUStandardUpdaterController
+
+  init(updaterDelegate: SPUUpdaterDelegate?) {
+    standard = SPUStandardUpdaterController(
+      startingUpdater: false,
+      updaterDelegate: updaterDelegate,
+      userDriverDelegate: nil)
+  }
+
+  func validateConfiguration() throws {
+    guard let info = Bundle.main.infoDictionary,
+          info["SUFeedURL"] != nil,
+          info["SUPublicEDKey"] != nil else {
+      throw MacOSUpdaterError.missingInfoPlistKeys
+    }
+  }
+
+  func startUpdater() {
+    standard.startUpdater()
+  }
+
+  func checkForUpdates() {
+    standard.checkForUpdates(nil)
+  }
+
+  var automaticallyChecksForUpdates: Bool {
+    get { standard.updater.automaticallyChecksForUpdates }
+    set { standard.updater.automaticallyChecksForUpdates = newValue }
+  }
+
+  func resetUpdateCycleAfterShortDelay() {
+    standard.updater.resetUpdateCycleAfterShortDelay()
+  }
+}
+
+enum MacOSUpdaterError: LocalizedError {
+  case missingInfoPlistKeys
+
+  var errorDescription: String? {
+    switch self {
+    case .missingInfoPlistKeys:
+      return "Sparkle is not configured: SUFeedURL and SUPublicEDKey are required in Info.plist"
+    }
+  }
+}
+
+/// Coordinates Sparkle with Decaid's Flutter settings. The Flutter side
+/// (net.tadel.reaprime/macos_updater) is the only entry point; no update
+/// replacement logic lives in Dart.
+@MainActor
+final class MacOSUpdater: NSObject, SPUUpdaterDelegate {
+  static let channelName = "net.tadel.reaprime/macos_updater"
+  static let automaticChecksMigrationKey =
+    "net.tadel.reaprime.sparkleAutomaticChecksMigrated"
+
+  private let injectedController: SPUUpdaterControlling?
+  private lazy var controller: SPUUpdaterControlling = {
+    injectedController ?? SparkleUpdaterController(updaterDelegate: self)
+  }()
+  private var methodChannel: FlutterMethodChannel?
+  private var allowedChannels: Set<String> = []
+  private var configured = false
+
+  init(controller: SPUUpdaterControlling? = nil) {
+    injectedController = controller
+    super.init()
+  }
+
+  /// Sparkle always includes the default channel, so Stable needs no entries.
+  nonisolated static func allowedChannels(for channel: String) -> Set<String> {
+    channel == "beta" ? ["beta"] : []
+  }
+
+  /// Registers the method channel and returns the updater; the caller keeps it
+  /// alive (the AppDelegate owns it).
+  @discardableResult
+  static func register(with flutterViewController: FlutterViewController) -> MacOSUpdater {
+    let updater = MacOSUpdater()
+    updater.methodChannel = FlutterMethodChannel(
+      name: channelName,
+      binaryMessenger: flutterViewController.engine.binaryMessenger)
+    updater.methodChannel?.setMethodCallHandler { [weak updater] call, result in
+      updater?.handle(call, result: result)
+    }
+    return updater
+  }
+
+  /// Starts the updater and applies the persisted Flutter settings. Idempotent;
+  /// safe to call again after a channel change or a settings reload.
+  func configure(automaticChecks: Bool, channel: String) throws {
+    try controller.validateConfiguration()
+    if !configured {
+      controller.startUpdater()
+      configured = true
+    }
+    // Copy the pre-Sparkle Flutter default into Sparkle exactly once. After
+    // migration, only setAutomaticChecks(_:) writes to Sparkle so the two
+    // settings surfaces cannot drift.
+    if !UserDefaults.standard.bool(forKey: Self.automaticChecksMigrationKey) {
+      controller.automaticallyChecksForUpdates = automaticChecks
+      UserDefaults.standard.set(true, forKey: Self.automaticChecksMigrationKey)
+    }
+    allowedChannels = Self.allowedChannels(for: channel)
+  }
+
+  func setAutomaticChecks(_ enabled: Bool) {
+    guard UserDefaults.standard.bool(forKey: Self.automaticChecksMigrationKey) else {
+      return
+    }
+    controller.automaticallyChecksForUpdates = enabled
+  }
+
+  func setChannel(_ channel: String) {
+    let next = Self.allowedChannels(for: channel)
+    guard next != allowedChannels else { return }
+    allowedChannels = next
+    controller.resetUpdateCycleAfterShortDelay()
+  }
+
+  func checkForUpdates() {
+    guard configured else { return }
+    controller.checkForUpdates()
+  }
+
+  // MARK: - Method channel
+
+  private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "configure":
+      let args = call.arguments as? [String: Any]
+      guard let automaticChecks = args?["automaticChecks"] as? Bool,
+            let channel = args?["channel"] as? String else {
+        result(FlutterError(
+          code: "bad_arguments",
+          message: "configure requires automaticChecks (bool) and channel (string)",
+          details: nil))
+        return
+      }
+      do {
+        try configure(automaticChecks: automaticChecks, channel: channel)
+        result(nil)
+      } catch {
+        result(FlutterError(code: "configure_failed", message: error.localizedDescription, details: nil))
+      }
+    case "setAutomaticChecks":
+      let enabled = (call.arguments as? [String: Any])?["enabled"] as? Bool
+      guard let enabled else {
+        result(FlutterError(code: "bad_arguments", message: "setAutomaticChecks requires enabled (bool)", details: nil))
+        return
+      }
+      setAutomaticChecks(enabled)
+      result(nil)
+    case "setChannel":
+      let channel = (call.arguments as? [String: Any])?["channel"] as? String
+      guard let channel else {
+        result(FlutterError(code: "bad_arguments", message: "setChannel requires channel (string)", details: nil))
+        return
+      }
+      setChannel(channel)
+      result(nil)
+    case "checkForUpdates":
+      checkForUpdates()
+      result(nil)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  // MARK: - SPUUpdaterDelegate
+
+  func allowedChannels(for updater: SPUUpdater) -> Set<String> {
+    allowedChannels
+  }
+}

--- a/macos/Runner/MacOSUpdater.swift
+++ b/macos/Runner/MacOSUpdater.swift
@@ -8,16 +8,11 @@ import Sparkle
 @MainActor
 protocol SPUUpdaterControlling: AnyObject {
   /// Pre-flight check that the host bundle is configured for Sparkle.
-  /// Defaults to a no-op; the production controller validates Info.plist keys.
   func validateConfiguration() throws
   func startUpdater()
   func checkForUpdates()
   var automaticallyChecksForUpdates: Bool { get set }
   func resetUpdateCycleAfterShortDelay()
-}
-
-extension SPUUpdaterControlling {
-  func validateConfiguration() throws {}
 }
 
 /// Production controller wrapping Sparkle's standard updater controller.

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -10,6 +10,11 @@ class MainFlutterWindow: NSWindow {
 
     RegisterGeneratedPlugins(registry: flutterViewController)
 
+    // Own the Sparkle coordinator on the AppDelegate so it outlives the window.
+    if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
+      appDelegate.macosUpdater = MacOSUpdater.register(with: flutterViewController)
+    }
+
     super.awakeFromNib()
   }
 }

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -14,5 +14,10 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
+	</array>
 </dict>
 </plist>

--- a/macos/RunnerTests/RunnerTests.swift
+++ b/macos/RunnerTests/RunnerTests.swift
@@ -1,12 +1,124 @@
 import Cocoa
 import FlutterMacOS
 import XCTest
+@testable import Decaid
 
-class RunnerTests: XCTestCase {
-
-  func testExample() {
-    // If you add code to the Runner application, consider adding tests here.
-    // See https://developer.apple.com/documentation/xctest for more information about using XCTest.
+/// Fake controller so MacOSUpdater can be exercised without starting Sparkle's
+/// updater (which would read the host bundle and schedule network checks).
+@MainActor
+private final class FakeUpdaterController: SPUUpdaterControlling {
+  var startCalls = 0
+  var checkCalls = 0
+  var resetCalls = 0
+  var automaticallyChecksForUpdates = false
+  var validateCalls = 0
+  var throwOnValidate = false
+  func validateConfiguration() throws {
+    validateCalls += 1
+    if throwOnValidate { throw MacOSUpdaterError.missingInfoPlistKeys }
   }
 
+  func startUpdater() {
+    startCalls += 1
+  }
+
+  func checkForUpdates() {
+    checkCalls += 1
+  }
+
+  func resetUpdateCycleAfterShortDelay() {
+    resetCalls += 1
+  }
+}
+
+final class RunnerTests: XCTestCase {
+
+  override func setUp() {
+    super.setUp()
+    UserDefaults.standard.removeObject(
+      forKey: MacOSUpdater.automaticChecksMigrationKey)
+  }
+
+  // MARK: - Channel mapping
+
+  func testStableChannelMapsToEmptyAllowedChannels() {
+    XCTAssertEqual(MacOSUpdater.allowedChannels(for: "stable"), [])
+  }
+
+  func testBetaChannelMapsToBeta() {
+    XCTAssertEqual(MacOSUpdater.allowedChannels(for: "beta"), ["beta"])
+  }
+
+  func testUnknownChannelMapsToEmptyAllowedChannels() {
+    XCTAssertEqual(MacOSUpdater.allowedChannels(for: "whatever"), [])
+  }
+
+  // MARK: - Configuration
+
+  @MainActor
+  func testConfigureStartsUpdaterExactlyOnce() throws {
+    let fake = FakeUpdaterController()
+    let updater = MacOSUpdater(controller: fake)
+
+    try updater.configure(automaticChecks: true, channel: "stable")
+    try updater.configure(automaticChecks: false, channel: "beta")
+
+    XCTAssertEqual(fake.startCalls, 1)
+    XCTAssertEqual(fake.validateCalls, 2)
+  }
+
+  @MainActor
+  func testConfigureValidatesBeforeStarting() throws {
+    let fake = FakeUpdaterController()
+    fake.throwOnValidate = true
+    let updater = MacOSUpdater(controller: fake)
+
+    XCTAssertThrowsError(try updater.configure(automaticChecks: true, channel: "stable"))
+    XCTAssertEqual(fake.startCalls, 0)
+  }
+
+  @MainActor
+  func testSetAutomaticChecksOnlyAfterMigration() throws {
+    let fake = FakeUpdaterController()
+    let updater = MacOSUpdater(controller: fake)
+
+    // Before configure() migrates, the setter is a no-op.
+    updater.setAutomaticChecks(false)
+    XCTAssertFalse(fake.automaticallyChecksForUpdates)
+
+    try updater.configure(automaticChecks: true, channel: "stable")
+    XCTAssertTrue(fake.automaticallyChecksForUpdates)
+
+    updater.setAutomaticChecks(false)
+    XCTAssertFalse(fake.automaticallyChecksForUpdates)
+  }
+
+  @MainActor
+  func testChannelChangeResetsUpdateCycle() throws {
+    let fake = FakeUpdaterController()
+    let updater = MacOSUpdater(controller: fake)
+
+    try updater.configure(automaticChecks: true, channel: "stable")
+    XCTAssertEqual(fake.resetCalls, 0)
+
+    updater.setChannel("beta")
+    XCTAssertEqual(fake.resetCalls, 1)
+
+    // Same channel again must not reset.
+    updater.setChannel("beta")
+    XCTAssertEqual(fake.resetCalls, 1)
+  }
+
+  @MainActor
+  func testCheckForUpdatesDelegatesOnlyWhenConfigured() throws {
+    let fake = FakeUpdaterController()
+    let updater = MacOSUpdater(controller: fake)
+
+    updater.checkForUpdates()
+    XCTAssertEqual(fake.checkCalls, 0)
+
+    try updater.configure(automaticChecks: true, channel: "stable")
+    updater.checkForUpdates()
+    XCTAssertEqual(fake.checkCalls, 1)
+  }
 }

--- a/scripts/appcast_helpers.sh
+++ b/scripts/appcast_helpers.sh
@@ -28,6 +28,29 @@ zip_read_build() {
     | plutil -extract CFBundleVersion raw -
 }
 
+# "total default-channel-count" pair for the feed.
+appcast_item_counts() {
+  local appcast="$1"
+  local total default_count
+  total=$(xmllint --xpath 'count(//*[local-name()="item"])' "$appcast" 2>/dev/null)
+  default_count=$(xmllint --xpath \
+    'count(//*[local-name()="item"][not(*[local-name()="channel"])])' "$appcast" 2>/dev/null)
+  echo "$total $default_count"
+}
+
+# Reject a feed that shrank: a beta publication must never erase stable or
+# historical items.
+assert_item_counts_not_decreased() {
+  local old_pair="$1" appcast="$2"
+  local old_total old_default new_total new_default
+  read -r old_total old_default <<< "$old_pair"
+  read -r new_total new_default <<< "$(appcast_item_counts "$appcast")"
+  [ "$new_total" -ge "$old_total" ] || {
+    echo "FAIL: feed item count decreased ($old_total -> $new_total)"; return 1; }
+  [ "$new_default" -ge "$old_default" ] || {
+    echo "FAIL: default-channel item count decreased ($old_default -> $new_default)"; return 1; }
+}
+
 # Assert the item for $build carries the expected enclosure URL, an EdDSA
 # signature, and the expected channel ("" for the default/stable channel).
 appcast_assert_item() {

--- a/scripts/appcast_helpers.sh
+++ b/scripts/appcast_helpers.sh
@@ -38,17 +38,50 @@ appcast_item_counts() {
   echo "$total $default_count"
 }
 
-# Reject a feed that shrank: a beta publication must never erase stable or
-# historical items.
-assert_item_counts_not_decreased() {
-  local old_pair="$1" appcast="$2"
+# Every non-bootstrap publication adds exactly one strictly newer item, so
+# assert the exact deltas: one more item total, and one more default-channel
+# item for a stable publication (a beta item leaves the default count alone).
+assert_feed_grew() {
+  local old_pair="$1" appcast="$2" channel="$3"
   local old_total old_default new_total new_default
   read -r old_total old_default <<< "$old_pair"
   read -r new_total new_default <<< "$(appcast_item_counts "$appcast")"
-  [ "$new_total" -ge "$old_total" ] || {
-    echo "FAIL: feed item count decreased ($old_total -> $new_total)"; return 1; }
-  [ "$new_default" -ge "$old_default" ] || {
-    echo "FAIL: default-channel item count decreased ($old_default -> $new_default)"; return 1; }
+  [ "$new_total" -eq $((old_total + 1)) ] || {
+    echo "FAIL: feed must grow by exactly one item ($old_total -> $new_total)"; return 1; }
+  local expected_default
+  if [ -z "$channel" ]; then
+    expected_default=$((old_default + 1))
+  else
+    expected_default=$old_default
+  fi
+  [ "$new_default" -eq "$expected_default" ] || {
+    echo "FAIL: default-channel items expected $expected_default, got $new_default"; return 1; }
+}
+
+# The old (version, channel) set must be a subset of the new feed: a beta
+# publication can never erase stable or historical items, and an existing
+# item's channel must not change.
+assert_old_items_preserved() {
+  local old_feed="$1" new_feed="$2"
+  local old_versions new_versions v old_ch new_ch
+  old_versions=$(xmllint --xpath \
+    '//*[local-name()="item"]/*[local-name()="version"]/text()' \
+    "$old_feed" 2>/dev/null | tr ' ' '\n')
+  new_versions=$(xmllint --xpath \
+    '//*[local-name()="item"]/*[local-name()="version"]/text()' \
+    "$new_feed" 2>/dev/null | tr ' ' '\n')
+  for v in $old_versions; do
+    grep -qx "$v" <<< "$new_versions" || {
+      echo "FAIL: version $v missing from the new feed"; return 1; }
+    old_ch=$(xmllint --xpath \
+      "string(//*[local-name()=\"item\"][*[local-name()=\"version\"]=\"$v\"]/*[local-name()=\"channel\"])" \
+      "$old_feed" 2>/dev/null)
+    new_ch=$(xmllint --xpath \
+      "string(//*[local-name()=\"item\"][*[local-name()=\"version\"]=\"$v\"]/*[local-name()=\"channel\"])" \
+      "$new_feed" 2>/dev/null)
+    [ "$old_ch" = "$new_ch" ] || {
+      echo "FAIL: version $v channel changed ('$old_ch' -> '$new_ch')"; return 1; }
+  done
 }
 
 # Assert the item for $build carries the expected enclosure URL, an EdDSA

--- a/scripts/appcast_helpers.sh
+++ b/scripts/appcast_helpers.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Pure appcast helpers for the Sparkle publish job. Sourced by
+# publish_appcast.sh and exercised by test_appcast_helpers.sh. All functions
+# exit non-zero on failure so callers can fail fast.
+
+# Largest sparkle:version (CFBundleVersion) among all appcast items.
+# Empty string when the feed has no items.
+appcast_max_build() {
+  local appcast="$1"
+  xmllint --xpath \
+    '//*[local-name()="item"]/*[local-name()="version"]/text()' \
+    "$appcast" 2>/dev/null | tr ' ' '\n' | sort -n | tail -1
+}
+
+# Refuse publishing an update Sparkle can never select (equal/lower build).
+assert_build_increasing() {
+  local new="$1" existing="$2"
+  if [ -n "$existing" ] && [ "$new" -le "$existing" ]; then
+    echo "FAIL: new CFBundleVersion $new is not greater than existing $existing"
+    return 1
+  fi
+}
+
+# Read CFBundleVersion out of a Decaid macOS release ZIP.
+zip_read_build() {
+  local zip="$1"
+  unzip -p "$zip" "Decaid.app/Contents/Info.plist" \
+    | plutil -extract CFBundleVersion raw -
+}
+
+# The appcast item for $build, matched by sparkle:version. Empty if absent.
+appcast_find_item() {
+  local appcast="$1" build="$2"
+  xmllint --xpath \
+    "//*[local-name()=\"item\"][*[local-name()=\"version\"]=\"$build\"]" \
+    "$appcast" 2>/dev/null
+}
+
+# Assert the item for $build carries the expected enclosure URL, an EdDSA
+# signature, and the expected channel ("" for the default/stable channel).
+appcast_assert_item() {
+  local appcast="$1" build="$2" expected_url="$3" expected_channel="$4"
+
+  appcast_find_item "$appcast" "$build" >/dev/null || {
+    echo "FAIL: no appcast item for version $build"; return 1; }
+
+  local url sig
+  url=$(xmllint --xpath \
+    "string(//*[local-name()=\"item\"][*[local-name()=\"version\"]=\"$build\"]/*[local-name()=\"enclosure\"]/@url)" \
+    "$appcast" 2>/dev/null)
+  [ "$url" = "$expected_url" ] || {
+    echo "FAIL: item $build url '$url' != '$expected_url'"; return 1; }
+
+  sig=$(xmllint --xpath \
+    "string(//*[local-name()=\"item\"][*[local-name()=\"version\"]=\"$build\"]/*[local-name()=\"enclosure\"]/@*[local-name()=\"edSignature\"])" \
+    "$appcast" 2>/dev/null)
+  [ -n "$sig" ] || {
+    echo "FAIL: item $build has no edSignature"; return 1; }
+
+  local channel_count
+  channel_count=$(xmllint --xpath \
+    "count(//*[local-name()=\"item\"][*[local-name()=\"version\"]=\"$build\"]/*[local-name()=\"channel\"])" \
+    "$appcast" 2>/dev/null)
+  if [ -z "$expected_channel" ]; then
+    [ "$channel_count" = "0" ] || {
+      echo "FAIL: stable item $build must not carry a sparkle:channel"; return 1; }
+  else
+    [ "$channel_count" = "1" ] || {
+      echo "FAIL: item $build must carry exactly one sparkle:channel"; return 1; }
+    local actual
+    actual=$(xmllint --xpath \
+      "string(//*[local-name()=\"item\"][*[local-name()=\"version\"]=\"$build\"]/*[local-name()=\"channel\"])" \
+      "$appcast" 2>/dev/null)
+    [ "$actual" = "$expected_channel" ] || {
+      echo "FAIL: item $build channel '$actual' != '$expected_channel'"; return 1; }
+  fi
+}

--- a/scripts/appcast_helpers.sh
+++ b/scripts/appcast_helpers.sh
@@ -28,21 +28,10 @@ zip_read_build() {
     | plutil -extract CFBundleVersion raw -
 }
 
-# The appcast item for $build, matched by sparkle:version. Empty if absent.
-appcast_find_item() {
-  local appcast="$1" build="$2"
-  xmllint --xpath \
-    "//*[local-name()=\"item\"][*[local-name()=\"version\"]=\"$build\"]" \
-    "$appcast" 2>/dev/null
-}
-
 # Assert the item for $build carries the expected enclosure URL, an EdDSA
 # signature, and the expected channel ("" for the default/stable channel).
 appcast_assert_item() {
   local appcast="$1" build="$2" expected_url="$3" expected_channel="$4"
-
-  appcast_find_item "$appcast" "$build" >/dev/null || {
-    echo "FAIL: no appcast item for version $build"; return 1; }
 
   local url sig
   url=$(xmllint --xpath \

--- a/scripts/publish_appcast.sh
+++ b/scripts/publish_appcast.sh
@@ -64,15 +64,17 @@ elif [ "$CHANNEL" != "stable" ]; then
   exit 1
 fi
 
+EXPECTED_CHANNEL=""
+[ "$CHANNEL" = "beta" ] && EXPECTED_CHANNEL="beta"
+
 echo "Running generate_appcast (channel: $CHANNEL)..."
 "${ARGS[@]}" "$STAGING"
 
 if [ "$BOOTSTRAP" = "0" ]; then
-  assert_item_counts_not_decreased "$OLD_COUNTS" "$STAGING/appcast.xml"
+  assert_feed_grew "$OLD_COUNTS" "$STAGING/appcast.xml" "$EXPECTED_CHANNEL"
+  assert_old_items_preserved "$PREVIOUS_FEED" "$STAGING/appcast.xml"
 fi
 
-EXPECTED_CHANNEL=""
-[ "$CHANNEL" = "beta" ] && EXPECTED_CHANNEL="beta"
 appcast_assert_item "$STAGING/appcast.xml" "$BUILD" "${PREFIX}${ZIP_BASENAME}" "$EXPECTED_CHANNEL"
 xmllint --noout "$STAGING/appcast.xml"
 echo "Feed validated: version $BUILD, channel '${CHANNEL}'"

--- a/scripts/publish_appcast.sh
+++ b/scripts/publish_appcast.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Publish the Sparkle appcast for a tagged macOS release.
+#
+# Usage:
+#   publish_appcast.sh <zip> <release-notes.md> <download-url-prefix> <channel> <key-file> <output>
+#
+#   <channel>          "beta" or "stable" (no channel is written for stable).
+#   <key-file>         Path to the EdDSA private key, or "-" to read it from
+#                      standard input (for a GitHub Actions secret).
+#   <output>           Where the generated appcast.xml is written.
+#
+# Fails unless the ZIP's CFBundleVersion is strictly greater than every item
+# already in the deployed feed, so Sparkle can always select the new update.
+set -euo pipefail
+source "$(dirname "$0")/appcast_helpers.sh"
+
+ZIP="${1:?usage: publish_appcast.sh <zip> <notes.md> <url-prefix> <channel> <key-file> <output>}"
+NOTES="${2:?}"
+PREFIX="${3:?}"
+CHANNEL="${4:?}"
+KEY_FILE="${5:?}"
+OUTPUT="${6:?}"
+
+FEED_URL="https://decentespresso.github.io/decaid/appcast.xml"
+
+STAGING="$(mktemp -d)"
+trap 'rm -rf "$STAGING"' EXIT
+
+cp "$ZIP" "$STAGING/"
+ZIP_BASENAME="$(basename "$ZIP")"
+cp "$NOTES" "$STAGING/${ZIP_BASENAME%.zip}.md"
+
+if curl -fsSL "$FEED_URL" -o "$STAGING/appcast.xml" 2>/dev/null; then
+  echo "Fetched existing appcast from $FEED_URL"
+else
+  echo "No existing appcast reachable; generating a fresh feed"
+fi
+
+BUILD="$(zip_read_build "$ZIP")"
+[ -n "$BUILD" ] || { echo "FAIL: could not read CFBundleVersion from $ZIP"; exit 1; }
+echo "Release CFBundleVersion: $BUILD"
+
+if [ -f "$STAGING/appcast.xml" ]; then
+  MAX="$(appcast_max_build "$STAGING/appcast.xml")"
+  echo "Existing feed max CFBundleVersion: ${MAX:-none}"
+  assert_build_increasing "$BUILD" "$MAX"
+fi
+
+ARGS=(generate_appcast
+  --ed-key-file "$KEY_FILE"
+  --download-url-prefix "$PREFIX"
+  --embed-release-notes
+  --versions "$BUILD"
+  --maximum-deltas 0
+  --maximum-versions 0)
+if [ "$CHANNEL" = "beta" ]; then
+  ARGS+=(--channel beta)
+elif [ "$CHANNEL" != "stable" ]; then
+  echo "FAIL: unknown channel '$CHANNEL' (expected 'stable' or 'beta')" >&2
+  exit 1
+fi
+
+echo "Running generate_appcast (channel: $CHANNEL)..."
+"${ARGS[@]}" "$STAGING"
+
+EXPECTED_CHANNEL=""
+[ "$CHANNEL" = "beta" ] && EXPECTED_CHANNEL="beta"
+appcast_assert_item "$STAGING/appcast.xml" "$BUILD" "${PREFIX}${ZIP_BASENAME}" "$EXPECTED_CHANNEL"
+xmllint --noout "$STAGING/appcast.xml"
+echo "Feed validated: version $BUILD, channel '${CHANNEL}'"
+
+mkdir -p "$(dirname "$OUTPUT")"
+cp "$STAGING/appcast.xml" "$OUTPUT"
+echo "Appcast written to $OUTPUT"

--- a/scripts/publish_appcast.sh
+++ b/scripts/publish_appcast.sh
@@ -2,26 +2,30 @@
 # Publish the Sparkle appcast for a tagged macOS release.
 #
 # Usage:
-#   publish_appcast.sh <zip> <release-notes.md> <download-url-prefix> <channel> <key-file> <output>
+#   publish_appcast.sh <zip> <release-notes.md> <download-url-prefix> <channel> <key-file> <output> [previous-feed]
 #
-#   <channel>          "beta" or "stable" (no channel is written for stable).
-#   <key-file>         Path to the EdDSA private key, or "-" to read it from
-#                      standard input (for a GitHub Actions secret).
-#   <output>           Where the generated appcast.xml is written.
+#   <channel>        "beta" or "stable" (no channel is written for stable).
+#   <key-file>       Path to the EdDSA private key, or "-" to read it from
+#                    standard input (for a GitHub Actions secret).
+#   <output>         Where the generated appcast.xml is written.
+#   [previous-feed]  The durable feed (gh-pages branch) to merge into. When
+#                    absent, a fresh feed is generated; that one-time bootstrap
+#                    must be authorized by the caller (see release.yml).
 #
-# Fails unless the ZIP's CFBundleVersion is strictly greater than every item
-# already in the deployed feed, so Sparkle can always select the new update.
+# The previous feed is the source of truth, read through git (not the Pages
+# CDN), so a transient Pages/TLS failure can never be mistaken for a first
+# publication. Fails unless the ZIP's CFBundleVersion is strictly greater than
+# every item already in the feed, and unless item counts never decrease.
 set -euo pipefail
 source "$(dirname "$0")/appcast_helpers.sh"
 
-ZIP="${1:?usage: publish_appcast.sh <zip> <notes.md> <url-prefix> <channel> <key-file> <output>}"
+ZIP="${1:?usage: publish_appcast.sh <zip> <notes.md> <url-prefix> <channel> <key-file> <output> [previous-feed]}"
 NOTES="${2:?}"
 PREFIX="${3:?}"
 CHANNEL="${4:?}"
 KEY_FILE="${5:?}"
 OUTPUT="${6:?}"
-
-FEED_URL="https://decentespresso.github.io/decaid/appcast.xml"
+PREVIOUS_FEED="${7:-}"
 
 STAGING="$(mktemp -d)"
 trap 'rm -rf "$STAGING"' EXIT
@@ -30,20 +34,20 @@ cp "$ZIP" "$STAGING/"
 ZIP_BASENAME="$(basename "$ZIP")"
 cp "$NOTES" "$STAGING/${ZIP_BASENAME%.zip}.md"
 
-if curl -fsSL "$FEED_URL" -o "$STAGING/appcast.xml" 2>/dev/null; then
-  echo "Fetched existing appcast from $FEED_URL"
-else
-  echo "No existing appcast reachable; generating a fresh feed"
-fi
-
 BUILD="$(zip_read_build "$ZIP")"
 [ -n "$BUILD" ] || { echo "FAIL: could not read CFBundleVersion from $ZIP"; exit 1; }
 echo "Release CFBundleVersion: $BUILD"
 
-if [ -f "$STAGING/appcast.xml" ]; then
+BOOTSTRAP=0
+if [ -n "$PREVIOUS_FEED" ] && [ -s "$PREVIOUS_FEED" ]; then
+  cp "$PREVIOUS_FEED" "$STAGING/appcast.xml"
   MAX="$(appcast_max_build "$STAGING/appcast.xml")"
-  echo "Existing feed max CFBundleVersion: ${MAX:-none}"
+  echo "Previous feed max CFBundleVersion: ${MAX:-none}"
   assert_build_increasing "$BUILD" "$MAX"
+  OLD_COUNTS="$(appcast_item_counts "$STAGING/appcast.xml")"
+else
+  BOOTSTRAP=1
+  echo "No previous feed; generating a fresh feed (bootstrap)"
 fi
 
 ARGS=(generate_appcast
@@ -62,6 +66,10 @@ fi
 
 echo "Running generate_appcast (channel: $CHANNEL)..."
 "${ARGS[@]}" "$STAGING"
+
+if [ "$BOOTSTRAP" = "0" ]; then
+  assert_item_counts_not_decreased "$OLD_COUNTS" "$STAGING/appcast.xml"
+fi
 
 EXPECTED_CHANNEL=""
 [ "$CHANNEL" = "beta" ] && EXPECTED_CHANNEL="beta"

--- a/scripts/sign_macos_deepest_first.sh
+++ b/scripts/sign_macos_deepest_first.sh
@@ -5,7 +5,8 @@
 # Autoupdate) must be signed deepest-first, each keeping its own embedded
 # entitlements. `codesign --deep` (especially with --entitlements) rewrites
 # nested code with the host's entitlements, which strips the sandboxed
-# Installer XPC service of what it needs. See doc/plans/521-macos-auto-update-sparkle.md.
+# Installer XPC service of what it needs. See
+# doc/plans/archive/521-macos-auto-update-sparkle/521-macos-auto-update-sparkle.md.
 #
 # Usage: sign_macos_deepest_first.sh <Decaid.app> [identity] [entitlements]
 set -euo pipefail

--- a/scripts/sign_macos_deepest_first.sh
+++ b/scripts/sign_macos_deepest_first.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Sign Decaid.app with Developer ID for distribution WITHOUT `codesign --deep`.
+#
+# Sparkle's nested helpers (Installer.xpc, Downloader.xpc, Updater.app,
+# Autoupdate) must be signed deepest-first, each keeping its own embedded
+# entitlements. `codesign --deep` (especially with --entitlements) rewrites
+# nested code with the host's entitlements, which strips the sandboxed
+# Installer XPC service of what it needs. See doc/plans/521-macos-auto-update-sparkle.md.
+#
+# Usage: sign_macos_deepest_first.sh <Decaid.app> [identity] [entitlements]
+set -euo pipefail
+
+APP="${1:?usage: sign_macos_deepest_first.sh <Decaid.app> [identity] [entitlements]}"
+IDENTITY="${2:-Developer ID Application}"
+ENTITLEMENTS="${3:-macos/Runner/Release.entitlements}"
+
+# codesign does not expand Xcode build variables; expand the bundle id so the
+# signed app carries literal net.tadel.reaprime-spks/-spki mach names.
+TMP_ENTITLEMENTS="$(mktemp)"
+trap 'rm -f "$TMP_ENTITLEMENTS"' EXIT
+sed "s/\$(PRODUCT_BUNDLE_IDENTIFIER)/net.tadel.reaprime/g" "$ENTITLEMENTS" > "$TMP_ENTITLEMENTS"
+
+FRAMEWORK="$APP/Contents/Frameworks/Sparkle.framework/Versions/Current"
+
+echo "== Signing Sparkle nested helpers deepest-first =="
+codesign --force --options runtime --timestamp --sign "$IDENTITY" \
+  "$FRAMEWORK/XPCServices/Installer.xpc"
+codesign --force --options runtime --timestamp --sign "$IDENTITY" \
+  "$FRAMEWORK/XPCServices/Downloader.xpc"
+codesign --force --options runtime --timestamp --sign "$IDENTITY" \
+  "$FRAMEWORK/Updater.app"
+codesign --force --options runtime --timestamp --sign "$IDENTITY" \
+  "$FRAMEWORK/Autoupdate"
+
+echo "== Signing Sparkle.framework =="
+codesign --force --options runtime --timestamp --sign "$IDENTITY" \
+  "$APP/Contents/Frameworks/Sparkle.framework"
+
+echo "== Signing host app =="
+codesign --force --options runtime --timestamp \
+  --entitlements "$TMP_ENTITLEMENTS" --sign "$IDENTITY" \
+  "$APP"
+
+echo "== Done =="

--- a/scripts/test_appcast_helpers.sh
+++ b/scripts/test_appcast_helpers.sh
@@ -67,17 +67,58 @@ appcast_assert_item "$TMP/fixture.xml" 101 \
   "https://github.com/decentespresso/decaid/releases/download/v2.0.0/decaid-macos-2.0.0.zip" \
   "beta" && echo "ok: beta item assertions pass"
 
-# --- Count assertions ---
-read -r TOTAL DEFAULT_COUNT <<< "$(appcast_item_counts "$TMP/fixture.xml")"
-[ "$TOTAL" = "2" ] || fail "appcast_item_counts total expected 2, got '$TOTAL'"
-[ "$DEFAULT_COUNT" = "1" ] || fail "appcast_item_counts default expected 1, got '$DEFAULT_COUNT'"
-echo "ok: appcast_item_counts = $TOTAL total, $DEFAULT_COUNT default"
-
-assert_item_counts_not_decreased "$TOTAL $DEFAULT_COUNT" "$TMP/fixture.xml" \
-  && echo "ok: equal counts accepted"
-if assert_item_counts_not_decreased "3 2" "$TMP/fixture.xml" >/dev/null 2>&1; then
-  fail "assert_item_counts_not_decreased accepted a shrunken feed"
+# --- Growth assertions ---
+# Old fixture: 2 items (1 default + 1 beta). A stable publication must add
+# one default item (3 total, 2 default); a beta one adds a beta item (3
+# total, 1 default).
+cat > "$TMP/grown-stable.xml" <<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <item><sparkle:version>101</sparkle:version><sparkle:channel>beta</sparkle:channel></item>
+    <item><sparkle:version>100</sparkle:version></item>
+    <item><sparkle:version>102</sparkle:version></item>
+  </channel>
+</rss>
+XML
+cat > "$TMP/grown-beta.xml" <<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <item><sparkle:version>101</sparkle:version><sparkle:channel>beta</sparkle:channel></item>
+    <item><sparkle:version>100</sparkle:version></item>
+    <item><sparkle:version>102</sparkle:version><sparkle:channel>beta</sparkle:channel></item>
+  </channel>
+</rss>
+XML
+assert_feed_grew "2 1" "$TMP/grown-stable.xml" "" \
+  && echo "ok: stable growth (3 total, 2 default) accepted"
+assert_feed_grew "2 1" "$TMP/grown-beta.xml" "beta" \
+  && echo "ok: beta growth (3 total, 1 default) accepted"
+if assert_feed_grew "2 1" "$TMP/fixture.xml" "" >/dev/null 2>&1; then
+  fail "assert_feed_grew accepted unchanged item counts"
 fi
+if assert_feed_grew "2 1" "$TMP/grown-beta.xml" "" >/dev/null 2>&1; then
+  fail "assert_feed_grew accepted a beta item as a stable one"
+fi
+
+assert_old_items_preserved "$TMP/fixture.xml" "$TMP/grown-stable.xml" \
+  && echo "ok: old items preserved in grown feed"
+# A feed that dropped item 100 while adding 102 must be rejected even though
+# its counts grew.
+cat > "$TMP/dropped.xml" <<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <item><sparkle:version>101</sparkle:version><sparkle:channel>beta</sparkle:channel></item>
+    <item><sparkle:version>102</sparkle:version></item>
+  </channel>
+</rss>
+XML
+if assert_old_items_preserved "$TMP/fixture.xml" "$TMP/dropped.xml" >/dev/null 2>&1; then
+  fail "assert_old_items_preserved accepted a feed that dropped item 100"
+fi
+echo "ok: dropped item rejected"
 
 if appcast_assert_item "$TMP/fixture.xml" 101 \
   "https://github.com/decentespresso/decaid/releases/download/v2.0.0/decaid-macos-2.0.0.zip" \

--- a/scripts/test_appcast_helpers.sh
+++ b/scripts/test_appcast_helpers.sh
@@ -67,6 +67,18 @@ appcast_assert_item "$TMP/fixture.xml" 101 \
   "https://github.com/decentespresso/decaid/releases/download/v2.0.0/decaid-macos-2.0.0.zip" \
   "beta" && echo "ok: beta item assertions pass"
 
+# --- Count assertions ---
+read -r TOTAL DEFAULT_COUNT <<< "$(appcast_item_counts "$TMP/fixture.xml")"
+[ "$TOTAL" = "2" ] || fail "appcast_item_counts total expected 2, got '$TOTAL'"
+[ "$DEFAULT_COUNT" = "1" ] || fail "appcast_item_counts default expected 1, got '$DEFAULT_COUNT'"
+echo "ok: appcast_item_counts = $TOTAL total, $DEFAULT_COUNT default"
+
+assert_item_counts_not_decreased "$TOTAL $DEFAULT_COUNT" "$TMP/fixture.xml" \
+  && echo "ok: equal counts accepted"
+if assert_item_counts_not_decreased "3 2" "$TMP/fixture.xml" >/dev/null 2>&1; then
+  fail "assert_item_counts_not_decreased accepted a shrunken feed"
+fi
+
 if appcast_assert_item "$TMP/fixture.xml" 101 \
   "https://github.com/decentespresso/decaid/releases/download/v2.0.0/decaid-macos-2.0.0.zip" \
   "stable" >/dev/null 2>&1; then

--- a/scripts/test_appcast_helpers.sh
+++ b/scripts/test_appcast_helpers.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Fixture test for scripts/appcast_helpers.sh. Run from the repo root:
+#   scripts/test_appcast_helpers.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+source scripts/appcast_helpers.sh
+
+FAILURES=0
+fail() { echo "FAIL: $1"; FAILURES=$((FAILURES + 1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- Fixture appcast: stable build 100, beta build 101 ---
+cat > "$TMP/fixture.xml" <<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>Decaid Changelog</title>
+    <item>
+      <title>Version 2.0.0</title>
+      <sparkle:version>101</sparkle:version>
+      <sparkle:channel>beta</sparkle:channel>
+      <enclosure url="https://github.com/decentespresso/decaid/releases/download/v2.0.0/decaid-macos-2.0.0.zip"
+                 sparkle:edSignature="AA==" type="application/octet-stream"/>
+    </item>
+    <item>
+      <title>Version 1.9.0</title>
+      <sparkle:version>100</sparkle:version>
+      <enclosure url="https://github.com/decentespresso/decaid/releases/download/v1.9.0/decaid-macos-1.9.0.zip"
+                 sparkle:edSignature="BB==" type="application/octet-stream"/>
+    </item>
+  </channel>
+</rss>
+XML
+
+MAX="$(appcast_max_build "$TMP/fixture.xml")"
+[ "$MAX" = "101" ] || fail "appcast_max_build expected 101, got '$MAX'"
+echo "ok: appcast_max_build = $MAX"
+
+assert_build_increasing 102 101 && echo "ok: 102 > 101 accepted"
+if assert_build_increasing 101 101 >/dev/null 2>&1; then
+  fail "assert_build_increasing accepted equal build 101"
+fi
+if assert_build_increasing 100 101 >/dev/null 2>&1; then
+  fail "assert_build_increasing accepted lower build 100"
+fi
+
+# --- Fake release ZIP ---
+mkdir -p "$TMP/zip/Decaid.app/Contents"
+cat > "$TMP/zip/Decaid.app/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleShortVersionString</key><string>2.1.0</string>
+  <key>CFBundleVersion</key><string>102</string>
+</dict></plist>
+PLIST
+ditto -c -k --keepParent "$TMP/zip/Decaid.app" "$TMP/decaid-macos-2.1.0.zip"
+
+BUILD="$(zip_read_build "$TMP/decaid-macos-2.1.0.zip")"
+[ "$BUILD" = "102" ] || fail "zip_read_build expected 102, got '$BUILD'"
+echo "ok: zip_read_build = $BUILD"
+
+# --- Item assertions ---
+appcast_assert_item "$TMP/fixture.xml" 101 \
+  "https://github.com/decentespresso/decaid/releases/download/v2.0.0/decaid-macos-2.0.0.zip" \
+  "beta" && echo "ok: beta item assertions pass"
+
+if appcast_assert_item "$TMP/fixture.xml" 101 \
+  "https://github.com/decentespresso/decaid/releases/download/v2.0.0/decaid-macos-2.0.0.zip" \
+  "stable" >/dev/null 2>&1; then
+  fail "appcast_assert_item accepted a beta item as stable"
+fi
+
+if appcast_assert_item "$TMP/fixture.xml" 100 \
+  "https://example.com/wrong.zip" "stable" >/dev/null 2>&1; then
+  fail "appcast_assert_item accepted a wrong enclosure URL"
+fi
+
+if [ "$FAILURES" -ne 0 ]; then
+  echo "$FAILURES assertion(s) failed"
+  exit 1
+fi
+echo "All appcast helper tests passed"

--- a/scripts/verify_macos_signature.sh
+++ b/scripts/verify_macos_signature.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Distribution-signing gates for the Sparkle-enabled macOS build. Runs after
+# scripts/sign_macos_deepest_first.sh and again after notarization/stapling.
+# Usage: verify_macos_signature.sh <Decaid.app> [team-id] [post-staple]
+set -euo pipefail
+
+APP="${1:?usage: verify_macos_signature.sh <Decaid.app> [team-id] [post-staple]}"
+TEAM_ID="${2:-XLS3XF57J8}"
+POST_STAPLE="${3:-0}"
+
+echo "== Gate 1: codesign --verify --deep --strict =="
+codesign --verify --deep --strict --verbose=4 "$APP"
+
+echo "== Gate 2: host Team ID + Hardened Runtime =="
+HOST_DETAILS="$(codesign -d --entitlements :- --verbose=4 "$APP" 2>&1 || true)"
+echo "$HOST_DETAILS" | grep -q "TeamIdentifier=$TEAM_ID" \
+  || { echo "FAIL: host TeamIdentifier is not $TEAM_ID"; echo "$HOST_DETAILS"; exit 1; }
+echo "$HOST_DETAILS" | grep -q "runtime" \
+  || { echo "FAIL: host lacks Hardened Runtime"; echo "$HOST_DETAILS"; exit 1; }
+
+echo "== Gate 3: host entitlements (sandbox, network, Sparkle mach names) =="
+echo "$HOST_DETAILS" | grep -q "com.apple.security.app-sandbox" \
+  || { echo "FAIL: host missing App Sandbox"; exit 1; }
+echo "$HOST_DETAILS" | grep -q "com.apple.security.network.client" \
+  || { echo "FAIL: host missing network client"; exit 1; }
+echo "$HOST_DETAILS" | grep -q "net.tadel.reaprime-spks" \
+  || { echo "FAIL: host missing net.tadel.reaprime-spks mach exception"; exit 1; }
+echo "$HOST_DETAILS" | grep -q "net.tadel.reaprime-spki" \
+  || { echo "FAIL: host missing net.tadel.reaprime-spki mach exception"; exit 1; }
+if echo "$HOST_DETAILS" | grep -q 'PRODUCT_BUNDLE_IDENTIFIER'; then
+  echo "FAIL: unexpanded PRODUCT_BUNDLE_IDENTIFIER leaked into entitlements"
+  exit 1
+fi
+
+echo "== Gate 4: Sparkle components present and signed by the Team =="
+FRAMEWORK="$APP/Contents/Frameworks/Sparkle.framework/Versions/Current"
+for component in \
+  "$FRAMEWORK/XPCServices/Installer.xpc" \
+  "$FRAMEWORK/XPCServices/Downloader.xpc" \
+  "$FRAMEWORK/Updater.app" \
+  "$FRAMEWORK/Autoupdate" \
+  "$APP/Contents/Frameworks/Sparkle.framework"; do
+  [ -e "$component" ] || { echo "FAIL: missing $component"; exit 1; }
+  DETAILS="$(codesign -d --verbose=4 "$component" 2>&1 || true)"
+  echo "$DETAILS" | grep -q "TeamIdentifier=$TEAM_ID" \
+    || { echo "FAIL: $component not signed by $TEAM_ID"; echo "$DETAILS"; exit 1; }
+done
+
+echo "== Gate 5: no get-task-allow in any Sparkle component =="
+for component in \
+  "$FRAMEWORK/XPCServices/Installer.xpc" \
+  "$FRAMEWORK/XPCServices/Downloader.xpc" \
+  "$FRAMEWORK/Updater.app" \
+  "$FRAMEWORK/Autoupdate"; do
+  if codesign -d --entitlements :- "$component" 2>/dev/null | grep -q "get-task-allow"; then
+    echo "FAIL: $component retains get-task-allow in a distribution build"
+    exit 1
+  fi
+done
+
+if [ "$POST_STAPLE" = "1" ]; then
+  echo "== Gate 6: spctl assessment =="
+  spctl --assess --type execute --verbose=4 "$APP" \
+    || { echo "FAIL: spctl rejected the app"; exit 1; }
+  echo "== Gate 7: stapler validate =="
+  xcrun stapler validate "$APP" \
+    || { echo "FAIL: stapler validation failed"; exit 1; }
+fi
+
+echo "== All signing gates passed =="

--- a/test/macos_updater_test.dart
+++ b/test/macos_updater_test.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/android_updater.dart' show UpdateChannel;
+import 'package:reaprime/src/services/macos_updater.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('net.tadel.reaprime/macos_updater');
+  final calls = <MethodCall>[];
+
+  setUp(() {
+    calls.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return null;
+        });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('is a no-op off macOS', () async {
+    final updater = MacOSUpdater(supported: false);
+
+    await updater.configure(
+      automaticChecks: true,
+      channel: UpdateChannel.stable,
+    );
+    await updater.setAutomaticChecks(false);
+    await updater.setChannel(UpdateChannel.beta);
+    await updater.checkForUpdates();
+
+    expect(calls, isEmpty);
+  });
+
+  test('configure sends automaticChecks and channel', () async {
+    final updater = MacOSUpdater(supported: true);
+
+    await updater.configure(automaticChecks: true, channel: UpdateChannel.beta);
+
+    expect(calls, hasLength(1));
+    expect(calls.single.method, 'configure');
+    expect(calls.single.arguments, {
+      'automaticChecks': true,
+      'channel': 'beta',
+    });
+  });
+
+  test('setAutomaticChecks sends the enabled flag', () async {
+    final updater = MacOSUpdater(supported: true);
+
+    await updater.setAutomaticChecks(false);
+
+    expect(calls, hasLength(1));
+    expect(calls.single.method, 'setAutomaticChecks');
+    expect(calls.single.arguments, {'enabled': false});
+  });
+
+  test('setChannel sends the channel name', () async {
+    final updater = MacOSUpdater(supported: true);
+
+    await updater.setChannel(UpdateChannel.stable);
+
+    expect(calls, hasLength(1));
+    expect(calls.single.method, 'setChannel');
+    expect(calls.single.arguments, {'channel': 'stable'});
+  });
+
+  test('checkForUpdates sends no arguments', () async {
+    final updater = MacOSUpdater(supported: true);
+
+    await updater.checkForUpdates();
+
+    expect(calls, hasLength(1));
+    expect(calls.single.method, 'checkForUpdates');
+    expect(calls.single.arguments, isNull);
+  });
+
+  test('defaults isSupported to the host platform', () {
+    final updater = MacOSUpdater();
+    expect(updater.isSupported, Platform.isMacOS);
+  });
+}

--- a/test/macos_updater_test.dart
+++ b/test/macos_updater_test.dart
@@ -37,23 +37,71 @@ void main() {
     await updater.checkForUpdates();
 
     expect(calls, isEmpty);
+    expect(updater.isAvailable, isFalse);
   });
 
-  test('configure sends automaticChecks and channel', () async {
+  test('starts unavailable until configure succeeds', () async {
+    final updater = MacOSUpdater(supported: true);
+    expect(updater.isAvailable, isFalse);
+
+    await updater.setAutomaticChecks(false);
+    await updater.setChannel(UpdateChannel.beta);
+    await updater.checkForUpdates();
+
+    // All commands no-op before the native side is configured.
+    expect(calls, isEmpty);
+  });
+
+  test(
+    'configure sends automaticChecks and channel and marks available',
+    () async {
+      final updater = MacOSUpdater(supported: true);
+
+      await updater.configure(
+        automaticChecks: true,
+        channel: UpdateChannel.beta,
+      );
+
+      expect(updater.isAvailable, isTrue);
+      expect(calls, hasLength(1));
+      expect(calls.single.method, 'configure');
+      expect(calls.single.arguments, {
+        'automaticChecks': true,
+        'channel': 'beta',
+      });
+    },
+  );
+
+  test('a failed configure stays unavailable and rethrows', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          if (call.method == 'configure') {
+            throw PlatformException(code: 'configure_failed');
+          }
+          calls.add(call);
+          return null;
+        });
     final updater = MacOSUpdater(supported: true);
 
-    await updater.configure(automaticChecks: true, channel: UpdateChannel.beta);
+    await expectLater(
+      updater.configure(automaticChecks: true, channel: UpdateChannel.stable),
+      throwsA(isA<PlatformException>()),
+    );
+    expect(updater.isAvailable, isFalse);
 
-    expect(calls, hasLength(1));
-    expect(calls.single.method, 'configure');
-    expect(calls.single.arguments, {
-      'automaticChecks': true,
-      'channel': 'beta',
-    });
+    // Commands stay no-ops after the failure.
+    await updater.setAutomaticChecks(false);
+    await updater.checkForUpdates();
+    expect(calls, isEmpty);
   });
 
   test('setAutomaticChecks sends the enabled flag', () async {
     final updater = MacOSUpdater(supported: true);
+    await updater.configure(
+      automaticChecks: true,
+      channel: UpdateChannel.stable,
+    );
+    calls.clear();
 
     await updater.setAutomaticChecks(false);
 
@@ -64,6 +112,11 @@ void main() {
 
   test('setChannel sends the channel name', () async {
     final updater = MacOSUpdater(supported: true);
+    await updater.configure(
+      automaticChecks: true,
+      channel: UpdateChannel.stable,
+    );
+    calls.clear();
 
     await updater.setChannel(UpdateChannel.stable);
 
@@ -74,6 +127,11 @@ void main() {
 
   test('checkForUpdates sends no arguments', () async {
     final updater = MacOSUpdater(supported: true);
+    await updater.configure(
+      automaticChecks: true,
+      channel: UpdateChannel.stable,
+    );
+    calls.clear();
 
     await updater.checkForUpdates();
 

--- a/test/settings/settings_view_updates_test.dart
+++ b/test/settings/settings_view_updates_test.dart
@@ -42,10 +42,14 @@ Future<(UpdateCheckService, _RecordingUpdater)> _pumpSettingsView(
   List<MethodCall> calls, {
   required bool macos,
   bool initializeService = false,
+  bool sparkleConfigureFails = false,
 }) async {
   TestWidgetsFlutterBinding.ensureInitialized();
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(_channel, (call) async {
+        if (sparkleConfigureFails && call.method == 'configure') {
+          throw PlatformException(code: 'configure_failed');
+        }
         calls.add(call);
         return null;
       });
@@ -70,6 +74,14 @@ Future<(UpdateCheckService, _RecordingUpdater)> _pumpSettingsView(
     await updateCheckService.initialize();
   }
 
+  final macosUpdater = MacOSUpdater(supported: macos);
+  try {
+    await macosUpdater.configure(
+      automaticChecks: settingsController.automaticUpdateCheck,
+      channel: settingsController.updateChannel,
+    );
+  } catch (_) {}
+
   // ShadApp provides no ScaffoldMessenger (WidgetsApp-based); SettingsView's
   // own Scaffold supplies the Material ancestor, so only the messenger needs
   // wrapping here.
@@ -79,7 +91,7 @@ Future<(UpdateCheckService, _RecordingUpdater)> _pumpSettingsView(
         child: SettingsView(
           controller: settingsController,
           updateCheckService: updateCheckService,
-          macosUpdater: MacOSUpdater(supported: macos),
+          macosUpdater: macosUpdater,
           presenceController: presenceController,
           webUIStorage: webUIStorage,
         ),
@@ -200,6 +212,65 @@ void main() {
       );
       await tester.pump(const Duration(hours: 13));
       expect(updater.checkCalls, 2);
+    });
+
+    testWidgets('macOS manual check falls back to the Dart path when Sparkle '
+        'configure failed', (tester) async {
+      final calls = <MethodCall>[];
+      await _pumpSettingsView(
+        tester,
+        calls,
+        macos: true,
+        sparkleConfigureFails: true,
+      );
+
+      await tester.tap(find.text('Check for updates'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // No Sparkle delegation: the failed configure disabled the capability.
+      expect(calls.where((c) => c.method == 'checkForUpdates'), isEmpty);
+      expect(find.text('Checking for updates...'), findsOneWidget);
+
+      // The Dart fallback keeps the existing Snackbar flow.
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.text('You are on the latest version'), findsOneWidget);
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pump(const Duration(milliseconds: 300));
+    });
+
+    testWidgets('macOS toggle still updates the Dart scheduler when Sparkle '
+        'configure failed', (tester) async {
+      final calls = <MethodCall>[];
+      final (_, updater) = await _pumpSettingsView(
+        tester,
+        calls,
+        macos: true,
+        sparkleConfigureFails: true,
+      );
+
+      // Initial switch value is on; toggle off, then on, then off so no
+      // periodic timer is left pending.
+      await tester.tap(
+        find.widgetWithText(ShadSwitch, 'Automatic update checks'),
+      );
+      await tester.pump();
+      expect(updater.checkCalls, 0); // disable does not check
+
+      await tester.tap(
+        find.widgetWithText(ShadSwitch, 'Automatic update checks'),
+      );
+      await tester.pump();
+      expect(updater.checkCalls, 1); // enable ran the Dart service
+
+      await tester.tap(
+        find.widgetWithText(ShadSwitch, 'Automatic update checks'),
+      );
+      await tester.pump();
+
+      // No Sparkle calls at all in the degraded state.
+      expect(calls.where((c) => c.method == 'setAutomaticChecks'), isEmpty);
     });
 
     testWidgets('non-macOS manual check keeps the existing Snackbar flow', (

--- a/test/settings/settings_view_updates_test.dart
+++ b/test/settings/settings_view_updates_test.dart
@@ -43,14 +43,19 @@ Future<(UpdateCheckService, _RecordingUpdater)> _pumpSettingsView(
   required bool macos,
   bool initializeService = false,
   bool sparkleConfigureFails = false,
+  bool sparkleCheckThrows = false,
+  bool serviceIsMacOS = false,
 }) async {
   TestWidgetsFlutterBinding.ensureInitialized();
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(_channel, (call) async {
+        calls.add(call);
         if (sparkleConfigureFails && call.method == 'configure') {
           throw PlatformException(code: 'configure_failed');
         }
-        calls.add(call);
+        if (sparkleCheckThrows && call.method == 'checkForUpdates') {
+          throw PlatformException(code: 'check_failed');
+        }
         return null;
       });
 
@@ -68,7 +73,7 @@ Future<(UpdateCheckService, _RecordingUpdater)> _pumpSettingsView(
     webUIStorage: webUIStorage,
     updater: updater,
     platformIsAndroid: false,
-    platformIsMacOS: false,
+    platformIsMacOS: serviceIsMacOS,
   );
   if (initializeService) {
     await updateCheckService.initialize();
@@ -214,31 +219,60 @@ void main() {
       expect(updater.checkCalls, 2);
     });
 
-    testWidgets('macOS manual check falls back to the Dart path when Sparkle '
-        'configure failed', (tester) async {
-      final calls = <MethodCall>[];
-      await _pumpSettingsView(
-        tester,
-        calls,
-        macos: true,
-        sparkleConfigureFails: true,
-      );
+    testWidgets(
+      'macOS manual check with Sparkle unavailable shows the manual-download '
+      'dialog instead of a false latest-version claim',
+      (tester) async {
+        final calls = <MethodCall>[];
+        final (_, updater) = await _pumpSettingsView(
+          tester,
+          calls,
+          macos: true,
+          sparkleConfigureFails: true,
+          // A real macOS service would no-op app checks; the degraded path
+          // must never route through it or claim "latest version".
+          serviceIsMacOS: true,
+        );
 
-      await tester.tap(find.text('Check for updates'));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
+        await tester.tap(find.text('Check for updates'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
 
-      // No Sparkle delegation: the failed configure disabled the capability.
-      expect(calls.where((c) => c.method == 'checkForUpdates'), isEmpty);
-      expect(find.text('Checking for updates...'), findsOneWidget);
+        // No Sparkle delegation and no APK/GitHub application check.
+        expect(calls.where((c) => c.method == 'checkForUpdates'), isEmpty);
+        expect(updater.checkCalls, 0);
 
-      // The Dart fallback keeps the existing Snackbar flow.
-      await tester.pump(const Duration(seconds: 4));
-      await tester.pump(const Duration(milliseconds: 300));
-      expect(find.text('You are on the latest version'), findsOneWidget);
-      await tester.pump(const Duration(seconds: 4));
-      await tester.pump(const Duration(milliseconds: 300));
-    });
+        // Explicit manual-download prompt, not a false "latest version".
+        expect(find.text('Checking for updates...'), findsNothing);
+        expect(find.text('You are on the latest version'), findsNothing);
+        expect(find.text('Auto-update unavailable'), findsOneWidget);
+        expect(find.text('Open Releases'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'macOS manual check shows failure feedback when Sparkle throws',
+      (tester) async {
+        final calls = <MethodCall>[];
+        await _pumpSettingsView(
+          tester,
+          calls,
+          macos: true,
+          sparkleCheckThrows: true,
+        );
+
+        await tester.tap(find.text('Check for updates'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(calls.where((c) => c.method == 'checkForUpdates'), hasLength(1));
+        expect(find.textContaining('Update check failed'), findsOneWidget);
+
+        // Let the Snackbar expire so no timer is left pending.
+        await tester.pump(const Duration(seconds: 4));
+        await tester.pump(const Duration(milliseconds: 300));
+      },
+    );
 
     testWidgets('macOS toggle still updates the Dart scheduler when Sparkle '
         'configure failed', (tester) async {

--- a/test/settings/settings_view_updates_test.dart
+++ b/test/settings/settings_view_updates_test.dart
@@ -1,0 +1,158 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/presence_controller.dart';
+import 'package:reaprime/src/services/android_updater.dart';
+import 'package:reaprime/src/services/macos_updater.dart';
+import 'package:reaprime/src/services/update_check_service.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/settings/settings_view.dart';
+import 'package:reaprime/src/webui_support/webui_storage.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+import '../helpers/mock_settings_service.dart';
+
+/// The SettingsView branches on the host platform. The macOS Sparkle path is
+/// only exercised when the test host is macOS; the Android dialog flow is
+/// covered by the Android-only tests elsewhere.
+final bool isMacOSHost = Platform.isMacOS;
+
+class _NoopUpdater extends AndroidUpdater {
+  _NoopUpdater() : super(owner: 'tadelv', repo: 'reaprime');
+  @override
+  Future<UpdateInfo?> checkForUpdate(
+    String v, {
+    UpdateChannel channel = UpdateChannel.stable,
+  }) async => null;
+  @override
+  void dispose() {}
+}
+
+const _channel = MethodChannel('net.tadel.reaprime/macos_updater');
+
+Future<UpdateCheckService> _pumpSettingsView(
+  WidgetTester tester,
+  List<MethodCall> calls,
+) async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(_channel, (call) async {
+        calls.add(call);
+        return null;
+      });
+
+  final settingsController = SettingsController(MockSettingsService());
+  await settingsController.loadSettings();
+
+  final presenceController = PresenceController(
+    de1Controller: De1Controller(controller: DeviceController(const [])),
+    settingsController: settingsController,
+  );
+  final webUIStorage = WebUIStorage(settingsController);
+  final updateCheckService = UpdateCheckService(
+    settingsService: MockSettingsService(),
+    webUIStorage: webUIStorage,
+    updater: _NoopUpdater(),
+    platformIsAndroid: false,
+    platformIsMacOS: false,
+  );
+
+  await tester.pumpWidget(
+    ShadApp(
+      home: SettingsView(
+        controller: settingsController,
+        updateCheckService: updateCheckService,
+        macosUpdater: MacOSUpdater(supported: isMacOSHost),
+        presenceController: presenceController,
+        webUIStorage: webUIStorage,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  addTearDown(() {
+    updateCheckService.dispose();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_channel, null);
+  });
+
+  return updateCheckService;
+}
+
+void main() {
+  group('SettingsView updates', () {
+    testWidgets(
+      'macOS manual check delegates to Sparkle without a Snackbar',
+      (tester) async {
+        final calls = <MethodCall>[];
+        await _pumpSettingsView(tester, calls);
+
+        await tester.tap(find.text('Check for updates'));
+        await tester.pumpAndSettle();
+
+        expect(calls.where((c) => c.method == 'checkForUpdates'), hasLength(1));
+        expect(find.text('Checking for updates...'), findsNothing);
+        expect(find.text('You are on the latest version'), findsNothing);
+      },
+      skip: !isMacOSHost,
+    );
+
+    testWidgets('macOS automatic-check toggle calls setAutomaticChecks', (
+      tester,
+    ) async {
+      final calls = <MethodCall>[];
+      await _pumpSettingsView(tester, calls);
+
+      await tester.tap(
+        find.widgetWithText(ShadSwitch, 'Automatic update checks'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        calls.where((c) => c.method == 'setAutomaticChecks'),
+        hasLength(1),
+      );
+      expect(
+        (calls.lastWhere((c) => c.method == 'setAutomaticChecks').arguments
+            as Map)['enabled'],
+        isFalse,
+      );
+    }, skip: !isMacOSHost);
+
+    testWidgets('macOS channel change calls setChannel', (tester) async {
+      final calls = <MethodCall>[];
+      await _pumpSettingsView(tester, calls);
+
+      await tester.tap(find.text('Update channel'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Beta'));
+      await tester.pumpAndSettle();
+
+      expect(calls.where((c) => c.method == 'setChannel'), hasLength(1));
+      expect(
+        (calls.lastWhere((c) => c.method == 'setChannel').arguments
+            as Map)['channel'],
+        'beta',
+      );
+    }, skip: !isMacOSHost);
+
+    testWidgets('non-macOS manual check keeps the existing Snackbar flow', (
+      tester,
+    ) async {
+      final calls = <MethodCall>[];
+      await _pumpSettingsView(tester, calls);
+
+      await tester.tap(find.text('Check for updates'));
+      await tester.pumpAndSettle();
+
+      // No Sparkle delegation on non-macOS hosts.
+      expect(calls.where((c) => c.method == 'checkForUpdates'), isEmpty);
+      // The fake updater reports no update, so the misleading-path is the
+      // existing "latest version" Snackbar.
+      expect(find.text('You are on the latest version'), findsOneWidget);
+    }, skip: isMacOSHost);
+  });
+}

--- a/test/settings/settings_view_updates_test.dart
+++ b/test/settings/settings_view_updates_test.dart
@@ -1,5 +1,4 @@
-import 'dart:io';
-
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
@@ -15,28 +14,35 @@ import 'package:shadcn_ui/shadcn_ui.dart';
 
 import '../helpers/mock_settings_service.dart';
 
-/// The SettingsView branches on the host platform. The macOS Sparkle path is
-/// only exercised when the test host is macOS; the Android dialog flow is
-/// covered by the Android-only tests elsewhere.
-final bool isMacOSHost = Platform.isMacOS;
+/// The SettingsView branches on the injected `macosUpdater.isSupported`
+/// capability, so both the macOS (Sparkle) and the Dart-service paths run on
+/// every test host. The harness's Dart service uses `platformIsMacOS: false`
+/// so its reactions (immediate checks, timers) stay observable.
+class _RecordingUpdater extends AndroidUpdater {
+  _RecordingUpdater() : super(owner: 'tadelv', repo: 'reaprime');
+  int checkCalls = 0;
 
-class _NoopUpdater extends AndroidUpdater {
-  _NoopUpdater() : super(owner: 'tadelv', repo: 'reaprime');
   @override
   Future<UpdateInfo?> checkForUpdate(
     String v, {
     UpdateChannel channel = UpdateChannel.stable,
-  }) async => null;
+  }) async {
+    checkCalls++;
+    return null;
+  }
+
   @override
   void dispose() {}
 }
 
 const _channel = MethodChannel('net.tadel.reaprime/macos_updater');
 
-Future<UpdateCheckService> _pumpSettingsView(
+Future<(UpdateCheckService, _RecordingUpdater)> _pumpSettingsView(
   WidgetTester tester,
-  List<MethodCall> calls,
-) async {
+  List<MethodCall> calls, {
+  required bool macos,
+  bool initializeService = false,
+}) async {
   TestWidgetsFlutterBinding.ensureInitialized();
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(_channel, (call) async {
@@ -52,22 +58,31 @@ Future<UpdateCheckService> _pumpSettingsView(
     settingsController: settingsController,
   );
   final webUIStorage = WebUIStorage(settingsController);
+  final updater = _RecordingUpdater();
   final updateCheckService = UpdateCheckService(
     settingsService: MockSettingsService(),
     webUIStorage: webUIStorage,
-    updater: _NoopUpdater(),
+    updater: updater,
     platformIsAndroid: false,
     platformIsMacOS: false,
   );
+  if (initializeService) {
+    await updateCheckService.initialize();
+  }
 
+  // ShadApp provides no ScaffoldMessenger (WidgetsApp-based); SettingsView's
+  // own Scaffold supplies the Material ancestor, so only the messenger needs
+  // wrapping here.
   await tester.pumpWidget(
     ShadApp(
-      home: SettingsView(
-        controller: settingsController,
-        updateCheckService: updateCheckService,
-        macosUpdater: MacOSUpdater(supported: isMacOSHost),
-        presenceController: presenceController,
-        webUIStorage: webUIStorage,
+      home: ScaffoldMessenger(
+        child: SettingsView(
+          controller: settingsController,
+          updateCheckService: updateCheckService,
+          macosUpdater: MacOSUpdater(supported: macos),
+          presenceController: presenceController,
+          webUIStorage: webUIStorage,
+        ),
       ),
     ),
   );
@@ -79,32 +94,30 @@ Future<UpdateCheckService> _pumpSettingsView(
         .setMockMethodCallHandler(_channel, null);
   });
 
-  return updateCheckService;
+  return (updateCheckService, updater);
 }
 
 void main() {
   group('SettingsView updates', () {
-    testWidgets(
-      'macOS manual check delegates to Sparkle without a Snackbar',
-      (tester) async {
-        final calls = <MethodCall>[];
-        await _pumpSettingsView(tester, calls);
+    testWidgets('macOS manual check delegates to Sparkle without a Snackbar', (
+      tester,
+    ) async {
+      final calls = <MethodCall>[];
+      await _pumpSettingsView(tester, calls, macos: true);
 
-        await tester.tap(find.text('Check for updates'));
-        await tester.pumpAndSettle();
+      await tester.tap(find.text('Check for updates'));
+      await tester.pumpAndSettle();
 
-        expect(calls.where((c) => c.method == 'checkForUpdates'), hasLength(1));
-        expect(find.text('Checking for updates...'), findsNothing);
-        expect(find.text('You are on the latest version'), findsNothing);
-      },
-      skip: !isMacOSHost,
-    );
+      expect(calls.where((c) => c.method == 'checkForUpdates'), hasLength(1));
+      expect(find.text('Checking for updates...'), findsNothing);
+      expect(find.text('You are on the latest version'), findsNothing);
+    });
 
     testWidgets('macOS automatic-check toggle calls setAutomaticChecks', (
       tester,
     ) async {
       final calls = <MethodCall>[];
-      await _pumpSettingsView(tester, calls);
+      await _pumpSettingsView(tester, calls, macos: true);
 
       await tester.tap(
         find.widgetWithText(ShadSwitch, 'Automatic update checks'),
@@ -120,11 +133,11 @@ void main() {
             as Map)['enabled'],
         isFalse,
       );
-    }, skip: !isMacOSHost);
+    });
 
     testWidgets('macOS channel change calls setChannel', (tester) async {
       final calls = <MethodCall>[];
-      await _pumpSettingsView(tester, calls);
+      await _pumpSettingsView(tester, calls, macos: true);
 
       await tester.tap(find.text('Update channel'));
       await tester.pumpAndSettle();
@@ -137,22 +150,82 @@ void main() {
             as Map)['channel'],
         'beta',
       );
-    }, skip: !isMacOSHost);
+    });
+
+    testWidgets('macOS toggle after initialization drives Sparkle and the Dart '
+        'skin scheduler', (tester) async {
+      final calls = <MethodCall>[];
+      final (_, updater) = await _pumpSettingsView(
+        tester,
+        calls,
+        macos: true,
+        initializeService: true,
+      );
+
+      // initialize() with automatic checks on ran one immediate check.
+      expect(updater.checkCalls, 1);
+
+      // Toggle OFF: Sparkle scheduling stops AND the Dart timer must stop.
+      await tester.tap(
+        find.widgetWithText(ShadSwitch, 'Automatic update checks'),
+      );
+      await tester.pump();
+      expect(
+        (calls.lastWhere((c) => c.method == 'setAutomaticChecks').arguments
+            as Map)['enabled'],
+        isFalse,
+      );
+      await tester.pump(const Duration(hours: 13));
+      expect(updater.checkCalls, 1); // no periodic check after disable
+
+      // Toggle ON: both surfaces update and the Dart timer restarts. No
+      // immediate check (the last one is fresh); the timer firing at +13h is
+      // the proof the periodic scheduler is back.
+      await tester.tap(
+        find.widgetWithText(ShadSwitch, 'Automatic update checks'),
+      );
+      await tester.pump();
+      expect(
+        (calls.lastWhere((c) => c.method == 'setAutomaticChecks').arguments
+            as Map)['enabled'],
+        isTrue,
+      );
+      expect(updater.checkCalls, 1);
+      await tester.pump(const Duration(hours: 13));
+      expect(updater.checkCalls, 2); // periodic timer ran
+
+      // Toggle OFF again so no timer is left pending.
+      await tester.tap(
+        find.widgetWithText(ShadSwitch, 'Automatic update checks'),
+      );
+      await tester.pump(const Duration(hours: 13));
+      expect(updater.checkCalls, 2);
+    });
 
     testWidgets('non-macOS manual check keeps the existing Snackbar flow', (
       tester,
     ) async {
       final calls = <MethodCall>[];
-      await _pumpSettingsView(tester, calls);
+      await _pumpSettingsView(tester, calls, macos: false);
 
       await tester.tap(find.text('Check for updates'));
-      await tester.pumpAndSettle();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.text('Checking for updates...'), findsOneWidget);
 
-      // No Sparkle delegation on non-macOS hosts.
+      // No Sparkle delegation without the capability.
       expect(calls.where((c) => c.method == 'checkForUpdates'), isEmpty);
-      // The fake updater reports no update, so the misleading-path is the
-      // existing "latest version" Snackbar.
+
+      // The fake updater reports no update; the "latest version" Snackbar is
+      // queued behind the "checking" one. Let the first expire, then the
+      // second becomes visible.
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pump(const Duration(milliseconds: 300));
       expect(find.text('You are on the latest version'), findsOneWidget);
-    }, skip: isMacOSHost);
+
+      // Let the second Snackbar expire so no timer is left pending.
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pump(const Duration(milliseconds: 300));
+    });
   });
 }

--- a/test/update_check_service_test.dart
+++ b/test/update_check_service_test.dart
@@ -76,7 +76,7 @@ void main() {
   late MockSettingsService settingsService;
   late WebUIStorage webUIStorage;
 
-  UpdateCheckService build({bool isAndroid = true}) {
+  UpdateCheckService build({bool isAndroid = true, bool isMacOS = false}) {
     updater = _FakeUpdater();
     settingsService = MockSettingsService();
     final settingsController = SettingsController(settingsService);
@@ -86,6 +86,7 @@ void main() {
       webUIStorage: webUIStorage,
       updater: updater,
       platformIsAndroid: isAndroid,
+      platformIsMacOS: isMacOS,
     );
   }
 
@@ -293,6 +294,43 @@ void main() {
 
       // Only the auto-check from downloadAndInstall ran.
       expect(checksDuring, 1);
+      svc.dispose();
+    });
+  });
+
+  group('macOS (Sparkle owns app updates)', () {
+    test('checkForUpdate is a no-op and leaves the state idle', () async {
+      final svc = build(isMacOS: true);
+      updater.nextCheck = _update();
+
+      final result = await svc.checkForUpdate();
+
+      expect(result, isNull);
+      expect(updater.checkCalls, 0);
+      expect(svc.currentState.phase, AppUpdatePhase.idle);
+      expect(svc.currentState.installable, isFalse);
+      svc.dispose();
+    });
+
+    test('requestCheck does not run the APK-based check', () async {
+      final svc = build(isMacOS: true);
+
+      await svc.requestCheck();
+
+      expect(updater.checkCalls, 0);
+      expect(svc.currentState.phase, AppUpdatePhase.idle);
+      svc.dispose();
+    });
+
+    test('initialize schedules skin refresh without an APK check', () async {
+      final svc = build(isMacOS: true);
+
+      // Automatic checks default on; the periodic path must skip the APK
+      // check while still refreshing skins. The network attempt is swallowed
+      // by _updateSkins, so this only asserts the scheduling choice.
+      await svc.initialize();
+
+      expect(updater.checkCalls, 0);
       svc.dispose();
     });
   });

--- a/test/update_handler_test.dart
+++ b/test/update_handler_test.dart
@@ -33,6 +33,7 @@ void main() {
       webUIStorage: WebUIStorage(settingsController),
       updater: _NoopUpdater(),
       platformIsAndroid: isAndroid,
+      platformIsMacOS: false,
     );
   }
 


### PR DESCRIPTION
## Summary

> **Naming:** The display name is **Decaid**. The Dart package, bundle ID, database, and plugin extension retain legacy identifiers for compatibility — see the naming table in [`CLAUDE.md`](CLAUDE.md).

- Problem: macOS Decaid had no auto-update path; Android already self-updates via GitHub Releases (#521). SideStep's updater replaces the app through an unsandboxed shell process, which is incompatible with Decaid's App Sandbox.
- Why it matters: macOS users must manually download and replace the app for every release; P2 requirement for Decaid 1.0.
- What changed: integrated Sparkle 2.9.5 via Swift Package Manager using its sandboxed Installer XPC service (keeps App Sandbox), a signed appcast hosted on GitHub Pages with Stable/Beta channels, Flutter Settings as the control surface, and a `publish-appcast` CI job that refuses non-increasing `CFBundleVersion` values.
- What did NOT change (scope boundary): App Sandbox stays enabled (no data-container migration); Android updater untouched; REST/WS update API still reports macOS in-app install as unsupported; no custom update dialog; no delta updates; no Mac App Store handling.

## Change Type (select all)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [x] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [x] UI / Flutter widgets
- [ ] Storage / Drift database
- [x] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Refs #521 (not closed: the plan requires a notarized baseline-to-newer update
  to succeed before #521 is closed; see Release Blocker below)
- Related #508 (explicitly not pulled in — sandbox/data location unchanged)

## Root Cause (if bug fix)

N/A — feature.

## Regression Test Plan (if bug fix or refactor)

N/A — feature. New behavior is covered by:
- `macos/RunnerTests/RunnerTests.swift` (8 XCTests: channel mapping, idempotent configure, migration marker, cycle reset, check delegation)
- `test/macos_updater_test.dart` (MethodChannel bridge incl. off-macOS no-op)
- `test/update_check_service_test.dart` (macOS skips APK checks, keeps skin scheduling)
- `test/settings/settings_view_updates_test.dart` (Settings delegates to Sparkle, no false Snackbar)
- `scripts/test_appcast_helpers.sh` (feed monotonicity + Stable/Beta item assertions)

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A — no docs affected (REST/WS surface unchanged). `doc/RELEASE.md` and `doc/AI_BUILD_NOTES.md` were updated for the new release flow and signing footguns.

## Security Impact (required)

- New or changed REST endpoints? (`No`)
- New or changed WebSocket topics? (`No`)
- New or changed network calls? (`Yes` — macOS app fetches the signed appcast from `decentespresso.github.io` and downloads update ZIPs from GitHub Releases)
- BLE/USB surface changed? (`No`)
- File system access changed? (`Yes` — Sparkle's Installer XPC replaces `Decaid.app` outside the host sandbox; the host itself keeps App Sandbox and gains only `-spks`/`-spki` mach-lookup exceptions)
- Plugin sandbox boundary changed? (`No`)
- If any `Yes`, explain risk and mitigation:
  - Feed and archives are EdDSA-signed (`SURequireSignedFeed`, `SUVerifyUpdateBeforeExtraction`, per-item `edSignature`); Sparkle verifies the Apple code-signing continuity (Team ID `XLS3XF57J8`) before installing. Tampered feeds/archives are rejected before extraction.
  - Release CI signs Sparkle's nested helpers deepest-first with Developer ID (never `codesign --deep`) and runs 7 verification gates pre/post notarization.

## User-Visible Changes

macOS only:
- Automatic update checks every 12 h by default (Sparkle owns scheduling; no duplicate Dart check).
- Settings → "Automatic update checks" switch now drives Sparkle; "Update channel" (Stable/Beta) re-resolves the feed; "Check for updates" opens Sparkle's native update UI (the previous "You are on the latest version" Snackbar no longer shows on macOS).
- Stable channel sees only default-channel releases; Beta sees Beta + Stable.
- First Sparkle-enabled release is a baseline: older Decaid macOS builds cannot self-update into it (manual ZIP install once).

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — no remaining changes
- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — 2770 pass, 1 platform-skip (non-macOS SettingsView path)
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds
- [x] `xcodebuild test -workspace macos/Runner.xcworkspace -scheme Runner` — 8 XCTests pass
- [x] `flutter build macos --release` — succeeds; Sparkle.framework + Installer.xpc embedded; SU keys present

### Manual verification (if applicable)

- OS / platform tested: macOS 26.4 (local), Xcode 26.4
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: signing pipeline end-to-end with a Team `XLS3XF57J8` identity (deepest-first sign + all 5 pre-notarization gates pass; ad-hoc build correctly rejected); `scripts/publish_appcast.sh` exercised against real Sparkle 2.9.5 `generate_appcast` for Stable + Beta feeds with monotonicity rejection; appcast helper fixture tests.
- Edge cases checked: non-increasing `CFBundleVersion` rejection (beta→stable from same commit); missing-item and wrong-channel/wrong-URL feed assertions; off-macOS bridge no-op; duplicate channel change does not reset the update cycle.
- What you did **not** verify: Apple notarization (needs CI credentials), a live two-build update/relaunch through the Installer XPC (Phase 4 — needs two Developer-ID-notarized builds), and a full tagged-release workflow run on GitHub Actions.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? (`No`) — the first Sparkle-enabled macOS release is a baseline: older builds cannot self-update into it; one manual ZIP install is required. After that, updates are automatic. Android/Windows/Linux behavior unchanged.
- Config / env changes needed? (`Yes`) — one-time maintainer setup documented in `doc/RELEASE.md`: store the Sparkle EdDSA private key as the `SPARKLE_ED_PRIVATE_KEY` secret, enable GitHub Pages (source: **Deploy from a branch** → `gh-pages` / root — the `publish-appcast` job maintains that branch), set the `SPARKLE_APPCAST_BOOTSTRAP` repo variable for the one-time first feed, and verify the appcast URL is reachable.
- Database migration needed? (`No`)

## Release Blocker (required before closing #521)

The most important behavior is unverified without real notarized builds: XPC
installation, relaunch, retained data/settings, Stable/Beta channel selection,
and tamper rejection. Before the first public Sparkle-enabled release (and
before closing #521), run the 8-step notarized two-build acceptance procedure
documented in `doc/RELEASE.md` (full detail in the archived plan,
`doc/plans/archive/521-macos-auto-update-sparkle/` Phase 4): manual check on
both channels, accept + relaunch with unchanged bundle ID and settings,
baseline-to-newer update on both channels, and one-byte-tamper / wrong-key
rejection. Merge may proceed ahead of this, but the release must not ship until
it passes.

## Risks & Mitigations

- Risk: first release could be signed with a mismatched EdDSA key (secret vs `SUPublicEDKey` in Info.plist) → Sparkle rejects the feed for everyone.
  - Mitigation: `publish-appcast` fails fast in CI on key mismatch; feed rollback = remove the latest appcast item (documented in `doc/RELEASE.md`).
- Risk: notarization or XPC install fails on first real release (only unit-verified locally).
  - Mitigation: signing gates + notarization in CI before the ZIP is published; the appcast job only runs after `create-release` succeeds; Phase 4 two-build smoke test documented as the final acceptance gate.
- Risk: beta→stable tags cut from the same commit produce equal `CFBundleVersion` values, so Sparkle could not select the stable update.
  - Mitigation: the appcast job hard-fails on non-increasing build numbers rather than publishing an unselectable item.


