### PR TITLE
Simulator: honor profile limiters and vary puck resistance

### DIFF
--- a/doc/Profiles.md
+++ b/doc/Profiles.md
@@ -546,7 +546,7 @@ Example error response:
 
 ### Simulated shot execution (MockDe1 / MockBengle)
 
-Mock machines execute profiles in a simulated shot loop that follows profile step targets (flow, pressure, temperature) with simplified machine-response dynamics. Design decisions are recorded in archived plans — see `doc/plans/mock-shot-fidelity.md` for the substate model, flow→pressure coupling, weight accumulation, transition shaping, and skipStep semantics.
+Mock machines execute profiles in a simulated shot loop that follows profile step targets (flow, pressure, temperature) with simplified machine-response dynamics. Pressure steps honor flow limiters, flow steps honor pressure limiters, and each shot samples bounded puck resistance so repeated pulls are not identical. Design decisions are recorded in archived plans — see `doc/plans/mock-shot-fidelity.md` for the substate model, flow→pressure coupling, weight accumulation, transition shaping, and skipStep semantics.
 
 ### Profile Wire Format
 

--- a/doc/Profiles.md
+++ b/doc/Profiles.md
@@ -546,7 +546,7 @@ Example error response:
 
 ### Simulated shot execution (MockDe1 / MockBengle)
 
-Mock machines execute profiles in a simulated shot loop that follows profile step targets (flow, pressure, temperature) with simplified machine-response dynamics. Pressure steps honor flow limiters, flow steps honor pressure limiters, and each shot samples bounded puck resistance so repeated pulls are not identical. Design decisions are recorded in archived plans — see `doc/plans/mock-shot-fidelity.md` for the substate model, flow→pressure coupling, weight accumulation, transition shaping, and skipStep semantics.
+Mock machines execute profiles in a simulated shot loop that follows profile step targets (flow, pressure, temperature) with simplified machine-response dynamics. Pressure steps model flow limiters and flow steps model pressure limiters with a progressive response across each limiter's range of action. This is a simulator approximation rather than firmware control-loop emulation. Each shot also samples bounded puck resistance so repeated pulls are not identical. Design decisions are recorded in archived plans — see `doc/plans/mock-shot-fidelity.md` for the substate model, flow→pressure coupling, weight accumulation, transition shaping, and skipStep semantics.
 
 ### Profile Wire Format
 

--- a/doc/Profiles.md
+++ b/doc/Profiles.md
@@ -546,7 +546,7 @@ Example error response:
 
 ### Simulated shot execution (MockDe1 / MockBengle)
 
-Mock machines execute profiles in a simulated shot loop that follows profile step targets (flow, pressure, temperature) with simplified machine-response dynamics. Pressure steps model flow limiters and flow steps model pressure limiters with a progressive response across each limiter's range of action. This is a simulator approximation rather than firmware control-loop emulation. Each shot also samples bounded puck resistance so repeated pulls are not identical. Design decisions are recorded in archived plans — see `doc/plans/mock-shot-fidelity.md` for the substate model, flow→pressure coupling, weight accumulation, transition shaping, and skipStep semantics.
+Mock machines execute profiles in a simulated shot loop that follows profile step targets (flow, pressure, temperature) with simplified machine-response dynamics. Pressure steps model flow limiters and flow steps model pressure limiters with a progressive response across each limiter's range of action. This is a simulator approximation rather than firmware control-loop emulation. Each shot also samples bounded puck resistance so repeated pulls are not identical. Design decisions are recorded in archived plans — see `doc/plans/archive/mock-shot-simulator/mock-shot-fidelity.md` for the substate model, flow→pressure coupling, weight accumulation, transition shaping, and skipStep semantics.
 
 ### Profile Wire Format
 

--- a/doc/plans/archive/simulator-profile-fidelity/design.md
+++ b/doc/plans/archive/simulator-profile-fidelity/design.md
@@ -7,7 +7,7 @@ Historical-shot replay ignores the selected profile and makes target-weight beha
 ## Plan
 
 1. Add regression coverage for profile-step limiters, repeat-shot variation, and stop-at-weight through MockDe1, MockScale, and ShotSequencer.
