### PR TITLE
chore: require accepted issues for external PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,10 +34,24 @@ Describe the problem and fix in 2–5 bullets:
 - [ ] CI / build / infra
 - [ ] Docs / specs
 
-## Linked Issues
+## Linked Issue (required for external contributions)
 
+External PRs must reference an **open issue accepted for implementation** with either the `ready-for-agent` or `ready-for-human` label. If a proposal went through a Discussion or Project first, link the concrete accepted implementation issue here.
+
+Use at least one:
+
+- Fixes #
 - Closes #
+- Resolves #
 - Related #
+
+Maintainer and automated repository-maintenance PRs may write `N/A`.
+
+## Contributor Responsibility (required)
+
+AI-assisted development is allowed. The person submitting the PR remains responsible for the submitted work.
+
+- [ ] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
 
 ## Root Cause (if bug fix)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,144 +1,33 @@
 ## Summary
 
-Describe the problem and fix in 2–5 bullets:
+What changed, and why?
 
-> **Naming:** The display name is **Decaid**. The Dart package, bundle ID, database, and plugin extension retain legacy identifiers for compatibility — see the naming table in [`CLAUDE.md`](CLAUDE.md).
+- 
 
-- Problem:
-- Why it matters:
-- What changed:
-- What did NOT change (scope boundary):
+## Linked Issue
 
-## Change Type (select all)
+Fixes #
 
-- [ ] Bug fix
-- [ ] Feature
-- [ ] Refactor required for the fix
-- [ ] Docs
-- [ ] Security hardening
-- [ ] Chore / infra
-- [ ] Plugin (DYE2 or bundled skin)
-
-## Scope (select all touched areas)
-
-- [ ] BLE transport / device comms
-- [ ] REST API / handlers
-- [ ] WebSocket API
-- [ ] Machine state / shot logic
-- [ ] Scale / weight / flow
-- [ ] Profiles / beans / grinders / workflows
-- [ ] WebUI skins
-- [ ] Plugins / JS runtime
-- [ ] UI / Flutter widgets
-- [ ] Storage / Drift database
-- [ ] CI / build / infra
-- [ ] Docs / specs
-
-## Linked Issue (required for external contributions)
-
-External PRs must reference an **open issue accepted for implementation** with either the `ready-for-agent` or `ready-for-human` label. If a proposal went through a Discussion or Project first, link the concrete accepted implementation issue here.
-
-Use at least one:
-
-- Fixes #
-- Closes #
-- Resolves #
-- Related #
-
-Maintainer and automated repository-maintenance PRs may write `N/A`.
-
-## Contributor Responsibility (required)
-
-AI-assisted development is allowed. The person submitting the PR remains responsible for the submitted work.
-
-- [ ] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
-
-## Root Cause (if bug fix)
-
-For bugs: explain why this happened, not just what changed. Otherwise write `N/A`.
-
-- Root cause:
-- Missing detection or guardrail:
-- Contributing context (if known):
-
-## Regression Test Plan (if bug fix or refactor)
-
-For bugs and refactors: name the smallest reliable test that should catch this. Otherwise write `N/A`.
-
-- Coverage level that should have caught this:
-  - [ ] Unit test
-  - [ ] Integration test (mock transport edge)
-  - [ ] End-to-end test (`simulate=1` + curl/websocat)
-  - [ ] Existing coverage already sufficient
-- Target test or file:
-- Scenario the test should lock in:
-- If no new test added, why not:
-
-## Documentation Obligations (required)
-
-These are **not optional**. Stale specs mislead clients and agents.
-
-- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
-- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
-- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
-- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
-- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
-- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
-- [ ] N/A — no docs affected
-
-## Security Impact (required)
-
-This app runs a local web server (port 8080) and connects to BLE/USB hardware.
-
-- New or changed REST endpoints? (`Yes/No`)
-- New or changed WebSocket topics? (`Yes/No`)
-- New or changed network calls? (`Yes/No`)
-- BLE/USB surface changed? (`Yes/No`)
-- File system access changed? (`Yes/No`)
-- Plugin sandbox boundary changed? (`Yes/No`)
-- If any `Yes`, explain risk and mitigation:
-
-## User-Visible Changes
-
-List user-visible changes (including defaults, config, behavior). If none, write `None`.
+<!--
+External contributions must reference an open issue accepted with the
+`ready-for-agent` or `ready-for-human` label. Maintainer and automated
+repository-maintenance PRs may write N/A.
+-->
 
 ## Verification
 
-### Local gates (run before pushing)
+How did you verify the change? Include relevant tests and any manual or hardware testing.
 
-- [ ] `dart format lib test` — no remaining changes
-- [ ] `flutter analyze` — clean (no new warnings)
-- [ ] `flutter test` — all pass
-- [ ] `./scripts/fetch_dye2_plugin.sh` — DYE2 plugin installed into `assets/plugins/dye2.reaplugin/`
+- 
 
-### Manual verification (if applicable)
+## Impact
 
-- OS / platform tested:
-- Simulated devices? (`simulate=1`): `Yes/No`
-- Real hardware? (DE1/Bengle/scale): `Yes/No`
-- What you personally verified and how:
-- Edge cases checked:
-- What you did **not** verify:
+Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.
 
