### PR TITLE
fix(plugins): protect secure settings

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -2485,9 +2485,10 @@ paths:
       tags: [Plugins]
       summary: Save settings for specific plugin
       description: >
-        Applies a settings patch. Omitted secure fields and isSet state objects
-        preserve the stored credential; null clears it. The response is always
-        redacted and never echoes a submitted credential.
+        Applies a settings patch. Omitted fields preserve the existing value;
+        a null value clears the setting. For secure fields, an isSet state
+        object preserves the stored credential; null clears it. The response
+        is always redacted and never echoes a submitted credential.
       parameters:
         - name: id
           in: path
@@ -5960,7 +5961,8 @@ components:
       description: >
         Plugin setting values. Fields marked secure in the manifest are returned
         as objects containing only an isSet boolean instead of their stored
-        values.
+        values. In POST bodies, omitted fields preserve the existing value and
+        a null value clears the setting.
       additionalProperties: true
       example:
         Username: user@example.com

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -2465,36 +2465,49 @@ paths:
     get:
       tags: [Plugins]
       summary: Fetch settings for specific plugin
+      description: Secure settings are represented by an isSet state object and never returned as plaintext.
       parameters:
         - name: id
           in: path
+          required: true
           description: the plugin id
+          schema:
+            type: string
       responses:
         "200":
+          description: Current settings with secure values redacted
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/PluginSettings'
 
     post:
       tags: [Plugins]
       summary: Save settings for specific plugin
+      description: >
+        Applies a settings patch. Omitted secure fields and isSet state objects
+        preserve the stored credential; null clears it. The response is always
+        redacted and never echoes a submitted credential.
       parameters:
         - name: id
           in: path
+          required: true
           description: the plugin id
+          schema:
+            type: string
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: '#/components/schemas/PluginSettings'
       responses:
         "200":
+          description: Updated settings with secure values redacted
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/PluginSettings'
 
   /api/v1/plugins/{id}/enable:
     post:
@@ -5941,6 +5954,18 @@ components:
         autoLoad:
           type: boolean
           description: Whether the plugin is set to auto-load on startup
+
+    PluginSettings:
+      type: object
+      description: >
+        Plugin setting values. Fields marked secure in the manifest are returned
+        as objects containing only an isSet boolean instead of their stored
+        values.
+      additionalProperties: true
+      example:
+        Username: user@example.com
+        Password:
+          isSet: true
 
     ProfileRecord:
       type: object

--- a/doc/AI_STORAGE_NOTES.md
+++ b/doc/AI_STORAGE_NOTES.md
@@ -24,10 +24,18 @@ Read this when changing database schema, migrations, persistent settings, Shared
 |-------|-------|---------|
 | Drift DB | `AppDatabase` | Shots, workflows, beans, grinders, profiles, settings |
 | `SharedPreferences` | `SharedPreferencesSettingsService` | App settings (telemetry consent, feature flags, preferences) |
-| Secure store | `DecentAccountService` | Account credentials (email, password, JWT tokens) |
+| Secure store | `DecentAccountService`, `PluginLoaderService` | Account credentials, API tokens, secure plugin settings |
 | File system | `StorageService` | Data export, log files, skin assets |
 
 Keep these stores independent. A settings reset must not clear account credentials unless explicitly requested.
+
+Plugin settings marked `secure` in the manifest are stored through
+`CredentialStore` under a plugin-scoped key. Ordinary plugin settings remain in
+SharedPreferences. Reads exposed to UI and REST clients return only `{isSet}`
+state for secure fields; `PluginLoaderService` joins the two stores only for
+`onLoad`. Legacy cleartext values migrate on first read. `--no-account` uses
+process-memory secure plugin values because headless Linux cannot access
+libsecret.
 
 ## Database Schema
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -250,13 +250,18 @@ Settings fields include: `gatewayMode`, `themeMode`, `logLevel`, `weightFlowMult
 | Method | Path | Description | Handler |
 |--------|------|-------------|---------|
 | GET | `/api/v1/plugins` | List all plugins (with `loaded`, `autoLoad` fields) | `plugins_handler.dart` |
-| GET | `/api/v1/plugins/:id/settings` | Get plugin settings | |
-| POST | `/api/v1/plugins/:id/settings` | Update plugin settings | |
+| GET | `/api/v1/plugins/:id/settings` | Get plugin settings; secure fields return `{isSet}` only | |
+| POST | `/api/v1/plugins/:id/settings` | Patch plugin settings and return a redacted result | |
 | POST | `/api/v1/plugins/:id/enable` | Load plugin + enable auto-load | |
 | POST | `/api/v1/plugins/:id/disable` | Unload plugin + disable auto-load | |
 | DELETE | `/api/v1/plugins/:id` | Remove plugin (unload + delete files) | |
 | POST | `/api/v1/plugins/install` | Install from URL (not yet implemented — returns 501) | |
 | GET/WS | `/api/v1/plugins/:id/:endpoint` | Plugin HTTP/WebSocket proxy | |
+
+Plugin setting updates use patch semantics. Omitting a secure field or sending
+its returned `{ "isSet": true|false }` object preserves the stored credential;
+sending `null` clears it. Secure values are never returned by either endpoint,
+including the POST response.
 
 ### Display
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -251,16 +251,17 @@ Settings fields include: `gatewayMode`, `themeMode`, `logLevel`, `weightFlowMult
 |--------|------|-------------|---------|
 | GET | `/api/v1/plugins` | List all plugins (with `loaded`, `autoLoad` fields) | `plugins_handler.dart` |
 | GET | `/api/v1/plugins/:id/settings` | Get plugin settings; secure fields return `{isSet}` only | |
-| POST | `/api/v1/plugins/:id/settings` | Patch plugin settings and return a redacted result | |
+| POST | `/api/v1/plugins/:id/settings` | Patch plugin settings (omitted preserves, `null` clears) and return a redacted result | |
 | POST | `/api/v1/plugins/:id/enable` | Load plugin + enable auto-load | |
 | POST | `/api/v1/plugins/:id/disable` | Unload plugin + disable auto-load | |
 | DELETE | `/api/v1/plugins/:id` | Remove plugin (unload + delete files) | |
 | POST | `/api/v1/plugins/install` | Install from URL (not yet implemented — returns 501) | |
 | GET/WS | `/api/v1/plugins/:id/:endpoint` | Plugin HTTP/WebSocket proxy | |
 
-Plugin setting updates use patch semantics. Omitting a secure field or sending
-its returned `{ "isSet": true|false }` object preserves the stored credential;
-sending `null` clears it. Secure values are never returned by either endpoint,
+Plugin setting updates use patch semantics for every field: an omitted field
+preserves the existing value, a field sent as `null` clears it, and a secure
+field sent as its returned `{ "isSet": true|false }` object preserves the
+stored credential. Secure values are never returned by either endpoint,
 including the POST response.
 
 ### Display

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -62,7 +62,7 @@ A Decaid plugin consists of two required files:
   - `emit`: Emit events to the Flutter app
   - `pluginStorage`: Persistent storage
   - `proxy.decent_api`: Call the linked Decent account proxy through `host.decentProxy`
-- **settings**: User-configurable options with `type` (`string`, `number`, `boolean`) and optional `secure` flag for passwords
+- **settings**: User-configurable options with `type` (`string`, `number`, `boolean`) and optional `secure` flag for credentials such as passwords. Secure values use platform credential storage, are supplied in memory to `onLoad(settings)`, and are never returned by the REST API.
 - **api**: Events this plugin emits, used for documentation and type checking
 
 ### 2. `plugin.js` - Main plugin implementation
@@ -436,6 +436,12 @@ Plugins can be managed via REST API:
 | POST | `/api/v1/plugins/install` | Install from URL (not yet implemented) |
 | GET | `/api/v1/plugins/:id/settings` | Get plugin settings |
 | POST | `/api/v1/plugins/:id/settings` | Update plugin settings |
+
+Settings updates are patches. Omitted secure fields and returned `{ "isSet":
+true|false }` markers preserve the credential; `null` clears it. GET and POST
+responses contain only the marker for secure fields, never the submitted or
+stored value. Existing cleartext secure fields are moved out of
+SharedPreferences on first read.
 
 The bundled **settings plugin** (`settings.reaplugin`) provides a web UI for plugin management at `/api/v1/plugins/settings.reaplugin/ui`. It includes an enable/disable toggle and remove button for each plugin, with a self-protection guard that prevents disabling itself.
 

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -437,11 +437,12 @@ Plugins can be managed via REST API:
 | GET | `/api/v1/plugins/:id/settings` | Get plugin settings |
 | POST | `/api/v1/plugins/:id/settings` | Update plugin settings |
 
