### PR TITLE
feat: bundle the MSL skin

### DIFF
--- a/skin_sources.json
+++ b/skin_sources.json
@@ -26,5 +26,9 @@
   {
     "type": "github_release",
     "repo": "decentespresso/insight-js"
+  },
+  {
+    "type": "github_release",
+    "repo": "allofmeng/MSL"
   }
 ]


### PR DESCRIPTION
## Summary

- Problem: MSL ([allofmeng/MSL](https://github.com/allofmeng/MSL)) is a streamline.js-inspired WebUI skin that ships tagged releases, but it is not offered as a skin option in the app.
- Why it matters: users have to sideload it instead of picking it from the bundled skin list.
- What changed: one `github_release` entry for `allofmeng/MSL` in `skin_sources.json`. `bundle_skins.sh` picks it up with no code change — same path as the other seven sources.
- What did NOT change (scope boundary): no bundler logic, no skin install/serve code, no other skin sources. The skin is bundled at its latest release, unpinned, like every other entry.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [x] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [x] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [x] CI / build / infra
- [ ] Docs / specs

## Linked Issues

- Closes #
- Related #

## Root Cause (if bug fix)

N/A

## Regression Test Plan (if bug fix or refactor)

N/A — data-only config addition. Existing coverage already applies: `test/webui_storage_bundled_test.dart` asserts `skin_sources.json` parses into typed source configs and that the generated `assets/bundled_skins/manifest.json` is a non-empty list of skin IDs. `bundle_skins.sh` itself exits non-zero if any source fails to fetch, so a bad repo/asset breaks the build loudly rather than silently shipping seven skins.

## Documentation Obligations (required)

- [ ] API spec updated
- [ ] API docs updated: `doc/Api.md`
- [ ] Plugin docs updated: `doc/Plugins.md`
- [ ] Skin docs updated: `doc/Skins.md`
- [ ] Profile docs updated: `doc/Profiles.md`
- [ ] Device docs updated: `doc/DeviceManagement.md`
- [x] N/A — no docs affected (`doc/Skins.md` documents the skin API, not the bundled-skin roster; no doc enumerates the sources)

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `Yes` — build-time only: `bundle_skins.sh` now fetches one more GitHub release asset from the public `allofmeng/MSL` repo. No runtime network change.
- BLE/USB surface changed? `No`
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`

Worth naming: bundling a skin means shipping third-party JS/CSS inside the app. MSL is served through the same WebUI storage path and origin protections as the other bundled skins, and the zip carries no `node_modules` (the bundler strips those for notarization anyway).

## User-Visible Changes

MSL appears as an additional skin option in the bundled skin list (skin id `msl`, display name `MSL`, currently `v0.0.6`).

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — no Dart touched, no changes
- [x] `flutter analyze` — `No issues found!`
- [x] `flutter test` — 2777 passing; 4 failures are pre-existing on clean `main` (see Evidence)
- [x] `./bundle_skins.sh` — 8 skins bundled, MSL among them

### Manual verification (if applicable)

- OS / platform tested: macOS (darwin 25.5.0)
- Simulated devices? `No`
- Real hardware? `No`
- What you personally verified and how:
  - Ran `./bundle_skins.sh`: downloaded `msl-v0.0.6.zip` and wrote `assets/bundled_skins/MSL.zip` (4.5 MB); the generated manifest lists 8 skins including `MSL`.
  - Inspected the release zip: `skin-manifest.json` at the archive root (`{"id":"msl","name":"MSL","version":"0.0.6"}`) plus `index.html` and `src/` — the layout `WebUIStorage` expects, no `node_modules`.
  - `flutter test test/webui_storage_bundled_test.dart` — both tests pass.
- Edge cases checked: repo is public, so the unauthenticated/`GITHUB_TOKEN` fetch path in CI works the same as for the other sources.
- What you did **not** verify: the skin has not been loaded and driven in a running app — this PR only makes it available.

### Evidence

```
$ ./bundle_skins.sh
--- Processing source 8/8: github_release allofmeng/MSL ---
Downloading: https://github.com/allofmeng/MSL/releases/download/v0.0.6/msl-v0.0.6.zip
Bundled skin: MSL
--- Done: 8 skins bundled ---

$ cat assets/bundled_skins/manifest.json
[
  "Beanie", "MSL", "NSX", "OverDose",
  "WorkFlow-Skin", "insight-js", "passione", "streamline_project"
]

$ flutter test test/webui_storage_bundled_test.dart
00:00 +2: All tests passed!

$ flutter analyze
No issues found! (ran in 8.0s)

$ flutter test
03:56 +2777 -4: Some tests failed.
Failing tests:
  test/webui_support/webui_token_injection_test.dart: serveFolderAtPath offline falls back to localhost when getWifiIP returns empty string
  test/webui_support/webui_token_injection_test.dart: serveFolderAtPath offline falls back to localhost when getWifiIP returns null
  test/webui_support/webui_token_injection_test.dart: serveFolderAtPath offline falls back to localhost when getWifiIP throws (gh#337)
  test/webui_support/webui_token_injection_test.dart: serveFolderAtPath offline protects the skin API across origins
```

Those 4 failures are pre-existing and unrelated — confirmed by stashing this change and re-running that file on clean `main`, where the same 4 fail.

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`

## Risks & Mitigations

- Risk: builds now depend on `allofmeng/MSL` having a fetchable latest release; a missing asset fails `bundle_skins.sh` and the build.
  - Mitigation: same failure mode as the seven existing sources, with a clear per-source error listing the failed repo.
- Risk: the skin is bundled unpinned, so a bad upstream release ships to users on the next build.
  - Mitigation: same policy as every other bundled skin; drop or pin the entry in `skin_sources.json` if that becomes a problem.
- Risk: app download size grows by ~4.5 MB.
  - Mitigation: comparable to `streamline_project` (4.5 MB) and well under `insight-js` (17.9 MB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
