### PR TITLE
Update dart_js and universal_ble dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -620,7 +620,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: c7cde7b5c9c6ad7013157f296a7320835aac6cdb
+      resolved-ref: dace4de60e8b03a191a9151223527e14ab2c7f2b
       url: "https://github.com/tadelv/dart_js"
     source: git
     version: "0.8.5"
@@ -1654,14 +1654,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
-  sync_http:
-    dependency: transitive
-    description:
-      name: sync_http
-      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -1706,11 +1698,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "2.2.5"
-      resolved-ref: a2639e32eb873a3b0d313a755ef3f43ca381fba9
+      ref: "2.2.6"
+      resolved-ref: "6116abba1d1c00fb66ecce1d14cc5314d7c184f1"
       url: "https://github.com/tadelv/universal_ble.git"
     source: git
-    version: "2.2.5"
+    version: "2.2.6"
   universal_image:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -619,7 +619,7 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: master
+      ref: dace4de60e8b03a191a9151223527e14ab2c7f2b
       resolved-ref: dace4de60e8b03a191a9151223527e14ab2c7f2b
       url: "https://github.com/tadelv/dart_js"
     source: git

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -619,8 +619,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: dace4de60e8b03a191a9151223527e14ab2c7f2b
-      resolved-ref: dace4de60e8b03a191a9151223527e14ab2c7f2b
+      ref: "6348eae"
+      resolved-ref: "6348eae3d7627109bd8555214feb9ed6541953d7"
       url: "https://github.com/tadelv/dart_js"
     source: git
     version: "0.8.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   universal_ble:
     git:
       url: https://github.com/tadelv/universal_ble.git
-      ref: 2.2.5
+      ref: 2.2.6
   shared_preferences: ^2.5.3
   # share_plus HELD at 12.x — 13.x requires win32 ^6, which conflicts with
   # file_picker 11's win32 ^5.9 pin. 13.x is only SDK-floor bumps, no API gain.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,7 +84,7 @@ dependencies:
     # path: ../dart_js
     git:
       url: https://github.com/tadelv/dart_js
-      ref: master
+      ref: dace4de60e8b03a191a9151223527e14ab2c7f2b
   firebase_core: ^4.3.0
   firebase_crashlytics: ^5.0.6
   firebase_performance: ^0.11.1+3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,7 +84,7 @@ dependencies:
     # path: ../dart_js
     git:
       url: https://github.com/tadelv/dart_js
-      ref: dace4de60e8b03a191a9151223527e14ab2c7f2b
+      ref: 6348eae
   firebase_core: ^4.3.0
   firebase_crashlytics: ^5.0.6
   firebase_performance: ^0.11.1+3


### PR DESCRIPTION
Milestone dependency update after tadelv/dart_js#5 (runtime stability/failure handling) and tadelv/universal_ble#15 (BLE lifecycle audit fixes) merged.

## Changes
- universal_ble 2.2.5 → 2.2.6 (tagged merge of universal_ble#15)
- flutter_js pinned to `dace4de` (merge commit of dart_js#5), previously tracked `master` — pinning prevents future pub get drift

## Verification
- `flutter pub get` resolves clean
- `flutter analyze`: no issues
- `flutter test`: 2819 passed

Establishes current Decaid is valid against the corrected dependencies before #582 and #591 land.