### PR TITLE
shot-upload: mark uploaded shots with annotations.extras.uploaded_to_decent

### DIFF
--- a/assets/plugins/shot-upload.reaplugin/plugin.js
+++ b/assets/plugins/shot-upload.reaplugin/plugin.js
@@ -47,6 +47,24 @@ function createPlugin(host) {
     return await res.json();
   }
 
+  // Mark the stored shot as uploaded, mirroring the de1app plugin: write
+  // `uploaded_to_decent <clock seconds>` into the shot's annotations.extras so
+  // the record itself records that it was uploaded (deep-merged by the app's
+  // PUT /shots/<id> handler). Best-effort -- never fails the upload.
+  async function markUploaded(shotId) {
+    try {
+      const seconds = Math.floor(Date.now() / 1000);
+      const res = await fetch(`${LOCAL_API_URL}/shots/${shotId}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ annotations: { extras: { uploaded_to_decent: seconds } } }),
+      });
+      if (!res || !res.ok) log(`mark ${shotId} uploaded -> HTTP ${res && res.status}`);
+    } catch (e) {
+      log(`could not mark ${shotId} uploaded: ${e.message}`);
+    }
+  }
+
   // Decaid app version (for provenance), cached.
   async function getDecaidVersion() {
     if (decaidVersion) return decaidVersion;
@@ -128,6 +146,7 @@ function createPlugin(host) {
     state.lastUploadedShot = full.id;
     state.lastResult = result;
     host.storage({ type: "write", key: "lastUploadedShot", data: full.id });
+    await markUploaded(full.id);
     host.emit("shotUploaded", { shotId: full.id, result: result, timestamp: Date.now() });
     return result;
   }

--- a/test/plugins/shot_upload_plugin_test.dart
+++ b/test/plugins/shot_upload_plugin_test.dart
@@ -137,7 +137,10 @@ void main() {
     final r = manager.js.evaluate('''
       globalThis.setTimeout = (cb) => { cb(); return 1; };
       globalThis.clearTimeout = () => {};
-      globalThis.fetch = async (url) => {
+      globalThis.__puts = [];
+      globalThis.fetch = async (url, init) => {
+        init = init || {};
+        if (init.method === 'PUT') { globalThis.__puts.push({ url: String(url), body: init.body }); return { ok:true, status:200, json: async () => ({}) }; }
         if (url.endsWith('/shots/latest')) return { ok:true, json: async () => ({ id:'shot-1' }) };
         if (url.endsWith('/shots/shot-1')) return { ok:true, json: async () => (${jsonEncode(_shot('shot-1'))}) };
         if (url.endsWith('/machine/info')) return { ok:true, json: async () => ({ serialNumber:'6262', version:'1293', model:'DE1Pro' }) };
@@ -194,6 +197,24 @@ void main() {
       expect(body['machine'].containsKey('bleId'), isFalse);
       // app version from /api/v1/info, not the hard-coded plugin version
       expect(body['app']['version'], '9.9.9');
+
+      // the shot record is marked uploaded: PUT /shots/<id> with
+      // annotations.extras.uploaded_to_decent = <epoch seconds>
+      final puts =
+          jsonDecode(
+                manager.js
+                    .evaluate('JSON.stringify(globalThis.__puts)')
+                    .stringResult,
+              )
+              as List;
+      expect(puts, hasLength(1));
+      expect(puts.single['url'], endsWith('/api/v1/shots/shot-1'));
+      final putBody =
+          jsonDecode(puts.single['body'] as String) as Map<String, dynamic>;
+      expect(
+        putBody['annotations']['extras']['uploaded_to_decent'],
+        isA<int>(),
+      );
     },
   );
 


### PR DESCRIPTION
## Summary

- **Problem:** A successfully-uploaded shot left no durable mark on the record itself — "was this uploaded?" depended on plugin-side state (`lastUploadedShot` / plugin KV).
- **Why it matters:** The de1app uploader now writes an in-record marker; decaid should match so the fact travels with the shot and survives loss of plugin state.
- **What changed:** After a successful upload, the `shot-upload.reaplugin` plugin PUTs `/api/v1/shots/<id>` with `{annotations:{extras:{uploaded_to_decent:<epoch seconds>}}}`, deep-merged onto the shot. Best-effort — never fails the upload.
- **What did NOT change (scope boundary):** No new endpoint/host API/permission/schema. Dedup logic, provenance, and the upload path are unchanged. Uses the existing deep-merge `PUT /shots/<id>` handler and the existing plugin `fetch`.

## Change Type (select all)

- [x] Feature
- [x] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] Plugins / JS runtime

## Linked Issues

- Related # (mirrors the de1app `uploaded_to_decent` marker; part of the shot-upload work in #565)

## Root Cause (if bug fix)

- N/A (feature)

## Regression Test Plan (if bug fix or refactor)

- N/A (feature). New coverage added — see below.

## Documentation Obligations (required)

- [x] N/A — no docs affected. No new endpoint (reuses existing `PUT /api/v1/shots/<id>`); no plugin event/API change.

## Security Impact (required)

- New or changed REST endpoints? **No** (reuses existing `PUT /shots/<id>`).
- New or changed WebSocket topics? **No**
- New or changed network calls? **Yes** — the plugin now makes one additional **local** `PUT` to the app's own shots endpoint after upload (it already did local GETs + the authenticated proxy POST). No new external network.
- BLE/USB surface changed? **No**
- File system access changed? **No**
- Plugin sandbox boundary changed? **No** — uses the existing `fetch` shim and `api` permission; no new capability.
- Risk/mitigation: writes only `annotations.extras.uploaded_to_decent` (an integer) via the app's own deep-merging endpoint; best-effort, wrapped in try/catch so it can't break the upload.

## User-Visible Changes

Uploaded shots now carry `annotations.extras.uploaded_to_decent` = upload time in epoch seconds. Internal/metadata only; enables a durable "already uploaded" signal without a sidecar file.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — no remaining changes
- [x] `flutter analyze` — clean
- [x] `flutter test` — all pass (2736)
- [ ] `(cd packages/dye2-plugin && npm run build)` — N/A (no dye2 change)

### Manual verification (if applicable)

- Simulated devices? N/A (unit-tested the plugin against a stubbed local API)
- What you personally verified: the plugin test records the outgoing `PUT` and asserts `…/api/v1/shots/shot-1` carries `annotations.extras.uploaded_to_decent` as an int.

### Evidence

- [x] Test output: `shot_upload_plugin_test.dart` 4/4 pass (incl. new marker assertion); full suite `+2736 All tests passed`.

## Compatibility & Migration

- Backward compatible? **Yes**
- Config / env changes needed? **No**
- Database migration needed? **No** — rides the existing `annotations.extras` map.

## Risks & Mitigations

- Risk: the marking PUT could fail (e.g., transient local API hiccup).
  - Mitigation: best-effort in try/catch; a failure only logs and never affects the upload or its `shotUploaded` event.