-### Evidence
+- 
 
-Attach at least one:
+## Contributor Responsibility
 
-- [ ] Test output (failing before + passing after)
-- [ ] Log snippets
-- [ ] Screenshot / recording (UI changes)
-- [ ] curl / websocat output (API changes)
+AI-assisted development is allowed. The submitter remains responsible for the submitted work.
 
-## Compatibility & Migration
-
-- Backward compatible? (`Yes/No`)
-- Config / env changes needed? (`Yes/No`)
-- Database migration needed? (`Yes/No`)
-- If any `No` or `Yes`, explain exact steps:
-
-## Risks & Mitigations
-
-List only real risks for this PR. If none, write `None`.
-
-- Risk:
-  - Mitigation:
+- [ ] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,10 +10,129 @@ concurrency:
 
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 
 jobs:
+  contribution-policy:
+    name: Contribution policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate issue-first policy and responsibility acknowledgement
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const trustedAssociations = new Set([
+              'OWNER',
+              'MEMBER',
+              'COLLABORATOR',
+            ]);
+
+            if (
+              pr.user?.type === 'Bot' ||
+              trustedAssociations.has(pr.author_association)
+            ) {
+              core.notice(
+                `Contribution policy gate skipped for ${
+                  pr.user?.type === 'Bot' ? 'bot' : pr.author_association
+                }.`,
+              );
+              return;
+            }
+
+            const body = pr.body || '';
+
+            const responsibilityPattern =
+              /^-\s*\[[xX]\].*<!--\s*contributor-responsibility\s*-->.*$/mi;
+            if (!responsibilityPattern.test(body)) {
+              core.setFailed(
+                'Check the Contributor Responsibility acknowledgement in the PR template.',
+              );
+              return;
+            }
+
+            const referencePattern =
+              /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|related)\s+(?:#(\d+)|https:\/\/github\.com\/decentespresso\/decaid\/issues\/(\d+))/gi;
+            const issueNumbers = [
+              ...new Set(
+                [...body.matchAll(referencePattern)].map((match) =>
+                  Number(match[1] || match[2]),
+                ),
+              ),
+            ];
+
+            if (issueNumbers.length === 0) {
+              core.setFailed(
+                'External PRs must reference an accepted open issue using Fixes #123, Closes #123, Resolves #123, or Related #123.',
+              );
+              return;
+            }
+
+            const acceptedLabels = new Set([
+              'ready-for-agent',
+              'ready-for-human',
+            ]);
+            const rejected = [];
+
+            for (const issue_number of issueNumbers) {
+              let issue;
+              try {
+                ({ data: issue } = await github.rest.issues.get({
+                  ...context.repo,
+                  issue_number,
+                }));
+              } catch (error) {
+                if (error.status === 404) {
+                  rejected.push(`#${issue_number} does not exist`);
+                  continue;
+                }
+                throw error;
+              }
+
+              if (issue.pull_request) {
+                rejected.push(`#${issue_number} is a pull request, not an issue`);
+                continue;
+              }
+
+              if (issue.state !== 'open') {
+                rejected.push(`#${issue_number} is not open`);
+                continue;
+              }
+
+              const labels = new Set(
+                issue.labels
+                  .map((label) =>
+                    typeof label === 'string' ? label : label.name,
+                  )
+                  .filter(Boolean),
+              );
+              const acceptedLabel = [...acceptedLabels].find((label) =>
+                labels.has(label),
+              );
+
+              if (acceptedLabel) {
+                core.notice(
+                  `Accepted issue #${issue_number} (${acceptedLabel}).`,
+                );
+                return;
+              }
+
+              rejected.push(
+                `#${issue_number} is missing ready-for-agent or ready-for-human`,
+              );
+            }
+
+            core.setFailed(
+              `No referenced issue satisfies the contribution policy: ${rejected.join(
+                '; ',
+              )}`,
+            );
+
   changes:
     name: Detect relevant changes
+    needs: contribution-policy
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -44,9 +163,17 @@ jobs:
 
   flutter:
     name: Analyze / test
+    needs: contribution-policy
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
+      - name: Enforce contribution policy
+        if: needs.contribution-policy.result != 'success'
+        run: |
+          echo "Contribution policy check failed; skipping test work." >&2
+          exit 1
+
       - name: Check out repository
         uses: actions/checkout@v5
         with:
@@ -132,6 +259,7 @@ jobs:
 
   build-smoke:
     name: Linux build smoke
+    needs: contribution-policy
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,10 @@ Thanks for contributing. This guide tells you what's required to land a PR — i
 
 ## Before You Start
 
-- **Non-trivial features:** Open an issue first to align on scope.
-- **Small fixes** (typos, one-line bugs): Go straight to a PR.
+- **Open an issue before implementation.** External contributors must do this for every proposed PR, including small fixes. This lets maintainers consider scope, alternatives, compatibility, and whether the change belongs in Decaid before implementation work starts.
+- **Wait for acceptance.** Start implementation only after a maintainer marks the issue `ready-for-agent` or `ready-for-human`.
+- If a proposal needs broader design discussion, maintainers may move it to a GitHub Discussion or Project and later create or reopen concrete issues for implementation. A PR still needs an accepted implementation issue.
+- Repository maintainers and automated repository-maintenance PRs may bypass the issue-first requirement when creating an issue would add no useful planning context.
 - **Read [`CLAUDE.md`](CLAUDE.md)** — it covers architecture, conventions, test patterns, and gotchas. Agents and humans both need it.
 
 ## Local Setup
@@ -40,7 +42,8 @@ See [`CLAUDE.md`](CLAUDE.md) for the full command reference.
 
 - Branch from `main`. Push to your fork, open a PR against `decentespresso/decaid:main`.
 - One feature or fix per PR. No bundling unrelated changes.
-- Reference the issue: `Fixes #123` or `Related #123`.
+- External contributions must reference an **open, accepted issue** using `Fixes #123`, `Closes #123`, `Resolves #123`, or `Related #123`. The issue must carry either the `ready-for-agent` or `ready-for-human` label when the PR is opened.
+- Do not finish an implementation first and then open an issue only to satisfy the PR gate. The issue-first process exists so the proposed change can be considered before code review becomes necessary.
 - A maintainer will review. Expect a few rounds of feedback.
 - **Do not push directly to `main`** — branch protection is active, and even with push access, direct pushes bypass reviews and CI.
 
@@ -48,7 +51,13 @@ See [`CLAUDE.md`](CLAUDE.md) for the full command reference.
 
 These are hard gates. PRs that skip them will be returned.
 
-### 1. Tests
+### 1. Accepted Issue
+
+For external contributions, the PR must reference at least one open issue in this repository that a maintainer has accepted with `ready-for-agent` or `ready-for-human`.
+
+CI validates this before running the expensive test/build jobs. Repository maintainers and automated repository-maintenance PRs are exempt from this gate.
+
+### 2. Tests
 
 **New behavior needs a test.** Bug fixes need a regression test.
 
@@ -60,7 +69,7 @@ These are hard gates. PRs that skip them will be returned.
 
 Web server handlers have a strong unit-test convention — see `test/services/webserver/de1handler_cup_warmer_test.dart` for the pattern.
 
-### 2. Spec & Docs (required)
+### 3. Spec & Docs (required)
 
 **Every API change must update the spec in the same PR.** The spec is authoritative — stale spec = stale agent knowledge.
 
@@ -73,7 +82,7 @@ Web server handlers have a strong unit-test convention — see `test/services/we
 | Profile handling changed | `doc/Profiles.md` |
 | Device discovery/connection changed | `doc/DeviceManagement.md` |
 
-### 3. Local Gates (required)
+### 4. Local Gates (required)
 
 Run these before pushing. Same checks that CI runs:
 
@@ -85,14 +94,14 @@ flutter test                             # all must pass
 
 `dart format` is currently **advisory** in CI — the codebase predates the Dart 3.7 "tall style" formatter. Format your own changes (`dart format lib test`) but don't reformat untouched files in the same PR.
 
-### 4. Architecture Boundaries (required)
+### 5. Architecture Boundaries (required)
 
 - **No 3rd-party BLE imports** outside `lib/src/services/ble/`. Wrap library-specific types at the transport boundary.
 - **Constructor dependency injection** — no service locators.
 - **Single Responsibility** — each controller/service has one job.
 - See [`CLAUDE.md` → Conventions & Gotchas](CLAUDE.md) for the full list.
 
-### 5. PR Template (required)
+### 6. PR Template (required)
 
 Fill out the PR template. Sections marked `(required)` must be completed. The template lives at [`.github/pull_request_template.md`](.github/pull_request_template.md).
 
@@ -112,9 +121,21 @@ Added GET/PUT /api/v1/de1/cup_warmer with temperature range
 validation (0–80°C). Updates rest_v1.yml spec and Api.md.
 ```
 
+## AI-Assisted Contributions
+
+AI-assisted development is allowed. Contributors may use tools such as Claude, Codex, ChatGPT, GitHub Copilot, or other coding agents and language models.
+
+AI assistance does not transfer responsibility for a contribution. By submitting a PR, you acknowledge that:
+
+- you have reviewed and understand the changes you are submitting, including AI-assisted or AI-generated changes;
+- you take responsibility for their correctness, security, behavior, licensing, and provenance; and
+- you are able to explain and maintain the submitted changes through review.
+
+Do not submit generated changes that you have not personally reviewed and validated.
+
 ## License & Sign-Off
 
-By submitting a PR you agree your contribution is licensed under the same terms as the repository. No CLA required.
+By submitting a PR you agree your contribution is licensed under the same terms as the repository and that you have the right to contribute it. No CLA required.
 
 ## Questions
 


### PR DESCRIPTION
## Summary

Require accepted issues for external contributions, enforce the policy mechanically in CI, explicitly permit AI-assisted work  while assigning responsibility to the contributor, and replace the exhaustive PR questionnaire with a concise human-facing template.