### PR TITLE
workaround for snack not dismissing itself sometimes

### DIFF
--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -304,10 +304,11 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
       instructions = 'Use back navigation to return to Dashboard';
     }
 
-    ScaffoldMessenger.of(context).showSnackBar(
+    final snackDuration = const Duration(seconds: 4);
+    final controller = ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(instructions),
-        duration: const Duration(seconds: 10),
+        duration: snackDuration,
         behavior: SnackBarBehavior.floating,
         margin: const EdgeInsets.all(16),
         showCloseIcon: true,
@@ -321,6 +322,15 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
           },
         ),
       ),
+    );
+
+    unawaited(
+      Future.delayed(snackDuration, () {
+        if (!mounted) {
+          return;
+        }
+        controller.close();
+      }),
     );
   }
 


### PR DESCRIPTION
## Summary

For some unknown reason (maybe Flutter bug), snack on SkinView did not auto dismiss even though `duration` was explicitly provided. This PR adds an unawaited Future that will close that specific snack after the same duration as the snack's specified duration.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [x] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs

## Root Cause (if bug fix)

Unknown, just didn't work

## Documentation Obligations (required)

These are **not optional**. Stale specs mislead clients and agents.

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A — no docs affected

## Security Impact (required)

This app runs a local web server (port 8080) and connects to BLE/USB hardware.

- New or changed REST endpoints? (`Yes/No`)
- New or changed WebSocket topics? (`Yes/No`)
- New or changed network calls? (`Yes/No`)
- BLE/USB surface changed? (`Yes/No`)
- File system access changed? (`Yes/No`)
- Plugin sandbox boundary changed? (`Yes/No`)
- If any `Yes`, explain risk and mitigation:

*NO* security impact from this PR

## User-Visible Changes

Snackbar on SkinView should now properly dismiss itself after 4 seconds

## Verification

Ran on my computer

### Local gates (run before pushing)

- [x] `dart format lib test` — no remaining changes
- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass
- [ ] `./scripts/fetch_dye2_plugin.sh` — DYE2 plugin installed into `assets/plugins/dye2.reaplugin/`
