### PR TITLE
fix(plugins): forward recipe and shot tags to Visualizer upload

### DIFF
--- a/assets/plugins/visualizer.reaplugin/manifest.json
+++ b/assets/plugins/visualizer.reaplugin/manifest.json
@@ -3,7 +3,7 @@
   "author": "Decent Espresso",
   "name": "Visualizer upload",
   "description": "Uploads shots to Visualizer and syncs your edited shot metadata back",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "apiVersion": 1,
   "permissions": [
     "log",

--- a/assets/plugins/visualizer.reaplugin/manifest.json
+++ b/assets/plugins/visualizer.reaplugin/manifest.json
@@ -3,7 +3,7 @@
   "author": "Decent Espresso",
   "name": "Visualizer upload",
   "description": "Uploads shots to Visualizer and syncs your edited shot metadata back",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "apiVersion": 1,
   "permissions": [
     "log",

--- a/assets/plugins/visualizer.reaplugin/plugin.js
+++ b/assets/plugins/visualizer.reaplugin/plugin.js
@@ -589,6 +589,9 @@ function createPlugin(host) {
     });
     if (!res.ok) {
       const text = await res.text();
+      if ((res.status === 400 || res.status === 403) && hasOwn(body?.shot, "tag_list")) {
+        throw new Error(`Visualizer tag sync requires Visualizer Premium. HTTP ${res.status}: ${text || res.statusText}`);
+      }
       throw new Error(`HTTP ${res.status}: ${text || res.statusText}`);
     }
     return await res.json();
@@ -757,7 +760,10 @@ function createPlugin(host) {
             [visualizerId]: merged.managedTags
           };
         }