-Settings updates are patches. Omitted secure fields and returned `{ "isSet":
-true|false }` markers preserve the credential; `null` clears it. GET and POST
-responses contain only the marker for secure fields, never the submitted or
-stored value. Existing cleartext secure fields are moved out of
-SharedPreferences on first read.
+Settings updates are patches for every field: an omitted field preserves the
+existing value, `null` clears it, and for secure fields a `{ "isSet":
+true|false }` marker preserves the stored credential. GET and POST responses
+contain only the marker for secure fields, never the submitted or stored
+value. Existing cleartext secure fields are moved out of SharedPreferences on
+first read.
 
 The bundled **settings plugin** (`settings.reaplugin`) provides a web UI for plugin management at `/api/v1/plugins/settings.reaplugin/ui`. It includes an enable/disable toggle and remove button for each plugin, with a self-protection guard that prevents disabling itself.
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -431,13 +431,14 @@ void main(List<String> args) async {
   DecentAccountService? decentAccountService;
   DecentProxyService? decentProxyService;
   AccountTokensController? accountTokensController;
+  CredentialStore? credentialStore;
   final proxyTokenService = ProxyTokenService();
   if (cliArgs.noAccount) {
     log.info('--no-account: skipping credential store and account service');
     decentAccountService = null;
     decentProxyService = null;
   } else {
-    final decentCredentialStore = await createCredentialStore();
+    credentialStore = await createCredentialStore();
     // Override with --dart-define=DECENT_BASE_URL=http://localhost:8000 for
     // local server development; defaults to production.
     const decentBaseUrl = String.fromEnvironment(
@@ -446,21 +447,21 @@ void main(List<String> args) async {
     );
     decentAccountService = DecentAccountService(
       httpClient: http.Client(),
-      credentialStore: decentCredentialStore,
+      credentialStore: credentialStore,
       baseUrl: decentBaseUrl,
     );
     // Same credential store as the account service: the proxy reads the
     // credentials that account login wrote, and never exposes them to callers.
     decentProxyService = DecentProxyService(
       httpClient: http.Client(),
-      credentialStore: decentCredentialStore,
+      credentialStore: credentialStore,
       baseUrl: decentBaseUrl,
     );
     // User-managed API-client tokens: persisted in the same secure store and
     // loaded into the validator alongside the per-process skin token.
     accountTokensController = AccountTokensController(
       tokenService: proxyTokenService,
-      store: ProxyTokenStore(credentialStore: decentCredentialStore),
+      store: ProxyTokenStore(credentialStore: credentialStore),
     );
     await accountTokensController.initialize();
   }
@@ -470,6 +471,7 @@ void main(List<String> args) async {
   final PluginLoaderService pluginService = PluginLoaderService(
     kvStore: HiveStoreService(defaultNamespace: "plugins")..initialize(),
     decentProxyService: decentProxyService,
+    credentialStore: credentialStore,
   );
   // Don't initialize plugins yet - wait for permissions to be granted
   // pluginService.initialize() will be called from PermissionsView after permissions are granted

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -303,11 +303,13 @@ class PluginLoaderService {
           : {...secure, entry.key: entry.value};
     }
 
+    final mergedOrdinary = {...stored.ordinary, ...ordinaryPatch};
+    for (final entry in ordinaryPatch.entries) {
+      if (entry.value == null) mergedOrdinary.remove(entry.key);
+    }
+
     await _writeSecureSettings(pluginId, secure);
-    await _writeOrdinarySettings(pluginId, {
-      ...stored.ordinary,
-      ...ordinaryPatch,
-    });
+    await _writeOrdinarySettings(pluginId, mergedOrdinary);
 
     _log.fine('Settings saved for plugin: $pluginId');
   });

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -38,6 +39,7 @@ class PluginLoaderService {
   final Map<String, PluginManifest> _availablePluginsCache = {};
   Map<String, Map<String, dynamic>> _volatileSecureSettings = {};
   Future<void> _pluginLoadQueue = Future.value();
+  final Map<String, Future<void>> _pluginSettingsLocks = {};
 
   PluginLoaderService({
     required KeyValueStoreService kvStore,
@@ -156,26 +158,22 @@ class PluginLoaderService {
       await unloadPlugin(pluginId);
     }
 
-    // Remove from cache
-    _availablePluginsCache.remove(pluginId);
+    await _withPluginSettingsLock(pluginId, () async {
+      await _deleteSecureSettings(pluginId);
+      await _prefs.remove('plugin.settings.$pluginId');
+      await _prefs.remove('plugin.autoload.$pluginId');
+      await _prefs.remove(_loadFailureKey(pluginId));
+      if (_prefs.getString(_loadingPluginKey) == pluginId) {
+        await _prefs.remove(_loadingPluginKey);
+      }
 
-    // Delete plugin directory
-    final pluginDir = Directory('${_pluginsDir.path}/$pluginId');
-    if (pluginDir.existsSync()) {
-      await pluginDir.delete(recursive: true);
-      _log.info('Plugin removed: $pluginId');
-    }
-
-    // Remove auto-load setting
-    await _prefs.remove('plugin.autoload.$pluginId');
-
-    // Remove plugin settings
-    await _prefs.remove('plugin.settings.$pluginId');
-    await _deleteSecureSettings(pluginId);
-    await _prefs.remove(_loadFailureKey(pluginId));
-    if (_prefs.getString(_loadingPluginKey) == pluginId) {
-      await _prefs.remove(_loadingPluginKey);
-    }
+      final pluginDir = Directory('${_pluginsDir.path}/$pluginId');
+      if (pluginDir.existsSync()) {
+        await pluginDir.delete(recursive: true);
+        _log.info('Plugin removed: $pluginId');
+      }
+      _availablePluginsCache.remove(pluginId);
+    });
   }
 
   /// Load plugin into the runtime
@@ -202,7 +200,7 @@ class PluginLoaderService {
       }
 
       final jsCode = await pluginFile.readAsString();
-      final settings = await _pluginSettingsForLoad(manifest);
+      final settings = await _pluginSettingsForLoad(pluginId);
 
       await pluginManager
           .loadPlugin(
@@ -265,27 +263,28 @@ class PluginLoaderService {
     return _prefs.getBool('plugin.autoload.$pluginId') ?? false;
   }
 
-  Future<Map<String, dynamic>> pluginSettings(String pluginId) async {
-    final manifest = _availablePluginsCache[pluginId];
-    if (manifest == null) return {};
+  Future<Map<String, dynamic>> pluginSettings(String pluginId) =>
+      _withPluginSettingsLock(pluginId, () async {
+        final manifest = _availablePluginsCache[pluginId];
+        if (manifest == null) return {};
 
-    final stored = await _storedSettings(manifest);
-    return {
-      ...stored.ordinary,
-      for (final key in _secureSettingKeys(manifest))
-        key: {'isSet': stored.secure.containsKey(key)},
-    };
-  }
+        final stored = await _storedSettings(manifest);
+        return {
+          ...stored.ordinary,
+          for (final key in _secureSettingKeys(manifest))
+            key: {'isSet': stored.secure.containsKey(key)},
+        };
+      });
 
   Future<void> savePluginSettings(
     String pluginId,
     Map<String, dynamic> settings,
-  ) async {
-    if (!_availablePluginsCache.containsKey(pluginId)) {
+  ) => _withPluginSettingsLock(pluginId, () async {
+    final manifest = _availablePluginsCache[pluginId];
+    if (manifest == null) {
       throw Exception('Plugin not found: $pluginId');
     }
 
-    final manifest = _availablePluginsCache[pluginId]!;
     _validateSettings(manifest, settings);
     final stored = await _storedSettings(manifest);
     final secureKeys = _secureSettingKeys(manifest);
@@ -311,7 +310,7 @@ class PluginLoaderService {
     });
 
     _log.fine('Settings saved for plugin: $pluginId');
-  }
+  });
 
   /// Get a list of all the available plugins
   List<PluginManifest> get availablePlugins {
@@ -371,6 +370,21 @@ class PluginLoaderService {
   String _secureSettingsKey(String pluginId) =>
       'plugin.settings.secure.$pluginId';
 
+  Future<T> _withPluginSettingsLock<T>(
+    String pluginId,
+    Future<T> Function() action,
+  ) {
+    final previous = _pluginSettingsLocks[pluginId] ?? Future<void>.value();
+    final next = Completer<void>();
+    _pluginSettingsLocks[pluginId] = next.future;
+    return previous.then((_) => action()).whenComplete(() {
+      next.complete();
+      if (identical(_pluginSettingsLocks[pluginId], next.future)) {
+        _pluginSettingsLocks.remove(pluginId);
+      }
+    });
+  }
+
   Set<String> _secureSettingKeys(PluginManifest manifest) => {
     for (final entry in manifest.settings.entries)
       if (entry.value is Map && entry.value['secure'] == true) entry.key,
@@ -379,12 +393,15 @@ class PluginLoaderService {
   bool _isSecureState(dynamic value) =>
       value is Map && value.length == 1 && value['isSet'] is bool;
 
-  Future<Map<String, dynamic>> _pluginSettingsForLoad(
-    PluginManifest manifest,
-  ) async {
-    final stored = await _storedSettings(manifest);
-    return {...stored.ordinary, ...stored.secure};
-  }
+  Future<Map<String, dynamic>> _pluginSettingsForLoad(String pluginId) =>
+      _withPluginSettingsLock(pluginId, () async {
+        final manifest = _availablePluginsCache[pluginId];
+        if (manifest == null) {
+          throw Exception('Plugin not found: $pluginId');
+        }
+        final stored = await _storedSettings(manifest);
+        return {...stored.ordinary, ...stored.secure};
+      });
 
   Future<({Map<String, dynamic> ordinary, Map<String, dynamic> secure})>
   _storedSettings(PluginManifest manifest) async {

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -11,6 +11,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
 import 'package:reaprime/src/plugins/plugin_runtime.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart'
+    show CredentialStore;
 import 'package:reaprime/src/services/account/decent_proxy_service.dart';
 import 'package:reaprime/src/util/safe_path.dart';
 
@@ -28,17 +30,21 @@ class PluginLoaderService {
   static const _loadingPluginKey = 'plugin.watchdog.loading';
 
   final PluginManager pluginManager;
+  final CredentialStore? _credentialStore;
   final _log = Logger('PluginLoaderService');
 
   late Directory _pluginsDir;
   late SharedPreferences _prefs;
   final Map<String, PluginManifest> _availablePluginsCache = {};
+  Map<String, Map<String, dynamic>> _volatileSecureSettings = {};
   Future<void> _pluginLoadQueue = Future.value();
 
   PluginLoaderService({
     required KeyValueStoreService kvStore,
     DecentProxyService? decentProxyService,
-  }) : pluginManager = PluginManager(
+    CredentialStore? credentialStore,
+  }) : _credentialStore = credentialStore,
+       pluginManager = PluginManager(
          kvStore: kvStore,
          decentProxyService: decentProxyService,
        );
@@ -165,6 +171,7 @@ class PluginLoaderService {
 
     // Remove plugin settings
     await _prefs.remove('plugin.settings.$pluginId');
+    await _deleteSecureSettings(pluginId);
     await _prefs.remove(_loadFailureKey(pluginId));
     if (_prefs.getString(_loadingPluginKey) == pluginId) {
       await _prefs.remove(_loadingPluginKey);
@@ -195,7 +202,7 @@ class PluginLoaderService {
       }
 
       final jsCode = await pluginFile.readAsString();
-      final settings = await pluginSettings(pluginId);
+      final settings = await _pluginSettingsForLoad(manifest);
 
       await pluginManager
           .loadPlugin(
@@ -258,23 +265,18 @@ class PluginLoaderService {
     return _prefs.getBool('plugin.autoload.$pluginId') ?? false;
   }
 
-  /// Load settings for specified plugin pluginId
   Future<Map<String, dynamic>> pluginSettings(String pluginId) async {
-    final settingsJson = _prefs.getString('plugin.settings.$pluginId');
-    if (settingsJson == null) {
-      return {};
-    }
+    final manifest = _availablePluginsCache[pluginId];
+    if (manifest == null) return {};
 
-    try {
-      return Map<String, dynamic>.from(jsonDecode(settingsJson));
-    } catch (e) {
-      _log.warning('Failed to parse settings for plugin $pluginId', e);
-      return {};
-    }
+    final stored = await _storedSettings(manifest);
+    return {
+      ...stored.ordinary,
+      for (final key in _secureSettingKeys(manifest))
+        key: {'isSet': stored.secure.containsKey(key)},
+    };
   }
 
-  /// Save settings for a specified pluginId,
-  /// Check they match with settings specified in manifest
   Future<void> savePluginSettings(
     String pluginId,
     Map<String, dynamic> settings,
@@ -284,12 +286,29 @@ class PluginLoaderService {
     }
 
     final manifest = _availablePluginsCache[pluginId]!;
-
-    // Validate settings against manifest
     _validateSettings(manifest, settings);
+    final stored = await _storedSettings(manifest);
+    final secureKeys = _secureSettingKeys(manifest);
+    final ordinaryPatch = Map.fromEntries(
+      settings.entries.where((entry) => !secureKeys.contains(entry.key)),
+    );
+    var secure = stored.secure;
+    for (final entry in settings.entries.where(
+      (entry) => secureKeys.contains(entry.key),
+    )) {
+      if (_isSecureState(entry.value)) continue;
+      secure = entry.value == null
+          ? Map.fromEntries(
+              secure.entries.where((current) => current.key != entry.key),
+            )
+          : {...secure, entry.key: entry.value};
+    }
 
-    // Save to SharedPreferences
-    await _prefs.setString('plugin.settings.$pluginId', jsonEncode(settings));
+    await _writeSecureSettings(pluginId, secure);
+    await _writeOrdinarySettings(pluginId, {
+      ...stored.ordinary,
+      ...ordinaryPatch,
+    });
 
     _log.fine('Settings saved for plugin: $pluginId');
   }
@@ -346,6 +365,136 @@ class PluginLoaderService {
 
   String _loadFailureKey(String pluginId) =>
       'plugin.watchdog.loadFailures.$pluginId';
+
+  String _settingsKey(String pluginId) => 'plugin.settings.$pluginId';
+
+  String _secureSettingsKey(String pluginId) =>
+      'plugin.settings.secure.$pluginId';
+
+  Set<String> _secureSettingKeys(PluginManifest manifest) => {
+    for (final entry in manifest.settings.entries)
+      if (entry.value is Map && entry.value['secure'] == true) entry.key,
+  };
+
+  bool _isSecureState(dynamic value) =>
+      value is Map && value.length == 1 && value['isSet'] is bool;
+
+  Future<Map<String, dynamic>> _pluginSettingsForLoad(
+    PluginManifest manifest,
+  ) async {
+    final stored = await _storedSettings(manifest);
+    return {...stored.ordinary, ...stored.secure};
+  }
+
+  Future<({Map<String, dynamic> ordinary, Map<String, dynamic> secure})>
+  _storedSettings(PluginManifest manifest) async {
+    final ordinary = _readOrdinarySettings(manifest.id);
+    final secureKeys = _secureSettingKeys(manifest);
+    final storedSecure = await _readSecureSettings(manifest.id);
+    final secure = Map.fromEntries(
+      storedSecure.entries.where((entry) => secureKeys.contains(entry.key)),
+    );
+    if (secure.length != storedSecure.length) {
+      await _writeSecureSettings(manifest.id, secure);
+    }
+    final legacySecure = Map.fromEntries(
+      ordinary.entries.where((entry) => secureKeys.contains(entry.key)),
+    );
+    if (legacySecure.isEmpty) {
+      return (ordinary: ordinary, secure: secure);
+    }
+
+    final migratedSecure = {...legacySecure, ...secure};
+    final migratedOrdinary = Map.fromEntries(
+      ordinary.entries.where((entry) => !secureKeys.contains(entry.key)),
+    );
+    await _writeSecureSettings(manifest.id, migratedSecure);
+    await _writeOrdinarySettings(manifest.id, migratedOrdinary);
+    return (ordinary: migratedOrdinary, secure: migratedSecure);
+  }
+
+  Map<String, dynamic> _readOrdinarySettings(String pluginId) {
+    final settingsJson = _prefs.getString(_settingsKey(pluginId));
+    if (settingsJson == null) return {};
+
+    try {
+      return Map<String, dynamic>.from(jsonDecode(settingsJson));
+    } catch (e) {
+      _log.warning('Failed to parse settings for plugin $pluginId', e);
+      return {};
+    }
+  }
+
+  Future<Map<String, dynamic>> _readSecureSettings(String pluginId) async {
+    if (_credentialStore == null) {
+      return Map.from(_volatileSecureSettings[pluginId] ?? {});
+    }
+    final settingsJson = await _credentialStore.read(
+      key: _secureSettingsKey(pluginId),
+    );
+    if (settingsJson == null) return {};
+    try {
+      return Map<String, dynamic>.from(jsonDecode(settingsJson));
+    } catch (_) {
+      throw StateError('Secure settings for plugin $pluginId are invalid');
+    }
+  }
+
+  Future<void> _writeOrdinarySettings(
+    String pluginId,
+    Map<String, dynamic> settings,
+  ) async {
+    if (settings.isEmpty) {
+      await _prefs.remove(_settingsKey(pluginId));
+      if (_prefs.containsKey(_settingsKey(pluginId))) {
+        throw StateError('Failed to remove settings for plugin $pluginId');
+      }
+      return;
+    }
+    final saved = await _prefs.setString(
+      _settingsKey(pluginId),
+      jsonEncode(settings),
+    );
+    if (!saved) {
+      throw StateError('Failed to save settings for plugin $pluginId');
+    }
+  }
+
+  Future<void> _writeSecureSettings(
+    String pluginId,
+    Map<String, dynamic> settings,
+  ) async {
+    if (_credentialStore == null) {
+      if (settings.isEmpty) {
+        _volatileSecureSettings = Map.fromEntries(
+          _volatileSecureSettings.entries.where(
+            (entry) => entry.key != pluginId,
+          ),
+        );
+      } else {
+        _volatileSecureSettings = {
+          ..._volatileSecureSettings,
+          pluginId: Map.from(settings),
+        };
+      }
+      return;
+    }
+    if (settings.isEmpty) {
+      await _credentialStore.delete(key: _secureSettingsKey(pluginId));
+      return;
+    }
+    await _credentialStore.write(
+      key: _secureSettingsKey(pluginId),
+      value: jsonEncode(settings),
+    );
+  }
+
+  Future<void> _deleteSecureSettings(String pluginId) async {
+    _volatileSecureSettings = Map.fromEntries(
+      _volatileSecureSettings.entries.where((entry) => entry.key != pluginId),
+    );
+    await _credentialStore?.delete(key: _secureSettingsKey(pluginId));
+  }
 
   Future<void> _recordLoadFailure(String pluginId) async {
     final failureKey = _loadFailureKey(pluginId);

--- a/lib/src/services/webserver/plugins_handler.dart
+++ b/lib/src/services/webserver/plugins_handler.dart
@@ -257,7 +257,7 @@ final class PluginsHandler {
         return jsonBadRequest({'error': e.message});
       }
       await pluginService.reloadPlugin(id);
-      return jsonOk(json);
+      return jsonOk(await pluginService.pluginSettings(id));
     });
   }
 }

--- a/lib/src/settings/plugins_settings_view.dart
+++ b/lib/src/settings/plugins_settings_view.dart
@@ -13,6 +13,35 @@ import 'package:reaprime/src/plugins/plugin_manifest.dart';
 const _maxPluginSafDepth = 32;
 const _maxPluginSafEntries = 10000;
 
+// Parses an input string into the value for a setting schema type.
+dynamic parseValue(String value, String type) {
+  if (type == 'number') {
+    return num.tryParse(value);
+  }
+  if (type == 'boolean') {
+    return switch (value.trim().toLowerCase()) {
+      'true' => true,
+      'false' => false,
+      _ => null,
+    };
+  }
+  return value;
+}
+
+/// Dialog-local draft for a secure setting input.
+///
+/// The editable text is kept separate from the stored credential state so
+/// that typing (or erasing) never touches the credential until Save. Only the
+/// explicit clear action marks the credential for deletion.
+class _SecureDraft {
+  _SecureDraft({required this.originalIsSet, this.type});
+
+  final bool originalIsSet;
+  final String? type;
+  String text = '';
+  bool clearRequested = false;
+}
+
 class _PluginSafCopyState {
   final visitedDirectoryUris = <String>{};
   int entriesSeen = 0;
@@ -528,6 +557,17 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
       return;
     }
 
+    final secureDrafts = <String, _SecureDraft>{
+      for (final entry in settingsSchema.entries)
+        if (entry.value is Map && entry.value['secure'] == true)
+          entry.key: _SecureDraft(
+            originalIsSet:
+                newSettings[entry.key] is Map &&
+                (newSettings[entry.key] as Map)['isSet'] == true,
+            type: entry.value['type'] as String?,
+          ),
+    };
+
     await showDialog<void>(
       context: context,
       builder: (context) => StatefulBuilder(
@@ -543,30 +583,17 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
                   final schema = entry.value;
                   final currentValue = newSettings[key];
                   final defaultValue = schema['default'];
+                  final secureDraft = secureDrafts[key];
                   final secureValueIsSet =
-                      schema['secure'] == true &&
-                      currentValue is Map &&
-                      currentValue['isSet'] == true;
+                      secureDraft != null &&
+                      secureDraft.originalIsSet &&
+                      secureDraft.text.isEmpty &&
+                      !secureDraft.clearRequested;
 
                   // Helper function to get display value
                   String getDisplayValue(dynamic value) {
                     if (value == null) return '';
                     return value.toString();
-                  }
-
-                  // Helper function to parse value based on type
-                  dynamic parseValue(String value, String type) {
-                    if (type == 'number') {
-                      return num.tryParse(value);
-                    }
-                    if (type == 'boolean') {
-                      return switch (value.trim().toLowerCase()) {
-                        'true' => true,
-                        'false' => false,
-                        _ => null,
-                      };
-                    }
-                    return value;
                   }
 
                   return Padding(
@@ -605,14 +632,10 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
                                 ? TextInputType.number
                                 : null,
                             onChanged: (value) {
-                              final parsedValue = value.isEmpty
-                                  ? null
-                                  : parseValue(value, schema['type']);
-                              if (value.isEmpty || parsedValue != null) {
-                                setState(() {
-                                  newSettings[key] = parsedValue;
-                                });
-                              }
+                              setState(() {
+                                secureDrafts[key]!.text = value;
+                                secureDrafts[key]!.clearRequested = false;
+                              });
                             },
                             obscureText: true,
                             autocorrect: false,
@@ -627,7 +650,9 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
                                     tooltip: 'Clear saved value',
                                     onPressed: () {
                                       setState(() {
-                                        newSettings[key] = null;
+                                        secureDrafts[key]!.clearRequested =
+                                            true;
+                                        secureDrafts[key]!.text = '';
                                       });
                                     },
                                   )
@@ -705,9 +730,22 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
               ShadButton(
                 onPressed: () async {
                   try {
+                    final outgoing = Map<String, dynamic>.from(newSettings);
+                    for (final entry in secureDrafts.entries) {
+                      final draft = entry.value;
+                      if (draft.clearRequested) {
+                        outgoing[entry.key] = null;
+                      } else if (draft.text.isEmpty) {
+                        outgoing[entry.key] = {'isSet': draft.originalIsSet};
+                      } else {
+                        outgoing[entry.key] =
+                            parseValue(draft.text, draft.type ?? 'string') ??
+                            {'isSet': draft.originalIsSet};
+                      }
+                    }
                     await widget.pluginLoaderService.savePluginSettings(
                       pluginId,
-                      newSettings,
+                      outgoing,
                     );
                     if (context.mounted == false) {
                       return;

--- a/lib/src/settings/plugins_settings_view.dart
+++ b/lib/src/settings/plugins_settings_view.dart
@@ -543,6 +543,10 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
                   final schema = entry.value;
                   final currentValue = newSettings[key];
                   final defaultValue = schema['default'];
+                  final secureValueIsSet =
+                      schema['secure'] == true &&
+                      currentValue is Map &&
+                      currentValue['isSet'] == true;
 
                   // Helper function to get display value
                   String getDisplayValue(dynamic value) {
@@ -620,16 +624,35 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
                           )
                         else if (schema['secure'] == true)
                           ShadInput(
-                            placeholder: Text('Enter secure value...'),
-                            initialValue: getDisplayValue(
-                              currentValue ?? defaultValue,
+                            placeholder: Text(
+                              secureValueIsSet
+                                  ? 'Value saved'
+                                  : 'Enter secure value...',
                             ),
+                            initialValue: '',
                             onChanged: (value) {
                               setState(() {
-                                newSettings[key] = value;
+                                newSettings[key] = value.isEmpty ? null : value;
                               });
                             },
                             obscureText: true,
+                            autocorrect: false,
+                            enableSuggestions: false,
+                            enableIMEPersonalizedLearning: false,
+                            trailing: secureValueIsSet
+                                ? IconButton(
+                                    icon: const Icon(
+                                      LucideIcons.trash2,
+                                      size: 18,
+                                    ),
+                                    tooltip: 'Clear saved value',
+                                    onPressed: () {
+                                      setState(() {
+                                        newSettings[key] = null;
+                                      });
+                                    },
+                                  )
+                                : null,
                           )
                         else
                           ShadInput(

--- a/lib/src/settings/plugins_settings_view.dart
+++ b/lib/src/settings/plugins_settings_view.dart
@@ -559,6 +559,13 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
                     if (type == 'number') {
                       return num.tryParse(value);
                     }
+                    if (type == 'boolean') {
+                      return switch (value.trim().toLowerCase()) {
+                        'true' => true,
+                        'false' => false,
+                        _ => null,
+                      };
+                    }
                     return value;
                   }
 
@@ -586,7 +593,47 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
                             ),
                           ),
                         const SizedBox(height: 4),
-                        if (schema['type'] == 'boolean')
+                        if (schema['secure'] == true)
+                          ShadInput(
+                            placeholder: Text(
+                              secureValueIsSet
+                                  ? 'Value saved'
+                                  : 'Enter secure value...',
+                            ),
+                            initialValue: '',
+                            keyboardType: schema['type'] == 'number'
+                                ? TextInputType.number
+                                : null,
+                            onChanged: (value) {
+                              final parsedValue = value.isEmpty
+                                  ? null
+                                  : parseValue(value, schema['type']);
+                              if (value.isEmpty || parsedValue != null) {
+                                setState(() {
+                                  newSettings[key] = parsedValue;
+                                });
+                              }
+                            },
+                            obscureText: true,
+                            autocorrect: false,
+                            enableSuggestions: false,
+                            enableIMEPersonalizedLearning: false,
+                            trailing: secureValueIsSet
+                                ? IconButton(
+                                    icon: const Icon(
+                                      LucideIcons.trash2,
+                                      size: 18,
+                                    ),
+                                    tooltip: 'Clear saved value',
+                                    onPressed: () {
+                                      setState(() {
+                                        newSettings[key] = null;
+                                      });
+                                    },
+                                  )
+                                : null,
+                          )
+                        else if (schema['type'] == 'boolean')
                           Row(
                             children: [
                               ShadSwitch(
@@ -621,38 +668,6 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
                                 });
                               }
                             },
-                          )
-                        else if (schema['secure'] == true)
-                          ShadInput(
-                            placeholder: Text(
-                              secureValueIsSet
-                                  ? 'Value saved'
-                                  : 'Enter secure value...',
-                            ),
-                            initialValue: '',
-                            onChanged: (value) {
-                              setState(() {
-                                newSettings[key] = value.isEmpty ? null : value;
-                              });
-                            },
-                            obscureText: true,
-                            autocorrect: false,
-                            enableSuggestions: false,
-                            enableIMEPersonalizedLearning: false,
-                            trailing: secureValueIsSet
-                                ? IconButton(
-                                    icon: const Icon(
-                                      LucideIcons.trash2,
-                                      size: 18,
-                                    ),
-                                    tooltip: 'Clear saved value',
-                                    onPressed: () {
-                                      setState(() {
-                                        newSettings[key] = null;
-                                      });
-                                    },
-                                  )
-                                : null,
                           )
                         else
                           ShadInput(

--- a/test/plugin_loader_service_appstore_test.dart
+++ b/test/plugin_loader_service_appstore_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -11,17 +12,42 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class FakeCredentialStore implements CredentialStore {
   Map<String, String> values = {};
+  Completer<void>? _nextWriteStarted;
+  Future<void>? _nextWriteRelease;
+  Object? _nextDeleteError;
+
+  void blockNextWrite(Completer<void> started, Future<void> release) {
+    _nextWriteStarted = started;
+    _nextWriteRelease = release;
+  }
+
+  void failNextDelete(Object error) {
+    _nextDeleteError = error;
+  }
 
   @override
   Future<String?> read({required String key}) async => values[key];
 
   @override
   Future<void> write({required String key, required String value}) async {
+    final started = _nextWriteStarted;
+    if (started != null) {
+      final release = _nextWriteRelease!;
+      _nextWriteStarted = null;
+      _nextWriteRelease = null;
+      started.complete();
+      await release;
+    }
     values = {...values, key: value};
   }
 
   @override
   Future<void> delete({required String key}) async {
+    final error = _nextDeleteError;
+    if (error != null) {
+      _nextDeleteError = null;
+      throw error;
+    }
     values = Map.fromEntries(values.entries.where((entry) => entry.key != key));
   }
 }
@@ -230,6 +256,79 @@ function createPlugin() {
         expect(credentialStore.values, isEmpty);
       },
     );
+
+    test('concurrent setting patches preserve both updates', () async {
+      const id = 'concurrent-patch.reaplugin';
+      const credentialKey = 'plugin.settings.secure.$id';
+      await service.addPlugin(
+        makePluginSource(
+          id,
+          settings: {
+            'Username': {'type': 'string'},
+            'Password': {'type': 'string', 'secure': true},
+          },
+        ).path,
+      );
+      credentialStore.values = {
+        credentialKey: jsonEncode({'Password': 'old-secret'}),
+      };
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'plugin.settings.$id',
+        jsonEncode({'Username': 'old-user'}),
+      );
+      final staleWriteStarted = Completer<void>();
+      final releaseStaleWrite = Completer<void>();
+      credentialStore.blockNextWrite(
+        staleWriteStarted,
+        releaseStaleWrite.future,
+      );
+
+      final usernameUpdate = service.savePluginSettings(id, {
+        'Username': 'new-user',
+      });
+      await staleWriteStarted.future;
+      final passwordUpdate = service.savePluginSettings(id, {
+        'Password': 'new-secret',
+      });
+      await Future<void>.delayed(Duration.zero);
+      releaseStaleWrite.complete();
+      await Future.wait([usernameUpdate, passwordUpdate]);
+
+      expect(jsonDecode(credentialStore.values[credentialKey]!), {
+        'Password': 'new-secret',
+      });
+      expect(jsonDecode(prefs.getString('plugin.settings.$id')!), {
+        'Username': 'new-user',
+      });
+    });
+
+    test('failed credential cleanup leaves uninstall retryable', () async {
+      const id = 'retry-remove.reaplugin';
+      await service.addPlugin(
+        makePluginSource(
+          id,
+          settings: {
+            'Password': {'type': 'string', 'secure': true},
+          },
+        ).path,
+      );
+      await service.savePluginSettings(id, {'Password': 'secret'});
+      final pluginDir = Directory('${tempDir.path}/plugins/$id');
+      credentialStore.failNextDelete(StateError('delete failed'));
+
+      await expectLater(service.removePlugin(id), throwsStateError);
+
+      expect(service.getPluginManifest(id), isNotNull);
+      expect(pluginDir.existsSync(), isTrue);
+      expect(credentialStore.values, isNotEmpty);
+
+      await service.removePlugin(id);
+
+      expect(service.getPluginManifest(id), isNull);
+      expect(pluginDir.existsSync(), isFalse);
+      expect(credentialStore.values, isEmpty);
+    });
 
     test('assembles secure settings only for plugin onLoad', () async {
       const id = 'load-secure.reaplugin';

--- a/test/plugin_loader_service_appstore_test.dart
+++ b/test/plugin_loader_service_appstore_test.dart
@@ -257,6 +257,98 @@ function createPlugin() {
       },
     );
 
+    test('ordinary setting patches set, preserve, and clear values', () async {
+      const id = 'ordinary-patch.reaplugin';
+      await service.addPlugin(
+        makePluginSource(
+          id,
+          settings: {
+            'Username': {'type': 'string'},
+            'Theme': {'type': 'string'},
+            'Nickname': {'type': 'string'},
+          },
+        ).path,
+      );
+      final prefs = await SharedPreferences.getInstance();
+
+      await service.savePluginSettings(id, {
+        'Username': 'user',
+        'Theme': 'dark',
+        'Nickname': 'nick',
+      });
+
+      // Omitted fields preserve the existing value.
+      await service.savePluginSettings(id, {'Username': 'new-user'});
+
+      expect(await service.pluginSettings(id), {
+        'Username': 'new-user',
+        'Theme': 'dark',
+        'Nickname': 'nick',
+      });
+
+      // A null value removes the setting instead of storing a JSON null.
+      await service.savePluginSettings(id, {'Nickname': null});
+
+      expect(await service.pluginSettings(id), {
+        'Username': 'new-user',
+        'Theme': 'dark',
+      });
+      expect(jsonDecode(prefs.getString('plugin.settings.$id')!), {
+        'Username': 'new-user',
+        'Theme': 'dark',
+      });
+    });
+
+    test(
+      'a mixed patch updates, preserves, and clears settings at once',
+      () async {
+        const id = 'mixed-patch.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Username': {'type': 'string'},
+              'Theme': {'type': 'string'},
+              'Password': {'type': 'string', 'secure': true},
+              'ApiKey': {'type': 'string', 'secure': true},
+              'Token': {'type': 'string', 'secure': true},
+            },
+          ).path,
+        );
+        final prefs = await SharedPreferences.getInstance();
+
+        await service.savePluginSettings(id, {
+          'Username': 'user',
+          'Theme': 'dark',
+          'Password': 'secret',
+          'ApiKey': 'key',
+          'Token': 'token',
+        });
+
+        await service.savePluginSettings(id, {
+          'Username': 'new-user',
+          'Theme': null,
+          'Password': 'new-secret',
+          'ApiKey': {'isSet': true},
+          'Token': null,
+        });
+
+        expect(await service.pluginSettings(id), {
+          'Username': 'new-user',
+          'Password': {'isSet': true},
+          'ApiKey': {'isSet': true},
+          'Token': {'isSet': false},
+        });
+        expect(jsonDecode(prefs.getString('plugin.settings.$id')!), {
+          'Username': 'new-user',
+        });
+        expect(
+          credentialStore.values.values.single,
+          jsonEncode({'Password': 'new-secret', 'ApiKey': 'key'}),
+        );
+      },
+    );
+
     test('concurrent setting patches preserve both updates', () async {
       const id = 'concurrent-patch.reaplugin';
       const credentialKey = 'plugin.settings.secure.$id';

--- a/test/plugin_loader_service_appstore_test.dart
+++ b/test/plugin_loader_service_appstore_test.dart
@@ -4,8 +4,27 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart'
+    show CredentialStore;
 import 'package:reaprime/src/services/storage/kv_store_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+class FakeCredentialStore implements CredentialStore {
+  Map<String, String> values = {};
+
+  @override
+  Future<String?> read({required String key}) async => values[key];
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    values = {...values, key: value};
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    values = Map.fromEntries(values.entries.where((entry) => entry.key != key));
+  }
+}
 
 class FakeKvStore implements KeyValueStoreService {
   final Map<String, Map<String, Object>> _store = {};
@@ -58,9 +77,14 @@ void main() {
   group('PluginLoaderService App Store mode', () {
     late Directory tempDir;
     late PluginLoaderService service;
+    late FakeCredentialStore credentialStore;
     var sourceCounter = 0;
 
-    Directory makePluginSource(String id) {
+    Directory makePluginSource(
+      String id, {
+      Map<String, Object> settings = const {},
+      String? jsCode,
+    }) {
       final dir = Directory('${tempDir.path}/source_${sourceCounter++}')
         ..createSync();
       File('${dir.path}/manifest.json').writeAsStringSync(
@@ -72,15 +96,18 @@ void main() {
           'version': '1.0.0',
           'apiVersion': 1,
           'permissions': <String>[],
-          'settings': <String, Object>{},
+          'settings': settings,
           'api': <Object>[],
         }),
       );
-      File('${dir.path}/plugin.js').writeAsStringSync('''
+      File('${dir.path}/plugin.js').writeAsStringSync(
+        jsCode ??
+            '''
 function createPlugin() {
   return { id: "x", onLoad() {} };
 }
-''');
+''',
+      );
       return dir;
     }
 
@@ -92,7 +119,11 @@ function createPlugin() {
             const MethodChannel('plugins.flutter.io/path_provider'),
             (_) async => tempDir.path,
           );
-      service = PluginLoaderService(kvStore: FakeKvStore());
+      credentialStore = FakeCredentialStore();
+      service = PluginLoaderService(
+        kvStore: FakeKvStore(),
+        credentialStore: credentialStore,
+      );
       await service.initialize();
     });
 
@@ -130,6 +161,112 @@ function createPlugin() {
 
       expect(pluginDir.existsSync(), isFalse);
       expect(service.getPluginManifest(id), isNull);
+    });
+
+    test('migrates and redacts legacy secure settings on first read', () async {
+      const id = 'secure.reaplugin';
+      await service.addPlugin(
+        makePluginSource(
+          id,
+          settings: {
+            'Username': {'type': 'string'},
+            'Password': {'type': 'string', 'secure': true},
+          },
+        ).path,
+      );
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'plugin.settings.$id',
+        jsonEncode({'Username': 'user', 'Password': 'secret'}),
+      );
+
+      expect(await service.pluginSettings(id), {
+        'Username': 'user',
+        'Password': {'isSet': true},
+      });
+      expect(jsonDecode(prefs.getString('plugin.settings.$id')!), {
+        'Username': 'user',
+      });
+      expect(
+        credentialStore.values.values.single,
+        jsonEncode({'Password': 'secret'}),
+      );
+    });
+
+    test(
+      'secure setting patches set, preserve, and clear credentials',
+      () async {
+        const id = 'patch.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Username': {'type': 'string'},
+              'Password': {'type': 'string', 'secure': true},
+            },
+          ).path,
+        );
+
+        await service.savePluginSettings(id, {
+          'Username': 'first',
+          'Password': 'secret',
+        });
+        await service.savePluginSettings(id, {
+          'Username': 'second',
+          'Password': {'isSet': true},
+        });
+
+        expect(await service.pluginSettings(id), {
+          'Username': 'second',
+          'Password': {'isSet': true},
+        });
+
+        await service.savePluginSettings(id, {'Password': null});
+
+        expect(await service.pluginSettings(id), {
+          'Username': 'second',
+          'Password': {'isSet': false},
+        });
+        expect(credentialStore.values, isEmpty);
+      },
+    );
+
+    test('assembles secure settings only for plugin onLoad', () async {
+      const id = 'load-secure.reaplugin';
+      await service.addPlugin(
+        makePluginSource(
+          id,
+          settings: {
+            'Username': {'type': 'string'},
+            'Password': {'type': 'string', 'secure': true},
+          },
+          jsCode:
+              '''
+function createPlugin() {
+  return {
+    id: "$id",
+    onLoad(settings) {
+      if (settings.Username !== "user" || settings.Password !== "secret") {
+        throw new Error("settings not assembled");
+      }
+    }
+  };
+}
+''',
+        ).path,
+      );
+      await service.savePluginSettings(id, {
+        'Username': 'user',
+        'Password': 'secret',
+      });
+
+      await service.loadPlugin(id);
+
+      expect(service.isPluginLoaded(id), isTrue);
+      expect(await service.pluginSettings(id), {
+        'Username': 'user',
+        'Password': {'isSet': true},
+      });
     });
 
     const unsafeIds = [

--- a/test/plugin_loader_service_watchdog_test.dart
+++ b/test/plugin_loader_service_watchdog_test.dart
@@ -5,18 +5,18 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart'
+    show CredentialStore;
 import 'package:reaprime/src/services/storage/kv_store_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-class _ControllablePluginLoaderService extends PluginLoaderService {
-  _ControllablePluginLoaderService({required super.kvStore});
-
-  String? _pausedPluginId;
+class _ControllableCredentialStore implements CredentialStore {
+  String? _pausedKey;
   Completer<void>? _pauseEntered;
   Completer<void>? _resume;
 
-  void pauseSettingsFor(String pluginId) {
-    _pausedPluginId = pluginId;
+  void pauseReadFor(String key) {
+    _pausedKey = key;
     _pauseEntered = Completer<void>();
     _resume = Completer<void>();
   }
@@ -26,13 +26,19 @@ class _ControllablePluginLoaderService extends PluginLoaderService {
   void resume() => _resume!.complete();
 
   @override
-  Future<Map<String, dynamic>> pluginSettings(String pluginId) async {
-    if (pluginId == _pausedPluginId) {
+  Future<String?> read({required String key}) async {
+    if (key == _pausedKey) {
       _pauseEntered!.complete();
       await _resume!.future;
     }
-    return super.pluginSettings(pluginId);
+    return null;
   }
+
+  @override
+  Future<void> write({required String key, required String value}) async {}
+
+  @override
+  Future<void> delete({required String key}) async {}
 }
 
 class _FakeKvStore implements KeyValueStoreService {
@@ -80,7 +86,8 @@ void main() {
   const pluginId = 'watchdog-test.reaplugin';
   late Directory tempDir;
   late Directory sourceDir;
-  late _ControllablePluginLoaderService service;
+  late PluginLoaderService service;
+  late _ControllableCredentialStore credentialStore;
 
   void writePlugin(String js) {
     File('${sourceDir.path}/plugin.js').writeAsStringSync(js);
@@ -115,7 +122,11 @@ void main() {
     );
     writePlugin('function createPlugin() { throw new Error("boom"); }');
 
-    service = _ControllablePluginLoaderService(kvStore: _FakeKvStore());
+    credentialStore = _ControllableCredentialStore();
+    service = PluginLoaderService(
+      kvStore: _FakeKvStore(),
+      credentialStore: credentialStore,
+    );
     await service.initialize();
     await service.addPlugin(sourceDir.path);
     await service.setPluginAutoLoad(pluginId, true);
@@ -217,9 +228,9 @@ function createPlugin() {
 }
 ''');
 
-    service.pauseSettingsFor(pluginId);
+    credentialStore.pauseReadFor('plugin.settings.secure.$pluginId');
     final firstLoad = service.loadPlugin(pluginId);
-    await service.waitUntilPaused();
+    await credentialStore.waitUntilPaused();
 
     var secondCompleted = false;
     final secondLoad = service
@@ -229,7 +240,7 @@ function createPlugin() {
 
     expect(secondCompleted, isFalse);
 
-    service.resume();
+    credentialStore.resume();
     await Future.wait([firstLoad, secondLoad]);
   });
 

--- a/test/plugins_settings_view_appstore_test.dart
+++ b/test/plugins_settings_view_appstore_test.dart
@@ -152,4 +152,61 @@ void main() {
 
     expect(fakePluginLoaderService.savedSettings, {'Password': null});
   });
+
+  testWidgets('secure number and boolean settings stay obscured and typed', (
+    tester,
+  ) async {
+    final manifest = PluginManifest(
+      id: 'typed-secure.reaplugin',
+      name: 'Typed Secure Plugin',
+      author: 'Test',
+      description: 'Test plugin',
+      version: '1.0.0',
+      apiVersion: 1,
+      permissions: {},
+      settings: {
+        'NumberSecret': {'type': 'number', 'secure': true},
+        'BooleanSecret': {'type': 'boolean', 'secure': true},
+      },
+      api: PluginApi(endpoints: []),
+    );
+    fakePluginLoaderService = FakePluginLoaderService(
+      plugins: [manifest],
+      settings: {
+        'NumberSecret': {'isSet': true},
+        'BooleanSecret': {'isSet': true},
+      },
+    );
+    await tester.pumpWidget(
+      ShadApp(
+        builder: (_, child) => ScaffoldMessenger(child: child!),
+        home: PluginsSettingsView(
+          pluginLoaderService: fakePluginLoaderService,
+          allowInstall: false,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.widgetWithText(ShadButton, 'Settings'));
+    await tester.pumpAndSettle();
+
+    final inputs = find.descendant(
+      of: find.byType(AlertDialog),
+      matching: find.byType(ShadInput),
+    );
+    expect(inputs, findsNWidgets(2));
+    expect(
+      tester.widgetList<ShadInput>(inputs).every((input) => input.obscureText),
+      isTrue,
+    );
+    await tester.enterText(inputs.at(0), '42');
+    await tester.enterText(inputs.at(1), 'true');
+    await tester.tap(find.widgetWithText(ShadButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(fakePluginLoaderService.savedSettings, {
+      'NumberSecret': 42,
+      'BooleanSecret': true,
+    });
+  });
 }

--- a/test/plugins_settings_view_appstore_test.dart
+++ b/test/plugins_settings_view_appstore_test.dart
@@ -12,6 +12,7 @@ class FakePluginLoaderService extends Fake implements PluginLoaderService {
   final List<PluginManifest> plugins;
   final Map<String, dynamic> settings;
   Map<String, dynamic>? savedSettings;
+  int saveCallCount = 0;
 
   @override
   List<PluginManifest> get availablePlugins => plugins;
@@ -39,6 +40,7 @@ class FakePluginLoaderService extends Fake implements PluginLoaderService {
     String pluginId,
     Map<String, dynamic> settings,
   ) async {
+    saveCallCount++;
     savedSettings = settings;
   }
 }
@@ -113,25 +115,27 @@ void main() {
     expect(find.text('proxyDecentApi'), findsNothing);
   });
 
-  testWidgets('clears a stored secure setting explicitly', (tester) async {
-    final manifest = PluginManifest(
-      id: 'secure.reaplugin',
-      name: 'Secure Plugin',
-      author: 'Test',
-      description: 'Test plugin',
-      version: '1.0.0',
-      apiVersion: 1,
-      permissions: {},
-      settings: {
-        'Password': {'type': 'string', 'secure': true},
-      },
-      api: PluginApi(endpoints: []),
-    );
+  PluginManifest secureManifest() => PluginManifest(
+    id: 'secure.reaplugin',
+    name: 'Secure Plugin',
+    author: 'Test',
+    description: 'Test plugin',
+    version: '1.0.0',
+    apiVersion: 1,
+    permissions: {},
+    settings: {
+      'Password': {'type': 'string', 'secure': true},
+    },
+    api: PluginApi(endpoints: []),
+  );
+
+  Future<void> openSecureSettingsDialog(
+    WidgetTester tester, {
+    required Map<String, dynamic> settings,
+  }) async {
     fakePluginLoaderService = FakePluginLoaderService(
-      plugins: [manifest],
-      settings: {
-        'Password': {'isSet': true},
-      },
+      plugins: [secureManifest()],
+      settings: settings,
     );
     await tester.pumpWidget(
       ShadApp(
@@ -145,6 +149,15 @@ void main() {
     await tester.pump();
     await tester.tap(find.widgetWithText(ShadButton, 'Settings'));
     await tester.pumpAndSettle();
+  }
+
+  testWidgets('clears a stored secure setting explicitly', (tester) async {
+    await openSecureSettingsDialog(
+      tester,
+      settings: {
+        'Password': {'isSet': true},
+      },
+    );
 
     await tester.tap(find.byTooltip('Clear saved value'));
     await tester.tap(find.widgetWithText(ShadButton, 'Save'));
@@ -152,6 +165,88 @@ void main() {
 
     expect(fakePluginLoaderService.savedSettings, {'Password': null});
   });
+
+  testWidgets(
+    'secure setting: replacing then erasing the typed value preserves the '
+    'stored credential on Save',
+    (tester) async {
+      await openSecureSettingsDialog(
+        tester,
+        settings: {
+          'Password': {'isSet': true},
+        },
+      );
+
+      final input = find.byType(ShadInput);
+      await tester.enterText(input, 'replacement');
+      await tester.enterText(input, '');
+      await tester.tap(find.widgetWithText(ShadButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      expect(fakePluginLoaderService.savedSettings, {
+        'Password': {'isSet': true},
+      });
+    },
+  );
+
+  testWidgets(
+    'secure setting: Cancel after typing never calls savePluginSettings',
+    (tester) async {
+      await openSecureSettingsDialog(
+        tester,
+        settings: {
+          'Password': {'isSet': true},
+        },
+      );
+
+      await tester.enterText(find.byType(ShadInput), 'replacement');
+      await tester.tap(find.widgetWithText(ShadButton, 'Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(fakePluginLoaderService.saveCallCount, 0);
+      expect(fakePluginLoaderService.savedSettings, isNull);
+    },
+  );
+
+  testWidgets('secure setting: typed replacement is committed on Save', (
+    tester,
+  ) async {
+    await openSecureSettingsDialog(
+      tester,
+      settings: {
+        'Password': {'isSet': true},
+      },
+    );
+
+    await tester.enterText(find.byType(ShadInput), 'new-secret');
+    await tester.tap(find.widgetWithText(ShadButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(fakePluginLoaderService.savedSettings, {'Password': 'new-secret'});
+  });
+
+  testWidgets(
+    'secure setting: typing then erasing with no stored credential never '
+    'sends an unintended clear',
+    (tester) async {
+      await openSecureSettingsDialog(
+        tester,
+        settings: {
+          'Password': {'isSet': false},
+        },
+      );
+
+      final input = find.byType(ShadInput);
+      await tester.enterText(input, 'typo');
+      await tester.enterText(input, '');
+      await tester.tap(find.widgetWithText(ShadButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      expect(fakePluginLoaderService.savedSettings, {
+        'Password': {'isSet': false},
+      });
+    },
+  );
 
   testWidgets('secure number and boolean settings stay obscured and typed', (
     tester,

--- a/test/plugins_settings_view_appstore_test.dart
+++ b/test/plugins_settings_view_appstore_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
@@ -6,9 +7,11 @@ import 'package:reaprime/src/settings/plugins_settings_view.dart';
 
 /// A fake PluginLoaderService that avoids creating a real PluginManager/JS runtime.
 class FakePluginLoaderService extends Fake implements PluginLoaderService {
-  FakePluginLoaderService({this.plugins = const []});
+  FakePluginLoaderService({this.plugins = const [], this.settings = const {}});
 
   final List<PluginManifest> plugins;
+  final Map<String, dynamic> settings;
+  Map<String, dynamic>? savedSettings;
 
   @override
   List<PluginManifest> get availablePlugins => plugins;
@@ -18,6 +21,26 @@ class FakePluginLoaderService extends Fake implements PluginLoaderService {
 
   @override
   Future<bool> shouldAutoLoad(String pluginId) async => false;
+
+  @override
+  PluginManifest? getPluginManifest(String pluginId) {
+    for (final plugin in plugins) {
+      if (plugin.id == pluginId) return plugin;
+    }
+    return null;
+  }
+
+  @override
+  Future<Map<String, dynamic>> pluginSettings(String pluginId) async =>
+      settings;
+
+  @override
+  Future<void> savePluginSettings(
+    String pluginId,
+    Map<String, dynamic> settings,
+  ) async {
+    savedSettings = settings;
+  }
 }
 
 void main() {
@@ -88,5 +111,45 @@ void main() {
 
     expect(find.text('proxy.decent_api'), findsOneWidget);
     expect(find.text('proxyDecentApi'), findsNothing);
+  });
+
+  testWidgets('clears a stored secure setting explicitly', (tester) async {
+    final manifest = PluginManifest(
+      id: 'secure.reaplugin',
+      name: 'Secure Plugin',
+      author: 'Test',
+      description: 'Test plugin',
+      version: '1.0.0',
+      apiVersion: 1,
+      permissions: {},
+      settings: {
+        'Password': {'type': 'string', 'secure': true},
+      },
+      api: PluginApi(endpoints: []),
+    );
+    fakePluginLoaderService = FakePluginLoaderService(
+      plugins: [manifest],
+      settings: {
+        'Password': {'isSet': true},
+      },
+    );
+    await tester.pumpWidget(
+      ShadApp(
+        builder: (_, child) => ScaffoldMessenger(child: child!),
+        home: PluginsSettingsView(
+          pluginLoaderService: fakePluginLoaderService,
+          allowInstall: false,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.widgetWithText(ShadButton, 'Settings'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Clear saved value'));
+    await tester.tap(find.widgetWithText(ShadButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(fakePluginLoaderService.savedSettings, {'Password': null});
   });
 }

--- a/test/services/webserver/plugins_handler_test.dart
+++ b/test/services/webserver/plugins_handler_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
@@ -8,6 +10,29 @@ import 'package:shelf_plus/shelf_plus.dart';
 import '../../plugins/plugin_test_helpers.dart';
 
 class _FakePluginLoaderService extends Fake implements PluginLoaderService {}
+
+class _SettingsPluginLoaderService extends Fake implements PluginLoaderService {
+  Map<String, dynamic> publicSettings = {
+    'Username': 'user',
+    'Password': {'isSet': true},
+  };
+  Map<String, dynamic>? savedPatch;
+
+  @override
+  Future<Map<String, dynamic>> pluginSettings(String pluginId) async =>
+      publicSettings;
+
+  @override
+  Future<void> savePluginSettings(
+    String pluginId,
+    Map<String, dynamic> settings,
+  ) async {
+    savedPatch = settings;
+  }
+
+  @override
+  Future<void> reloadPlugin(String pluginId) async {}
+}
 
 void main() {
   const pluginId = 'http.plugin';
@@ -29,6 +54,58 @@ void main() {
       ),
     );
   }
+
+  group('plugin settings API', () {
+    late PluginManager manager;
+    late _SettingsPluginLoaderService pluginService;
+    late RouterPlus app;
+
+    setUp(() {
+      manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      addTearDown(manager.cancelAllOperations);
+      pluginService = _SettingsPluginLoaderService();
+      app = Router().plus;
+      PluginsHandler(
+        pluginManager: manager,
+        pluginService: pluginService,
+      ).addRoutes(app);
+    });
+
+    test('GET returns secure state without the credential', () async {
+      final response = await app.call(
+        Request(
+          'GET',
+          Uri.parse('http://localhost/api/v1/plugins/$pluginId/settings'),
+        ),
+      );
+
+      expect(response.statusCode, 200);
+      expect(jsonDecode(await response.readAsString()), {
+        'Username': 'user',
+        'Password': {'isSet': true},
+      });
+    });
+
+    test('POST never echoes a submitted credential', () async {
+      final response = await app.call(
+        Request(
+          'POST',
+          Uri.parse('http://localhost/api/v1/plugins/$pluginId/settings'),
+          headers: {'content-type': 'application/json'},
+          body: jsonEncode({'Password': 'new-secret'}),
+        ),
+      );
+
+      expect(pluginService.savedPatch, {'Password': 'new-secret'});
+      expect(response.statusCode, 200);
+      final body = await response.readAsString();
+      expect(body, isNot(contains('new-secret')));
+      expect(jsonDecode(body), {
+        'Username': 'user',
+        'Password': {'isSet': true},
+      });
+    });
+  });
 
   test('synchronous plugin response completes the request directly', () async {
     final manager = PluginManager(

--- a/test/services/webserver/plugins_handler_test.dart
+++ b/test/services/webserver/plugins_handler_test.dart
@@ -105,6 +105,23 @@ void main() {
         'Password': {'isSet': true},
       });
     });
+
+    test('POST passes null clears through to the service unchanged', () async {
+      final response = await app.call(
+        Request(
+          'POST',
+          Uri.parse('http://localhost/api/v1/plugins/$pluginId/settings'),
+          headers: {'content-type': 'application/json'},
+          body: jsonEncode({'Username': 'new-user', 'Password': null}),
+        ),
+      );
+
+      expect(pluginService.savedPatch, {
+        'Username': 'new-user',
+        'Password': null,
+      });
+      expect(response.statusCode, 200);
+    });
   });
 
   test('synchronous plugin response completes the request directly', () async {


### PR DESCRIPTION
## Summary

- Problem: Plugin settings marked `secure` were stored and returned like ordinary settings.
- Why it matters: LAN API clients and broad logging could retrieve plugin credentials, including the bundled Visualizer password.
- What changed: Secure fields now use `CredentialStore`, migrate out of SharedPreferences, return `{ "isSet": true|false }`, support serialized patch and clear semantics, and reach plugins only through `onLoad(settings)`. Secure UI fields are obscured and parsed according to their declared type. Failed credential cleanup leaves uninstall retryable.
- What did NOT change (scope boundary): Ordinary plugin settings remain in SharedPreferences. This PR does not change LAN authentication, plugin permissions, WebSocket behavior, or device code.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [x] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [x] Plugins / JS runtime
- [x] UI / Flutter widgets
- [x] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes: N/A
- Related: N/A

## Root Cause (if bug fix)

- Root cause: The manifest's `secure` flag only selected an obscured text field. The storage and REST layers treated the value as ordinary JSON.
- Missing detection or guardrail: Service and handler tests did not assert that secure values stay out of SharedPreferences and API responses.
- Contributing context (if known): Most of the API follows the repository's LAN-trust model, so the settings endpoints had no credential-specific redaction layer.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/plugin_loader_service_appstore_test.dart`, `test/plugins_settings_view_appstore_test.dart`, and `test/services/webserver/plugins_handler_test.dart`
- Scenario the test should lock in: Migrate legacy plaintext, redact GET and POST responses, preserve omitted or redacted credentials, serialize concurrent patches, clear on `null`, keep uninstall retryable after cleanup failure, preserve declared secure types in the UI, and assemble plaintext only for plugin `onLoad`.
- If no new test added, why not: N/A

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [x] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [x] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A - no docs affected

## Security Impact (required)

- New or changed REST endpoints? `Yes`, response and update behavior changed for the existing plugin settings endpoints.
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `No`
- File system access changed? `No`
- Plugin sandbox boundary changed? `Yes`
- If any `Yes`, explain risk and mitigation: API clients can no longer read secure values or recover them from POST responses. Plugins receive plaintext only while `PluginManager.loadPlugin` invokes `onLoad`. Tests cover migration, redaction, patch behavior, clearing, concurrency, failed cleanup, and runtime assembly.

## User-Visible Changes

Secure plugin inputs open blank, show whether a value is saved, disable input learning and suggestions, preserve the manifest's declared type, and provide an explicit clear button.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` - no remaining changes
- [x] `flutter analyze` - clean (no new warnings)
- [x] `flutter test` - all pass
- [x] `./scripts/fetch_dye2_plugin.sh` - DYE2 plugin installed into `assets/plugins/dye2.reaplugin/`

The focused service, API, widget, and watchdog run passed all 43 tests. The full parallel suite passed all 2,827 tests.

### Manual verification (if applicable)

- OS / platform tested: Windows
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: Focused Flutter tests exercised secure storage, migration, API redaction, serialized patch semantics, typed secure inputs, retryable uninstall, UI clearing, and plugin loading. The OpenAPI YAML parsed successfully.
- Edge cases checked: Legacy plaintext migration, redacted marker preservation, omitted fields, explicit clear, concurrent ordinary and secure patches, failed credential deletion during uninstall, secure number and boolean values, account-disabled in-memory storage, and concurrent plugin loads.
- What you did **not** verify: Live `curl` smoke. A Windows run would share this account's app documents and credential namespace, so handler and service tests were used instead of mutating unrelated local plugin credentials.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? `No` for clients that depended on retrieving secure plaintext; this is the intentional security boundary. Ordinary settings remain compatible.
- Config / env changes needed? `No`
- Database migration needed? `No`
- If any `No` or `Yes`, explain exact steps: No operator action is required. The first secure-settings read moves legacy values into the platform credential store and removes the SharedPreferences copy.

## Risks & Mitigations

- Risk: Credential-store failures now fail the secure settings operation instead of falling back to plaintext.
  - Mitigation: The service never writes a secret back to SharedPreferences, and tests cover write, read, clear, migration, and uninstall cleanup paths.
- Risk: `--no-account` cannot persist secure plugin values across restarts.
  - Mitigation: Account-disabled mode keeps secure settings in process memory and documents the limitation.
