### PR TITLE
docs(skills): index decent-app scenarios, harden skill description

### DIFF
--- a/.agents/skills/decent-app/SKILL.md
+++ b/.agents/skills/decent-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: decent-app
-description: Use when touching the Flutter app, its REST/WebSocket API, profiles, shots, simulated devices, or real BLE/USB hardware via an Android tablet or desktop, or whenever exercising a code change against a running Decent instance. Covers the dev loop (sb-dev start/reload/stop in simulate or real-hardware mode), REST calls via curl, WebSocket streams via websocat, and smoke-test verification.
+description: Use when touching the Decent Flutter app, its REST/WebSocket API, profiles, shots, simulated devices, or real BLE/USB hardware via an Android tablet or desktop, or whenever exercising a code change against a running Decent instance. Covers the sb-dev dev loop and shell-based verification.
 ---
 
 # Decent — agent skill
@@ -18,9 +18,34 @@ The skill lives under `.agents/skills/decent-app/` following the [agentskills.io
 | Read/write WebSocket streams | `websocket.md` |
 | Work with MockDe1 / MockScale | `simulated-devices.md` |
 | Smoke-test a code change | `verification.md` |
-| End-to-end regression recipes | `scenarios/` |
+| End-to-end regression recipes | `scenarios/` (index below) |
 
 All files above are siblings of this `SKILL.md` under `.agents/skills/decent-app/`. Relative paths in the sub-files resolve against that directory.
+
+### Scenario index
+
+Pick the scenario that matches the task, run it verbatim, and finish before calling related work done. Each file lists preconditions, a `curl` / `websocat` sequence, expected output hints, and postconditions.
+
+| Scenario | File |
+|---|---|
+| BLE error surfacing (adapterOff, scaleConnectFailed, sticky errors) | `scenarios/ble-error-surfacing.md` |
+| Device scan + connection policy | `scenarios/device-scan-connection-policy.md` |
+| Onboarding connection phases (MockDe1 + MockScale auto-connect) | `scenarios/onboarding-connection-phases.md` |
+| Preferred-device fast-path round-trip | `scenarios/onboarding-preferred-device.md` |
+| Build-info endpoint | `scenarios/build-info.md` |
+| Firmware endpoints | `scenarios/firmware.md` |
+| ETag / If-None-Match on list endpoints | `scenarios/etag-conditional-gets.md` |
+| Discover / restore default profiles | `scenarios/profiles-defaults.md` |
+| Hot-water stop-at-weight | `scenarios/hot-water-stop-at-weight.md` |
+| Shot-state WebSocket + persisted stop reason | `scenarios/shot-state-ws.md` |
+| Display brightness 0-100 + low-battery toggle | `scenarios/display-brightness.md` |
+| Debug scale control (simulate) | `scenarios/debug-scale-control.md` |
+| Bengle LED strip v2 | `scenarios/bengle-led-strip.md` |
+| Bengle integrated scale end-to-end | `scenarios/bengle-integrated-scale.md` |
+| Bengle cup-warmer + capability discovery | `scenarios/bengle-cup-warmer.md` |
+| Account-proxy CORS pinned to skin origin | `scenarios/account-proxy-cors.md` |
+| Account-proxy write forwarding + write-scope gate | `scenarios/account-proxy-write.md` |
+| Plugin Decent-account proxy bridge (host.decentProxy) | `scenarios/plugin-decent-proxy.md` |
 
 ## Authoritative sources
 

--- a/.agents/skills/decent-app/verification.md
+++ b/.agents/skills/decent-app/verification.md
@@ -60,14 +60,7 @@ Before opening a PR, merging locally, or calling work done:
 
 ## Regression scenarios
 
-Concrete end-to-end recipes that used to live as MCP yaml fixtures now live as markdown under `scenarios/`:
-
-- `scenarios/build-info.md` — `/api/v1/info` compile-time metadata.
-- `scenarios/display-brightness.md` — display REST + WebSocket + validation + low-battery toggle.
-- `scenarios/onboarding-connection-phases.md` — verify MockDe1 + MockScale auto-connect reaches a healthy machine state.
-- `scenarios/onboarding-preferred-device.md` — `/api/v1/settings` round-trip and null-clear of preferred IDs.
-
-Run any scenario before calling related work done. Each file lists preconditions, a sequence of `curl` / `websocat` commands, expected output hints, and postconditions — paste them verbatim.
+Concrete end-to-end recipes that used to live as MCP yaml fixtures now live as markdown under `scenarios/`. The full index is in `SKILL.md` - pick the scenario that matches your task there. Run it before calling related work done. Each file lists preconditions, a sequence of `curl` / `websocat` commands, expected output hints, and postconditions - paste them verbatim.
 
 ## Stale spec, stale skill
 


### PR DESCRIPTION
## What

Two small skill-quality fixes to `.agents/skills/decent-app/`, from a skills-vs-MCP research review:

**P1 - Scenario index** (`SKILL.md`)
The routing table pointed at `scenarios/` with no way to pick the right one without reading all 18 files. `verification.md` also carried a partial 4-item list that had already drifted from the folder. Adds a one-line-per-scenario index to `SKILL.md` and points `verification.md` at it. Verified: all 18 indexed files exist, all 18 on-disk scenarios are indexed.

**P3 - Description hardening** (`SKILL.md` frontmatter)
Trigger words front-loaded; tail execution detail (sb-dev flags, curl/websocat mention) collapsed - that detail already lives in the body, and clients that trim descriptions cut the tail first.

## Why

Progressive disclosure (metadata first, body on demand) is the load-bearing pattern of the skill format: agents route on the description and index, not on reading every file.

## Test plan

None - markdown docs only. No code touched.