-2. Apply pressure-step flow limiters and flow-step pressure limiters in MockDe1.
+2. Model pressure-step flow limiters and flow-step pressure limiters progressively from their value toward the non-exceedable value-plus-range boundary.
 3. Sample one bounded puck-resistance multiplier at each shot start from a fixed-seed random sequence so pulls vary while test runs remain deterministic.
 4. Run formatting, focused tests, analysis, the full test suite, and a simulate-mode smoke test.
 

--- a/doc/plans/archive/simulator-profile-fidelity/design.md
+++ b/doc/plans/archive/simulator-profile-fidelity/design.md
@@ -1,0 +1,18 @@
+# Simulator profile fidelity
+
+## Problem
+
+Historical-shot replay ignores the selected profile and makes target-weight behavior incidental to the recording. The existing simulator follows the selected profile and uses the normal scale and ShotSequencer path, but every pull has the same puck response and step limiters are ignored.
+
+## Plan
+
+1. Add regression coverage for profile-step limiters, repeat-shot variation, and stop-at-weight through MockDe1, MockScale, and ShotSequencer.
+2. Apply pressure-step flow limiters and flow-step pressure limiters in MockDe1.
+3. Sample one bounded puck-resistance multiplier at each shot start from a fixed-seed random sequence so pulls vary while test runs remain deterministic.
+4. Run formatting, focused tests, analysis, the full test suite, and a simulate-mode smoke test.
+
+## Boundaries
+
+- Keep profiles, scale behavior, target weight, and shot persistence on their existing production paths.
+- Do not add replay assets, asset loaders, simulator settings, or duplicate stop-at-weight logic.
+- Keep the synthetic fallback for profile-less unit tests unchanged.

--- a/doc/plans/archive/simulator-profile-fidelity/design.md
+++ b/doc/plans/archive/simulator-profile-fidelity/design.md
@@ -4,12 +4,12 @@
 
 Historical-shot replay ignores the selected profile and makes target-weight behavior incidental to the recording. The existing simulator follows the selected profile and uses the normal scale and ShotSequencer path, but every pull has the same puck response and step limiters are ignored.
 
-## Plan
+## Design
 
-1. Add regression coverage for profile-step limiters, repeat-shot variation, and stop-at-weight through MockDe1, MockScale, and ShotSequencer.
-2. Model pressure-step flow limiters and flow-step pressure limiters progressively from their value toward the non-exceedable value-plus-range boundary.
-3. Sample one bounded puck-resistance multiplier at each shot start from a fixed-seed random sequence so pulls vary while test runs remain deterministic.
-4. Run formatting, focused tests, analysis, the full test suite, and a simulate-mode smoke test.
+- **Profile-aware synthetic simulation over replay.** Replay assets would decouple the simulator from the currently loaded profile, so target-weight and limiter behavior would stop reflecting what the skin author is editing. Keeping the synthetic loop on the existing profile, scale, and ShotSequencer paths means simulated shots exercise the same stop-at-weight and step-exit logic as hardware, with no new asset pipeline.
+- **Limiters are an approximation.** Pressure steps model flow limiters and flow steps model pressure limiters with a progressive response across each limiter's range of action. This approximates the observable machine response to limiter settings without emulating firmware control loops; exact tuning is not a goal.
+- **Bounded puck-resistance variation.** Each shot samples one puck-resistance multiplier from a fixed-seed random sequence, so repeated pulls differ without making test runs nondeterministic. Variation is bounded to keep pressures plausible within the selected profile.
+- **Scope.** Keep profiles, scale behavior, target weight, and shot persistence on their existing production paths. No replay assets, asset loaders, simulator settings, or duplicate stop-at-weight logic. The synthetic fallback for profile-less unit tests stays unchanged.
 
 ## Boundaries
 