-        const detail = await visualizerPatch(`/shots/${visualizerId}`, { shot: merged.update });
+        const visualizerUpdate = hasOwn(merged.update, "tags")
+          ? { ...withoutKey(merged.update, "tags"), tag_list: merged.update.tags }
+          : merged.update;
+        const detail = await visualizerPatch(`/shots/${visualizerId}`, { shot: visualizerUpdate });
         const updatedAt = Number(detail?.updated_at) || Number(detail?.meta?.visualizer?.updated_at) || 0;
         if (updatedAt > 0) {
           state.backSyncState = {

--- a/assets/plugins/visualizer.reaplugin/plugin.js
+++ b/assets/plugins/visualizer.reaplugin/plugin.js
@@ -178,6 +178,20 @@ function createPlugin(host) {
     return Array.from(new Set(tags.map((tag) => String(tag).trim()).filter((tag) => tag.length > 0)));
   }
 
+  function canonicalizeVisualizerTag(tag) {
+    return String(tag).replace(/\s+/g, " ").trim().replace(/[^\w\s-]/g, "").toLowerCase();
+  }
+
+  function canonicalizeVisualizerTags(tags) {
+    if (!Array.isArray(tags)) return [];
+    return Array.from(new Set(
+      tags
+        .flatMap((tag) => String(tag).split(","))
+        .map(canonicalizeVisualizerTag)
+        .filter((tag) => tag.length > 0)
+    ));
+  }
+
   function extractTags(shot) {
     const annotations = shot?.annotations || {};
     const context = shot?.workflow?.context || {};
@@ -740,12 +754,14 @@ function createPlugin(host) {
     }
     const detail = await visualizerGet(`/shots/${visualizerId}?essentials=1`);
     const localTags = normalizeTags(pending.update.tags);
-    const managedTags = new Set(normalizeTags(state.managedLocalTags[visualizerId]));
-    const remoteOnlyTags = normalizeTags(detail?.tags).filter((tag) => !managedTags.has(tag));
-    const remoteOnlySet = new Set(remoteOnlyTags);
+    const managedTags = new Set(canonicalizeVisualizerTags(state.managedLocalTags[visualizerId]));
+    const remoteOnlyTags = normalizeTags(detail?.tags).filter(
+      (tag) => !managedTags.has(canonicalizeVisualizerTag(tag))
+    );
+    const remoteOnlySet = new Set(canonicalizeVisualizerTags(remoteOnlyTags));
     return {
       update: { ...pending.update, tags: normalizeTags([...localTags, ...remoteOnlyTags]) },
-      managedTags: localTags.filter((tag) => !remoteOnlySet.has(tag))
+      managedTags: canonicalizeVisualizerTags(localTags).filter((tag) => !remoteOnlySet.has(tag))
     };
   }
 
@@ -1138,7 +1154,7 @@ function createPlugin(host) {
   // Return the plugin object
   return {
     id: "visualizer.reaplugin",
-    version: "1.5.4",
+    version: "1.5.5",
 
     onLoad(settings) {
       state.username = settings.Username;

--- a/assets/plugins/visualizer.reaplugin/plugin.js
+++ b/assets/plugins/visualizer.reaplugin/plugin.js
@@ -45,6 +45,10 @@ function createPlugin(host) {
     localSyncStatus: { lastCheck: null, lastResult: null, lastError: null, lastShotId: null, lastVisualizerId: null },
     backSyncStatus: { lastCheck: null, lastResult: null, lastError: null, lastApplied: 0 },
   };
+  let managedLocalTagsReadyResolve;
+  const managedLocalTagsReady = new Promise((resolve) => {
+    managedLocalTagsReadyResolve = resolve;
+  });
 
   function log(msg) {
     host.log(`[visualizer] ${msg}`);
@@ -351,6 +355,15 @@ function createPlugin(host) {
       state.backSyncCursor = Number(payload.value) || 0;
     } else if (payload.key === "backSyncState") {
       state.backSyncState = safeParseObject(payload.value) || {};
+    } else if (payload.key === "managedLocalTags") {
+      const stored = safeParseObject(payload.value) || {};
+      state.managedLocalTags = Object.fromEntries(
+        Object.entries(stored).map(([visualizerId, tags]) => [
+          visualizerId,
+          canonicalizeVisualizerTags(tags)
+        ])
+      );
+      managedLocalTagsReadyResolve();
     }
   }
 
@@ -496,6 +509,7 @@ function createPlugin(host) {
     host.storage({ type: "write", key: "shotMap", namespace: NS, data: JSON.stringify(state.shotMap) });
     host.storage({ type: "write", key: "backSyncCursor", namespace: NS, data: String(state.backSyncCursor) });
     host.storage({ type: "write", key: "backSyncState", namespace: NS, data: JSON.stringify(state.backSyncState) });
+    host.storage({ type: "write", key: "managedLocalTags", namespace: NS, data: JSON.stringify(state.managedLocalTags) });
   }
 
   function localShotVisualizerId(shot) {
@@ -752,6 +766,7 @@ function createPlugin(host) {
     if (!hasOwn(pending.update, "tags")) {
       return { update: pending.update, managedTags: null };
     }
+    await managedLocalTagsReady;
     const detail = await visualizerGet(`/shots/${visualizerId}?essentials=1`);
     const localTags = normalizeTags(pending.update.tags);
     const managedTags = new Set(canonicalizeVisualizerTags(state.managedLocalTags[visualizerId]));
@@ -775,6 +790,7 @@ function createPlugin(host) {
             ...state.managedLocalTags,
             [visualizerId]: merged.managedTags
           };
+          persistBackSyncState();
         }
         const visualizerUpdate = hasOwn(merged.update, "tags")
           ? { ...withoutKey(merged.update, "tags"), tag_list: merged.update.tags }
@@ -1172,6 +1188,7 @@ function createPlugin(host) {
       host.storage({ type: "read", key: "shotMap", namespace: NS });
       host.storage({ type: "read", key: "backSyncCursor", namespace: NS });
       host.storage({ type: "read", key: "backSyncState", namespace: NS });
+      host.storage({ type: "read", key: "managedLocalTags", namespace: NS });
 
       // First run ~30s after load so storage reads have settled.
       if (state.backSyncEnabled) armBackSync(30000);

--- a/assets/plugins/visualizer.reaplugin/plugin.js
+++ b/assets/plugins/visualizer.reaplugin/plugin.js
@@ -37,8 +37,11 @@ function createPlugin(host) {
     shotMap: {}, // visualizerId -> localShotId, for our own uploads only
     backSyncState: {}, // visualizerId -> { remoteUpdatedAt }
     backSyncRunning: false,
+    localSyncPending: {},
     localSyncRunning: {},
-    localSyncSuppressUntil: {},
+    localSyncSuppressions: {},
+    localTagRevisions: {},
+    managedLocalTags: {},
     localSyncStatus: { lastCheck: null, lastResult: null, lastError: null, lastShotId: null, lastVisualizerId: null },
     backSyncStatus: { lastCheck: null, lastResult: null, lastError: null, lastApplied: 0 },
   };
@@ -170,31 +173,17 @@ function createPlugin(host) {
     return measurements.slice(firstEspressoIndex, lastEspressoIndex + 1);
   }
 
-  // Recipe tags (set in the recipe editor, carried in workflow.context.extras)
-  // and shot-review tags (added after the pour, carried in annotations.extras)
-  // are separate sources — merge and dedupe them into the single tags list
-  // Visualizer expects.
+  function normalizeTags(tags) {
+    if (!Array.isArray(tags)) return [];
+    return Array.from(new Set(tags.map((tag) => String(tag).trim()).filter((tag) => tag.length > 0)));
+  }
+
   function extractTags(shot) {
     const annotations = shot?.annotations || {};
     const context = shot?.workflow?.context || {};
     const recipeTags = Array.isArray(context.extras?.tags) ? context.extras.tags : [];
     const shotTags = Array.isArray(annotations.extras?.tags) ? annotations.extras.tags : [];
-    return Array.from(new Set([...recipeTags, ...shotTags]));
-  }
-
-  // Push tags onto an already-uploaded Visualizer shot. The /shots/upload JSON
-  // importer only captures a fixed field set that does not include tags, so
-  // tags must be applied as a separate PATCH using the same field name
-  // Visualizer's own API (and our back-sync reader) uses.
-  async function pushTagsToVisualizer(shot, visualizerId) {
-    const tags = extractTags(shot);
-    if (tags.length === 0) return;
-    try {
-      await visualizerPatch(`/shots/${visualizerId}`, { shot: { tags } });
-      log(`Synced ${tags.length} tag(s) to Visualizer shot ${visualizerId}`);
-    } catch (e) {
-      log(`Failed to sync tags to Visualizer shot ${visualizerId}: ${e.message}`);
-    }
+    return normalizeTags([...recipeTags, ...shotTags]);
   }
 
   function convertReaToVisualizerFormat(reaShot) {
@@ -312,34 +301,15 @@ function createPlugin(host) {
       }
 
       const result = await uploadShot(convertReaToVisualizerFormat(fullShot), null);
-      state.lastUploadedShot = fullShot.id;
-      state.lastVisualizerId = result.id;
-
-      await pushTagsToVisualizer(fullShot, result.id);
-
-      host.storage({
-        type: "write",
-        key: "lastUploadedShot",
-        namespace: NS,
-        data: fullShot.id
-      });
-
-      host.storage({
-        type: "write",
-        key: "lastVisualizerId",
-        namespace: NS,
-        data: result.id
-      });
-
-      // Record the local↔visualizer mapping so back-sync can later find this
-      // shot, and only ever touches shots we uploaded ourselves.
-      await rememberUpload(fullShot.id, result.id);
+      rememberSuccessfulUpload(fullShot.id, result.id);
+      syncSuccessfulUpload(fullShot.id, result.id, fullShot);
 
       log(`Uploaded ${fullShot.id} → ${result.id}`);
 
       host.emit("shotUploaded", {
         shotId: fullShot.id,
         visualizerId: result.id,
+        tagSyncPending: true,
         timestamp: Date.now()
       });
     } catch (e) {
@@ -554,22 +524,48 @@ function createPlugin(host) {
     return { total: Object.keys(state.shotMap).length, added };
   }
 
-  // Remember a successful upload: map visualizerId → localShotId, and stamp the
-  // visualizer id onto the local shot so it's durable and visible to clients.
-  async function rememberUpload(localId, visualizerId) {
+  function rememberUpload(localId, visualizerId) {
     if (!localId || visualizerId == null) return;
-    state.shotMap[String(visualizerId)] = localId;
+    state.shotMap = { ...state.shotMap, [String(visualizerId)]: localId };
     persistBackSyncState();
-    try {
-      suppressLocalSync(localId);
-      await fetch(`${LOCAL_API_URL}/shots/${localId}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ annotations: { extras: { visualizerId: String(visualizerId) } } }),
+    const update = { annotations: { extras: { visualizerId: String(visualizerId) } } };
+    suppressLocalSync(localId, update);
+    fetch(`${LOCAL_API_URL}/shots/${localId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(update),
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status} ${response.statusText}`);
+      })
+      .catch((e) => {
+        consumeLocalSyncSuppression(localId, update);
+        log(`Could not stamp visualizerId on ${localId}: ${e.message}`);
       });
-    } catch (e) {
-      log(`Could not stamp visualizerId on ${localId}: ${e.message}`);
-    }
+  }
+
+  function rememberSuccessfulUpload(localId, visualizerId) {
+    state.lastUploadedShot = localId;
+    state.lastVisualizerId = visualizerId;
+    host.storage({ type: "write", key: "lastUploadedShot", namespace: NS, data: localId });
+    host.storage({ type: "write", key: "lastVisualizerId", namespace: NS, data: visualizerId });
+    rememberUpload(localId, visualizerId);
+  }
+
+  function syncSuccessfulUpload(localId, visualizerId, fallbackShot) {
+    const id = String(visualizerId);
+    const tagRevision = Number(state.localTagRevisions[id]) || 0;
+    return fetchShot(localId)
+      .then((currentShot) => {
+        if ((Number(state.localTagRevisions[id]) || 0) !== tagRevision) {
+          return { skipped: "newer tag update" };
+        }
+        return queueLocalSync(localId, id, { tags: extractTags(currentShot || fallbackShot) });
+      })
+      .catch((e) => {
+        log(`Post-upload tag sync failed for ${localId}: ${e.message}`);
+        recordLocalSyncStatus(localId, visualizerId, "error", e.message);
+      });
   }
 
   async function visualizerGet(path) {
@@ -598,17 +594,30 @@ function createPlugin(host) {
     return await res.json();
   }
 
-  function suppressLocalSync(localId) {
-    if (!localId) return;
-    state.localSyncSuppressUntil[localId] = Date.now() + 10000;
+  function withoutKey(object, key) {
+    return Object.fromEntries(Object.entries(object).filter(([entryKey]) => entryKey !== key));
   }
 
-  function consumeLocalSyncSuppression(localId) {
-    const until = state.localSyncSuppressUntil[localId];
-    if (!until) return false;
-    if (Date.now() <= until) return true;
-    delete state.localSyncSuppressUntil[localId];
-    return false;
+  function suppressLocalSync(localId, patch) {
+    if (!localId) return;
+    const id = String(localId);
+    state.localSyncSuppressions = {
+      ...state.localSyncSuppressions,
+      [id]: [...(state.localSyncSuppressions[id] || []), JSON.stringify(patch || {})]
+    };
+    setTimeout(() => consumeLocalSyncSuppression(id, patch), 10000);
+  }
+
+  function consumeLocalSyncSuppression(localId, patch) {
+    const id = String(localId || "");
+    const suppressions = state.localSyncSuppressions[id] || [];
+    const index = suppressions.indexOf(JSON.stringify(patch || {}));
+    if (index < 0) return false;
+    const remaining = [...suppressions.slice(0, index), ...suppressions.slice(index + 1)];
+    state.localSyncSuppressions = remaining.length > 0
+      ? { ...state.localSyncSuppressions, [id]: remaining }
+      : withoutKey(state.localSyncSuppressions, id);
+    return true;
   }
 
   function visualizerIdForLocalShot(shot) {
@@ -626,6 +635,32 @@ function createPlugin(host) {
     return null;
   }
 
+  function hasOwn(object, key) {
+    return object != null && Object.prototype.hasOwnProperty.call(object, key);
+  }
+
+  function localTagsTouched(patch) {
+    if (hasOwn(patch, "metadata")) {
+      if (patch.metadata == null || hasOwn(patch.metadata, "tags")) return true;
+    }
+    if (hasOwn(patch, "annotations")) {
+      if (patch.annotations == null) return true;
+      if (hasOwn(patch.annotations, "extras")) {
+        if (patch.annotations.extras == null || hasOwn(patch.annotations.extras, "tags")) return true;
+      }
+    }
+    if (hasOwn(patch, "workflow")) {
+      if (patch.workflow == null) return true;
+      if (hasOwn(patch.workflow, "context")) {
+        if (patch.workflow.context == null) return true;
+        if (hasOwn(patch.workflow.context, "extras")) {
+          if (patch.workflow.context.extras == null || hasOwn(patch.workflow.context.extras, "tags")) return true;
+        }
+      }
+    }
+    return false;
+  }
+
   // Build a Visualizer update from a local shot. In edit mode (force=false) a
   // field is pushed ONLY when the incoming patch touched it, so editing one
   // field (e.g. enjoyment) never re-sends — and clobbers — Visualizer-side
@@ -637,11 +672,10 @@ function createPlugin(host) {
     const patchAnnotations = patch?.annotations || {};
     const patchContext = patch?.workflow?.context || {};
     const payload = {};
-    const has = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
-    const touched = (source, sourceKey) => force === true || has(source, sourceKey);
+    const touched = (source, sourceKey) => force === true || hasOwn(source, sourceKey);
     const setNumber = (key, value, source, sourceKey, transform) => {
       if (!touched(source, sourceKey)) return;
-      if (has(source, sourceKey) && (value == null || value === "")) {
+      if (hasOwn(source, sourceKey) && (value == null || value === "")) {
         payload[key] = null;
         return;
       }
@@ -650,9 +684,9 @@ function createPlugin(host) {
       if (!Number.isFinite(number)) return;
       payload[key] = transform ? transform(number) : String(number);
     };
-    const setString = (key, value, source, sourceKey) => {
-      if (!touched(source, sourceKey)) return;
-      if (has(source, sourceKey) && (value == null || value === "")) {
+    const setString = (key, value, source, sourceKey, extraTouched) => {
+      if (!extraTouched && !touched(source, sourceKey)) return;
+      if ((extraTouched || hasOwn(source, sourceKey)) && (value == null || value === "")) {
         payload[key] = null;
         return;
       }
@@ -664,7 +698,13 @@ function createPlugin(host) {
     setNumber("drink_ey", annotations.drinkEy, patchAnnotations, "drinkEy");
     setNumber("bean_weight", annotations.actualDoseWeight ?? context.targetDoseWeight, patchAnnotations, "actualDoseWeight");
     setNumber("drink_weight", annotations.actualYield ?? context.targetYield, patchAnnotations, "actualYield");
-    setString("espresso_notes", annotations.espressoNotes, patchAnnotations, "espressoNotes");
+    setString(
+      "espresso_notes",
+      annotations.espressoNotes,
+      patchAnnotations,
+      "espressoNotes",
+      hasOwn(patch, "shotNotes")
+    );
     setString("barista", context.baristaName, patchContext, "baristaName");
     setString("grinder_setting", context.grinderSetting, patchContext, "grinderSetting");
     setString("bean_brand", context.coffeeRoaster, patchContext, "coffeeRoaster");
@@ -674,14 +714,7 @@ function createPlugin(host) {
       const title = shot.workflow?.profile?.title || shot.workflow?.name;
       if (typeof title === "string" && title.trim() !== "") payload.profile_title = title;
     }
-    // Tags can change on either side (recipe extras or shot-review extras), so
-    // touched-ness is checked on both patch sources; the value sent is always
-    // the full deduped set (there's no per-tag diff to send).
-    if (
-      force === true ||
-      has(patchAnnotations.extras || {}, "tags") ||
-      has(patchContext.extras || {}, "tags")
-    ) {
+    if (force === true || localTagsTouched(patch)) {
       payload.tags = extractTags(shot);
     }
 
@@ -698,19 +731,123 @@ function createPlugin(host) {
     };
   }
 
+  async function mergeCurrentVisualizerTags(visualizerId, pending) {
+    if (!hasOwn(pending.update, "tags")) {
+      return { update: pending.update, managedTags: null };
+    }
+    const detail = await visualizerGet(`/shots/${visualizerId}?essentials=1`);
+    const localTags = normalizeTags(pending.update.tags);
+    const managedTags = new Set(normalizeTags(state.managedLocalTags[visualizerId]));
+    const remoteOnlyTags = normalizeTags(detail?.tags).filter((tag) => !managedTags.has(tag));
+    const remoteOnlySet = new Set(remoteOnlyTags);
+    return {
+      update: { ...pending.update, tags: normalizeTags([...localTags, ...remoteOnlyTags]) },
+      managedTags: localTags.filter((tag) => !remoteOnlySet.has(tag))
+    };
+  }
+
+  async function drainLocalSync(visualizerId) {
+    while (state.localSyncPending[visualizerId]) {
+      const pending = state.localSyncPending[visualizerId];
+      try {
+        const merged = await mergeCurrentVisualizerTags(visualizerId, pending);
+        if (merged.managedTags !== null) {
+          state.managedLocalTags = {
+            ...state.managedLocalTags,
+            [visualizerId]: merged.managedTags
+          };
+        }
+        const detail = await visualizerPatch(`/shots/${visualizerId}`, { shot: merged.update });
+        const updatedAt = Number(detail?.updated_at) || Number(detail?.meta?.visualizer?.updated_at) || 0;
+        if (updatedAt > 0) {
+          state.backSyncState = {
+            ...state.backSyncState,
+            [visualizerId]: { remoteUpdatedAt: updatedAt }
+          };
+          persistBackSyncState();
+        }
+        const current = state.localSyncPending[visualizerId];
+        if (current?.revision !== pending.revision) {
+          const update = Object.fromEntries(
+            Object.entries(current.update).filter(([key, value]) =>
+              !hasOwn(pending.update, key) || JSON.stringify(value) !== JSON.stringify(pending.update[key])
+            )
+          );
+          if (Object.keys(update).length > 0) {
+            state.localSyncPending = {
+              ...state.localSyncPending,
+              [visualizerId]: { ...current, update }
+            };
+            continue;
+          }
+        }
+        state.localSyncPending = withoutKey(state.localSyncPending, visualizerId);
+        host.emit("shotForwardSynced", {
+          shotId: pending.shotId,
+          visualizerId,
+          timestamp: Date.now()
+        });
+        log(`Local sync: updated ${pending.shotId} → ${visualizerId}`);
+        recordLocalSyncStatus(pending.shotId, visualizerId, "updated", null);
+        return { ok: true, visualizerId };
+      } catch (e) {
+        const current = state.localSyncPending[visualizerId] || pending;
+        if (current.revision !== pending.revision) continue;
+        state.localSyncPending = withoutKey(state.localSyncPending, visualizerId);
+        log(`Local sync failed for ${current.shotId}: ${e.message}`);
+        host.emit("shotForwardSyncError", {
+          shotId: current.shotId,
+          visualizerId,
+          error: e.message,
+          timestamp: Date.now()
+        });
+        recordLocalSyncStatus(current.shotId, visualizerId, "error", e.message);
+        return { error: e.message, visualizerId };
+      }
+    }
+    return { ok: true, visualizerId };
+  }
+
+  function startLocalSync(visualizerId) {
+    const id = String(visualizerId);
+    if (state.localSyncRunning[id]) return state.localSyncRunning[id];
+    const running = drainLocalSync(id).finally(() => {
+      state.localSyncRunning = withoutKey(state.localSyncRunning, id);
+      if (state.localSyncPending[id]) startLocalSync(id);
+    });
+    state.localSyncRunning = { ...state.localSyncRunning, [id]: running };
+    return running;
+  }
+
+  function queueLocalSync(shotId, visualizerId, update) {
+    const id = String(visualizerId);
+    const previous = state.localSyncPending[id] || {};
+    if (hasOwn(update, "tags")) {
+      state.localTagRevisions = {
+        ...state.localTagRevisions,
+        [id]: (Number(state.localTagRevisions[id]) || 0) + 1
+      };
+    }
+    state.localSyncPending = {
+      ...state.localSyncPending,
+      [id]: {
+        shotId,
+        update: { ...(previous.update || {}), ...update },
+        revision: (Number(previous.revision) || 0) + 1
+      }
+    };
+    return startLocalSync(id);
+  }
+
   async function pushLocalShotUpdate(shot, patch, opts) {
     opts = opts || {};
     if (!shot || !shot.id) {
       recordLocalSyncStatus(null, null, "skipped: missing shot", null);
       return { skipped: "missing shot" };
     }
-    if (!opts.force && consumeLocalSyncSuppression(shot.id)) {
+    if (!opts.force && consumeLocalSyncSuppression(shot.id, patch)) {
       recordLocalSyncStatus(shot.id, null, "skipped: suppressed", null);
       return { skipped: "suppressed" };
-    }
-    if (state.localSyncRunning[shot.id]) {
-      recordLocalSyncStatus(shot.id, null, "skipped: already running", null);
-      return { skipped: "already running" };
     }
     if (!state.username || !state.password) {
       recordLocalSyncStatus(shot.id, null, "skipped: no credentials", null);
@@ -730,27 +867,7 @@ function createPlugin(host) {
       return { skipped: "empty update" };
     }
 
-    state.localSyncRunning[shot.id] = true;
-    try {
-      const detail = await visualizerPatch(`/shots/${visualizerId}`, { shot: update });
-      const updatedAt = Number(detail?.updated_at) || Number(detail?.meta?.visualizer?.updated_at) || 0;
-      if (updatedAt > 0) {
-        state.backSyncState[visualizerId] = { remoteUpdatedAt: updatedAt };
-        state.backSyncCursor = Math.max(Number(state.backSyncCursor) || 0, updatedAt);
-        persistBackSyncState();
-      }
-      host.emit("shotForwardSynced", { shotId: shot.id, visualizerId, timestamp: Date.now() });
-      log(`Local sync: updated ${shot.id} → ${visualizerId}`);
-      recordLocalSyncStatus(shot.id, visualizerId, "updated", null);
-      return { ok: true, visualizerId };
-    } catch (e) {
-      log(`Local sync failed for ${shot.id}: ${e.message}`);
-      host.emit("shotForwardSyncError", { shotId: shot.id, visualizerId, error: e.message, timestamp: Date.now() });
-      recordLocalSyncStatus(shot.id, visualizerId, "error", e.message);
-      return { error: e.message };
-    } finally {
-      delete state.localSyncRunning[shot.id];
-    }
+    return await queueLocalSync(shot.id, visualizerId, update);
   }
 
   async function syncLocalShotNow(shotId) {
@@ -952,7 +1069,7 @@ function createPlugin(host) {
         const update = mapRemoteToLocal(detail);
         let processed = Object.keys(update).length === 0;
         if (Object.keys(update).length > 0) {
-          suppressLocalSync(localId);
+          suppressLocalSync(localId, update);
           const res = await fetch(`${LOCAL_API_URL}/shots/${localId}`, {
             method: "PUT",
             headers: { "Content-Type": "application/json" },
@@ -963,6 +1080,7 @@ function createPlugin(host) {
             processed = true;
             host.emit("shotBackSynced", { shotId: localId, visualizerId: item.id, timestamp: Date.now() });
           } else {
+            consumeLocalSyncSuppression(localId, update);
             log(`Back-sync: PUT ${localId} failed ${res.status}`);
           }
         }
@@ -1014,7 +1132,7 @@ function createPlugin(host) {
   // Return the plugin object
   return {
     id: "visualizer.reaplugin",
-    version: "1.5.3",
+    version: "1.5.4",
 
     onLoad(settings) {
       state.username = settings.Username;
@@ -1117,15 +1235,18 @@ function createPlugin(host) {
             requestedShot = shot;
             return uploadShot(convertReaToVisualizerFormat(shot), null);
           })
-          .then(async (shotResponse) => {
-            await rememberUpload(shotId, shotResponse.id);
-            await pushTagsToVisualizer(requestedShot, shotResponse.id);
+          .then((shotResponse) => {
+            rememberSuccessfulUpload(shotId, shotResponse.id);
+            syncSuccessfulUpload(shotId, shotResponse.id, requestedShot);
 
             return {
               requestId: request.requestId,
-              status: 200,
+              status: 202,
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ visualizer_id: shotResponse.id }),
+              body: JSON.stringify({
+                visualizer_id: shotResponse.id,
+                tag_sync_pending: true
+              }),
             };
           })
           .catch((error) => ({
@@ -1264,6 +1385,7 @@ function createPlugin(host) {
             lastShotId: state.localSyncStatus.lastShotId,
             lastVisualizerId: state.localSyncStatus.lastVisualizerId,
             running: Object.keys(state.localSyncRunning),
+            pending: Object.keys(state.localSyncPending),
           })
         };
       }

--- a/assets/plugins/visualizer.reaplugin/plugin.js
+++ b/assets/plugins/visualizer.reaplugin/plugin.js
@@ -170,6 +170,33 @@ function createPlugin(host) {
     return measurements.slice(firstEspressoIndex, lastEspressoIndex + 1);
   }
 
+  // Recipe tags (set in the recipe editor, carried in workflow.context.extras)
+  // and shot-review tags (added after the pour, carried in annotations.extras)
+  // are separate sources — merge and dedupe them into the single tags list
+  // Visualizer expects.
+  function extractTags(shot) {
+    const annotations = shot?.annotations || {};
+    const context = shot?.workflow?.context || {};
+    const recipeTags = Array.isArray(context.extras?.tags) ? context.extras.tags : [];
+    const shotTags = Array.isArray(annotations.extras?.tags) ? annotations.extras.tags : [];
+    return Array.from(new Set([...recipeTags, ...shotTags]));
+  }
+
+  // Push tags onto an already-uploaded Visualizer shot. The /shots/upload JSON
+  // importer only captures a fixed field set that does not include tags, so
+  // tags must be applied as a separate PATCH using the same field name
+  // Visualizer's own API (and our back-sync reader) uses.
+  async function pushTagsToVisualizer(shot, visualizerId) {
+    const tags = extractTags(shot);
+    if (tags.length === 0) return;
+    try {
+      await visualizerPatch(`/shots/${visualizerId}`, { shot: { tags } });
+      log(`Synced ${tags.length} tag(s) to Visualizer shot ${visualizerId}`);
+    } catch (e) {
+      log(`Failed to sync tags to Visualizer shot ${visualizerId}: ${e.message}`);
+    }
+  }
+
   function convertReaToVisualizerFormat(reaShot) {
     if (!reaShot || !reaShot.measurements || reaShot.measurements.length === 0) {
       throw new Error("Invalid or empty Decent shot data for conversion.");
@@ -182,14 +209,6 @@ function createPlugin(host) {
     const annotations = reaShot.annotations || {};
     const context = reaShot.workflow?.context || {};
     let totalWaterDispensed = 0;
-
-    // Recipe tags (set in the recipe editor, carried in workflow.context.extras)
-    // and shot-review tags (added after the pour, carried in annotations.extras)
-    // are separate sources — merge and dedupe them into the single tags list
-    // Visualizer expects.
-    const recipeTags = Array.isArray(context.extras?.tags) ? context.extras.tags : [];
-    const shotTags = Array.isArray(annotations.extras?.tags) ? annotations.extras.tags : [];
-    const tags = Array.from(new Set([...recipeTags, ...shotTags]));
 
     const visualizerShot = {
       // start_time: reaShot.measurements[0].machine.timestamp,
@@ -216,7 +235,6 @@ function createPlugin(host) {
             drink_ey: annotations.drinkEy != null ? String(annotations.drinkEy) : undefined,
             espresso_enjoyment: annotations.enjoyment != null ? String(Math.round(Number(annotations.enjoyment))) : undefined,
             espresso_notes: annotations.espressoNotes,
-            tags: tags.length > 0 ? tags : undefined,
           }
         }
       },
@@ -296,6 +314,8 @@ function createPlugin(host) {
       const result = await uploadShot(convertReaToVisualizerFormat(fullShot), null);
       state.lastUploadedShot = fullShot.id;
       state.lastVisualizerId = result.id;
+
+      await pushTagsToVisualizer(fullShot, result.id);
 
       host.storage({
         type: "write",
@@ -653,6 +673,16 @@ function createPlugin(host) {
     if (force === true) {
       const title = shot.workflow?.profile?.title || shot.workflow?.name;
       if (typeof title === "string" && title.trim() !== "") payload.profile_title = title;
+    }
+    // Tags can change on either side (recipe extras or shot-review extras), so
+    // touched-ness is checked on both patch sources; the value sent is always
+    // the full deduped set (there's no per-tag diff to send).
+    if (
+      force === true ||
+      has(patchAnnotations.extras || {}, "tags") ||
+      has(patchContext.extras || {}, "tags")
+    ) {
+      payload.tags = extractTags(shot);
     }
 
     return payload;
@@ -1070,6 +1100,7 @@ function createPlugin(host) {
           };
         }
 
+        let requestedShot;
         return fetch(`${LOCAL_API_URL}/shots/${encodeURIComponent(shotId)}`)
           .then(async (response) => {
             const body = await response.text();
@@ -1082,9 +1113,13 @@ function createPlugin(host) {
 
             return JSON.parse(body);
           })
-          .then((shot) => uploadShot(convertReaToVisualizerFormat(shot), null))
+          .then((shot) => {
+            requestedShot = shot;
+            return uploadShot(convertReaToVisualizerFormat(shot), null);
+          })
           .then(async (shotResponse) => {
             await rememberUpload(shotId, shotResponse.id);
+            await pushTagsToVisualizer(requestedShot, shotResponse.id);
 
             return {
               requestId: request.requestId,

--- a/assets/plugins/visualizer.reaplugin/plugin.js
+++ b/assets/plugins/visualizer.reaplugin/plugin.js
@@ -183,6 +183,14 @@ function createPlugin(host) {
     const context = reaShot.workflow?.context || {};
     let totalWaterDispensed = 0;
 
+    // Recipe tags (set in the recipe editor, carried in workflow.context.extras)
+    // and shot-review tags (added after the pour, carried in annotations.extras)
+    // are separate sources — merge and dedupe them into the single tags list
+    // Visualizer expects.
+    const recipeTags = Array.isArray(context.extras?.tags) ? context.extras.tags : [];
+    const shotTags = Array.isArray(annotations.extras?.tags) ? annotations.extras.tags : [];
+    const tags = Array.from(new Set([...recipeTags, ...shotTags]));
+
     const visualizerShot = {
       // start_time: reaShot.measurements[0].machine.timestamp,
       timestamp: Math.floor(firstTimestamp / 1000),
@@ -208,6 +216,7 @@ function createPlugin(host) {
             drink_ey: annotations.drinkEy != null ? String(annotations.drinkEy) : undefined,
             espresso_enjoyment: annotations.enjoyment != null ? String(Math.round(Number(annotations.enjoyment))) : undefined,
             espresso_notes: annotations.espressoNotes,
+            tags: tags.length > 0 ? tags : undefined,
           }
         }
       },

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -203,7 +203,7 @@ Plugins receive events in the `onEvent` method:
 
 #### Visualizer Forward Sync
 
-The bundled Visualizer plugin merges recipe and shot-review tags, reads the current Visualizer tags before replacing them, and forwards later local edits in order. Visualizer tag writes require a Visualizer Premium account. The upload endpoint returns `202` with `visualizer_id` after the Visualizer upload succeeds while the tag PATCH continues in memory. Follow-up failures, including Visualizer's premium-account rejection, are reported through `shotForwardSyncError` and `forwardSyncStatus`; tag ownership and pending work are not restored after an app or plugin restart.
+The bundled Visualizer plugin merges recipe and shot-review tags, reads the current Visualizer tags before replacing them, and forwards later local edits in order. Visualizer tag writes require a Visualizer Premium account. The upload endpoint returns `202` with `visualizer_id` after the Visualizer upload succeeds while the tag PATCH continues in memory. Follow-up failures, including Visualizer's premium-account rejection, are reported through `shotForwardSyncError` and `forwardSyncStatus`; tag ownership is restored after an app or plugin restart. Pending work is not restored though.
 
 ### Events from Plugin → Flutter
 

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -203,7 +203,7 @@ Plugins receive events in the `onEvent` method:
 
 #### Visualizer Forward Sync
 
-The bundled Visualizer plugin merges recipe and shot-review tags, reads the current Visualizer tags before replacing them, and forwards later local edits in order. The upload endpoint returns `202` with `visualizer_id` after the Visualizer upload succeeds while the tag PATCH continues in memory. Follow-up failures are reported through `shotForwardSyncError` and `forwardSyncStatus`; tag ownership and pending work are not restored after an app or plugin restart.
+The bundled Visualizer plugin merges recipe and shot-review tags, reads the current Visualizer tags before replacing them, and forwards later local edits in order. Visualizer tag writes require a Visualizer Premium account. The upload endpoint returns `202` with `visualizer_id` after the Visualizer upload succeeds while the tag PATCH continues in memory. Follow-up failures, including Visualizer's premium-account rejection, are reported through `shotForwardSyncError` and `forwardSyncStatus`; tag ownership and pending work are not restored after an app or plugin restart.
 
 ### Events from Plugin → Flutter
 

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -201,6 +201,10 @@ Plugins receive events in the `onEvent` method:
   }
   ```
 
+#### Visualizer Forward Sync
+
+The bundled Visualizer plugin merges recipe and shot-review tags, reads the current Visualizer tags before replacing them, and forwards later local edits in order. The upload endpoint returns `202` with `visualizer_id` after the Visualizer upload succeeds while the tag PATCH continues in memory. Follow-up failures are reported through `shotForwardSyncError` and `forwardSyncStatus`; tag ownership and pending work are not restored after an app or plugin restart.
+
 ### Events from Plugin → Flutter
 
 Plugins can emit custom events that the Flutter app can listen to:

--- a/test/plugins/visualizer_plugin_test.dart
+++ b/test/plugins/visualizer_plugin_test.dart
@@ -224,13 +224,15 @@ void main() {
     final patch =
         await _waitForJs(manager, 'globalThis.__patch') as Map<String, dynamic>;
 
-    expect((patch['shot'] as Map<String, dynamic>)['tags'], [
+    final shotPatch = patch['shot'] as Map<String, dynamic>;
+    expect(shotPatch['tag_list'], [
       'fast shot',
       'washed',
       'bright',
       'floral',
       'remote',
     ]);
+    expect(shotPatch.containsKey('tags'), isFalse);
   });
 
   test(
@@ -281,7 +283,7 @@ void main() {
         if (url.endsWith('/shots/visualizer-1') && init.method === 'PATCH') {
           const patch = JSON.parse(init.body);
           globalThis.__patches = [...globalThis.__patches, patch];
-          globalThis.__remoteTags = patch.shot.tags;
+          globalThis.__remoteTags = patch.shot.tag_list;
           return { ok: true, json: async () => ({ id: 'visualizer-1', updated_at: globalThis.__patches.length }) };
         }
         throw new Error('Unexpected URL: ' + url + ' ' + (init.method || 'GET'));
@@ -308,7 +310,7 @@ void main() {
                 'globalThis.__patches.length === 1 ? globalThis.__patches[0] : null',
               )
               as Map<String, dynamic>;
-      expect((firstPatch['shot'] as Map<String, dynamic>)['tags'], [
+      expect((firstPatch['shot'] as Map<String, dynamic>)['tag_list'], [
         'during-upload',
       ]);
 
@@ -330,7 +332,7 @@ void main() {
                 'globalThis.__patches.length === 2 ? globalThis.__patches[1] : null',
               )
               as Map<String, dynamic>;
-      expect((secondPatch['shot'] as Map<String, dynamic>)['tags'], [
+      expect((secondPatch['shot'] as Map<String, dynamic>)['tag_list'], [
         'after-mapping',
       ]);
     },
@@ -419,7 +421,7 @@ void main() {
     expect(patches, hasLength(1));
     expect(
       ((patches.single as Map<String, dynamic>)['shot']
-          as Map<String, dynamic>)['tags'],
+          as Map<String, dynamic>)['tag_list'],
       ['latest'],
     );
   });
@@ -435,7 +437,7 @@ void main() {
         if (url.endsWith('/shots/visualizer-9') && init.method === 'PATCH') {
           const patch = JSON.parse(init.body);
           globalThis.__patches = [...globalThis.__patches, patch];
-          globalThis.__remoteTags = patch.shot.tags;
+          globalThis.__remoteTags = patch.shot.tag_list;
           return { ok: true, json: async () => ({ id: 'visualizer-9', updated_at: globalThis.__patches.length }) };
         }
         throw new Error('Unexpected URL: ' + url);
@@ -466,7 +468,7 @@ void main() {
               'globalThis.__patches.length === 1 ? globalThis.__patches[0] : null',
             )
             as Map<String, dynamic>;
-    expect((firstPatch['shot'] as Map<String, dynamic>)['tags'], [
+    expect((firstPatch['shot'] as Map<String, dynamic>)['tag_list'], [
       'local',
       'remote',
     ]);
@@ -490,7 +492,9 @@ void main() {
               'globalThis.__patches.length === 2 ? globalThis.__patches[1] : null',
             )
             as Map<String, dynamic>;
-    expect((secondPatch['shot'] as Map<String, dynamic>)['tags'], ['remote']);
+    expect((secondPatch['shot'] as Map<String, dynamic>)['tag_list'], [
+      'remote',
+    ]);
   });
 
   test('legacy metadata and shotNotes patches use canonical shot values', () async {
@@ -504,7 +508,7 @@ void main() {
         if (url.endsWith('/shots/visualizer-9') && init.method === 'PATCH') {
           const patch = JSON.parse(init.body);
           globalThis.__patches = [...globalThis.__patches, patch];
-          if (patch.shot.tags) globalThis.__remoteTags = patch.shot.tags;
+          if (patch.shot.tag_list) globalThis.__remoteTags = patch.shot.tag_list;
           return { ok: true, json: async () => ({ id: 'visualizer-9', updated_at: globalThis.__patches.length }) };
         }
         throw new Error('Unexpected URL: ' + url);
@@ -533,7 +537,9 @@ void main() {
               'globalThis.__patches.length === 1 ? globalThis.__patches[0] : null',
             )
             as Map<String, dynamic>;
-    expect((firstPatch['shot'] as Map<String, dynamic>)['tags'], ['washed']);
+    expect((firstPatch['shot'] as Map<String, dynamic>)['tag_list'], [
+      'washed',
+    ]);
 
     _dispatchShotUpdate(
       manager,
@@ -550,7 +556,7 @@ void main() {
               'globalThis.__patches.length === 2 ? globalThis.__patches[1] : null',
             )
             as Map<String, dynamic>;
-    expect((secondPatch['shot'] as Map<String, dynamic>)['tags'], isEmpty);
+    expect((secondPatch['shot'] as Map<String, dynamic>)['tag_list'], isEmpty);
 
     _dispatchShotUpdate(
       manager,
@@ -710,12 +716,12 @@ void main() {
             as List<dynamic>;
     final latest = (patches.last as Map<String, dynamic>)['shot'] as Map;
 
-    expect(latest['tags'], ['latest', 'remote']);
+    expect(latest['tag_list'], ['latest', 'remote']);
     expect(latest.containsKey('espresso_notes'), isFalse);
   });
 
   test(
-    'successful upload returns its id before best-effort tag sync',
+    'successful upload returns its id and surfaces the premium tag gate',
     () async {
       final shot = _shot(
         annotations: {
@@ -740,11 +746,16 @@ void main() {
           return { ok: true, json: async () => ({}) };
         }
         if (url.endsWith('/shots/visualizer-1?essentials=1')) {
+          return { ok: true, json: async () => ({ id: 'visualizer-1', tags: [] }) };
+        }
+        if (url.endsWith('/shots/visualizer-1') && init.method === 'PATCH') {
+          globalThis.__tagPatch = JSON.parse(init.body);
           return await new Promise((resolve) => {
             globalThis.__failTagSync = () => resolve({
               ok: false,
-              status: 503,
-              statusText: 'Service Unavailable',
+              status: 400,
+              statusText: 'Bad Request',
+              text: async () => '{"error":"param is missing or the value is empty or invalid: shot"}',
             });
           });
         }
@@ -762,11 +773,21 @@ void main() {
       expect(response['status'], 202);
       expect(body, {'visualizer_id': 'visualizer-1', 'tag_sync_pending': true});
 
-      await _waitForJs(manager, 'globalThis.__failTagSync ? true : null');
+      final tagPatch =
+          await _waitForJs(manager, 'globalThis.__tagPatch')
+              as Map<String, dynamic>;
+      expect((tagPatch['shot'] as Map<String, dynamic>)['tag_list'], [
+        'bright',
+      ]);
+      expect(
+        (tagPatch['shot'] as Map<String, dynamic>).containsKey('tags'),
+        isFalse,
+      );
       final failTagSync = manager.js.evaluate('globalThis.__failTagSync()');
       expect(failTagSync.isError, isFalse, reason: failTagSync.stringResult);
       final event = await errorEvent.timeout(const Duration(seconds: 5));
-      expect(event['payload']['error'], contains('HTTP 503'));
+      expect(event['payload']['error'], contains('Visualizer Premium'));
+      expect(event['payload']['error'], contains('HTTP 400'));
     },
   );
 

--- a/test/plugins/visualizer_plugin_test.dart
+++ b/test/plugins/visualizer_plugin_test.dart
@@ -4,327 +4,777 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
-import 'package:reaprime/src/services/storage/kv_store_service.dart';
 
-class _FakeKeyValueStore implements KeyValueStoreService {
-  @override
-  Future<void> initialize() async {}
+import 'plugin_test_helpers.dart';
 
-  @override
-  Future<void> set({
-    String namespace = 'default',
-    required String key,
-    required Object value,
-  }) async {}
+final _pluginSource = File(
+  'assets/plugins/visualizer.reaplugin/plugin.js',
+).readAsStringSync();
+final _manifest = PluginManifest.fromJson(
+  jsonDecode(
+        File(
+          'assets/plugins/visualizer.reaplugin/manifest.json',
+        ).readAsStringSync(),
+      )
+      as Map<String, dynamic>,
+);
 
-  @override
-  Future<bool> delete({
-    String namespace = 'default',
-    required String key,
-  }) async => false;
+Map<String, dynamic> _shot({
+  Map<String, dynamic>? annotations,
+  Map<String, dynamic>? context,
+}) => {
+  'id': 'shot-1',
+  'annotations': annotations ?? <String, dynamic>{},
+  'workflow': {
+    'profile': {'target_weight': 36},
+    'context': context ?? <String, dynamic>{},
+  },
+  'measurements': [
+    for (var i = 0; i < 4; i++)
+      {
+        'machine': {
+          'timestamp': '2026-01-01T00:00:0${i * 2}Z',
+          'state': {'substate': 'pouring'},
+          'profileFrame': [0, 0, 1, 2][i],
+          'pressure': 9,
+          'targetPressure': 9,
+          'flow': 2,
+          'targetFlow': 2,
+          'mixTemperature': 93,
+          'groupTemperature': 92,
+          'targetGroupTemperature': 93,
+          'targetMixTemperature': 93,
+        },
+        'scale': {'weight': i * 10, 'weightFlow': 2},
+      },
+  ],
+};
 
-  @override
-  Future<Object?> get({
-    String namespace = 'default',
-    required String key,
-  }) async => null;
+Future<PluginManager> _loadPlugin(
+  String fetchSource, {
+  Map<String, dynamic> settings = const {},
+}) async {
+  final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+  final setupResult = manager.js.evaluate('''
+    globalThis.__testTimers = [];
+    globalThis.__nextTimerId = 1;
+    globalThis.__timerSet = (pluginId, generation, callback, delay = 0) => {
+      if (delay === 5000) {
+        callback();
+        return 0;
+      }
+      const timer = { id: globalThis.__nextTimerId++, callback, delay };
+      globalThis.__testTimers = [...globalThis.__testTimers, timer];
+      return timer.id;
+    };
+    globalThis.__timerClear = (pluginId, id) => {
+      globalThis.__testTimers = globalThis.__testTimers.filter((timer) => timer.id !== id);
+    };
+    globalThis.__runTimers = (delay) => {
+      const ready = globalThis.__testTimers.filter((timer) => timer.delay === delay);
+      globalThis.__testTimers = globalThis.__testTimers.filter((timer) => timer.delay !== delay);
+      for (const timer of ready) timer.callback();
+    };
+    $fetchSource
+    globalThis.__fetchFor = (pluginId, generation, url, init = {}) => globalThis.fetch(url, init);
+  ''');
+  expect(setupResult.isError, isFalse, reason: setupResult.stringResult);
+  await manager.loadPlugin(
+    id: _manifest.id,
+    manifest: _manifest,
+    settings: {
+      'Username': 'user',
+      'Password': 'password',
+      'LengthThreshold': 0,
+      ...settings,
+    },
+    jsCode: _pluginSource,
+  );
+  addTearDown(() => manager.unloadPlugin(_manifest.id));
+  return manager;
+}
 
-  @override
-  Future<List<String>> keys({String namespace = 'default'}) async => [];
+Future<Object?> _waitForJs(PluginManager manager, String expression) async {
+  for (var i = 0; i < 500; i++) {
+    manager.js.executePendingJob();
+    final result = manager.js.evaluate('JSON.stringify(($expression) ?? null)');
+    expect(result.isError, isFalse, reason: result.stringResult);
+    final value = jsonDecode(result.stringResult);
+    if (value != null) return value;
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+  }
+  fail('Timed out waiting for JavaScript expression: $expression');
+}
 
-  @override
-  List<String> get namespaces => [];
+Future<Map<String, dynamic>> _callApi(
+  PluginManager manager,
+  String endpoint,
+  Map<String, dynamic> body,
+) async {
+  const requestId = 'request-1';
+  final response = manager.registerPendingHttp(_manifest.id, requestId);
+  manager.dispatchEvent(_manifest.id, 'httpRequest', {
+    'requestId': requestId,
+    'endpoint': endpoint,
+    'method': 'POST',
+    'headers': <String, String>{},
+    'body': body,
+  });
+  return response.timeout(const Duration(seconds: 5));
+}
 
-  @override
-  Future<Map<String, Object>> getAll({String namespace = 'default'}) async =>
-      {};
+void _startAutoUpload(PluginManager manager) {
+  manager.dispatchEvent(_manifest.id, 'stateUpdate', {
+    'state': {'state': 'espresso'},
+  });
+  manager.dispatchEvent(_manifest.id, 'stateUpdate', {
+    'state': {'state': 'idle'},
+  });
+}
+
+void _dispatchShotUpdate(
+  PluginManager manager,
+  Map<String, dynamic> shot,
+  Map<String, dynamic> patch,
+) {
+  manager.dispatchEvent(_manifest.id, 'shotUpdated', {
+    'id': shot['id'],
+    'shot': shot,
+    'patch': patch,
+  });
 }
 
 void main() {
-  test(
-    'Visualizer upload encodes state_change as non-zero stage markers',
-    () async {
-      final pluginSource = File(
-        'assets/plugins/visualizer.reaplugin/plugin.js',
-      ).readAsStringSync();
-      final manifest = PluginManifest.fromJson(
-        jsonDecode(
-              File(
-                'assets/plugins/visualizer.reaplugin/manifest.json',
-              ).readAsStringSync(),
-            )
-            as Map<String, dynamic>,
-      );
-      final shot = {
-        'id': 'shot-1',
-        'annotations': <String, dynamic>{},
-        'workflow': {
-          'profile': {'target_weight': 36},
-          'context': <String, dynamic>{},
-        },
-        'measurements': [
-          for (var i = 0; i < 4; i++)
-            {
-              'machine': {
-                'timestamp': '2026-01-01T00:00:0${i * 2}Z',
-                'state': {'substate': 'pouring'},
-                'profileFrame': [0, 0, 1, 2][i],
-                'pressure': 9,
-                'targetPressure': 9,
-                'flow': 2,
-                'targetFlow': 2,
-                'mixTemperature': 93,
-                'groupTemperature': 92,
-                'targetGroupTemperature': 93,
-                'targetMixTemperature': 93,
-              },
-              'scale': {'weight': i * 10, 'weightFlow': 2},
-            },
-        ],
-      };
-      final manager = PluginManager(kvStore: _FakeKeyValueStore());
-      final setupResult = manager.js.evaluate('''
-      globalThis.__timerSet = (pluginId, generation, callback, delay) => { callback(); return 1; };
-      globalThis.__timerClear = () => {};
-      globalThis.__fetchFor = async (pluginId, generation, url, init = {}) => {
+  test('upload encodes non-zero stage markers', () async {
+    final shot = _shot();
+    final manager = await _loadPlugin('''
+      globalThis.fetch = async (url, init = {}) => {
         if (url.endsWith('/shots/latest')) {
           return { ok: true, json: async () => ({ id: 'shot-1' }) };
         }
-        if (url.endsWith('/shots/shot-1')) {
+        if (url.endsWith('/shots/shot-1') && (!init.method || init.method === 'GET')) {
           return { ok: true, json: async () => (${jsonEncode(shot)}) };
         }
         if (url.endsWith('/shots/upload')) {
-          const body = init.body;
-          const start = body.indexOf('\\r\\n\\r\\n') + 4;
-          const end = body.lastIndexOf('\\r\\n--');
-          globalThis.__visualizerUpload = JSON.parse(body.slice(start, end));
+          const start = init.body.indexOf('\\r\\n\\r\\n') + 4;
+          const end = init.body.lastIndexOf('\\r\\n--');
+          globalThis.__upload = JSON.parse(init.body.slice(start, end));
           return { ok: true, json: async () => ({ id: 'visualizer-1' }) };
+        }
+        if (url.endsWith('/shots/shot-1') && init.method === 'PUT') {
+          return { ok: true, json: async () => ({}) };
+        }
+        if (url.endsWith('/shots/visualizer-1?essentials=1')) {
+          return { ok: true, json: async () => ({ id: 'visualizer-1', tags: [] }) };
+        }
+        if (url.endsWith('/shots/visualizer-1') && init.method === 'PATCH') {
+          return { ok: true, json: async () => ({ id: 'visualizer-1', updated_at: 1 }) };
         }
         throw new Error('Unexpected URL: ' + url);
       };
     ''');
-      expect(setupResult.isError, isFalse, reason: setupResult.stringResult);
 
-      await manager.loadPlugin(
-        id: manifest.id,
-        manifest: manifest,
-        settings: {
-          'Username': 'user',
-          'Password': 'password',
-          'LengthThreshold': 0,
+    _startAutoUpload(manager);
+    final upload =
+        await _waitForJs(manager, 'globalThis.__upload')
+            as Map<String, dynamic>;
+
+    expect(upload['state_change'], [1, 1, 2, 3]);
+  });
+
+  test('upload merges deduped local tags with current remote tags', () async {
+    final shot = _shot(
+      annotations: {
+        'extras': {
+          'tags': ['bright', 'floral'],
         },
-        jsCode: pluginSource,
-      );
-      manager.dispatchEvent(manifest.id, 'stateUpdate', {
-        'state': {'state': 'espresso'},
-      });
-      manager.dispatchEvent(manifest.id, 'stateUpdate', {
-        'state': {'state': 'idle'},
-      });
-
-      Map<String, dynamic>? upload;
-      for (var i = 0; i < 20 && upload == null; i++) {
-        manager.js.executePendingJob();
-        final result = manager.js.evaluate(
-          'JSON.stringify(globalThis.__visualizerUpload ?? null)',
-        );
-        upload = jsonDecode(result.stringResult) as Map<String, dynamic>?;
-        await Future<void>.delayed(Duration.zero);
-      }
-
-      expect(upload?['state_change'], [1, 1, 2, 3]);
-    },
-  );
-
-  test(
-    'Visualizer upload PATCHes deduped recipe and shot-review tags after the initial import',
-    () async {
-      // The /shots/upload JSON importer doesn't persist a tags field, so tags
-      // must be pushed via a follow-up PATCH to /shots/<visualizerId> using
-      // the same flat field name Visualizer's own API returns on read.
-      final pluginSource = File(
-        'assets/plugins/visualizer.reaplugin/plugin.js',
-      ).readAsStringSync();
-      final manifest = PluginManifest.fromJson(
-        jsonDecode(
-              File(
-                'assets/plugins/visualizer.reaplugin/manifest.json',
-              ).readAsStringSync(),
-            )
-            as Map<String, dynamic>,
-      );
-      final shot = {
-        'id': 'shot-1',
-        'annotations': <String, dynamic>{
-          'extras': {
-            // "bright" overlaps with the recipe tags below to exercise dedupe.
-            'tags': ['bright', 'floral'],
-          },
+      },
+      context: {
+        'extras': {
+          'tags': ['fast shot', 'washed', 'bright'],
         },
-        'workflow': {
-          'profile': {'target_weight': 36},
-          'context': {
-            'extras': {
-              'tags': ['fast shot', 'washed', 'bright'],
-            },
-          },
-        },
-        'measurements': [
-          for (var i = 0; i < 4; i++)
-            {
-              'machine': {
-                'timestamp': '2026-01-01T00:00:0${i * 2}Z',
-                'state': {'substate': 'pouring'},
-                'profileFrame': [0, 0, 1, 2][i],
-                'pressure': 9,
-                'targetPressure': 9,
-                'flow': 2,
-                'targetFlow': 2,
-                'mixTemperature': 93,
-                'groupTemperature': 92,
-                'targetGroupTemperature': 93,
-                'targetMixTemperature': 93,
-              },
-              'scale': {'weight': i * 10, 'weightFlow': 2},
-            },
-        ],
-      };
-      final manager = PluginManager(kvStore: _FakeKeyValueStore());
-      final setupResult = manager.js.evaluate('''
-      globalThis.setTimeout = (callback) => { callback(); return 1; };
-      globalThis.clearTimeout = () => {};
+      },
+    );
+    final manager = await _loadPlugin('''
       globalThis.fetch = async (url, init = {}) => {
         if (url.endsWith('/shots/latest')) {
           return { ok: true, json: async () => ({ id: 'shot-1' }) };
         }
-        if (url.endsWith('/shots/shot-1')) {
+        if (url.endsWith('/shots/shot-1') && (!init.method || init.method === 'GET')) {
           return { ok: true, json: async () => (${jsonEncode(shot)}) };
         }
         if (url.endsWith('/shots/upload')) {
-          const body = init.body;
-          const start = body.indexOf('\\r\\n\\r\\n') + 4;
-          const end = body.lastIndexOf('\\r\\n--');
-          globalThis.__visualizerUpload = JSON.parse(body.slice(start, end));
           return { ok: true, json: async () => ({ id: 'visualizer-1' }) };
         }
+        if (url.endsWith('/shots/shot-1') && init.method === 'PUT') {
+          return { ok: true, json: async () => ({}) };
+        }
+        if (url.endsWith('/shots/visualizer-1?essentials=1')) {
+          return { ok: true, json: async () => ({ id: 'visualizer-1', tags: ['remote'] }) };
+        }
         if (url.endsWith('/shots/visualizer-1') && init.method === 'PATCH') {
-          globalThis.__visualizerTagPatch = JSON.parse(init.body);
-          return { ok: true, json: async () => ({ id: 'visualizer-1', updated_at: 0 }) };
+          globalThis.__patch = JSON.parse(init.body);
+          return { ok: true, json: async () => ({ id: 'visualizer-1', updated_at: 1 }) };
         }
         throw new Error('Unexpected URL: ' + url + ' ' + (init.method || 'GET'));
       };
     ''');
-      expect(setupResult.isError, isFalse, reason: setupResult.stringResult);
 
-      await manager.loadPlugin(
-        id: manifest.id,
-        manifest: manifest,
-        settings: {
-          'Username': 'user',
-          'Password': 'password',
-          'LengthThreshold': 0,
-        },
-        jsCode: pluginSource,
-      );
-      manager.dispatchEvent(manifest.id, 'stateUpdate', {
-        'state': {'state': 'espresso'},
-      });
-      manager.dispatchEvent(manifest.id, 'stateUpdate', {
-        'state': {'state': 'idle'},
-      });
+    _startAutoUpload(manager);
+    final patch =
+        await _waitForJs(manager, 'globalThis.__patch') as Map<String, dynamic>;
 
-      Map<String, dynamic>? tagPatch;
-      for (var i = 0; i < 20 && tagPatch == null; i++) {
-        manager.js.executePendingJob();
-        final result = manager.js.evaluate(
-          'JSON.stringify(globalThis.__visualizerTagPatch ?? null)',
-        );
-        tagPatch = jsonDecode(result.stringResult) as Map<String, dynamic>?;
-        await Future<void>.delayed(Duration.zero);
-      }
-
-      final patchedShot = tagPatch?['shot'] as Map<String, dynamic>?;
-      expect(patchedShot?['tags'], ['fast shot', 'washed', 'bright', 'floral']);
-    },
-  );
+    expect((patch['shot'] as Map<String, dynamic>)['tags'], [
+      'fast shot',
+      'washed',
+      'bright',
+      'floral',
+      'remote',
+    ]);
+  });
 
   test(
-    'Visualizer forward-sync pushes shot-review tag edits made after upload',
+    'upload forwards an in-flight edit and does not suppress the next edit',
     () async {
-      final pluginSource = File(
-        'assets/plugins/visualizer.reaplugin/plugin.js',
-      ).readAsStringSync();
-      final manifest = PluginManifest.fromJson(
-        jsonDecode(
-              File(
-                'assets/plugins/visualizer.reaplugin/manifest.json',
-              ).readAsStringSync(),
-            )
-            as Map<String, dynamic>,
+      final initialShot = _shot();
+      final duringUpload = _shot(
+        annotations: {
+          'extras': {
+            'tags': ['during-upload'],
+          },
+        },
       );
-      final manager = PluginManager(kvStore: _FakeKeyValueStore());
-      final setupResult = manager.js.evaluate('''
-      globalThis.setTimeout = (callback) => { callback(); return 1; };
-      globalThis.clearTimeout = () => {};
+      final afterMapping = _shot(
+        annotations: {
+          'extras': {
+            'visualizerId': 'visualizer-1',
+            'tags': ['after-mapping'],
+          },
+        },
+      );
+      final manager = await _loadPlugin('''
+      globalThis.__currentShot = ${jsonEncode(initialShot)};
+      globalThis.__remoteTags = [];
+      globalThis.__patches = [];
       globalThis.fetch = async (url, init = {}) => {
-        if (url.endsWith('/shots/visualizer-9') && init.method === 'PATCH') {
-          globalThis.__forwardSyncPatch = JSON.parse(init.body);
-          return { ok: true, json: async () => ({ id: 'visualizer-9', updated_at: 0 }) };
+        if (url.endsWith('/shots/latest')) {
+          return { ok: true, json: async () => ({ id: 'shot-1' }) };
+        }
+        if (url.endsWith('/shots/shot-1') && (!init.method || init.method === 'GET')) {
+          return { ok: true, json: async () => globalThis.__currentShot };
+        }
+        if (url.endsWith('/shots/upload')) {
+          globalThis.__uploadStarted = true;
+          return await new Promise((resolve) => {
+            globalThis.__finishUpload = () => resolve({
+              ok: true,
+              json: async () => ({ id: 'visualizer-1' }),
+            });
+          });
+        }
+        if (url.endsWith('/shots/shot-1') && init.method === 'PUT') {
+          return { ok: true, json: async () => ({}) };
+        }
+        if (url.endsWith('/shots/visualizer-1?essentials=1')) {
+          return { ok: true, json: async () => ({ id: 'visualizer-1', tags: globalThis.__remoteTags }) };
+        }
+        if (url.endsWith('/shots/visualizer-1') && init.method === 'PATCH') {
+          const patch = JSON.parse(init.body);
+          globalThis.__patches = [...globalThis.__patches, patch];
+          globalThis.__remoteTags = patch.shot.tags;
+          return { ok: true, json: async () => ({ id: 'visualizer-1', updated_at: globalThis.__patches.length }) };
         }
         throw new Error('Unexpected URL: ' + url + ' ' + (init.method || 'GET'));
       };
     ''');
-      expect(setupResult.isError, isFalse, reason: setupResult.stringResult);
 
-      await manager.loadPlugin(
-        id: manifest.id,
-        manifest: manifest,
-        settings: {
-          'Username': 'user',
-          'Password': 'password',
-          'LengthThreshold': 0,
-        },
-        jsCode: pluginSource,
-      );
-
-      // A shot already uploaded to Visualizer (visualizerId known) gets a tag
-      // added during shot review, well after the initial upload completed.
-      manager.dispatchEvent(manifest.id, 'shotUpdated', {
-        'id': 'shot-1',
-        'shot': {
-          'id': 'shot-1',
-          'annotations': {
-            'extras': {
-              'visualizerId': 'visualizer-9',
-              'tags': ['bright'],
-            },
-          },
-          'workflow': {
-            'profile': {'target_weight': 36},
-            'context': {'extras': <String, dynamic>{}},
-          },
-        },
-        'patch': {
-          'annotations': {
-            'extras': {
-              'tags': ['bright'],
-            },
+      _startAutoUpload(manager);
+      await _waitForJs(manager, 'globalThis.__uploadStarted');
+      _dispatchShotUpdate(manager, duringUpload, {
+        'annotations': {
+          'extras': {
+            'tags': ['during-upload'],
           },
         },
       });
+      final finishUpload = manager.js.evaluate('''
+      globalThis.__currentShot = ${jsonEncode(duringUpload)};
+      globalThis.__finishUpload();
+    ''');
+      expect(finishUpload.isError, isFalse, reason: finishUpload.stringResult);
+      final firstPatch =
+          await _waitForJs(
+                manager,
+                'globalThis.__patches.length === 1 ? globalThis.__patches[0] : null',
+              )
+              as Map<String, dynamic>;
+      expect((firstPatch['shot'] as Map<String, dynamic>)['tags'], [
+        'during-upload',
+      ]);
 
-      Map<String, dynamic>? forwardPatch;
-      for (var i = 0; i < 20 && forwardPatch == null; i++) {
-        manager.js.executePendingJob();
-        final result = manager.js.evaluate(
-          'JSON.stringify(globalThis.__forwardSyncPatch ?? null)',
-        );
-        forwardPatch = jsonDecode(result.stringResult) as Map<String, dynamic>?;
-        await Future<void>.delayed(Duration.zero);
-      }
-
-      final patchedShot = forwardPatch?['shot'] as Map<String, dynamic>?;
-      expect(patchedShot?['tags'], ['bright']);
+      _dispatchShotUpdate(manager, duringUpload, {
+        'annotations': {
+          'extras': {'visualizerId': 'visualizer-1'},
+        },
+      });
+      _dispatchShotUpdate(manager, afterMapping, {
+        'annotations': {
+          'extras': {
+            'tags': ['after-mapping'],
+          },
+        },
+      });
+      final secondPatch =
+          await _waitForJs(
+                manager,
+                'globalThis.__patches.length === 2 ? globalThis.__patches[1] : null',
+              )
+              as Map<String, dynamic>;
+      expect((secondPatch['shot'] as Map<String, dynamic>)['tags'], [
+        'after-mapping',
+      ]);
     },
   );
+
+  test('post-upload refresh does not overwrite a newer tag edit', () async {
+    final staleShot = _shot(
+      annotations: {
+        'extras': {
+          'tags': ['stale'],
+        },
+      },
+    );
+    final latestShot = _shot(
+      annotations: {
+        'extras': {
+          'visualizerId': 'visualizer-1',
+          'tags': ['latest'],
+        },
+      },
+    );
+    final manager = await _loadPlugin('''
+      globalThis.__shotReads = 0;
+      globalThis.__patches = [];
+      globalThis.fetch = async (url, init = {}) => {
+        if (url.endsWith('/shots/latest')) {
+          return { ok: true, json: async () => ({ id: 'shot-1' }) };
+        }
+        if (url.endsWith('/shots/shot-1') && (!init.method || init.method === 'GET')) {
+          globalThis.__shotReads += 1;
+          if (globalThis.__shotReads === 1) {
+            return { ok: true, json: async () => (${jsonEncode(staleShot)}) };
+          }
+          globalThis.__refreshStarted = true;
+          return await new Promise((resolve) => {
+            globalThis.__finishRefresh = () => resolve({
+              ok: true,
+              json: async () => {
+                globalThis.__refreshRead = true;
+                return ${jsonEncode(staleShot)};
+              },
+            });
+          });
+        }
+        if (url.endsWith('/shots/upload')) {
+          return { ok: true, json: async () => ({ id: 'visualizer-1' }) };
+        }
+        if (url.endsWith('/shots/shot-1') && init.method === 'PUT') {
+          return { ok: true, json: async () => ({}) };
+        }
+        if (url.endsWith('/shots/visualizer-1?essentials=1')) {
+          return { ok: true, json: async () => ({ id: 'visualizer-1', tags: [] }) };
+        }
+        if (url.endsWith('/shots/visualizer-1') && init.method === 'PATCH') {
+          globalThis.__patches = [...globalThis.__patches, JSON.parse(init.body)];
+          return { ok: true, json: async () => ({ id: 'visualizer-1', updated_at: globalThis.__patches.length }) };
+        }
+        throw new Error('Unexpected URL: ' + url + ' ' + (init.method || 'GET'));
+      };
+    ''');
+
+    _startAutoUpload(manager);
+    await _waitForJs(manager, 'globalThis.__refreshStarted');
+    _dispatchShotUpdate(manager, latestShot, {
+      'annotations': {
+        'extras': {
+          'tags': ['latest'],
+        },
+      },
+    });
+    await _waitForJs(
+      manager,
+      'globalThis.__patches.length === 1 ? true : null',
+    );
+
+    final finishRefresh = manager.js.evaluate('globalThis.__finishRefresh()');
+    expect(finishRefresh.isError, isFalse, reason: finishRefresh.stringResult);
+    await _waitForJs(manager, 'globalThis.__refreshRead');
+    for (var i = 0; i < 20; i++) {
+      manager.js.executePendingJob();
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+    }
+    final patches =
+        await _waitForJs(manager, 'globalThis.__patches') as List<dynamic>;
+
+    expect(patches, hasLength(1));
+    expect(
+      ((patches.single as Map<String, dynamic>)['shot']
+          as Map<String, dynamic>)['tags'],
+      ['latest'],
+    );
+  });
+
+  test('forward sync preserves remote-only tags and removes local tags', () async {
+    final manager = await _loadPlugin('''
+      globalThis.__remoteTags = ['remote'];
+      globalThis.__patches = [];
+      globalThis.fetch = async (url, init = {}) => {
+        if (url.endsWith('/shots/visualizer-9?essentials=1')) {
+          return { ok: true, json: async () => ({ id: 'visualizer-9', tags: globalThis.__remoteTags }) };
+        }
+        if (url.endsWith('/shots/visualizer-9') && init.method === 'PATCH') {
+          const patch = JSON.parse(init.body);
+          globalThis.__patches = [...globalThis.__patches, patch];
+          globalThis.__remoteTags = patch.shot.tags;
+          return { ok: true, json: async () => ({ id: 'visualizer-9', updated_at: globalThis.__patches.length }) };
+        }
+        throw new Error('Unexpected URL: ' + url);
+      };
+    ''');
+
+    _dispatchShotUpdate(
+      manager,
+      _shot(
+        annotations: {
+          'extras': {
+            'visualizerId': 'visualizer-9',
+            'tags': ['local'],
+          },
+        },
+      ),
+      {
+        'annotations': {
+          'extras': {
+            'tags': ['local'],
+          },
+        },
+      },
+    );
+    final firstPatch =
+        await _waitForJs(
+              manager,
+              'globalThis.__patches.length === 1 ? globalThis.__patches[0] : null',
+            )
+            as Map<String, dynamic>;
+    expect((firstPatch['shot'] as Map<String, dynamic>)['tags'], [
+      'local',
+      'remote',
+    ]);
+
+    _dispatchShotUpdate(
+      manager,
+      _shot(
+        annotations: {
+          'extras': {'visualizerId': 'visualizer-9'},
+        },
+      ),
+      {
+        'annotations': {
+          'extras': {'tags': <String>[]},
+        },
+      },
+    );
+    final secondPatch =
+        await _waitForJs(
+              manager,
+              'globalThis.__patches.length === 2 ? globalThis.__patches[1] : null',
+            )
+            as Map<String, dynamic>;
+    expect((secondPatch['shot'] as Map<String, dynamic>)['tags'], ['remote']);
+  });
+
+  test('legacy metadata and shotNotes patches use canonical shot values', () async {
+    final manager = await _loadPlugin('''
+      globalThis.__remoteTags = [];
+      globalThis.__patches = [];
+      globalThis.fetch = async (url, init = {}) => {
+        if (url.endsWith('/shots/visualizer-9?essentials=1')) {
+          return { ok: true, json: async () => ({ id: 'visualizer-9', tags: globalThis.__remoteTags }) };
+        }
+        if (url.endsWith('/shots/visualizer-9') && init.method === 'PATCH') {
+          const patch = JSON.parse(init.body);
+          globalThis.__patches = [...globalThis.__patches, patch];
+          if (patch.shot.tags) globalThis.__remoteTags = patch.shot.tags;
+          return { ok: true, json: async () => ({ id: 'visualizer-9', updated_at: globalThis.__patches.length }) };
+        }
+        throw new Error('Unexpected URL: ' + url);
+      };
+    ''');
+
+    _dispatchShotUpdate(
+      manager,
+      _shot(
+        annotations: {
+          'extras': {
+            'visualizerId': 'visualizer-9',
+            'tags': ['washed'],
+          },
+        },
+      ),
+      {
+        'metadata': {
+          'tags': ['washed'],
+        },
+      },
+    );
+    final firstPatch =
+        await _waitForJs(
+              manager,
+              'globalThis.__patches.length === 1 ? globalThis.__patches[0] : null',
+            )
+            as Map<String, dynamic>;
+    expect((firstPatch['shot'] as Map<String, dynamic>)['tags'], ['washed']);
+
+    _dispatchShotUpdate(
+      manager,
+      _shot(
+        annotations: {
+          'extras': {'visualizerId': 'visualizer-9'},
+        },
+      ),
+      {'metadata': null},
+    );
+    final secondPatch =
+        await _waitForJs(
+              manager,
+              'globalThis.__patches.length === 2 ? globalThis.__patches[1] : null',
+            )
+            as Map<String, dynamic>;
+    expect((secondPatch['shot'] as Map<String, dynamic>)['tags'], isEmpty);
+
+    _dispatchShotUpdate(
+      manager,
+      _shot(
+        annotations: {
+          'espressoNotes': 'legacy note',
+          'extras': {'visualizerId': 'visualizer-9'},
+        },
+      ),
+      {'shotNotes': 'legacy note'},
+    );
+    final thirdPatch =
+        await _waitForJs(
+              manager,
+              'globalThis.__patches.length === 3 ? globalThis.__patches[2] : null',
+            )
+            as Map<String, dynamic>;
+    expect(
+      (thirdPatch['shot'] as Map<String, dynamic>)['espresso_notes'],
+      'legacy note',
+    );
+  });
+
+  test('forward sync leaves the global back-sync cursor unchanged', () async {
+    final manager = await _loadPlugin(
+      '''
+      globalThis.fetch = async (url, init = {}) => {
+        if (url.endsWith('/shots/visualizer-b') && init.method === 'PATCH') {
+          globalThis.__forwardPatch = JSON.parse(init.body);
+          return { ok: true, json: async () => ({ id: 'visualizer-b', updated_at: 120 }) };
+        }
+        if (url.endsWith('/me')) {
+          return { ok: true, json: async () => ({ id: 'user-1' }) };
+        }
+        if (url.includes('/shots?sort=updated_at&items=50&page=1')) {
+          globalThis.__changedUrl = url;
+          return { ok: true, json: async () => ({ user_id: 'user-1', data: [{ id: 'visualizer-a', updated_at: 110 }] }) };
+        }
+        if (url.endsWith('/shots/visualizer-a?essentials=1')) {
+          return { ok: true, json: async () => ({ id: 'visualizer-a', updated_at: 110, espresso_notes: 'remote edit' }) };
+        }
+        if (url.endsWith('/shots/local-a') && init.method === 'PUT') {
+          globalThis.__localUpdate = JSON.parse(init.body);
+          return { ok: true, json: async () => ({}) };
+        }
+        throw new Error('Unexpected URL: ' + url + ' ' + (init.method || 'GET'));
+      };
+    ''',
+      settings: const {'BackSync': true},
+    );
+    manager.dispatchEvent(_manifest.id, 'storageRead', {
+      'key': 'shotMap',
+      'value': jsonEncode({
+        'visualizer-a': 'local-a',
+        'visualizer-b': 'shot-1',
+      }),
+    });
+    manager.dispatchEvent(_manifest.id, 'storageRead', {
+      'key': 'backSyncCursor',
+      'value': '100',
+    });
+
+    _dispatchShotUpdate(
+      manager,
+      _shot(
+        annotations: {
+          'espressoNotes': 'local edit',
+          'extras': {'visualizerId': 'visualizer-b'},
+        },
+      ),
+      {
+        'annotations': {'espressoNotes': 'local edit'},
+      },
+    );
+    await _waitForJs(manager, 'globalThis.__forwardPatch');
+    manager.js.evaluate('globalThis.__runTimers(30000)');
+    final localUpdate =
+        await _waitForJs(manager, 'globalThis.__localUpdate')
+            as Map<String, dynamic>;
+    final changedUrl =
+        await _waitForJs(manager, 'globalThis.__changedUrl') as String;
+
+    expect(changedUrl, contains('updated_after=100'));
+    expect(localUpdate['annotations']['espressoNotes'], 'remote edit');
+  });
+
+  test('a stale success keeps ownership and drops completed fields', () async {
+    final manager = await _loadPlugin('''
+      globalThis.__patches = [];
+      globalThis.__remoteTags = ['remote'];
+      globalThis.fetch = (url, init = {}) => {
+        if (url.endsWith('/shots/visualizer-9?essentials=1')) {
+          return Promise.resolve({ ok: true, json: async () => ({ id: 'visualizer-9', tags: globalThis.__remoteTags }) });
+        }
+        if (url.endsWith('/shots/visualizer-9') && init.method === 'PATCH') {
+          const patch = JSON.parse(init.body);
+          globalThis.__patches = [...globalThis.__patches, patch];
+          if (globalThis.__patches.length === 1) {
+            return new Promise((resolve) => { globalThis.__firstResolver = resolve; });
+          }
+          return Promise.resolve({ ok: true, json: async () => ({ id: 'visualizer-9', updated_at: 2 }) });
+        }
+        throw new Error('Unexpected URL: ' + url);
+      };
+    ''');
+
+    _dispatchShotUpdate(
+      manager,
+      _shot(
+        annotations: {
+          'espressoNotes': 'local notes',
+          'extras': {
+            'visualizerId': 'visualizer-9',
+            'tags': ['old'],
+          },
+        },
+      ),
+      {
+        'annotations': {
+          'espressoNotes': 'local notes',
+          'extras': {
+            'tags': ['old'],
+          },
+        },
+      },
+    );
+    await _waitForJs(manager, 'globalThis.__firstResolver ? true : null');
+    _dispatchShotUpdate(
+      manager,
+      _shot(
+        annotations: {
+          'espressoNotes': 'local notes',
+          'extras': {
+            'visualizerId': 'visualizer-9',
+            'tags': ['latest'],
+          },
+        },
+      ),
+      {
+        'annotations': {
+          'extras': {
+            'tags': ['latest'],
+          },
+        },
+      },
+    );
+    final resolve = manager.js.evaluate('''
+      globalThis.__remoteTags = ['old', 'remote'];
+      globalThis.__firstResolver({ ok: true, json: async () => ({ id: 'visualizer-9', updated_at: 1 }) });
+    ''');
+    expect(resolve.isError, isFalse, reason: resolve.stringResult);
+    final patches =
+        await _waitForJs(
+              manager,
+              'globalThis.__patches.length === 2 ? globalThis.__patches : null',
+            )
+            as List<dynamic>;
+    final latest = (patches.last as Map<String, dynamic>)['shot'] as Map;
+
+    expect(latest['tags'], ['latest', 'remote']);
+    expect(latest.containsKey('espresso_notes'), isFalse);
+  });
+
+  test(
+    'successful upload returns its id before best-effort tag sync',
+    () async {
+      final shot = _shot(
+        annotations: {
+          'extras': {
+            'tags': ['bright'],
+          },
+        },
+      );
+      final manager = await _loadPlugin('''
+      globalThis.fetch = async (url, init = {}) => {
+        if (url.endsWith('/shots/shot-1') && (!init.method || init.method === 'GET')) {
+          return {
+            ok: true,
+            json: async () => (${jsonEncode(shot)}),
+            text: async () => '${jsonEncode(shot)}',
+          };
+        }
+        if (url.endsWith('/shots/upload')) {
+          return { ok: true, json: async () => ({ id: 'visualizer-1' }) };
+        }
+        if (url.endsWith('/shots/shot-1') && init.method === 'PUT') {
+          return { ok: true, json: async () => ({}) };
+        }
+        if (url.endsWith('/shots/visualizer-1?essentials=1')) {
+          return await new Promise((resolve) => {
+            globalThis.__failTagSync = () => resolve({
+              ok: false,
+              status: 503,
+              statusText: 'Service Unavailable',
+            });
+          });
+        }
+        throw new Error('Unexpected URL: ' + url + ' ' + (init.method || 'GET'));
+      };
+    ''');
+      final errorEvent = manager.emitStream.firstWhere(
+        (event) => event['event'] == 'shotForwardSyncError',
+      );
+
+      final response = await _callApi(manager, 'upload', {'shotId': 'shot-1'});
+      final body =
+          jsonDecode(response['body'] as String) as Map<String, dynamic>;
+
+      expect(response['status'], 202);
+      expect(body, {'visualizer_id': 'visualizer-1', 'tag_sync_pending': true});
+
+      await _waitForJs(manager, 'globalThis.__failTagSync ? true : null');
+      final failTagSync = manager.js.evaluate('globalThis.__failTagSync()');
+      expect(failTagSync.isError, isFalse, reason: failTagSync.stringResult);
+      final event = await errorEvent.timeout(const Duration(seconds: 5));
+      expect(event['payload']['error'], contains('HTTP 503'));
+    },
+  );
+
+  test('plugin source and manifest versions match', () {
+    final sourceVersion = RegExp(
+      r'version:\s*"([^"]+)"',
+    ).firstMatch(_pluginSource)?.group(1);
+
+    expect(sourceVersion, _manifest.version);
+  });
 }

--- a/test/plugins/visualizer_plugin_test.dart
+++ b/test/plugins/visualizer_plugin_test.dart
@@ -567,6 +567,87 @@ void main() {
     expect((secondPatch['shot'] as Map<String, dynamic>)['tag_list'], isEmpty);
   });
 
+  test('tag ownership survives plugin restart', () async {
+    final manager = await _loadPlugin('''
+      globalThis.__remoteTags = [];
+      globalThis.__patches = [];
+      globalThis.fetch = async (url, init = {}) => {
+        if (url.endsWith('/shots/visualizer-9?essentials=1')) {
+          return { ok: true, json: async () => ({ id: 'visualizer-9', tags: globalThis.__remoteTags }) };
+        }
+        if (url.endsWith('/shots/visualizer-9') && init.method === 'PATCH') {
+          const patch = JSON.parse(init.body);
+          globalThis.__patches = [...globalThis.__patches, patch];
+          globalThis.__remoteTags = patch.shot.tag_list;
+          return { ok: true, json: async () => ({ id: 'visualizer-9', updated_at: globalThis.__patches.length }) };
+        }
+        throw new Error('Unexpected URL: ' + url);
+      };
+    ''');
+    final firstSync = manager.emitStream.firstWhere(
+      (event) => event['event'] == 'shotForwardSynced',
+    );
+
+    _dispatchShotUpdate(
+      manager,
+      _shot(
+        annotations: {
+          'extras': {
+            'visualizerId': 'visualizer-9',
+            'tags': ['washed'],
+          },
+        },
+      ),
+      {
+        'annotations': {
+          'extras': {
+            'tags': ['washed'],
+          },
+        },
+      },
+    );
+    await firstSync.timeout(const Duration(seconds: 5));
+    await manager.unloadPlugin(_manifest.id);
+    final storedOwnership = await manager.kvStore.get(
+      namespace: _manifest.id,
+      key: 'managedLocalTags',
+    );
+    expect(jsonDecode(storedOwnership as String), {
+      'visualizer-9': ['washed'],
+    });
+
+    await manager.loadPlugin(
+      id: _manifest.id,
+      manifest: _manifest,
+      settings: const {
+        'Username': 'user',
+        'Password': 'password',
+        'LengthThreshold': 0,
+      },
+      jsCode: _pluginSource,
+    );
+    _dispatchShotUpdate(
+      manager,
+      _shot(
+        annotations: {
+          'extras': {'visualizerId': 'visualizer-9'},
+        },
+      ),
+      {
+        'annotations': {
+          'extras': {'tags': <String>[]},
+        },
+      },
+    );
+    final removalPatch =
+        await _waitForJs(
+              manager,
+              'globalThis.__patches.length === 2 ? globalThis.__patches[1] : null',
+            )
+            as Map<String, dynamic>;
+    expect((removalPatch['shot'] as Map<String, dynamic>)['tag_list'], isEmpty);
+  });
+
   test('legacy metadata and shotNotes patches use canonical shot values', () async {
     final manager = await _loadPlugin('''
       globalThis.__remoteTags = [];

--- a/test/plugins/visualizer_plugin_test.dart
+++ b/test/plugins/visualizer_plugin_test.dart
@@ -785,6 +785,7 @@ void main() {
       );
       final failTagSync = manager.js.evaluate('globalThis.__failTagSync()');
       expect(failTagSync.isError, isFalse, reason: failTagSync.stringResult);
+      while (manager.js.executePendingJob() > 0) {}
       final event = await errorEvent.timeout(const Duration(seconds: 5));
       expect(event['payload']['error'], contains('Visualizer Premium'));
       expect(event['payload']['error'], contains('HTTP 400'));

--- a/test/plugins/visualizer_plugin_test.dart
+++ b/test/plugins/visualizer_plugin_test.dart
@@ -135,4 +135,109 @@ void main() {
       expect(upload?['state_change'], [1, 1, 2, 3]);
     },
   );
+
+  test(
+    'Visualizer upload forwards recipe and shot-review tags',
+    () async {
+      final pluginSource = File(
+        'assets/plugins/visualizer.reaplugin/plugin.js',
+      ).readAsStringSync();
+      final manifest = PluginManifest.fromJson(
+        jsonDecode(
+              File(
+                'assets/plugins/visualizer.reaplugin/manifest.json',
+              ).readAsStringSync(),
+            )
+            as Map<String, dynamic>,
+      );
+      final shot = {
+        'id': 'shot-1',
+        'annotations': <String, dynamic>{
+          'extras': {
+            'tags': ['bright'],
+          },
+        },
+        'workflow': {
+          'profile': {'target_weight': 36},
+          'context': {
+            'extras': {
+              'tags': ['fast shot', 'washed'],
+            },
+          },
+        },
+        'measurements': [
+          for (var i = 0; i < 4; i++)
+            {
+              'machine': {
+                'timestamp': '2026-01-01T00:00:0${i * 2}Z',
+                'state': {'substate': 'pouring'},
+                'profileFrame': [0, 0, 1, 2][i],
+                'pressure': 9,
+                'targetPressure': 9,
+                'flow': 2,
+                'targetFlow': 2,
+                'mixTemperature': 93,
+                'groupTemperature': 92,
+                'targetGroupTemperature': 93,
+                'targetMixTemperature': 93,
+              },
+              'scale': {'weight': i * 10, 'weightFlow': 2},
+            },
+        ],
+      };
+      final manager = PluginManager(kvStore: _FakeKeyValueStore());
+      final setupResult = manager.js.evaluate('''
+      globalThis.setTimeout = (callback) => { callback(); return 1; };
+      globalThis.clearTimeout = () => {};
+      globalThis.fetch = async (url, init = {}) => {
+        if (url.endsWith('/shots/latest')) {
+          return { ok: true, json: async () => ({ id: 'shot-1' }) };
+        }
+        if (url.endsWith('/shots/shot-1')) {
+          return { ok: true, json: async () => (${jsonEncode(shot)}) };
+        }
+        if (url.endsWith('/shots/upload')) {
+          const body = init.body;
+          const start = body.indexOf('\\r\\n\\r\\n') + 4;
+          const end = body.lastIndexOf('\\r\\n--');
+          globalThis.__visualizerUpload = JSON.parse(body.slice(start, end));
+          return { ok: true, json: async () => ({ id: 'visualizer-1' }) };
+        }
+        throw new Error('Unexpected URL: ' + url);
+      };
+    ''');
+      expect(setupResult.isError, isFalse, reason: setupResult.stringResult);
+
+      await manager.loadPlugin(
+        id: manifest.id,
+        manifest: manifest,
+        settings: {
+          'Username': 'user',
+          'Password': 'password',
+          'LengthThreshold': 0,
+        },
+        jsCode: pluginSource,
+      );
+      manager.dispatchEvent(manifest.id, 'stateUpdate', {
+        'state': {'state': 'espresso'},
+      });
+      manager.dispatchEvent(manifest.id, 'stateUpdate', {
+        'state': {'state': 'idle'},
+      });
+
+      Map<String, dynamic>? upload;
+      for (var i = 0; i < 20 && upload == null; i++) {
+        manager.js.executePendingJob();
+        final result = manager.js.evaluate(
+          'JSON.stringify(globalThis.__visualizerUpload ?? null)',
+        );
+        upload = jsonDecode(result.stringResult) as Map<String, dynamic>?;
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      final settings =
+          upload?['app']?['data']?['settings'] as Map<String, dynamic>?;
+      expect(settings?['tags'], ['fast shot', 'washed', 'bright']);
+    },
+  );
 }

--- a/test/plugins/visualizer_plugin_test.dart
+++ b/test/plugins/visualizer_plugin_test.dart
@@ -497,6 +497,76 @@ void main() {
     ]);
   });
 
+  test('tag ownership follows Visualizer canonicalization', () async {
+    final manager = await _loadPlugin('''
+      globalThis.__remoteTags = [];
+      globalThis.__patches = [];
+      globalThis.fetch = async (url, init = {}) => {
+        if (url.endsWith('/shots/visualizer-9?essentials=1')) {
+          return { ok: true, json: async () => ({ id: 'visualizer-9', tags: globalThis.__remoteTags }) };
+        }
+        if (url.endsWith('/shots/visualizer-9') && init.method === 'PATCH') {
+          const patch = JSON.parse(init.body);
+          globalThis.__patches = [...globalThis.__patches, patch];
+          globalThis.__remoteTags = globalThis.__patches.length === 1
+            ? ['high-speed']
+            : patch.shot.tag_list;
+          return { ok: true, json: async () => ({ id: 'visualizer-9', updated_at: globalThis.__patches.length }) };
+        }
+        throw new Error('Unexpected URL: ' + url);
+      };
+    ''');
+
+    _dispatchShotUpdate(
+      manager,
+      _shot(
+        annotations: {
+          'extras': {
+            'visualizerId': 'visualizer-9',
+            'tags': ['  High@-Speed  '],
+          },
+        },
+      ),
+      {
+        'annotations': {
+          'extras': {
+            'tags': ['  High@-Speed  '],
+          },
+        },
+      },
+    );
+    final firstPatch =
+        await _waitForJs(
+              manager,
+              'globalThis.__patches.length === 1 ? globalThis.__patches[0] : null',
+            )
+            as Map<String, dynamic>;
+    expect((firstPatch['shot'] as Map<String, dynamic>)['tag_list'], [
+      'High@-Speed',
+    ]);
+
+    _dispatchShotUpdate(
+      manager,
+      _shot(
+        annotations: {
+          'extras': {'visualizerId': 'visualizer-9'},
+        },
+      ),
+      {
+        'annotations': {
+          'extras': {'tags': <String>[]},
+        },
+      },
+    );
+    final secondPatch =
+        await _waitForJs(
+              manager,
+              'globalThis.__patches.length === 2 ? globalThis.__patches[1] : null',
+            )
+            as Map<String, dynamic>;
+    expect((secondPatch['shot'] as Map<String, dynamic>)['tag_list'], isEmpty);
+  });
+
   test('legacy metadata and shotNotes patches use canonical shot values', () async {
     final manager = await _loadPlugin('''
       globalThis.__remoteTags = [];

--- a/test/plugins/visualizer_plugin_test.dart
+++ b/test/plugins/visualizer_plugin_test.dart
@@ -137,8 +137,11 @@ void main() {
   );
 
   test(
-    'Visualizer upload forwards recipe and shot-review tags',
+    'Visualizer upload PATCHes deduped recipe and shot-review tags after the initial import',
     () async {
+      // The /shots/upload JSON importer doesn't persist a tags field, so tags
+      // must be pushed via a follow-up PATCH to /shots/<visualizerId> using
+      // the same flat field name Visualizer's own API returns on read.
       final pluginSource = File(
         'assets/plugins/visualizer.reaplugin/plugin.js',
       ).readAsStringSync();
@@ -154,14 +157,15 @@ void main() {
         'id': 'shot-1',
         'annotations': <String, dynamic>{
           'extras': {
-            'tags': ['bright'],
+            // "bright" overlaps with the recipe tags below to exercise dedupe.
+            'tags': ['bright', 'floral'],
           },
         },
         'workflow': {
           'profile': {'target_weight': 36},
           'context': {
             'extras': {
-              'tags': ['fast shot', 'washed'],
+              'tags': ['fast shot', 'washed', 'bright'],
             },
           },
         },
@@ -203,7 +207,11 @@ void main() {
           globalThis.__visualizerUpload = JSON.parse(body.slice(start, end));
           return { ok: true, json: async () => ({ id: 'visualizer-1' }) };
         }
-        throw new Error('Unexpected URL: ' + url);
+        if (url.endsWith('/shots/visualizer-1') && init.method === 'PATCH') {
+          globalThis.__visualizerTagPatch = JSON.parse(init.body);
+          return { ok: true, json: async () => ({ id: 'visualizer-1', updated_at: 0 }) };
+        }
+        throw new Error('Unexpected URL: ' + url + ' ' + (init.method || 'GET'));
       };
     ''');
       expect(setupResult.isError, isFalse, reason: setupResult.stringResult);
@@ -225,19 +233,98 @@ void main() {
         'state': {'state': 'idle'},
       });
 
-      Map<String, dynamic>? upload;
-      for (var i = 0; i < 20 && upload == null; i++) {
+      Map<String, dynamic>? tagPatch;
+      for (var i = 0; i < 20 && tagPatch == null; i++) {
         manager.js.executePendingJob();
         final result = manager.js.evaluate(
-          'JSON.stringify(globalThis.__visualizerUpload ?? null)',
+          'JSON.stringify(globalThis.__visualizerTagPatch ?? null)',
         );
-        upload = jsonDecode(result.stringResult) as Map<String, dynamic>?;
+        tagPatch = jsonDecode(result.stringResult) as Map<String, dynamic>?;
         await Future<void>.delayed(Duration.zero);
       }
 
-      final settings =
-          upload?['app']?['data']?['settings'] as Map<String, dynamic>?;
-      expect(settings?['tags'], ['fast shot', 'washed', 'bright']);
+      final patchedShot = tagPatch?['shot'] as Map<String, dynamic>?;
+      expect(patchedShot?['tags'], ['fast shot', 'washed', 'bright', 'floral']);
+    },
+  );
+
+  test(
+    'Visualizer forward-sync pushes shot-review tag edits made after upload',
+    () async {
+      final pluginSource = File(
+        'assets/plugins/visualizer.reaplugin/plugin.js',
+      ).readAsStringSync();
+      final manifest = PluginManifest.fromJson(
+        jsonDecode(
+              File(
+                'assets/plugins/visualizer.reaplugin/manifest.json',
+              ).readAsStringSync(),
+            )
+            as Map<String, dynamic>,
+      );
+      final manager = PluginManager(kvStore: _FakeKeyValueStore());
+      final setupResult = manager.js.evaluate('''
+      globalThis.setTimeout = (callback) => { callback(); return 1; };
+      globalThis.clearTimeout = () => {};
+      globalThis.fetch = async (url, init = {}) => {
+        if (url.endsWith('/shots/visualizer-9') && init.method === 'PATCH') {
+          globalThis.__forwardSyncPatch = JSON.parse(init.body);
+          return { ok: true, json: async () => ({ id: 'visualizer-9', updated_at: 0 }) };
+        }
+        throw new Error('Unexpected URL: ' + url + ' ' + (init.method || 'GET'));
+      };
+    ''');
+      expect(setupResult.isError, isFalse, reason: setupResult.stringResult);
+
+      await manager.loadPlugin(
+        id: manifest.id,
+        manifest: manifest,
+        settings: {
+          'Username': 'user',
+          'Password': 'password',
+          'LengthThreshold': 0,
+        },
+        jsCode: pluginSource,
+      );
+
+      // A shot already uploaded to Visualizer (visualizerId known) gets a tag
+      // added during shot review, well after the initial upload completed.
+      manager.dispatchEvent(manifest.id, 'shotUpdated', {
+        'id': 'shot-1',
+        'shot': {
+          'id': 'shot-1',
+          'annotations': {
+            'extras': {
+              'visualizerId': 'visualizer-9',
+              'tags': ['bright'],
+            },
+          },
+          'workflow': {
+            'profile': {'target_weight': 36},
+            'context': {'extras': <String, dynamic>{}},
+          },
+        },
+        'patch': {
+          'annotations': {
+            'extras': {
+              'tags': ['bright'],
+            },
+          },
+        },
+      });
+
+      Map<String, dynamic>? forwardPatch;
+      for (var i = 0; i < 20 && forwardPatch == null; i++) {
+        manager.js.executePendingJob();
+        final result = manager.js.evaluate(
+          'JSON.stringify(globalThis.__forwardSyncPatch ?? null)',
+        );
+        forwardPatch = jsonDecode(result.stringResult) as Map<String, dynamic>?;
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      final patchedShot = forwardPatch?['shot'] as Map<String, dynamic>?;
+      expect(patchedShot?['tags'], ['bright']);
     },
   );
 }


### PR DESCRIPTION
## Summary

- Problem: recipe, shot-review, and Visualizer-only tags could be lost during upload races, retries, and concurrent forward or back synchronization.
- Why it matters: lost tags damage a user's tasting history, while a timeout after a successful upload can prompt a retry that creates a duplicate Visualizer shot.
- What changed: uploads now return their Visualizer ID after persisting the mapping and pending sync, then refresh the local shot in the background. Tag ownership is stored with the pending PATCH before the request starts. Forward writes no longer advance the global back-sync cursor, stale successful requests discard fields they already applied, and legacy `metadata` edits keep their documented raw patch while Visualizer reads tags from the canonical shot.
- Scope boundary: no BLE/USB behavior, database schema, WebSocket contract, or core REST request/response schema changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [x] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] REST API / handlers
- [x] Plugins / JS runtime
- [x] Docs / specs

## Linked Issues

- Closes: N/A
- Related: N/A

## Root Cause (if bug fix)

- Visualizer's upload importer does not persist `app.data.settings.tags`, so tags require a supported post-upload PATCH.
- The upload handler waited for follow-up network requests under the same 30-second outer deadline, so it could hide a completed upload ID from the caller.
- Tag ownership was recorded only after a successful response, which misclassified a committed PATCH when its response was lost.
- Forward PATCHes advanced the global back-sync cursor past unrelated remote changes.
- Queued revisions retained fields that an older successful request had already applied.
- Visualizer only recognized canonical annotation patches, while the documented `shotUpdated.patch` value remains the raw PUT body.

## Regression Test Plan (if bug fix or refactor)

- [x] Unit tests in `test/plugins/visualizer_plugin_test.dart` and `test/plugins/visualizer_plugin_sync_cases.dart`
- [x] Handler integration coverage in `test/webserver/shots_handler_test.dart`
- A stalled follow-up request cannot delay the `202` response containing `visualizer_id`.
- A committed PATCH with a lost response retains ownership through retry and later removal.
- A forward update at timestamp 120 leaves an unprocessed back-sync change at timestamp 110 visible from cursor 100.
- A stale successful notes PATCH does not carry notes into a newer tag-only PATCH.
- Legacy `metadata.tags` and `metadata: null` updates retain the raw event patch while Visualizer forwards canonical tags.
- Existing upload-race, remote-only tag, rapid-edit, retry, deduplication, and ancestor-clear cases remain covered.

## Documentation Obligations (required)

- [ ] API spec updated: no REST or WebSocket request/response schema changed.
- [ ] API docs updated: no user-facing core endpoint contract changed.
- [x] Plugin docs updated: `doc/Plugins.md` documents immediate `202` upload responses and background follow-up sync.
- [ ] Skin docs updated: no skin behavior changed.
- [ ] Profile docs updated: no profile handling changed.
- [ ] Device docs updated: no device flow changed.

## Security Impact (required)

- New or changed REST endpoints? No
- New or changed WebSocket topics? No
- New or changed network calls? Yes
- BLE/USB surface changed? No
- File system access changed? No
- Plugin sandbox boundary changed? No
- Risk and mitigation: the bundled plugin performs authenticated GET and PATCH requests against the existing Visualizer shot endpoints. Requests remain scoped to configured credentials and mapped shots.

## User-Visible Changes

Completed uploads return their Visualizer ID before tag sync finishes. Tags entered during upload remain queued, Visualizer-only tags survive local edits, local removals still propagate, and back-sync does not skip unrelated remote changes.

## Verification

### Local gates

- [x] `dart format lib test`: 688 files, 0 changed
- [x] `flutter analyze --no-pub`: no issues
- [x] `flutter test test/plugins/visualizer_plugin_test.dart test/webserver/shots_handler_test.dart --no-pub`: 26 passed
- [x] `node --check assets/plugins/visualizer.reaplugin/plugin.js`
- [x] `git diff --check`

### Full-suite note

The Windows full-suite run passed 2,822 tests and hit the same eight pre-existing `origin/main` PluginLoaderService path-separator failures. Their independent fix is green in #592. GitHub's PR test job runs on Ubuntu.

### Manual verification

- OS / platform: Windows unit-test harness
- Simulated devices: No
- Real hardware: No
- Live Visualizer account: Not exercised

### Evidence

- [x] Tests failed on all five new regressions before the fix and passed afterward.

## Compatibility & Migration

- Backward compatible? Yes
- Config / env changes needed? No
- Database migration needed? No
- Bundled plugin version: 1.5.5

## Risks & Mitigations

- Risk: Visualizer state may change between the fresh GET and PATCH because the API does not expose a conditional tag update.
- Mitigation: the plugin reads immediately before PATCH, serializes pending local revisions, preserves remote-only tags, and persists retry state.