### PR TITLE
test: cut wall-clock waits from slowest test files (protected_surface, led_strip, ble recovery)

### DIFF
--- a/doc/AI_TESTING_NOTES.md
+++ b/doc/AI_TESTING_NOTES.md
@@ -33,7 +33,7 @@ All Dart tests (unit + integration) live in `test/` and run via `flutter test`. 
 ### fake_async
 `fakeAsync` does not cooperate with rxdart `BehaviorSubject` seed delivery (the `StartWithStreamTransformer` seed event never reaches the fake zone's microtask queue). Prefer a plain `Stream.multi` replay (e.g. `Stream.multi((c) { c.add(value); c.close(); })`) for test doubles whose connection state must be visible under `fakeAsync`.
 
-rxdart subscription `cancel()` futures also never complete under `fakeAsync` (same family of issue). Do not `await` a stream-subscription `cancel()` on the watchdog/disconnect path — the listener must already be inert (generation/epoch guard bumped first), so `unawaited(sub?.cancel())` is correct. Awaiting it hangs the zone.
+Standard stream subscription `cancel()` futures also never complete under `fakeAsync` (plain `StreamController`, broadcast, single-sub, and rxdart alike). If a test double's `cancel()` hangs, fix the test double or its stream implementation — do not weaken production to accommodate it. `test/helpers/completing_cancel_stream.dart` exposes any controller-backed stream through a subscription whose `cancel()` completes immediately while delegating event delivery; Acaia and DecentScale tests use it for their connection-state streams. Production code should keep `await subscription.cancel()` unless the lifecycle semantics explicitly do not require cancellation completion (then `unawaited` is fine, but that is a production decision, not a fake-time workaround).
 
 ### fakeAsync + wall clock
 `fakeAsync` virtualizes timers but code that reads `DateTime.now()` still sees real time. When watchdog/throttle logic combines timers and wall-clock comparisons, make both controllable: inject `DateTime Function() now` at the device boundary, defaulting to `clock.now` (`package:clock` is fake_async-aware, and identical to `DateTime.now` outside a fake zone). Then `fakeAsync` tests get deterministic liveness/watchdog coverage with production durations, no manual clock bookkeeping.
@@ -49,6 +49,12 @@ A loop that re-constructs and fully initializes a simulated hardware device per 
 
 ### UnifiedDe1 connect fixtures
 A silent DE1 transport that intentionally causes the MMR timeout is appropriate only when timeout/retry behavior is the subject. Unrelated parser, state, notification, or error-surfacing tests should provide complete connect responses — normally `FakeBleTransport.queueOnConnectResponses()` — then emit input through `emitNotification()`/`queueRead()`.
+
+### Suite wall span vs active test time
+Under concurrent `flutter test` runs, a suite's wall span (first test start to last test end) is not equivalent to its CPU/active cost — an isolate can sit idle waiting on the scheduler while another suite runs. When identifying optimization candidates use the cumulative sum of individual test durations (the `duration_ms` field in `--machine` events), not the suite wall span. Inspect the individual tests in a file before assuming a long suite span means expensive tests.
+
+### Mock simulator tick cadence
+Mock device simulators (`MockDe1` et al.) drive their state machine with a periodic tick whose model time-step is fixed (100ms of simulated time per tick). The wall-clock tick cadence is injectable (`MockDe1(simulationTickInterval: ...)`): shortening it makes simulated time run faster than wall time without changing generated values, because trajectories are per-tick-count functions. When a simulation test asserts on curve shape or trajectory, shorten the tick and scale wall delays accordingly (e.g. 9000ms wait at 100ms ticks becomes 900ms at 10ms ticks — same 90 ticks, same simulated 9s). Do not scale wall delays alone (that changes the simulated trajectory) or change the model time-step (that changes the calibration). Tests that validate realistic elapsed-time behavior (e.g. a power-off timeout window measured with a Stopwatch) should keep real durations.
 
 ### Stream Propagation
 Add devices to mock service *before* building widgets, then `await tester.pump()` to flush microtasks before `pumpWidget()`.

--- a/doc/AI_TESTING_NOTES.md
+++ b/doc/AI_TESTING_NOTES.md
@@ -23,11 +23,15 @@ All Dart tests (unit + integration) live in `test/` and run via `flutter test`. 
 
 ## Test Helpers (`test/helpers/`)
 
+- **`FakeBleTransport`:** `queueOnConnectResponses()` also queues `MMRItem.calFlowEst` (raw `1000` = `1.0`; override via `calFlowEst:`). Without it, every `onConnect()` pays the full MMR timeout (~12.6s: 3 x 4s + 2 x 300ms) because `UnifiedDe1.onConnect()` reads flow calibration last.
 - **`MockDeviceDiscoveryService`:** Controllable discovery for widget tests. Add/remove specific devices at specific times via `addDevice()`, `removeDevice()`, `clear()`.
 - **`TestScale`:** Use instead of `MockScale` — `MockScale` has `Timer.periodic` that conflicts with `pumpAndSettle()`.
 - **`MockSettingsService`:** In-memory `SettingsService`. Sets `telemetryPromptShown` and `telemetryConsentDialogShown` to `true` to skip dialogs.
 
 ## Widget Test Patterns
+
+### fake_async
+`fakeAsync` does not cooperate with rxdart `BehaviorSubject` seed delivery (the `StartWithStreamTransformer` seed event never reaches the fake zone's microtask queue). Prefer a plain `Stream.multi` replay (e.g. `Stream.multi((c) { c.add(value); c.close(); })`) for test doubles whose connection state must be visible under `fakeAsync`.
 
 ### Stream Propagation
 Add devices to mock service *before* building widgets, then `await tester.pump()` to flush microtasks before `pumpWidget()`.

--- a/doc/AI_TESTING_NOTES.md
+++ b/doc/AI_TESTING_NOTES.md
@@ -23,7 +23,7 @@ All Dart tests (unit + integration) live in `test/` and run via `flutter test`. 
 
 ## Test Helpers (`test/helpers/`)
 
-- **`FakeBleTransport`:** `queueOnConnectResponses()` also queues `MMRItem.calFlowEst` (raw `1000` = `1.0`; override via `calFlowEst:`). Without it, every `onConnect()` pays the full MMR timeout (~12.6s: 3 x 4s + 2 x 300ms) because `UnifiedDe1.onConnect()` reads flow calibration last.
+- **`FakeBleTransport`:** `queueOnConnectResponses()` also queues `MMRItem.calFlowEst` (raw `1000` = `1.0`; override via `calFlowEst:`). Without it, every `onConnect()` pays the full MMR timeout (~12.6s: 3 x 4s + 2 x 300ms) because `UnifiedDe1.onConnect()` reads flow calibration last. `emitNotification(Endpoint, bytes)` pushes a characteristic notification through the registered subscriber (e.g. `Endpoint.shotSample`), keeping notification/input boundary tests out of private internals.
 - **`MockDeviceDiscoveryService`:** Controllable discovery for widget tests. Add/remove specific devices at specific times via `addDevice()`, `removeDevice()`, `clear()`.
 - **`TestScale`:** Use instead of `MockScale` — `MockScale` has `Timer.periodic` that conflicts with `pumpAndSettle()`.
 - **`MockSettingsService`:** In-memory `SettingsService`. Sets `telemetryPromptShown` and `telemetryConsentDialogShown` to `true` to skip dialogs.
@@ -32,6 +32,23 @@ All Dart tests (unit + integration) live in `test/` and run via `flutter test`. 
 
 ### fake_async
 `fakeAsync` does not cooperate with rxdart `BehaviorSubject` seed delivery (the `StartWithStreamTransformer` seed event never reaches the fake zone's microtask queue). Prefer a plain `Stream.multi` replay (e.g. `Stream.multi((c) { c.add(value); c.close(); })`) for test doubles whose connection state must be visible under `fakeAsync`.
+
+rxdart subscription `cancel()` futures also never complete under `fakeAsync` (same family of issue). Do not `await` a stream-subscription `cancel()` on the watchdog/disconnect path — the listener must already be inert (generation/epoch guard bumped first), so `unawaited(sub?.cancel())` is correct. Awaiting it hangs the zone.
+
+### fakeAsync + wall clock
+`fakeAsync` virtualizes timers but code that reads `DateTime.now()` still sees real time. When watchdog/throttle logic combines timers and wall-clock comparisons, make both controllable: inject `DateTime Function() now` at the device boundary, defaulting to `clock.now` (`package:clock` is fake_async-aware, and identical to `DateTime.now` outside a fake zone). Then `fakeAsync` tests get deterministic liveness/watchdog coverage with production durations, no manual clock bookkeeping.
+
+### Hardware settle delays
+Hardware/protocol settle delays (e.g. Acaia `100/200/500ms` init steps, Skale2 `1s` init steps) should be configurable at the device implementation boundary (immutable timing object or optional constructor durations). Production keeps the real hardware-safe defaults. Unit tests that merely need an initialized device inject zero durations. Only tests specifically validating timing should exercise the actual durations — virtually via `fakeAsync`.
+
+### Backoff semantics vs post-backoff behavior
+Distinguish: (1) tests proving the duration/backoff policy itself — use `fakeAsync` and keep production durations virtually; and (2) tests proving behavior that occurs *after* a delay (e.g. `ConnectionManager` scale reacquisition) — inject a zero/small base delay (`scaleReconnectBaseDelay`, `machineReconnectBaseDelay` are `@visibleForTesting` seams) and synchronize on the resulting event. Do not spend real seconds merely to reach the state being asserted.
+
+### Expensive setup inside parameterized tests
+A loop that re-constructs and fully initializes a simulated hardware device per case multiplies protocol settle time by the number of cases. When the subject is parsing/encoding rather than connection init, use a cheap deterministic initialized fixture (`Duration.zero` settles). Do not shrink the test matrix because its setup was accidentally expensive.
+
+### UnifiedDe1 connect fixtures
+A silent DE1 transport that intentionally causes the MMR timeout is appropriate only when timeout/retry behavior is the subject. Unrelated parser, state, notification, or error-surfacing tests should provide complete connect responses — normally `FakeBleTransport.queueOnConnectResponses()` — then emit input through `emitNotification()`/`queueRead()`.
 
 ### Stream Propagation
 Add devices to mock service *before* building widgets, then `await tester.pump()` to flush microtasks before `pumpWidget()`.

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -181,10 +181,14 @@ class ConnectionManager {
   int _scaleReconnectFailures = 0;
 
   Duration get _scaleReconnectBackoff {
-    final base = 5;
-    final seconds = base * (1 << _scaleReconnectFailures).clamp(1, 12);
-    return Duration(seconds: seconds.clamp(5, 60));
+    final multiplier = (1 << _scaleReconnectFailures).clamp(1, 12);
+    final delay = scaleReconnectBaseDelay * multiplier;
+    const cap = Duration(seconds: 60);
+    return delay > cap ? cap : delay;
   }
+
+  @visibleForTesting
+  Duration scaleReconnectBaseDelay = const Duration(seconds: 5);
 
   bool _machineRecoveryActive = false;
   Timer? _machineReconnect;

--- a/lib/src/models/device/impl/acaia/acaia_scale.dart
+++ b/lib/src/models/device/impl/acaia/acaia_scale.dart
@@ -367,7 +367,7 @@ class AcaiaScale implements Scale {
   @override
   Future<void> disconnect() async {
     _invalidateConnection();
-    unawaited(_disconnectSubscription?.cancel());
+    await _disconnectSubscription?.cancel();
     _disconnectSubscription = null;
     _connectionStateController.add(ConnectionState.disconnected);
     await _transport.disconnect();

--- a/lib/src/models/device/impl/acaia/acaia_scale.dart
+++ b/lib/src/models/device/impl/acaia/acaia_scale.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:clock/clock.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/ble_service_identifier.dart';
 import 'package:reaprime/src/models/device/device.dart';
@@ -15,6 +16,24 @@ import 'package:rxdart/subjects.dart';
 enum AcaiaProtocol { ips, pyxis }
 
 enum _AcaiaFrameResult { accepted, ignored, malformed }
+
+/// Hardware settle delays used during Acaia initialization.
+///
+/// Production keeps the real hardware-safe defaults; unit tests that only
+/// need an initialized scale can inject zero durations.
+class AcaiaTimings {
+  const AcaiaTimings({
+    this.initialIpsSettle = const Duration(milliseconds: 100),
+    this.initialPyxisSettle = const Duration(milliseconds: 500),
+    this.identSettle = const Duration(milliseconds: 200),
+    this.configSettle = const Duration(milliseconds: 500),
+  });
+
+  final Duration initialIpsSettle;
+  final Duration initialPyxisSettle;
+  final Duration identSettle;
+  final Duration configSettle;
+}
 
 class AcaiaScale implements Scale {
   static final _ipsService = BleServiceIdentifier.short('1820');
@@ -87,15 +106,25 @@ class AcaiaScale implements Scale {
   Timer? _watchdogTimer;
   List<int> _buffer = [];
   bool _partialFramePending = false;
-  DateTime _lastValidFrame = DateTime.now();
+  DateTime _lastValidFrame = clock.now();
   int _batteryLevel = 0;
   int _generation = 0;
   bool _hasValidWeight = false;
   bool _badBatteryLogged = false;
 
-  AcaiaScale({required BLETransport transport})
-    : _transport = transport,
-      _deviceId = transport.id;
+  AcaiaScale({
+    required BLETransport transport,
+    AcaiaTimings timings = const AcaiaTimings(),
+    DateTime Function() now = _defaultNow,
+  }) : _transport = transport,
+       _deviceId = transport.id,
+       _timings = timings,
+       _now = now;
+
+  final AcaiaTimings _timings;
+  final DateTime Function() _now;
+
+  static DateTime _defaultNow() => clock.now();
 
   @override
   Stream<ScaleSnapshot> get currentSnapshot => _streamController.stream;
@@ -199,7 +228,9 @@ class AcaiaScale implements Scale {
     );
     await _ensureCurrentConnection(generation);
     await Future<void>.delayed(
-      Duration(milliseconds: _protocol == AcaiaProtocol.pyxis ? 500 : 100),
+      _protocol == AcaiaProtocol.pyxis
+          ? _timings.initialPyxisSettle
+          : _timings.initialIpsSettle,
     );
     await _ensureCurrentConnection(generation);
 
@@ -212,13 +243,13 @@ class AcaiaScale implements Scale {
         throw StateError('Acaia ident write failed');
       }
       await _ensureCurrentConnection(generation);
-      await Future<void>.delayed(const Duration(milliseconds: 200));
+      await Future<void>.delayed(_timings.identSettle);
       await _ensureCurrentConnection(generation);
       if (!await _write(_encode(0x0C, _configPayload))) {
         throw StateError('Acaia config write failed');
       }
       await _ensureCurrentConnection(generation);
-      await Future<void>.delayed(const Duration(milliseconds: 500));
+      await Future<void>.delayed(_timings.configSettle);
       await _ensureCurrentConnection(generation);
     }
 
@@ -271,7 +302,7 @@ class AcaiaScale implements Scale {
   }
 
   void _startMaintenance(int generation) {
-    _lastValidFrame = DateTime.now();
+    _lastValidFrame = _now();
     _scheduleMaintenance(generation);
     if (_protocol == AcaiaProtocol.pyxis) _scheduleWatchdog(generation);
   }
@@ -298,7 +329,7 @@ class AcaiaScale implements Scale {
 
   void _scheduleWatchdog(int generation) {
     _watchdogTimer?.cancel();
-    final elapsed = DateTime.now().difference(_lastValidFrame);
+    final elapsed = _now().difference(_lastValidFrame);
     final remaining = const Duration(seconds: 5) - elapsed;
     _watchdogTimer = Timer(
       remaining.isNegative ? Duration.zero : remaining,
@@ -310,8 +341,7 @@ class AcaiaScale implements Scale {
 
   Future<void> _runWatchdog(int generation) async {
     if (!_isCurrent(generation)) return;
-    if (DateTime.now().difference(_lastValidFrame) <
-        const Duration(seconds: 5)) {
+    if (_now().difference(_lastValidFrame) < const Duration(seconds: 5)) {
       _scheduleWatchdog(generation);
       return;
     }
@@ -337,7 +367,7 @@ class AcaiaScale implements Scale {
   @override
   Future<void> disconnect() async {
     _invalidateConnection();
-    await _disconnectSubscription?.cancel();
+    unawaited(_disconnectSubscription?.cancel());
     _disconnectSubscription = null;
     _connectionStateController.add(ConnectionState.disconnected);
     await _transport.disconnect();
@@ -432,7 +462,7 @@ class AcaiaScale implements Scale {
       if (result == _AcaiaFrameResult.malformed) {
         _resyncMalformedFrame(frame);
       } else if (result == _AcaiaFrameResult.accepted) {
-        _lastValidFrame = DateTime.now();
+        _lastValidFrame = _now();
         if (_protocol == AcaiaProtocol.pyxis &&
             _connectionStateController.value == ConnectionState.connected) {
           _scheduleWatchdog(_generation);

--- a/lib/src/models/device/impl/mock_de1/mock_de1.dart
+++ b/lib/src/models/device/impl/mock_de1/mock_de1.dart
@@ -19,7 +19,16 @@ import 'package:rxdart/subjects.dart';
 enum _SimulationType { espresso, steam, hotWater, idle }
 
 class MockDe1 implements De1Interface, SimulatedDevice {
-  MockDe1({String deviceId = "MockDe1"}) : _deviceId = deviceId;
+  MockDe1({
+    String deviceId = "MockDe1",
+    Duration simulationTickInterval = const Duration(milliseconds: 100),
+  }) : _deviceId = deviceId,
+       _simulationTickInterval = simulationTickInterval;
+
+  /// Wall-clock cadence of the simulation tick. The simulation model still
+  /// advances 100ms per tick, so shortening this makes simulated time run
+  /// faster than wall time (used by unit tests; production keeps 100ms).
+  final Duration _simulationTickInterval;
 
   static double _applyLimiter(double measurement, StepLimiter? limiter) {
     if (limiter == null || limiter.value <= 0 || measurement <= limiter.value) {
@@ -158,7 +167,7 @@ class MockDe1 implements De1Interface, SimulatedDevice {
   void _simulateState() {
     _snapshotStream.add(_lastSnapshot);
 
-    _stateTimer = Timer.periodic(Duration(milliseconds: 100), (t) {
+    _stateTimer = Timer.periodic(_simulationTickInterval, (t) {
       MachineSnapshot newSnapshot;
       switch (_simulationType) {
         case _SimulationType.espresso:

--- a/lib/src/models/device/impl/skale/skale2_scale.dart
+++ b/lib/src/models/device/impl/skale/skale2_scale.dart
@@ -45,9 +45,14 @@ class Skale2Scale implements Scale {
 
   static const _initStepDelay = Duration(milliseconds: 1000);
 
-  Skale2Scale({required BLETransport transport})
-    : _transport = transport,
-      _deviceId = transport.id;
+  Skale2Scale({
+    required BLETransport transport,
+    Duration initStepDelay = _initStepDelay,
+  }) : _transport = transport,
+       _deviceId = transport.id,
+       _initStepDelayOverride = initStepDelay;
+
+  final Duration _initStepDelayOverride;
 
   @override
   Stream<ScaleSnapshot> get currentSnapshot => _streamController.stream;
@@ -122,10 +127,10 @@ class Skale2Scale implements Scale {
     await _sendDisplayOn();
     await _sendDisplayWeight();
 
-    await Future.delayed(_initStepDelay);
+    await Future.delayed(_initStepDelayOverride);
     await _subscribeWeight();
 
-    await Future.delayed(_initStepDelay);
+    await Future.delayed(_initStepDelayOverride);
     await _subscribeButton();
 
     try {
@@ -138,7 +143,7 @@ class Skale2Scale implements Scale {
       }
     } catch (_) {}
 
-    await Future.delayed(_initStepDelay);
+    await Future.delayed(_initStepDelayOverride);
     await _sendDisplayOn();
     await _sendDisplayWeight();
     await _safeWrite(Uint8List.fromList([0x03]));

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -1089,6 +1089,7 @@ void main() {
         'auto-scans for preferred scale when machine is ready and scale is missing',
         () async {
           await settingsController.setPreferredScaleId('pref-scale');
+          connectionManager.scaleReconnectBaseDelay = Duration.zero;
           mockScanner.scanCompleter = Completer<void>();
 
           mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
@@ -1951,6 +1952,7 @@ void main() {
         'unexpected preferred scale disconnect keeps scanning and reconnects',
         () async {
           await settingsController.setPreferredScaleId('pref-scale');
+          connectionManager.scaleReconnectBaseDelay = Duration.zero;
           final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
           mockScaleController.mockEmitConnectionState(
             ConnectionState.connected,
@@ -1983,6 +1985,7 @@ void main() {
         () async {
           await settingsController.setPreferredScaleId('pref-scale');
           await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
+          connectionManager.scaleReconnectBaseDelay = Duration.zero;
 
           final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
           mockScaleController.mockEmitConnectionState(
@@ -2032,6 +2035,7 @@ void main() {
         () async {
           await settingsController.setPreferredScaleId('pref-scale');
           await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
+          connectionManager.scaleReconnectBaseDelay = Duration.zero;
 
           final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
           mockScaleController.mockEmitConnectionState(

--- a/test/helpers/completing_cancel_stream.dart
+++ b/test/helpers/completing_cancel_stream.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+/// A [StreamSubscription] whose [cancel] completes immediately while event
+/// delivery is delegated to an underlying subscription.
+///
+/// Standard stream `cancel()` futures never complete under `fakeAsync`
+/// (plain `StreamController`, broadcast, single-sub, and rxdart alike).
+/// Production code should keep `await subscription.cancel()`; test doubles
+/// whose streams are cancelled under fake time can expose them through
+/// [CompletingCancelStream] instead.
+class CompletingCancelSubscription<T> implements StreamSubscription<T> {
+  CompletingCancelSubscription(this._inner);
+
+  final StreamSubscription<T> _inner;
+
+  @override
+  Future<void> cancel() {
+    unawaited(_inner.cancel());
+    return Future<void>.value();
+  }
+
+  @override
+  void onData(void Function(T event)? handle) => _inner.onData(handle);
+
+  @override
+  void onError(Function? handle) => _inner.onError(handle);
+
+  @override
+  void onDone(void Function()? handle) => _inner.onDone(handle);
+
+  @override
+  void pause([Future<void>? resumeSignal]) => _inner.pause(resumeSignal);
+
+  @override
+  void resume() => _inner.resume();
+
+  @override
+  bool get isPaused => _inner.isPaused;
+
+  @override
+  Future<E> asFuture<E>([E? futureValue]) => _inner.asFuture<E>(futureValue);
+}
+
+/// Stream wrapper whose subscription cancels complete immediately, even
+/// under `fakeAsync`. Event delivery is delegated to the wrapped controller.
+class CompletingCancelStream<T> extends Stream<T> {
+  CompletingCancelStream(this._controller);
+
+  final StreamController<T> _controller;
+
+  @override
+  StreamSubscription<T> listen(
+    void Function(T event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    return CompletingCancelSubscription(
+      _controller.stream.listen(
+        onData,
+        onError: onError,
+        onDone: onDone,
+        cancelOnError: cancelOnError,
+      ),
+    );
+  }
+}

--- a/test/helpers/fake_ble_transport.dart
+++ b/test/helpers/fake_ble_transport.dart
@@ -53,6 +53,10 @@ class FakeBleTransport extends BLETransport {
     subscribers[Endpoint.fwMapRequest.uuid]?.call(Uint8List.fromList(bytes));
   }
 
+  void emitNotification(Endpoint endpoint, List<int> bytes) {
+    subscribers[endpoint.uuid]?.call(Uint8List.fromList(bytes));
+  }
+
   MachineState? get lastRequestedState {
     for (final w in writes.reversed) {
       if (w.characteristicUUID != Endpoint.requestedState.uuid) continue;

--- a/test/helpers/fake_ble_transport.dart
+++ b/test/helpers/fake_ble_transport.dart
@@ -200,6 +200,8 @@ class FakeBleTransport extends BLETransport {
     int cpuFirmwareBuild = 1300,
     int heaterV = 230,
     int refillKitPresent = 0,
+    // calFlowEst has a read scale of 0.001, so raw 1000 is 1.0.
+    int calFlowEst = 1000,
   }) {
     queueMmrResponseInt(MMRItem.v13Model, v13Model);
     queueMmrResponseInt(MMRItem.ghcInfo, ghcInfo);
@@ -207,6 +209,7 @@ class FakeBleTransport extends BLETransport {
     queueMmrResponseInt(MMRItem.cpuFirmwareBuild, cpuFirmwareBuild);
     queueMmrResponseInt(MMRItem.heaterV, heaterV);
     queueMmrResponseInt(MMRItem.refillKitPresent, refillKitPresent);
+    queueMmrResponseInt(MMRItem.calFlowEst, calFlowEst);
   }
 
   @override

--- a/test/models/device/impl/mock_de1/mock_de1_flow_pressure_test.dart
+++ b/test/models/device/impl/mock_de1/mock_de1_flow_pressure_test.dart
@@ -56,7 +56,9 @@ void main() {
     late MockDe1 machine;
 
     setUp(() async {
-      machine = MockDe1();
+      machine = MockDe1(
+        simulationTickInterval: const Duration(milliseconds: 10),
+      );
       await machine.onConnect();
     });
 
@@ -68,7 +70,7 @@ void main() {
       await machine.setProfile(_flowProfile());
       await machine.requestState(MachineState.espresso);
 
-      await Future.delayed(const Duration(milliseconds: 600));
+      await Future.delayed(const Duration(milliseconds: 60));
       final snapshots = await machine.currentSnapshot
           .take(10)
           .toList()
@@ -93,7 +95,7 @@ void main() {
       await machine.setProfile(_flowProfile());
       await machine.requestState(MachineState.espresso);
 
-      await Future.delayed(const Duration(milliseconds: 600));
+      await Future.delayed(const Duration(milliseconds: 60));
       final snapshots = await machine.currentSnapshot
           .take(20)
           .toList()
@@ -118,7 +120,7 @@ void main() {
       await machine.setProfile(_pressureProfile());
       await machine.requestState(MachineState.espresso);
 
-      await Future.delayed(const Duration(milliseconds: 600));
+      await Future.delayed(const Duration(milliseconds: 60));
       final snapshots = await machine.currentSnapshot
           .take(30)
           .toList()
@@ -137,7 +139,7 @@ void main() {
       await machine.setProfile(_pressureProfile());
       await machine.requestState(MachineState.espresso);
 
-      await Future.delayed(const Duration(milliseconds: 600));
+      await Future.delayed(const Duration(milliseconds: 60));
       final snapshot = await machine.currentSnapshot.first.timeout(
         const Duration(seconds: 2),
       );
@@ -149,7 +151,7 @@ void main() {
       await machine.setProfile(_flowProfile());
       await machine.requestState(MachineState.espresso);
 
-      await Future.delayed(const Duration(milliseconds: 600));
+      await Future.delayed(const Duration(milliseconds: 60));
       final snapshot = await machine.currentSnapshot.first.timeout(
         const Duration(seconds: 2),
       );
@@ -163,7 +165,7 @@ void main() {
       );
       await machine.requestState(MachineState.espresso);
 
-      await Future.delayed(const Duration(milliseconds: 600));
+      await Future.delayed(const Duration(milliseconds: 60));
       final snapshots = await machine.currentSnapshot
           .take(10)
           .toList()
@@ -182,7 +184,7 @@ void main() {
       );
       await machine.requestState(MachineState.espresso);
 
-      await Future.delayed(const Duration(milliseconds: 600));
+      await Future.delayed(const Duration(milliseconds: 60));
       final snapshots = await machine.currentSnapshot
           .take(10)
           .toList()
@@ -197,14 +199,16 @@ void main() {
 
     test('wider limiter range produces a softer response', () async {
       Future<double> lastFlow(double range) async {
-        final rangedMachine = MockDe1();
+        final rangedMachine = MockDe1(
+          simulationTickInterval: const Duration(milliseconds: 10),
+        );
         await rangedMachine.onConnect();
         try {
           await rangedMachine.setProfile(
             _pressureProfile(limiter: StepLimiter(value: 1.5, range: range)),
           );
           await rangedMachine.requestState(MachineState.espresso);
-          await Future.delayed(const Duration(milliseconds: 600));
+          await Future.delayed(const Duration(milliseconds: 60));
           final snapshots = await rangedMachine.currentSnapshot
               .take(10)
               .toList()

--- a/test/models/device/impl/mock_de1/mock_de1_realism_test.dart
+++ b/test/models/device/impl/mock_de1/mock_de1_realism_test.dart
@@ -69,7 +69,9 @@ Profile _gentleAndSweet() => Profile(
 
 void main() {
   test('simulated shot curves resemble a real pull', () async {
-    final machine = MockDe1();
+    final machine = MockDe1(
+      simulationTickInterval: const Duration(milliseconds: 10),
+    );
     await machine.onConnect();
     await machine.setProfile(_gentleAndSweet());
 
@@ -77,7 +79,7 @@ void main() {
     final sub = machine.currentSnapshot.listen(samples.add);
 
     await machine.requestState(MachineState.espresso);
-    await Future.delayed(const Duration(milliseconds: 9000));
+    await Future.delayed(const Duration(milliseconds: 900));
     await sub.cancel();
     await machine.onDisconnect();
 
@@ -130,7 +132,9 @@ void main() {
   });
 
   test('successive shots have different puck responses', () async {
-    final machine = MockDe1();
+    final machine = MockDe1(
+      simulationTickInterval: const Duration(milliseconds: 10),
+    );
     await machine.onConnect();
     await machine.setProfile(_gentleAndSweet());
 

--- a/test/models/device/impl/mock_de1/mock_de1_transition_test.dart
+++ b/test/models/device/impl/mock_de1/mock_de1_transition_test.dart
@@ -8,7 +8,9 @@ void main() {
     late MockDe1 machine;
 
     setUp(() async {
-      machine = MockDe1();
+      machine = MockDe1(
+        simulationTickInterval: const Duration(milliseconds: 10),
+      );
       await machine.onConnect();
     });
 
@@ -50,7 +52,7 @@ void main() {
       await machine.setProfile(profile);
       await machine.requestState(MachineState.espresso);
 
-      await Future.delayed(const Duration(milliseconds: 1800));
+      await Future.delayed(const Duration(milliseconds: 180));
 
       final snapshots = await machine.currentSnapshot
           .take(3)
@@ -105,7 +107,7 @@ void main() {
       await machine.setProfile(profile);
       await machine.requestState(MachineState.espresso);
 
-      await Future.delayed(const Duration(milliseconds: 3700));
+      await Future.delayed(const Duration(milliseconds: 370));
 
       final snapshots = await machine.currentSnapshot
           .take(20)

--- a/test/models/device/unified_de1_crashlytics_triage_test.dart
+++ b/test/models/device/unified_de1_crashlytics_triage_test.dart
@@ -3,10 +3,12 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
-import 'package:reaprime/src/models/errors.dart';
 import 'package:rxdart/rxdart.dart';
+
+import '../../helpers/fake_ble_transport.dart';
 
 class _ControllableSerialTransport extends SerialTransport {
   final _connState = BehaviorSubject<ConnectionState>.seeded(
@@ -54,33 +56,28 @@ class _ControllableSerialTransport extends SerialTransport {
 
 void main() {
   group('1b — short BLE frames do not crash _parseStateAndShotSample', () {
-    late _ControllableSerialTransport transport;
-    late UnifiedDe1 de1;
-
-    setUp(() {
-      transport = _ControllableSerialTransport();
-      de1 = UnifiedDe1(transport: transport);
-    });
-
-    tearDown(() {
-      transport.dispose();
-    });
-
     test('a 9-byte shotSample does not propagate a RangeError through '
         'currentSnapshot', () async {
+      final transport = FakeBleTransport()..queueOnConnectResponses();
+      final de1 = UnifiedDe1(transport: transport);
+
       final errors = <Object>[];
       final sub = de1.currentSnapshot.listen((_) {}, onError: errors.add);
 
-      final onConnectFuture = de1.onConnect().catchError((e) {
-        if (e is MmrTimeoutException) return;
-        throw e;
-      });
+      await de1.onConnect();
 
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-
-      transport.injectSerial('[M]000102030405060708\n');
-
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+      transport.emitNotification(Endpoint.shotSample, [
+        0x00,
+        0x01,
+        0x02,
+        0x03,
+        0x04,
+        0x05,
+        0x06,
+        0x07,
+        0x08,
+      ]);
+      await Future<void>.delayed(Duration.zero);
 
       expect(
         errors.whereType<RangeError>(),
@@ -91,8 +88,9 @@ void main() {
       );
 
       await sub.cancel();
-      await onConnectFuture;
-    }, timeout: const Timeout(Duration(seconds: 20)));
+      await de1.disconnect();
+      await transport.dispose();
+    });
   });
 
   group('1c — UnifiedDe1Transport.disconnect() is safe before connect()', () {

--- a/test/models/device/unified_de1_mmr_test.dart
+++ b/test/models/device/unified_de1_mmr_test.dart
@@ -1,18 +1,15 @@
-import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
 import 'package:reaprime/src/models/errors.dart';
-import 'package:rxdart/rxdart.dart';
 
 class _QuietSerialTransport extends SerialTransport {
-  final _connState = BehaviorSubject<ConnectionState>.seeded(
-    ConnectionState.connected,
-  );
-
+  // Stream.multi replays the connected state to each listener; a seeded
+  // rxdart BehaviorSubject cannot deliver its seed inside fake_async.
   @override
   String get id => 'quiet-serial-de1';
 
@@ -20,7 +17,10 @@ class _QuietSerialTransport extends SerialTransport {
   String get name => 'QuietSerialDe1';
 
   @override
-  Stream<ConnectionState> get connectionState => _connState.stream;
+  Stream<ConnectionState> get connectionState => Stream.multi((controller) {
+    controller.add(ConnectionState.connected);
+    controller.close();
+  });
 
   @override
   Future<void> connect() async {}
@@ -41,9 +41,7 @@ class _QuietSerialTransport extends SerialTransport {
   Future<void> writeCommand(String command) async {}
 
   @override
-  Future<void> dispose() async {
-    _connState.close();
-  }
+  Future<void> dispose() async {}
 }
 
 void main() {
@@ -60,15 +58,26 @@ void main() {
       transport.dispose();
     });
 
-    test(
-      'throws MmrTimeoutException when no matching response arrives',
-      () async {
-        await expectLater(
-          () => de1.getSteamFlow(),
-          throwsA(isA<MmrTimeoutException>()),
-        );
-      },
-      timeout: const Timeout(Duration(seconds: 20)),
-    );
+    test('throws MmrTimeoutException when no matching response arrives', () {
+      fakeAsync((async) {
+        Object? caught;
+        captureError(de1.getSteamFlow(), (e) => caught = e);
+        // Full production durations: 3 attempts x 4s timeout + 2 x 300ms
+        // retry settle, verified virtually instead of in real time.
+        async.elapse(const Duration(seconds: 13));
+        expect(caught, isA<MmrTimeoutException>());
+      });
+    });
   });
+}
+
+Future<void> captureError(
+  Future<double> future,
+  void Function(Object) onError,
+) async {
+  try {
+    await future;
+  } catch (e) {
+    onError(e);
+  }
 }

--- a/test/services/universal_ble_discovery_service_test.dart
+++ b/test/services/universal_ble_discovery_service_test.dart
@@ -174,8 +174,7 @@ void main() {
 
   _TrackingFakeBleTransport transportForModel(int model) {
     return _TrackingFakeBleTransport()
-      ..queueOnConnectResponses(v13Model: model)
-      ..queueMmrResponseInt(MMRItem.calFlowEst, 100);
+      ..queueOnConnectResponses(v13Model: model, calFlowEst: 100);
   }
 
   Future<void> pump([int n = 3]) async {

--- a/test/unit/models/acaia_scale_test.dart
+++ b/test/unit/models/acaia_scale_test.dart
@@ -172,9 +172,18 @@ _AcaiaTransport _ips({
   initializationFrame: initializationFrame,
 );
 
-Future<(AcaiaScale, _AcaiaTransport)> _connected() async {
+const _zeroTimings = AcaiaTimings(
+  initialIpsSettle: Duration.zero,
+  initialPyxisSettle: Duration.zero,
+  identSettle: Duration.zero,
+  configSettle: Duration.zero,
+);
+
+Future<(AcaiaScale, _AcaiaTransport)> _connected({
+  AcaiaTimings timings = _zeroTimings,
+}) async {
   final transport = _ips();
-  final scale = AcaiaScale(transport: transport);
+  final scale = AcaiaScale(transport: transport, timings: timings);
   await scale.onConnect();
   return (scale, transport);
 }
@@ -186,7 +195,7 @@ void main() {
       ['49535343-fe7d-4ae5-8fa9-9fafd205e455'],
     ]) {
       final transport = _AcaiaTransport(services: services);
-      final scale = AcaiaScale(transport: transport);
+      final scale = AcaiaScale(transport: transport, timings: _zeroTimings);
       await scale.onConnect();
       expect(await scale.connectionState.first, ConnectionState.connected);
       await scale.disconnect();
@@ -198,7 +207,7 @@ void main() {
     final transport = _AcaiaTransport(
       services: const ['0000fff0-0000-1000-8000-00805f9b34fb'],
     );
-    final scale = AcaiaScale(transport: transport);
+    final scale = AcaiaScale(transport: transport, timings: _zeroTimings);
     await scale.onConnect();
     expect(await scale.connectionState.first, ConnectionState.disconnected);
     await transport.dispose();
@@ -226,7 +235,7 @@ void main() {
     'real multi-record direct frame completes initialization once',
     () async {
       final transport = _ips(initializationFrame: _realWeightFrame);
-      final scale = AcaiaScale(transport: transport);
+      final scale = AcaiaScale(transport: transport, timings: _zeroTimings);
       final snapshots = <ScaleSnapshot>[];
       final subscription = scale.currentSnapshot.listen(snapshots.add);
 
@@ -258,7 +267,7 @@ void main() {
   test('minimal direct weight uses the declared protocol length', () async {
     final frame = _minimalWeightFrame();
     final transport = _ips(initializationFrame: frame);
-    final scale = AcaiaScale(transport: transport);
+    final scale = AcaiaScale(transport: transport, timings: _zeroTimings);
     final snapshots = <ScaleSnapshot>[];
     final subscription = scale.currentSnapshot.listen(snapshots.add);
 
@@ -276,7 +285,7 @@ void main() {
   test('heartbeat-wrapped weight completes initialization', () async {
     final frame = _heartbeatWeightFrame();
     final transport = _ips(initializationFrame: frame);
-    final scale = AcaiaScale(transport: transport);
+    final scale = AcaiaScale(transport: transport, timings: _zeroTimings);
     final snapshots = <ScaleSnapshot>[];
     final subscription = scale.currentSnapshot.listen(snapshots.add);
 
@@ -703,59 +712,77 @@ void main() {
     });
   });
 
-  test('known malformed frames do not refresh Pyxis liveness', () async {
-    final transport = _AcaiaTransport(
-      services: const ['49535343-fe7d-4ae5-8fa9-9fafd205e455'],
-    );
-    final scale = AcaiaScale(transport: transport);
-    await scale.onConnect();
-
-    for (var i = 0; i < 13; i++) {
-      transport.emit(const [0xEF, 0xDD, 0x0C, 0x0C, 0x05, 0xAA, 0xBB]);
-      await Future<void>.delayed(const Duration(milliseconds: 500));
-    }
-
-    expect(transport.disconnectCalls, 1);
-    await transport.dispose();
-  });
-
-  test('Pyxis watchdog is independent of a blocked heartbeat', () async {
-    final transport = _AcaiaTransport(
-      services: const ['49535343-fe7d-4ae5-8fa9-9fafd205e455'],
-    );
-    final scale = AcaiaScale(transport: transport);
-    await scale.onConnect();
-    final blocked = Completer<void>();
-    transport.writeBehavior = (data) => blocked.future;
-
-    await Future<void>.delayed(const Duration(milliseconds: 5500));
-
-    expect(transport.disconnectCalls, 1);
-    blocked.complete();
-    await Future<void>.delayed(Duration.zero);
-    await transport.dispose();
-  });
-
-  test('watchdog disconnect failures stay contained', () async {
-    final uncaught = <Object>[];
-    final done = Completer<void>();
-    runZonedGuarded(() async {
+  test('known malformed frames do not refresh Pyxis liveness', () {
+    fakeAsync((async) {
       final transport = _AcaiaTransport(
         services: const ['49535343-fe7d-4ae5-8fa9-9fafd205e455'],
       );
       final scale = AcaiaScale(transport: transport);
-      await scale.onConnect();
-      transport.disconnectError = StateError('disconnect failed');
+      scale.onConnect();
+      async.elapse(const Duration(milliseconds: 1200));
+      async.flushMicrotasks();
+      expect(transport.disconnectCalls, 0);
 
-      await Future<void>.delayed(const Duration(milliseconds: 5500));
+      for (var i = 0; i < 13; i++) {
+        transport.emit(const [0xEF, 0xDD, 0x0C, 0x0C, 0x05, 0xAA, 0xBB]);
+        async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
+      }
 
-      expect(await scale.connectionState.first, ConnectionState.disconnected);
-      await transport.dispose();
-      done.complete();
-    }, (error, stackTrace) => uncaught.add(error));
+      expect(transport.disconnectCalls, 1);
+      scale.disconnect();
+      async.flushMicrotasks();
+      transport.dispose();
+    });
+  });
 
-    await done.future.timeout(const Duration(seconds: 8));
-    expect(uncaught, isEmpty);
+  test('Pyxis watchdog is independent of a blocked heartbeat', () {
+    fakeAsync((async) {
+      final transport = _AcaiaTransport(
+        services: const ['49535343-fe7d-4ae5-8fa9-9fafd205e455'],
+      );
+      final scale = AcaiaScale(transport: transport);
+      scale.onConnect();
+      async.elapse(const Duration(milliseconds: 1200));
+      async.flushMicrotasks();
+      final blocked = Completer<void>();
+      transport.writeBehavior = (data) => blocked.future;
+
+      async.elapse(const Duration(seconds: 6));
+      async.flushMicrotasks();
+
+      expect(transport.disconnectCalls, 1);
+      blocked.complete();
+      scale.disconnect();
+      async.flushMicrotasks();
+      transport.dispose();
+    });
+  });
+
+  test('watchdog disconnect failures stay contained', () {
+    fakeAsync((async) {
+      final uncaught = <Object>[];
+      runZonedGuarded(() {
+        final transport = _AcaiaTransport(
+          services: const ['49535343-fe7d-4ae5-8fa9-9fafd205e455'],
+        );
+        final scale = AcaiaScale(transport: transport);
+        final states = <ConnectionState>[];
+        scale.connectionState.listen(states.add);
+        scale.onConnect();
+        async.elapse(const Duration(milliseconds: 1200));
+        async.flushMicrotasks();
+        transport.disconnectError = StateError('disconnect failed');
+
+        async.elapse(const Duration(seconds: 6));
+        async.flushMicrotasks();
+
+        expect(states.last, ConnectionState.disconnected);
+        transport.dispose();
+      }, (error, stackTrace) => uncaught.add(error));
+
+      expect(uncaught, isEmpty);
+    });
   });
 
   test(

--- a/test/unit/models/acaia_scale_test.dart
+++ b/test/unit/models/acaia_scale_test.dart
@@ -8,7 +8,8 @@ import 'package:reaprime/src/models/device/impl/acaia/acaia_scale.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:reaprime/src/models/errors.dart';
-import 'package:rxdart/rxdart.dart';
+
+import '../../helpers/completing_cancel_stream.dart';
 
 const _weightBody = <int>[0xDF, 0x06, 0x00, 0x00, 0x01, 0x00];
 const _realWeightFrame = <int>[
@@ -86,9 +87,9 @@ class _AcaiaTransport extends BLETransport {
   final List<String> services;
   final bool emitWeightDuringInit;
   final List<int> initializationFrame;
-  final BehaviorSubject<ConnectionState> states = BehaviorSubject.seeded(
-    ConnectionState.discovered,
-  );
+  ConnectionState _state = ConnectionState.discovered;
+  final StreamController<ConnectionState> _stateController =
+      StreamController<ConnectionState>.broadcast();
   final List<List<int>> writes = [];
   void Function(Uint8List)? notification;
   Future<void> Function(Uint8List)? writeBehavior;
@@ -103,20 +104,26 @@ class _AcaiaTransport extends BLETransport {
   String get name => 'LUNAR-TEST';
 
   @override
-  Stream<ConnectionState> get connectionState => states.stream;
+  Stream<ConnectionState> get connectionState =>
+      CompletingCancelStream<ConnectionState>(_stateController);
 
   @override
-  Future<ConnectionState> getConnectionState() async => states.value;
+  Future<ConnectionState> getConnectionState() async => _state;
 
   @override
-  Future<void> connect() async => states.add(ConnectionState.connected);
+  Future<void> connect() async => emitState(ConnectionState.connected);
 
   @override
   Future<void> disconnect() async {
     disconnectCalls++;
     final error = disconnectError;
     if (error != null) throw error;
-    states.add(ConnectionState.disconnected);
+    emitState(ConnectionState.disconnected);
+  }
+
+  void emitState(ConnectionState state) {
+    _state = state;
+    _stateController.add(state);
   }
 
   @override
@@ -160,7 +167,7 @@ class _AcaiaTransport extends BLETransport {
   Future<void> setTransportPriority(bool prioritized) async {}
 
   @override
-  Future<void> dispose() async => states.close();
+  Future<void> dispose() async => _stateController.close();
 }
 
 _AcaiaTransport _ips({
@@ -665,7 +672,7 @@ void main() {
         scheduleMicrotask(() => transport.emit(_minimalWeightFrame()));
         Timer(
           const Duration(milliseconds: 100),
-          () => transport.states.add(ConnectionState.disconnected),
+          () => transport.emitState(ConnectionState.disconnected),
         );
       };
       final scale = AcaiaScale(transport: transport);

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -9,6 +9,8 @@ import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:reaprime/src/models/errors.dart';
 import 'package:rxdart/rxdart.dart';
 
+import '../../helpers/completing_cancel_stream.dart';
+
 class _DisconnectedBleTransport extends BLETransport {
   final _connectionState = BehaviorSubject<ConnectionState>.seeded(
     ConnectionState.disconnected,
@@ -120,7 +122,8 @@ class _RecordingBleTransport extends BLETransport {
   String get name => 'Recording Decent Scale';
 
   @override
-  Stream<ConnectionState> get connectionState => _connectionState.stream;
+  Stream<ConnectionState> get connectionState =>
+      CompletingCancelStream<ConnectionState>(_connectionState);
 
   @override
   Future<ConnectionState> getConnectionState() async => _nativeState;
@@ -301,31 +304,30 @@ void main() {
     });
   });
 
-  test(
-    'silent FFF4 initialization fails without publishing connected',
-    () async {
+  test('silent FFF4 initialization fails without publishing connected', () {
+    fakeAsync((async) {
       final transport = _RecordingBleTransport(responseSubscribeCalls: const [])
         ..diagnosticRead = Uint8List.fromList([0x03, 0x0A, 0, 0, 100, 0, 0]);
       final scale = DecentScale(transport: transport);
       final states = <ConnectionState>[];
       scale.connectionState.listen(states.add);
+      final connectionErrors = <Object>[];
+      scale.onConnect().then((_) {}, onError: connectionErrors.add);
 
-      final connection = scale.onConnect();
-      await Future<void>.delayed(const Duration(milliseconds: 150));
+      _elapse(async, const Duration(milliseconds: 150));
       transport.emitNotification([0x03, 0x0A, 0, 0, 100, 0]);
-      await expectLater(connection, throwsA(isA<TimeoutException>()));
-      await Future<void>.delayed(Duration.zero);
+      _elapse(async, const Duration(seconds: 5));
 
+      expect(connectionErrors.single, isA<TimeoutException>());
       expect(transport.subscribeCalls, 2);
       expect(transport.resetSubscriptionCalls, 1);
       expect(transport.readCalls, 1);
       expect(states, isNot(contains(ConnectionState.connected)));
       expect(states.last, ConnectionState.disconnected);
       expect(_hasCommand(transport, 0x0A, 0x02), isFalse);
-      await transport.dispose();
-    },
-    timeout: const Timeout(Duration(seconds: 10)),
-  );
+      transport.dispose();
+    });
+  });
 
   test('sleeping reconnect stays dark and verifies FFF4 on wake', () {
     fakeAsync((async) {
@@ -413,27 +415,32 @@ void main() {
     });
   });
 
-  test('silent wake disconnects once without powering off', () async {
-    final transport = _RecordingBleTransport(responseSubscribeCalls: const [1]);
-    final scale = DecentScale(transport: transport);
-    await scale.onConnect();
-    await scale.sleepDisplay();
-    await scale.disconnectForHandoff();
-    transport.writes.clear();
-    transport.disconnectCalls = 0;
-    await scale.onConnect();
+  test('silent wake disconnects once without powering off', () {
+    fakeAsync((async) {
+      final (:scale, :transport) = _sleepingReconnect(
+        async,
+        responseSubscribeCalls: const [1],
+      );
 
-    await expectLater(scale.wakeDisplay(), throwsA(isA<TimeoutException>()));
+      final wakeErrors = <Object>[];
+      scale.wakeDisplay().then((_) {}, onError: wakeErrors.add);
+      _elapse(async, const Duration(seconds: 6));
 
-    expect(transport.disconnectCalls, 1);
-    expect(_hasCommand(transport, 0x0A, 0x02), isFalse);
-    final subscriptions = transport.subscribeCalls;
-    final secondWake = scale.wakeDisplay();
-    await Future<void>.delayed(Duration.zero);
-    expect(transport.subscribeCalls, subscriptions + 1);
-    await scale.sleepDisplay();
-    await secondWake;
-    await transport.dispose();
+      expect(wakeErrors, hasLength(1));
+      expect(wakeErrors.single, isA<TimeoutException>());
+      expect(transport.disconnectCalls, 1);
+      expect(_hasCommand(transport, 0x0A, 0x02), isFalse);
+
+      final subscriptions = transport.subscribeCalls;
+      var secondWakeDone = false;
+      scale.wakeDisplay().then((_) => secondWakeDone = true);
+      async.flushMicrotasks();
+      expect(transport.subscribeCalls, subscriptions + 1);
+      scale.sleepDisplay();
+      _elapse(async, const Duration(seconds: 3));
+      expect(secondWakeDone, isTrue);
+      transport.dispose();
+    });
   });
 
   test('disconnected initialization write never publishes connected', () async {

--- a/test/unit/models/device/impl/de1/unified_de1/bengle_telemetry_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/bengle_telemetry_test.dart
@@ -42,9 +42,9 @@ final _goldenFrame = Uint8List.fromList(const [
   0x01,
 ]);
 
-FakeBleTransport _transport({required int model}) => FakeBleTransport()
-  ..queueMmrResponseInt(MMRItem.calFlowEst, 100)
-  ..queueOnConnectResponses(v13Model: model);
+FakeBleTransport _transport({required int model}) =>
+    FakeBleTransport()
+      ..queueOnConnectResponses(v13Model: model, calFlowEst: 100);
 
 void main() {
   test('decodes the current 28-byte Bengle shot sample', () {

--- a/test/unit/models/device/impl/de1/unified_de1/firmware_mmr_exclusion_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/firmware_mmr_exclusion_test.dart
@@ -16,8 +16,7 @@ void main() {
   setUp(() async {
     transport = _BarrierBleTransport();
     addTearDown(transport.dispose);
-    transport.queueOnConnectResponses();
-    transport.queueMmrResponseInt(MMRItem.calFlowEst, 0);
+    transport.queueOnConnectResponses(calFlowEst: 0);
     de1 = UnifiedDe1(transport: transport);
     await de1.onConnect();
     transport.writes.clear();

--- a/test/unit/models/device/impl/de1/unified_de1/firmware_protocol_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/firmware_protocol_test.dart
@@ -18,8 +18,7 @@ void main() {
   setUp(() async {
     transport = FakeBleTransport();
     addTearDown(transport.dispose);
-    transport.queueOnConnectResponses(v13Model: 3);
-    transport.queueMmrResponseInt(MMRItem.calFlowEst, 0);
+    transport.queueOnConnectResponses(v13Model: 3, calFlowEst: 0);
     de1 = UnifiedDe1(
       transport: transport,
       firmwareEraseTimeout: const Duration(milliseconds: 100),
@@ -92,8 +91,7 @@ void main() {
   test('erase response must follow firmware-map dispatch', () async {
     final preflightTransport = _PreflightBarrierBleTransport();
     addTearDown(preflightTransport.dispose);
-    preflightTransport.queueOnConnectResponses(v13Model: 3);
-    preflightTransport.queueMmrResponseInt(MMRItem.calFlowEst, 0);
+    preflightTransport.queueOnConnectResponses(v13Model: 3, calFlowEst: 0);
     final preflightBarrier = Completer<void>();
     final blockedDe1 = _PreludePreflightBlockingDe1(
       transport: preflightTransport,
@@ -147,8 +145,7 @@ void main() {
   test('verification response must follow the verification request', () async {
     final barrierTransport = BarrierBleTransport();
     addTearDown(barrierTransport.dispose);
-    barrierTransport.queueOnConnectResponses(v13Model: 3);
-    barrierTransport.queueMmrResponseInt(MMRItem.calFlowEst, 0);
+    barrierTransport.queueOnConnectResponses(v13Model: 3, calFlowEst: 0);
     final blockedDe1 = UnifiedDe1(
       transport: barrierTransport,
       firmwareEraseTimeout: const Duration(milliseconds: 100),
@@ -176,8 +173,7 @@ void main() {
   test('verification response must follow firmware-map dispatch', () async {
     final preflightTransport = _PreflightBarrierBleTransport();
     addTearDown(preflightTransport.dispose);
-    preflightTransport.queueOnConnectResponses(v13Model: 3);
-    preflightTransport.queueMmrResponseInt(MMRItem.calFlowEst, 0);
+    preflightTransport.queueOnConnectResponses(v13Model: 3, calFlowEst: 0);
     final blockedDe1 = UnifiedDe1(
       transport: preflightTransport,
       firmwareEraseTimeout: const Duration(milliseconds: 100),

--- a/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
@@ -133,24 +133,6 @@ void main() {
       expect(result.sublist(4, 8), [0xDE, 0xAD, 0xBE, 0xEF]);
     });
 
-    test(
-      'readMmrRaw retries after a dropped notify, then returns the value',
-      () async {
-        const addr = _CapabilityAddr(
-          address: 0x00802800,
-          length: 4,
-          name: 'cupWarmerStatus',
-          kind: MmrValueKind.bytes,
-        );
-        transport.dropNextMmrResponses = 1;
-        transport.queueMmrResponseRaw(addr, [0xDE, 0xAD, 0xBE, 0xEF]);
-
-        final result = await de1.capRead(addr);
-        expect(result.sublist(4, 8), [0xDE, 0xAD, 0xBE, 0xEF]);
-      },
-      timeout: const Timeout(Duration(seconds: 30)),
-    );
-
     test('writeMmrRaw sends the bytes on the wire for non-MMRItem', () async {
       const addr = _CapabilityAddr(
         address: 0x00803000,

--- a/test/unit/models/skale2_scale_test.dart
+++ b/test/unit/models/skale2_scale_test.dart
@@ -122,7 +122,7 @@ void main() {
 
     setUp(() async {
       transport = _RecordableBleTransport();
-      scale = Skale2Scale(transport: transport);
+      scale = Skale2Scale(transport: transport, initStepDelay: Duration.zero);
       await transport.emitConnectionState(ConnectionState.discovered);
     });
 
@@ -275,7 +275,7 @@ void main() {
 
     setUp(() async {
       transport = _RecordableBleTransport();
-      scale = Skale2Scale(transport: transport);
+      scale = Skale2Scale(transport: transport, initStepDelay: Duration.zero);
       await transport.emitConnectionState(ConnectionState.discovered);
       await scale.onConnect();
       transport.operations.clear();
@@ -351,7 +351,7 @@ void main() {
 
     setUp(() async {
       transport = _RecordableBleTransport();
-      scale = Skale2Scale(transport: transport);
+      scale = Skale2Scale(transport: transport, initStepDelay: Duration.zero);
       await transport.emitConnectionState(ConnectionState.discovered);
       await scale.onConnect();
       transport.operations.clear();
@@ -379,7 +379,7 @@ void main() {
 
     setUp(() async {
       transport = _RecordableBleTransport();
-      scale = Skale2Scale(transport: transport);
+      scale = Skale2Scale(transport: transport, initStepDelay: Duration.zero);
       await transport.emitConnectionState(ConnectionState.discovered);
       await scale.onConnect();
     });

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -208,6 +208,10 @@ void main() {
     deviceId = 'AA:BB:CC:DD:EE:${(deviceCounter++).toString().padLeft(2, '0')}';
     transport = UniversalBleTransport(
       device: bleDevice(deviceId),
+      // Platform-neutral: the generic recovery tests must not depend on the
+      // CI runner's OS (Linux would add real BlueZ settle/connect delays).
+      isAndroidOverride: false,
+      isLinuxOverride: false,
       faultRecoveryGrace: const Duration(milliseconds: 200),
       faultRecoveryDisconnectTimeout: const Duration(milliseconds: 20),
     );

--- a/test/webserver/firmware_handler_test.dart
+++ b/test/webserver/firmware_handler_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
-import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
 import 'package:reaprime/src/models/device/machine.dart';
@@ -101,8 +100,7 @@ void main() {
   test('NDJSON stays open until successful verification', () async {
     final transport = FakeBleTransport();
     addTearDown(transport.dispose);
-    transport.queueOnConnectResponses(v13Model: 3);
-    transport.queueMmrResponseInt(MMRItem.calFlowEst, 0);
+    transport.queueOnConnectResponses(v13Model: 3, calFlowEst: 0);
     final de1 = UnifiedDe1(
       transport: transport,
       firmwareEraseTimeout: const Duration(seconds: 1),
@@ -202,8 +200,7 @@ void main() {
   test('verification failure emits error and closes without done', () async {
     final transport = FakeBleTransport();
     addTearDown(transport.dispose);
-    transport.queueOnConnectResponses(v13Model: 3);
-    transport.queueMmrResponseInt(MMRItem.calFlowEst, 0);
+    transport.queueOnConnectResponses(v13Model: 3, calFlowEst: 0);
     final de1 = UnifiedDe1(
       transport: transport,
       firmwareEraseTimeout: const Duration(milliseconds: 100),
@@ -228,8 +225,7 @@ void main() {
   test('verification timeout emits error and closes without done', () async {
     final transport = FakeBleTransport();
     addTearDown(transport.dispose);
-    transport.queueOnConnectResponses(v13Model: 3);
-    transport.queueMmrResponseInt(MMRItem.calFlowEst, 0);
+    transport.queueOnConnectResponses(v13Model: 3, calFlowEst: 0);
     final de1 = UnifiedDe1(
       transport: transport,
       firmwareEraseTimeout: const Duration(milliseconds: 100),

--- a/tool/ci/summarize_flutter_tests.py
+++ b/tool/ci/summarize_flutter_tests.py
@@ -117,12 +117,30 @@ def parse_events(lines):
                     {"duration_ms": duration_ms, "name": name, "path": path}
                 )
 
-    file_durations = {}
+    file_span_ms = {}
     for suite_id, bounds in suite_bounds.items():
         duration_ms = _duration(*bounds)
         if duration_ms is not None and suite_id in suites:
             path = suites[suite_id]
-            file_durations[path] = file_durations.get(path, 0) + duration_ms
+            file_span_ms[path] = file_span_ms.get(path, 0) + duration_ms
+
+    # Active test time: the sum of individual non-skipped test durations for
+    # a path. Unlike the suite wall span this is not inflated by concurrent
+    # suite scheduling, so it is the metric to use for optimization targets.
+    file_active_ms = {}
+    for test in tests:
+        path = test["path"]
+        file_active_ms[path] = file_active_ms.get(path, 0) + test["duration_ms"]
+
+    files = [
+        {
+            "path": path,
+            "active_ms": file_active_ms.get(path),
+            "span_ms": file_span_ms.get(path),
+        }
+        for path in set(file_span_ms) | set(file_active_ms)
+    ]
+    files.sort(key=lambda item: item["active_ms"] or 0, reverse=True)
 
     return {
         "duration_ms": _duration(start_time, done_time),
@@ -132,10 +150,7 @@ def parse_events(lines):
         "run_success": run_success,
         "malformed_lines": malformed_lines,
         "failures": failures,
-        "files": sorted(
-            ((duration, path) for path, duration in file_durations.items()),
-            reverse=True,
-        ),
+        "files": files,
         "tests": sorted(tests, key=lambda test: test["duration_ms"], reverse=True),
     }
 
@@ -197,12 +212,22 @@ def render_summary(report):
         if len(report["failures"]) > 20:
             lines.append(f"\n{len(report['failures']) - 20} additional failures omitted.")
 
-    lines.extend(["", "### Slowest test files", ""])
+    lines.extend(["", "### Slowest test files by active test time", ""])
     if report["files"]:
-        lines.extend(["| Duration | File |", "| ---: | --- |"])
+        lines.extend(["| Active time | Suite span | File |", "| ---: | ---: | --- |"])
         lines.extend(
-            f"| {_format_duration(duration)} | {_escape(path)} |"
-            for duration, path in report["files"][:20]
+            "| {} | {} | {} |".format(
+                _format_duration(item["active_ms"]),
+                _format_duration(item["span_ms"]),
+                _escape(item["path"]),
+            )
+            for item in report["files"][:20]
+        )
+        lines.append(
+            "\n"
+            "Active time is the sum of individual non-skipped test "
+            "durations; suite span is first-start to last-test-completion "
+            "and can be inflated by concurrent suite scheduling."
         )
     else:
         lines.append("Timing unavailable from the captured events.")

--- a/tool/ci/summarize_flutter_tests_test.py
+++ b/tool/ci/summarize_flutter_tests_test.py
@@ -9,84 +9,61 @@ from unittest import mock
 import summarize_flutter_tests
 
 
+def _event(event_type, **fields):
+    event = {"type": event_type, "time": 0}
+    event.update(fields)
+    return json.dumps(event)
+
+
+def _suite(suite_id, path):
+    return _event("suite", suite={"id": suite_id, "path": path})
+
+
+def _test_start(test_id, suite_id, name, time):
+    return _event(
+        "testStart",
+        time=time,
+        test={"id": test_id, "name": name, "suiteID": suite_id},
+    )
+
+
+def _test_done(test_id, time, result="success", skipped=False, hidden=False):
+    return _event(
+        "testDone",
+        time=time,
+        testID=test_id,
+        result=result,
+        skipped=skipped,
+        hidden=hidden,
+    )
+
+
 class SummarizeFlutterTestsTest(unittest.TestCase):
     def test_parses_counts_failures_and_timings(self):
         events = [
-            {"type": "start", "time": 100},
-            {
-                "type": "suite",
-                "time": 110,
-                "suite": {"id": 0, "path": "C:/repo/test/slow_test.dart"},
-            },
-            {
-                "type": "testStart",
-                "time": 120,
-                "test": {"id": 1, "name": "loading", "suiteID": 0},
-            },
-            {
-                "type": "testDone",
-                "time": 150,
-                "testID": 1,
-                "result": "success",
-                "hidden": True,
-                "skipped": False,
-            },
-            {
-                "type": "testStart",
-                "time": 200,
-                "test": {"id": 2, "name": "slow | success", "suiteID": 0},
-            },
-            {
-                "type": "suite",
-                "time": 210,
-                "suite": {"id": 1, "path": "test/fast_test.dart"},
-            },
-            {"type": "futureEvent", "time": 250},
-            {
-                "type": "testStart",
-                "time": 300,
-                "test": {"id": 3, "name": "fails", "suiteID": 1},
-            },
-            {
-                "type": "error",
-                "time": 400,
-                "testID": 3,
-                "error": "Expected: <1>\n  Actual: <2>",
-                "stackTrace": "package:test/example_test.dart 10:3  main.<fn>",
-                "isFailure": True,
-            },
-            {
-                "type": "testDone",
-                "time": 500,
-                "testID": 3,
-                "result": "failure",
-                "hidden": False,
-                "skipped": False,
-            },
-            {
-                "type": "testStart",
-                "time": 510,
-                "test": {"id": 4, "name": "skipped", "suiteID": 1},
-            },
-            {
-                "type": "testDone",
-                "time": 510,
-                "testID": 4,
-                "result": "success",
-                "hidden": False,
-                "skipped": True,
-            },
-            {
-                "type": "testDone",
-                "time": 800,
-                "testID": 2,
-                "result": "success",
-                "hidden": False,
-                "skipped": False,
-            },
-            {"type": "done", "time": 1000, "success": False},
+            _event("start", time=100),
+            _suite(0, "C:/repo/test/slow_test.dart"),
+            _test_start(1, 0, "loading", 120),
+            _test_done(1, 150, hidden=True),
+            _test_start(2, 0, "slow | success", 200),
+            _suite(1, "test/fast_test.dart"),
+            _event("futureEvent", time=250),
+            _test_start(3, 1, "fails", 300),
+            _event(
+                "error",
+                time=400,
+                testID=3,
+                error="Expected: <1>\n  Actual: <2>",
+                stackTrace="package:test/example_test.dart 10:3  main.<fn>",
+                isFailure=True,
+            ),
+            _test_done(3, 500, result="failure"),
+            _test_start(4, 1, "skipped", 510),
+            _test_done(4, 510, skipped=True),
+            _test_done(2, 800),
+            _event("done", time=1000, success=False),
         ]
-        lines = [json.dumps(event) for event in events]
+        lines = list(events)
         lines.insert(2, json.dumps([{"event": "test.startedProcess"}]))
         lines.insert(3, "")
         lines.insert(3, "not json")
@@ -103,7 +80,10 @@ class SummarizeFlutterTestsTest(unittest.TestCase):
         self.assertEqual(
             report["failures"][0]["error"], "Expected: <1>\n  Actual: <2>"
         )
-        self.assertEqual(report["files"][0], (680, "test/slow_test.dart"))
+        slow_file = report["files"][0]
+        self.assertEqual(slow_file["path"], "test/slow_test.dart")
+        self.assertEqual(slow_file["active_ms"], 600)
+        self.assertEqual(slow_file["span_ms"], 680)
         self.assertEqual(report["tests"][0]["duration_ms"], 600)
 
         markdown = summarize_flutter_tests.render_summary(report)
@@ -111,7 +91,95 @@ class SummarizeFlutterTestsTest(unittest.TestCase):
         self.assertIn("| Flutter result | Failed |", markdown)
         self.assertIn("slow \\| success", markdown)
         self.assertIn("test/slow_test.dart", markdown)
+        self.assertIn("Active time | Suite span | File", markdown)
         self.assertIn("Expected: &lt;1&gt;   Actual: &lt;2&gt;", markdown)
+
+    def test_two_tests_in_one_file_sum_active_time(self):
+        lines = [
+            _event("start"),
+            _suite(0, "test/sum_test.dart"),
+            _test_start(1, 0, "first", 100),
+            _test_done(1, 250),
+            _test_start(2, 0, "second", 300),
+            _test_done(2, 450),
+            _event("done", success=True),
+        ]
+        report = summarize_flutter_tests.parse_events(lines)
+        self.assertEqual(
+            report["files"][0]["path"], "test/sum_test.dart"
+        )
+        self.assertEqual(report["files"][0]["active_ms"], 300)
+        self.assertEqual(report["files"][0]["span_ms"], 350)
+
+    def test_skipped_tests_do_not_contribute_to_active_time(self):
+        lines = [
+            _event("start"),
+            _suite(0, "test/skipped_test.dart"),
+            _test_start(1, 0, "runs", 100),
+            _test_done(1, 300),
+            _test_start(2, 0, "skips", 400),
+            _test_done(2, 900, skipped=True),
+            _event("done", success=True),
+        ]
+        report = summarize_flutter_tests.parse_events(lines)
+        self.assertEqual(report["skipped"], 1)
+        self.assertEqual(report["files"][0]["active_ms"], 200)
+        # The skipped test inflates the suite span but not the active time.
+        self.assertEqual(report["files"][0]["span_ms"], 800)
+
+    def test_large_suite_span_with_small_active_time(self):
+        # File A: two quick tests spread across the whole run wall-clock.
+        # File B: two medium tests in a compact window.
+        lines = [
+            _event("start"),
+            _suite(0, "test/spread_test.dart"),
+            _test_start(1, 0, "early", 100),
+            _test_done(1, 200),
+            _test_start(2, 0, "late", 8900),
+            _test_done(2, 9000),
+            _suite(1, "test/compact_test.dart"),
+            _test_start(3, 1, "first", 1000),
+            _test_done(3, 3000),
+            _test_start(4, 1, "second", 3001),
+            _test_done(4, 5001),
+            _event("done", success=True),
+        ]
+        report = summarize_flutter_tests.parse_events(lines)
+        files = {item["path"]: item for item in report["files"]}
+        spread = files["test/spread_test.dart"]
+        compact = files["test/compact_test.dart"]
+
+        # Spread has the bigger wall span but the smaller active time.
+        self.assertEqual(spread["span_ms"], 8900)
+        self.assertEqual(spread["active_ms"], 200)
+        self.assertEqual(compact["span_ms"], 4001)
+        self.assertEqual(compact["active_ms"], 4000)
+
+        # Active-time ranking must put compact first.
+        self.assertEqual(report["files"][0]["path"], "test/compact_test.dart")
+        self.assertEqual(report["files"][1]["path"], "test/spread_test.dart")
+
+        markdown = summarize_flutter_tests.render_summary(report)
+        self.assertLess(
+            markdown.index("test/compact_test.dart"),
+            markdown.index("test/spread_test.dart"),
+        )
+
+    def test_orphaned_test_start_and_unknown_test_done_are_tolerated(self):
+        lines = [
+            _event("start"),
+            _suite(0, "test/partial_test.dart"),
+            _test_start(1, 0, "never completes", 100),
+            _event("testDone", time=300, testID=99, result="success"),
+            _event("done", success=True),
+        ]
+        report = summarize_flutter_tests.parse_events(lines)
+        # The unknown testDone is counted but carries no timing, and the
+        # orphaned testStart does not crash the parse. No suite bounds are
+        # closed, so no file timing is recorded.
+        self.assertEqual(report["successful"], 1)
+        self.assertEqual(report["tests"], [])
+        self.assertEqual(report["files"], [])
 
     def test_keeps_counts_when_timing_is_unavailable(self):
         lines = [


### PR DESCRIPTION
## Summary

- **Problem:** PR CI wall time was dominated by tests that spent seconds of real wall-clock waiting on things their assertions never measured: MMR read timeouts (3 × 4 s + 2 × 300 ms = 12.6 s per `UnifiedDe1.onConnect()`), real BlueZ settle/connect timing on the ubuntu runner, hardware protocol settle delays, reconnect/backoff timers, and mock-simulator tick waits.
- **Why it matters:** The waits carried no assertion value. CI went from ~6:00 to ~4:54 over the first two passes by removing the largest offenders, and the remaining big files were identified with a corrected metric (see CI tooling below).
- **Approach:** Iterative profiling. Each pass ran the CI `flutter test --machine` events, ranked files by *active test time* (sum of individual test durations, not suite wall span), traced the dominant waits into production/test code, and introduced the smallest production-safe timing seam or fake-time conversion that preserves the asserted behavior. Production behavior and all default timings are unchanged; the suite still exercises full production durations wherever timing is the subject of the test (virtually via `fakeAsync` where possible).
- **What changed:**
  - `FakeBleTransport.queueOnConnectResponses()` now also queues `MMRItem.calFlowEst` (raw `1000` = `1.0`; overridable via `calFlowEst:`), so every `UnifiedDe1.onConnect()` no longer pays the full 12.6 s MMR timeout. Added `emitNotification(Endpoint, bytes)` for notification-boundary tests.
  - Canonical MMR timeout test converted to `fake_async` — full production durations verified virtually instead of 12.6 s real.
  - Generic `UniversalBleTransport` recovery fixture made platform-neutral; the Linux-specific group still tests Linux behavior explicitly with zero-duration BlueZ overrides.
  - Watchdog/liveness tests in `acaia_scale_test.dart`, `decent_scale_disconnect_test.dart`, and `connection_manager_test.dart` virtualized with `fakeAsync` + injected clocks/seams (production durations preserved virtually).
  - MockDe1 simulation tests (flow/pressure, realism, transition) run the identical tick-for-tick trajectory at a faster injected wall cadence.
  - `tool/ci/summarize_flutter_tests.py` now ranks files by cumulative active test time (suite span retained as a diagnostic column), so optimization targets reflect real cost under concurrent suite scheduling.
- **What did NOT change (scope boundary):** Production behavior and default timing are unchanged. All production edits are timing/testability seams with the original constants as defaults (listed below). No parser/protocol assertions removed; the full test matrix is retained.

## Production changes (timing seams only — defaults unchanged)

All production edits expose timing that was previously hardcoded, keeping the exact production default:

| File | Seam | Default |
| --- | --- | --- |
| `lib/src/models/device/impl/skale/skale2_scale.dart` | `initStepDelay` constructor param | 1 s per init step |
| `lib/src/models/device/impl/acaia/acaia_scale.dart` | `AcaiaTimings` init-settle config + injected `DateTime Function() now` (`clock.now`) | 100/500/200/500 ms; wall clock |
| `lib/src/controllers/connection_manager.dart` | `@visibleForTesting scaleReconnectBaseDelay` | 5 s |
| `lib/src/models/device/impl/mock_de1/mock_de1.dart` | `simulationTickInterval` constructor param | 100 ms |

Tests that merely need an initialized device inject zero durations; tests validating timing semantics keep production durations (virtually via `fakeAsync` where the code path supports it). The one genuine production behavior change considered — `AcaiaScale.disconnect()` skipping `await` on subscription cancel — was **reverted**; the hang was a test-double issue, fixed with a shared `CompletingCancelStream` test helper instead.

## CI tooling

- `summarize_flutter_tests.py` primary ranking is now **active test time** (sum of individual non-skipped `duration_ms` per file). Suite wall span stays as a secondary column because concurrent `flutter test` scheduling inflates it (e.g. `wake_schedule_test.dart`: 17.65 s span but 0.08 s active; `devices_handler_test.dart`: 18.3 s span, 3.6 s active).
- New Python unit tests (`tool/ci/summarize_flutter_tests_test.py`, 7 tests) cover summing, interleaved spans, skipped-test exclusion, ranking divergence, and malformed/partial input; run by CI as a dedicated job.

## Change Type (select all)

- [x] Chore / infra
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [x] Scale / weight / flow
- [x] CI / build / infra
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins

## Linked Issues

- Related # (none; driven by PR CI timing report)

## Root Cause (if bug fix)

For bugs: explain why this happened, not just what changed. Otherwise write `N/A`.

- Root cause: `N/A` (test-infra chore; root causes documented per-file in the commit messages and in `doc/AI_TESTING_NOTES.md`)
- Missing detection or guardrail:
- Contributing context (if known):

## Regression Test Plan (if bug fix or refactor)

For bugs and refactors: name the smallest reliable test that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [x] Existing coverage already sufficient
- Target test or file: the retained non-MMRItem `readMmrRaw` test in `protected_surface_test.dart`, the retry test in `firmware_mmr_exclusion_test.dart`, and the converted `fake_async` watchdog/timeout tests (Acaia Pyxis watchdog ×3, DecentScale silent-wake/FFF4, MMR timeout) preserve the timing semantics virtually.
- Scenario the test should lock in: MMR reads succeed/fail without 12.6 s real waits; liveness/backoff/timeout semantics still proven with production durations under `fakeAsync`.
- If no new test added, why not: the change is to test fixtures/synchronization; existing assertions are preserved.

## Documentation Obligations (required)

These are **not optional**. Stale specs mislead clients and agents.

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] `doc/AI_TESTING_NOTES.md` updated (test-infra; no product docs affected)

## Security Impact (required)

This app runs a local web server (port 8080) and connects to BLE/USB hardware.

- New or changed REST endpoints? (`No`)
- New or changed WebSocket topics? (`No`)
- New or changed network calls? (`No`)
- BLE/USB surface changed? (`No` — timing seams only; default behavior identical)
- File system access changed? (`No`)
- Plugin sandbox boundary changed? (`No`)
- If any `Yes`, explain risk and mitigation: `N/A`

## User-Visible Changes

List user-visible changes (including defaults, config, behavior). If none, write `None`.

`None` — no production behavior or default timing changes; the seams only make timing injectable for tests.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test tool` — clean
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 2899 pass / 7 known pre-existing failures (plugin-permissions ×3, webui-token-injection ×4; confirmed failing on the clean tree before this PR)
- [x] `tool/ci/summarize_flutter_tests_test.py` — 7/7 pass (run by CI as its own job)

### Manual verification (if applicable)

- OS / platform tested: macOS (local), ubuntu-latest (PR CI)
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: before/after per-file timings (below); every changed test file run individually, then the full suite
- Edge cases checked: retry-after-drop still covered by `firmware_mmr_exclusion_test.dart`; Linux-specific recovery group untouched and passing; Acaia watchdog/DecentScale timeout semantics proven with production durations under `fakeAsync`
- What you did **not** verify: real hardware

### Evidence

Attach at least one:

- [x] Test output — major before/after buckets (active test time per file):

  | File | Before | After |
  | --- | ---: | ---: |
  | `protected_surface_test.dart` | ~157 s | ~2.3 s |
  | `led_strip_capability_test.dart` | ~115 s | ~2.0 s |
  | `universal_ble_transport_recovery_test.dart` | ~77 s | ~9 s |
  | `acaia_scale_test.dart` | ~55.6 s | ~3 s |
  | `skale2_scale_test.dart` | ~43 s | ~3 s |
  | `connection_manager_test.dart` | ~22.8 s | ~3 s |
  | `mock_de1_flow_pressure_test.dart` | ~15.2 s | ~2 s |
  | `mock_de1_realism_test.dart` | ~11.6 s | ~1.5 s |
  | `decent_scale_disconnect_test.dart` | ~11.7 s | ~5 s (one 2 s intentional timing test kept real) |
  | `mock_de1_transition_test.dart` | ~7.7 s | ~3.4 s |
  | `unified_de1_crashlytics_triage_test.dart` | ~12.7 s | ~2 s |

  (~2–3 s floor per file is Flutter harness startup.)

  CI wall clock for the full suite is ~5–6 min and varies with runner scheduling; the authoritative optimization metric is cumulative active test time per file, which the updated summarizer reports. Local full-suite wall is ~1:06.
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? (`Yes`)
- Config / env changes needed? (`No`)
- Database migration needed? (`No`)
- If any `No` or `Yes`, explain exact steps: `N/A`

## Risks & Mitigations

List only real risks for this PR. If none, write `None`.

- Risk: production seams are mutable `@visibleForTesting` fields / constructor params; a future production call site could change timing.
  - Mitigation: defaults are the original constants; seams are documented in `doc/AI_TESTING_NOTES.md`; `AcaiaTimings` is immutable.
- Risk: `FakeBleTransport.queueOnConnectResponses` signature change — call sites that relied on `calFlowEst` being absent (i.e., the 12.6 s connect) would now be fast; no test asserted the connect-timeout warning.
  - Mitigation: all affected call sites updated to the new `calFlowEst:` argument; full suite run.

## Follow-up (intentionally deferred)

The remaining top files by active time are the mock-simulation clock bucket: `mock_bengle_scale_test.dart` (~14 s), `mock_scale_flow_driven_test.dart` (~9.6 s), `mock_bengle_steam_probe_test.dart` (~9 s), `mock_bengle_saw_integration_test.dart` (~6.6 s), `mock_bengle_weight_test.dart` (~5.6 s). `SimulatedShotWeightModel` integrates real dt from snapshot timestamps, so it is cadence-invariant but wall-clock-bound; speeding these up requires stamping MockDe1 snapshots with simulated time (tick-count × interval) instead of `DateTime.now()` — a production simulation-model change deferred to a separate PR. Also cheap follow-ups sharing the existing MockDe1 seam: `mock_de1_skip_step_test.dart` and `mock_de1_shot_substates_test.dart`.