--- a/lib/src/models/device/impl/mock_de1/mock_de1.dart
+++ b/lib/src/models/device/impl/mock_de1/mock_de1.dart
@@ -22,6 +22,17 @@ enum _SimulationType { espresso, steam, hotWater, idle }
 class MockDe1 implements De1Interface, SimulatedDevice {
   MockDe1({String deviceId = "MockDe1"}) : _deviceId = deviceId;
 
+  static double _applyLimiter(double measurement, StepLimiter? limiter) {
+    if (limiter == null || limiter.value <= 0 || measurement <= limiter.value) {
+      return measurement;
+    }
+    if (limiter.range <= 0) {
+      return limiter.value;
+    }
+    final excess = measurement - limiter.value;
+    return limiter.value + limiter.range * excess / (limiter.range + excess);
+  }
+
   final Random _puckRandom = Random(0);
   double _puckResistanceMultiplier = 1.0;
 
@@ -394,9 +405,8 @@ class MockDe1 implements De1Interface, SimulatedDevice {
         _lastSnapshot.flow +
         (targetFlow - _lastSnapshot.flow) * flowResponseRate;
 
-    final limiterValue = currentStep.limiter?.value ?? 0;
-    if (currentStep is ProfileStepPressure && limiterValue > 0) {
-      newFlow = min(newFlow, limiterValue);
+    if (currentStep is ProfileStepPressure) {
+      newFlow = _applyLimiter(newFlow, currentStep.limiter);
     }
 
     // Pressure lags behind flow (puck-mediated).
@@ -416,9 +426,7 @@ class MockDe1 implements De1Interface, SimulatedDevice {
       if (newPressure >= targetPressure) {
         newPressure = targetPressure;
         newFlow = min(targetPressure / resistance, pumpMaxFlow);
-        if (limiterValue > 0) {
-          newFlow = min(newFlow, limiterValue);
-        }
+        newFlow = _applyLimiter(newFlow, currentStep.limiter);
       }
     }
 
@@ -426,11 +434,12 @@ class MockDe1 implements De1Interface, SimulatedDevice {
     if (currentStep is ProfileStepFlow && newFlow > targetFlow) {
       newFlow = targetFlow;
     }
-    if (currentStep is ProfileStepFlow &&
-        limiterValue > 0 &&
-        newPressure > limiterValue) {
-      newPressure = limiterValue;
-      newFlow = min(newFlow, limiterValue / resistance);
+    if (currentStep is ProfileStepFlow) {
+      final limitedPressure = _applyLimiter(newPressure, currentStep.limiter);
+      if (limitedPressure < newPressure) {
+        newPressure = limitedPressure;
+        newFlow = min(newFlow, limitedPressure / resistance);
+      }
     }
 
     // Physical pressure ceiling (real DE1 tops out ~11 bar; the puck model

--- a/lib/src/models/device/impl/mock_de1/mock_de1.dart
+++ b/lib/src/models/device/impl/mock_de1/mock_de1.dart
@@ -22,6 +22,9 @@ enum _SimulationType { espresso, steam, hotWater, idle }
 class MockDe1 implements De1Interface, SimulatedDevice {
   MockDe1({String deviceId = "MockDe1"}) : _deviceId = deviceId;
 
+  final Random _puckRandom = Random(0);
+  double _puckResistanceMultiplier = 1.0;
+
   final StreamController<MachineSnapshot> _snapshotStream =
       StreamController.broadcast();
 
@@ -107,6 +110,7 @@ class MockDe1 implements De1Interface, SimulatedDevice {
       _shotElapsedMs = 0.0;
       _fromFlowTarget = 0;
       _fromPressureTarget = 0;
+      _puckResistanceMultiplier = 0.85 + _puckRandom.nextDouble() * 0.3;
     } else if (_currentState == MachineState.hotWater) {
       _simulationType = _SimulationType.hotWater;
       _hotWaterElapsedMs = 0.0;
@@ -323,6 +327,7 @@ class MockDe1 implements De1Interface, SimulatedDevice {
       final e = min((shotSecs - peakSecs) / erodeSecs, 1.0);
       resistance = rPeak - (rPeak - rErode) * e;
     }
+    resistance *= _puckResistanceMultiplier;
 
     // --- Temperature: cold-puck dip, then recovery ---
     // Group temp plunges ~16C when water first hits the cold puck (start of
@@ -389,6 +394,11 @@ class MockDe1 implements De1Interface, SimulatedDevice {
         _lastSnapshot.flow +
         (targetFlow - _lastSnapshot.flow) * flowResponseRate;
 
+    final limiterValue = currentStep.limiter?.value ?? 0;
+    if (currentStep is ProfileStepPressure && limiterValue > 0) {
+      newFlow = min(newFlow, limiterValue);
+    }
+
     // Pressure lags behind flow (puck-mediated).
     final unboundedPressure = newFlow * resistance;
     double newPressure =
@@ -406,12 +416,21 @@ class MockDe1 implements De1Interface, SimulatedDevice {
       if (newPressure >= targetPressure) {
         newPressure = targetPressure;
         newFlow = min(targetPressure / resistance, pumpMaxFlow);
+        if (limiterValue > 0) {
+          newFlow = min(newFlow, limiterValue);
+        }
       }
     }
 
     // Clamp flow-step: don't exceed target (pump can't deliver more).
     if (currentStep is ProfileStepFlow && newFlow > targetFlow) {
       newFlow = targetFlow;
+    }
+    if (currentStep is ProfileStepFlow &&
+        limiterValue > 0 &&
+        newPressure > limiterValue) {
+      newPressure = limiterValue;
+      newFlow = min(newFlow, limiterValue / resistance);
     }
 
     // Physical pressure ceiling (real DE1 tops out ~11 bar; the puck model

--- a/test/integration/simulated_shot_target_weight_test.dart
+++ b/test/integration/simulated_shot_target_weight_test.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/persistence_controller.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/controllers/shot_sequencer.dart';
+import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+import 'package:reaprime/src/models/device/impl/mock_scale/mock_scale.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
+import 'package:reaprime/src/services/database/database.dart';
+import 'package:reaprime/src/services/storage/drift_storage_service.dart';
+
+class _EmptyDiscovery extends DeviceDiscoveryService {
+  @override
+  Stream<List<Device>> get devices => const Stream.empty();
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
+}
+
+Profile _targetWeightProfile() => Profile(
+  version: '2',
+  title: 'Target weight',
+  notes: '',
+  author: 'test',
+  beverageType: BeverageType.espresso,
+  targetVolumeCountStart: 0,
+  tankTemperature: 92,
+  targetWeight: 1,
+  steps: [
+    ProfileStepFlow(
+      name: 'Pour',
+      transition: TransitionType.fast,
+      volume: 0,
+      seconds: 30,
+      temperature: 92,
+      sensor: TemperatureSensor.coffee,
+      flow: 4,
+    ),
+  ],
+);
+
+void main() {
+  test('simulated shot stops at the configured target weight', () async {
+    final database = AppDatabase(NativeDatabase.memory());
+    final persistence = PersistenceController(
+      storageService: DriftStorageService(database),
+    );
+    final de1Controller = De1Controller(
+      controller: DeviceController([_EmptyDiscovery()]),
+    );
+    final scaleController = ScaleController();
+    final machine = MockDe1();
+    final scale = MockScale();
+    ShotSequencer? sequencer;
+
+    try {
+      await de1Controller.connectToDe1(machine);
+      scale.attachMachine(machine);
+      await scaleController.connectToScale(scale);
+      await scaleController.connectionState
+          .firstWhere((state) => state == ConnectionState.connected)
+          .timeout(const Duration(seconds: 2));
+      await scaleController.weightSnapshot.first.timeout(
+        const Duration(seconds: 2),
+      );
+
+      final profile = _targetWeightProfile();
+      await machine.setProfile(profile);
+      sequencer = ShotSequencer(
+        scaleController: scaleController,
+        de1controller: de1Controller,
+        persistenceController: persistence,
+        targetProfile: profile,
+        targetYield: profile.targetWeight ?? 0,
+        bypassSAW: false,
+        blockOnNoScale: false,
+        weightFlowMultiplier: 0,
+        volumeFlowMultiplier: 0,
+        stepExitArbiterEnabled: true,
+      );
+
+      final stopped = sequencer.decisions.firstWhere(
+        (decision) => decision.reason == ShotDecisionReason.targetWeight,
+      );
+      await machine.requestState(MachineState.espresso);
+
+      final decision = await stopped.timeout(const Duration(seconds: 12));
+      expect(decision.kind, ShotDecisionKind.stop);
+      expect(decision.data?['targetYield'], profile.targetWeight);
+      await machine.currentSnapshot
+          .firstWhere((snapshot) => snapshot.state.state == MachineState.idle)
+          .timeout(const Duration(seconds: 2));
+    } finally {
+      sequencer?.dispose();
+      scaleController.dispose();
+      persistence.dispose();
+      scale.simulateDisconnect();
+      await machine.disconnect();
+      await database.close();
+    }
+  });
+}

--- a/test/models/device/impl/mock_de1/mock_de1_flow_pressure_test.dart
+++ b/test/models/device/impl/mock_de1/mock_de1_flow_pressure_test.dart
@@ -3,7 +3,7 @@ import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 
-Profile _flowProfile() {
+Profile _flowProfile({StepLimiter? limiter}) {
   return Profile(
     version: '1.0',
     title: 'flow-test',
@@ -16,6 +16,7 @@ Profile _flowProfile() {
       ProfileStepFlow(
         name: 'pour',
         flow: 3.0,
+        limiter: limiter,
         seconds: 5,
         temperature: 94,
         sensor: TemperatureSensor.coffee,
@@ -26,7 +27,7 @@ Profile _flowProfile() {
   );
 }
 
-Profile _pressureProfile() {
+Profile _pressureProfile({StepLimiter? limiter}) {
   return Profile(
     version: '1.0',
     title: 'pressure-test',
@@ -39,6 +40,7 @@ Profile _pressureProfile() {
       ProfileStepPressure(
         name: 'pour',
         pressure: 6.0,
+        limiter: limiter,
         seconds: 5,
         temperature: 94,
         sensor: TemperatureSensor.coffee,
@@ -158,6 +160,42 @@ void main() {
       );
 
       expect(snapshot.targetFlow, closeTo(3.0, 0.1));
+    });
+
+    test('pressure-step: flow limiter caps flow', () async {
+      await machine.setProfile(
+        _pressureProfile(limiter: const StepLimiter(value: 1.5, range: 0.5)),
+      );
+      await machine.requestState(MachineState.espresso);
+
+      await Future.delayed(const Duration(milliseconds: 600));
+      final snapshots = await machine.currentSnapshot
+          .take(10)
+          .toList()
+          .timeout(const Duration(seconds: 3));
+
+      expect(
+        snapshots.map((snapshot) => snapshot.flow),
+        everyElement(lessThanOrEqualTo(1.5)),
+      );
+    });
+
+    test('flow-step: pressure limiter caps pressure', () async {
+      await machine.setProfile(
+        _flowProfile(limiter: const StepLimiter(value: 0.15, range: 0.05)),
+      );
+      await machine.requestState(MachineState.espresso);
+
+      await Future.delayed(const Duration(milliseconds: 600));
+      final snapshots = await machine.currentSnapshot
+          .take(10)
+          .toList()
+          .timeout(const Duration(seconds: 3));
+
+      expect(
+        snapshots.map((snapshot) => snapshot.pressure),
+        everyElement(lessThanOrEqualTo(0.15)),
+      );
     });
   });
 }

--- a/test/models/device/impl/mock_de1/mock_de1_flow_pressure_test.dart
+++ b/test/models/device/impl/mock_de1/mock_de1_flow_pressure_test.dart
@@ -162,9 +162,9 @@ void main() {
       expect(snapshot.targetFlow, closeTo(3.0, 0.1));
     });
 
-    test('pressure-step: flow limiter caps flow', () async {
+    test('pressure-step: flow limiter applies its range', () async {
       await machine.setProfile(
-        _pressureProfile(limiter: const StepLimiter(value: 1.5, range: 0.5)),
+        _pressureProfile(limiter: const StepLimiter(value: 1.5, range: 5)),
       );
       await machine.requestState(MachineState.espresso);
 
@@ -176,13 +176,14 @@ void main() {
 
       expect(
         snapshots.map((snapshot) => snapshot.flow),
-        everyElement(lessThanOrEqualTo(1.5)),
+        everyElement(lessThanOrEqualTo(6.5)),
       );
+      expect(snapshots.any((snapshot) => snapshot.flow > 1.5), isTrue);
     });
 
-    test('flow-step: pressure limiter caps pressure', () async {
+    test('flow-step: pressure limiter applies its range', () async {
       await machine.setProfile(
-        _flowProfile(limiter: const StepLimiter(value: 0.15, range: 0.05)),
+        _flowProfile(limiter: const StepLimiter(value: 0.15, range: 1)),
       );
       await machine.requestState(MachineState.espresso);
 
@@ -194,8 +195,35 @@ void main() {
 
       expect(
         snapshots.map((snapshot) => snapshot.pressure),
-        everyElement(lessThanOrEqualTo(0.15)),
+        everyElement(lessThanOrEqualTo(1.15)),
       );
+      expect(snapshots.any((snapshot) => snapshot.pressure > 0.15), isTrue);
+    });
+
+    test('wider limiter range produces a softer response', () async {
+      Future<double> lastFlow(double range) async {
+        final rangedMachine = MockDe1();
+        await rangedMachine.onConnect();
+        try {
+          await rangedMachine.setProfile(
+            _pressureProfile(limiter: StepLimiter(value: 1.5, range: range)),
+          );
+          await rangedMachine.requestState(MachineState.espresso);
+          await Future.delayed(const Duration(milliseconds: 600));
+          final snapshots = await rangedMachine.currentSnapshot
+              .take(10)
+              .toList()
+              .timeout(const Duration(seconds: 3));
+          return snapshots.last.flow;
+        } finally {
+          await rangedMachine.onDisconnect();
+        }
+      }
+
+      final narrowRangeFlow = await lastFlow(0.1);
+      final wideRangeFlow = await lastFlow(5);
+
+      expect(wideRangeFlow, greaterThan(narrowRangeFlow));
     });
   });
 }

--- a/test/models/device/impl/mock_de1/mock_de1_realism_test.dart
+++ b/test/models/device/impl/mock_de1/mock_de1_realism_test.dart
@@ -140,4 +140,31 @@ void main() {
       reason: 'flow should not collapse to ~0 (no transition glitch)',
     );
   });
+
+  test('successive shots have different puck responses', () async {
+    final machine = MockDe1();
+    await machine.onConnect();
+    await machine.setProfile(_gentleAndSweet());
+
+    Future<List<double>> pull() async {
+      await machine.requestState(MachineState.espresso);
+      final pressures = await machine.currentSnapshot
+          .where((snapshot) => snapshot.state.state == MachineState.espresso)
+          .take(12)
+          .map((snapshot) => snapshot.pressure)
+          .toList()
+          .timeout(const Duration(seconds: 3));
+      await machine.requestState(MachineState.idle);
+      await machine.currentSnapshot
+          .firstWhere((snapshot) => snapshot.state.state == MachineState.idle)
+          .timeout(const Duration(seconds: 2));
+      return pressures;
+    }
+
+    final first = await pull();
+    final second = await pull();
+
+    expect(second, isNot(equals(first)));
+    await machine.onDisconnect();
+  });
 }

--- a/test/models/device/impl/mock_de1/mock_de1_realism_test.dart
+++ b/test/models/device/impl/mock_de1/mock_de1_realism_test.dart
@@ -161,10 +161,13 @@ void main() {
       return pressures;
     }
 
-    final first = await pull();
-    final second = await pull();
+    try {
+      final first = await pull();
+      final second = await pull();
 
-    expect(second, isNot(equals(first)));
-    await machine.onDisconnect();
+      expect(second, isNot(equals(first)));
+    } finally {
+      await machine.onDisconnect();
+    }
   });
 }


### PR DESCRIPTION
## Summary

- Problem: MockDe1 repeated the same puck response on every pull and ignored profile step limiters.
- Why it matters: selected profiles could look less distinct in simulation, while replaying a fixed historical shot would ignore them entirely.
- What changed: pressure steps model flow limiters, flow steps model pressure limiters, and both use `StepLimiter.value` plus `StepLimiter.range` as a progressive action band. Each shot also gets bounded deterministic puck-resistance variation.
- What did NOT change (scope boundary): profiles, MockScale, ShotSequencer stop-at-weight behavior, and persistence stay on their existing production paths; no replay assets or loaders were added.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [x] Machine state / shot logic
- [x] Scale / weight / flow
- [x] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Related PR: #586

## Root Cause (if bug fix)

- Root cause: the synthetic puck curve used one fixed resistance response and the shot loop never applied `StepLimiter`. The first limiter patch then treated `value` as a hard cap and ignored `range`.
- Missing detection or guardrail: simulator tests covered profile targets but not limiter range behavior, repeat-shot variation, or target-weight stopping across MockDe1 + MockScale + ShotSequencer.
- Contributing context (if known): historical-shot replay avoids synthetic limitations but discards the selected profile and target-weight dynamics.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `mock_de1_flow_pressure_test.dart`, `mock_de1_realism_test.dart`, and `simulated_shot_target_weight_test.dart`.
- Scenario the test should lock in: both limiter directions stay below `value + range`, wider ranges produce softer control than narrow ranges with the same value, consecutive pulls differ, and the configured target weight stops a real simulated shot.
- If no new test added, why not: N/A.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [x] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A - no docs affected

## Security Impact (required)

- New or changed REST endpoints? (`Yes/No`) No
- New or changed WebSocket topics? (`Yes/No`) No
- New or changed network calls? (`Yes/No`) No
- BLE/USB surface changed? (`Yes/No`) No
- File system access changed? (`Yes/No`) No
- Plugin sandbox boundary changed? (`Yes/No`) No
- If any `Yes`, explain risk and mitigation: N/A

## User-Visible Changes

Simulated espresso pulls now respond to each profile limiter's value and range of action, and vary within a bounded puck-resistance range instead of replaying an identical curve. Existing profile target weight still stops through the normal scale and ShotSequencer path.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` - no remaining changes
- [x] `flutter analyze` - clean (no new warnings)
- [ ] `flutter test` - focused simulator tests pass (11/11). The latest full Windows run reached 2,756 passes with 67 unrelated plugin fixture/native-runtime and missing bundled-skin manifest failures. An earlier isolated run with the QuickJS DLL available reached 2,813 passes with 9 fixture failures.
- [x] `./scripts/fetch_dye2_plugin.sh` - DYE2 plugin installed into `assets/plugins/dye2.reaplugin/`

### Manual verification (if applicable)

- OS / platform tested: Windows
- Simulated devices? (`simulate=1`): Yes, through MockDe1 + MockScale integration coverage
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: pressure-step flow limiting, flow-step pressure limiting, different responses for identical limiter values with ranges 0.1 and 5.0, successive-shot variation, and target-weight stopping through focused Flutter tests. Isolated QuickJS plugin tests also pass with the native DLL available.
- Edge cases checked: narrow and wide limiter ranges, repeated pulls on one MockDe1 instance, and a 1 g target that must stop before the profile duration ends.
- What you did **not** verify: real hardware. An isolated `sb-dev` smoke was attempted, but another active Flutter run held the shared SDK lock until the 120-second readiness timeout; `sb-dev` cleaned up and reported `Not running`.

### Evidence

- [x] Test output (failing before + passing after)
- [x] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? (`Yes/No`) Yes
- Config / env changes needed? (`Yes/No`) No
- Database migration needed? (`Yes/No`) No
- If any `No` or `Yes`, explain exact steps: No migration or configuration changes are required.

## Risks & Mitigations

- Risk: the simulator uses a progressive limiter approximation rather than the DE1 firmware's P/I control loop.
  - Mitigation: the response starts at `value`, approaches the non-exceedable `value + range` boundary, and the profile docs state the approximation explicitly.
- Risk: simulator traces change slightly between successive pulls.
  - Mitigation: resistance variation is bounded to +/-15% and uses a fixed-seed sequence, keeping automated runs deterministic.
