### PR TITLE
fix(visualizer): shift state_change frame markers to non-zero

### DIFF
--- a/assets/plugins/visualizer.reaplugin/manifest.json
+++ b/assets/plugins/visualizer.reaplugin/manifest.json
@@ -3,7 +3,7 @@
   "author": "Decent Espresso",
   "name": "Visualizer upload",
   "description": "Uploads shots to Visualizer and syncs your edited shot metadata back",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "apiVersion": 1,
   "permissions": [
     "log",

--- a/assets/plugins/visualizer.reaplugin/plugin.js
+++ b/assets/plugins/visualizer.reaplugin/plugin.js
@@ -240,7 +240,9 @@ function createPlugin(host) {
       visualizerShot.temperature.mix_goal.push(machine.targetMixTemperature);
       visualizerShot.totals.weight.push(scale?.weight ?? 0);
       visualizerShot.totals.water_dispensed.push(waterDispensed / 10);
-      visualizerShot.state_change.push(machine.profileFrame);
+      // Visualizer's stage parser ignores numeric 0, so the zero-based DE1
+      // frame index must be shifted to a 1-based marker.
+      visualizerShot.state_change.push(machine.profileFrame + 1);
     }
 
     return visualizerShot;
@@ -973,7 +975,7 @@ function createPlugin(host) {
   // Return the plugin object
   return {
     id: "visualizer.reaplugin",
-    version: "1.5.2",
+    version: "1.5.3",
 
     onLoad(settings) {
       state.username = settings.Username;

--- a/test/plugins/visualizer_plugin_test.dart
+++ b/test/plugins/visualizer_plugin_test.dart
@@ -42,7 +42,7 @@ class _FakeKeyValueStore implements KeyValueStoreService {
 
 void main() {
   test(
-    'Visualizer upload uses profile frame indices for state_change',
+    'Visualizer upload encodes state_change as non-zero stage markers',
     () async {
       final pluginSource = File(
         'assets/plugins/visualizer.reaplugin/plugin.js',
@@ -132,7 +132,7 @@ void main() {
         await Future<void>.delayed(Duration.zero);
       }
 
-      expect(upload?['state_change'], [0, 0, 1, 2]);
+      expect(upload?['state_change'], [1, 1, 2, 3]);
     },
   );
 }


### PR DESCRIPTION
## Summary

> **Naming:** The display name is **Decent.app**. The repo, package, and bundle ID use legacy `reaprime` / `streamline-bridge` — see the naming table in [`CLAUDE.md`](CLAUDE.md).

- Problem: Short espresso shots were missing a step line in Visualizer, even though the DE1 parser and shot recorder captured the correct frame transitions.
- Why it matters: Users can't see all of their profile's step boundaries on the Visualizer chart for shorter shots.
- What changed: `visualizer.reaplugin` now encodes `state_change` frame markers as 1-based (`profileFrame + 1`) instead of raw zero-based indices, since Visualizer's stage parser treats numeric `0` as absent and silently drops it.
- What did NOT change (scope boundary): profile execution, the DE1 shot-sample parser, shot persistence, and upload measurement slicing are all untouched. Change is confined to `assets/plugins/visualizer.reaplugin/` and its test.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [x] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] Plugins / JS runtime

## Linked Issues

- Closes #545

## Root Cause (if bug fix)

- Root cause: `state_change.push(machine.profileFrame)` (introduced in #492) pushes the raw zero-based DE1 frame index. Visualizer's stage parser (`parsed_shot.rb`) deliberately ignores numeric `0` as "not present," so a shot with frames `[0, 0, 1, 2]` only surfaces the `1 -> 2` transition and silently drops the real `0 -> 1` transition.
- Missing detection or guardrail: the original test asserted the raw pass-through (`[0, 0, 1, 2]`) as correct output, so it locked in the buggy encoding instead of catching it.
- Contributing context: confirmed via maintainer investigation on #545 — DE1 recorded the transitions correctly at ~5.617s and ~8.537s; the bug is purely in how those transitions are encoded for Visualizer's consumption.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `test/plugins/visualizer_plugin_test.dart`
- Scenario the test should lock in: given machine frames `[0, 0, 1, 2]`, the uploaded `state_change` array must be `[1, 1, 2, 3]` (shifted non-zero), not the raw zero-based values.
- If no new test added, why not: N/A — existing test updated in place (renamed + new expected value), zero-based input fixture retained since frame zero is the regression case.

## Documentation Obligations (required)

- [x] N/A — no docs affected (plugin-internal encoding fix, no API/skin/profile/device surface changed)

## Security Impact (required)

- New or changed REST endpoints? No
- New or changed WebSocket topics? No
- New or changed network calls? No
- BLE/USB surface changed? No
- File system access changed? No
- Plugin sandbox boundary changed? No
- If any `Yes`, explain risk and mitigation: N/A

## User-Visible Changes

Visualizer-uploaded shots (via the bundled Visualizer plugin) will now show the correct number of step lines for shots that pass through profile frame `0`, including short/normal-length espresso shots that previously lost their first transition. Bundled plugin version bumped `1.5.2` → `1.5.3`.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass (2499 tests)
- [x] `(cd packages/dye2-plugin && npm run build)` — plugin builds

### Manual verification (if applicable)

- OS / platform tested: macOS (dev environment), fix is platform-agnostic (JS plugin runtime)
- Simulated devices? (`simulate=1`): No — verified via focused unit test with a scripted 4-measurement shot fixture (frames `[0, 0, 1, 2]`), not manual app interaction
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: ran `test/plugins/visualizer_plugin_test.dart` against the pre-fix `plugin.js` to confirm it fails with `Expected: [1, 1, 2, 3] / Actual: [0, 0, 1, 2]`, then confirmed it passes after the fix. Also ran the full `flutter test` suite and `flutter analyze`.
- Edge cases checked: frame `0` at both leading positions (multiple consecutive `0`s before the first transition) — covered by the existing fixture's `[0, 0, 1, 2]` input.
- What you did **not** verify: end-to-end upload to a live Visualizer instance / visual confirmation on visualizer.coffee.

### Evidence

- [x] Test output (failing before + passing after)

Before (old `plugin.js`, new test expectation):
```
00:00 +0 -1: Visualizer upload encodes state_change as non-zero stage markers [E]
  Expected: [1, 1, 2, 3]
    Actual: [0, 0, 1, 2]
     Which: at location [0] is <0> instead of <1>
```

After (fix applied):
```
00:00 +1: All tests passed!
```

## Compatibility & Migration

- Backward compatible? Yes — purely an encoding change on upload; no stored data format changes.
- Config / env changes needed? No
- Database migration needed? No

## Risks & Mitigations

- Risk: Visualizer or other consumers of `state_change` could theoretically expect zero-based values.
  - Mitigation: Confirmed against Visualizer's actual parser source (linked in #545) that it ignores `0`; 1-based encoding is what Visualizer expects. Change is isolated to this one plugin's upload payload construction.
