### PR TITLE
fix: round Bengle scaled MMR writes

### DIFF
--- a/.agents/skills/decent-app/scenarios/bengle-integrated-scale.md
+++ b/.agents/skills/decent-app/scenarios/bengle-integrated-scale.md
@@ -1,6 +1,6 @@
 # Scenario: Bengle integrated scale end-to-end
 
-Verifies that when a Bengle is the connected machine, the integrated scale is auto-attached as a virtual scale (no external scale connection needed), capability discovery advertises `integratedScale`, the `/api/v1/scale/*` REST surface and `/ws/v1/scale/snapshot` stream both flow through the integrated scale, and software stop-at-weight (SAW) ends an espresso shot when the integrated scale weight crosses the profile target.
+Verifies that when a Bengle is the connected machine, the integrated scale is auto-attached as a virtual scale (no external scale connection needed), capability discovery advertises all Bengle surfaces, the `/api/v1/scale/*` REST surface and `/ws/v1/scale/snapshot` stream both flow through the integrated scale, and Bengle firmware stops an espresso shot autonomously when the integrated scale weight reaches the configured target.
 
 ## Preconditions
 
@@ -12,7 +12,7 @@ No `--connect-scale` flag. On Bengle the integrated scale always wins — extern
 
 ## Steps
 
-### 1. Capability discovery lists both Bengle surfaces
+### 1. Capability discovery lists all Bengle surfaces
 
 ```bash
 curl -sf http://localhost:8080/api/v1/machine/capabilities | jq .
@@ -21,17 +21,17 @@ curl -sf http://localhost:8080/api/v1/machine/capabilities | jq .
 Expected:
 
 ```json
-{ "capabilities": ["cupWarmer", "integratedScale"] }
+{ "capabilities": ["cupWarmer", "integratedScale", "ledStrip", "stopAtWeight"] }
 ```
 
 Quick assertions:
 
 ```bash
 curl -sf http://localhost:8080/api/v1/machine/capabilities \
-  | jq -e '.capabilities | index("integratedScale") != null and index("cupWarmer") != null'
+  | jq -e '.capabilities | contains(["cupWarmer", "integratedScale", "ledStrip", "stopAtWeight"])'
 ```
 
-Exit 0 → both identifiers present.
+Exit 0 means all four identifiers are present.
 
 ### 2. Scale snapshot stream is alive without an external scale
 
@@ -59,14 +59,22 @@ websocat --no-async-stdio -n -U -t --max-messages-rev 1 \
 
 Expected: a value within ~±0.1 g of zero.
 
-### 4. Run a shot — software SAW stops at the profile target weight
+### 4. Run a shot — Bengle firmware stops at the profile target weight
 
-Upload the bundled flow profile (target weight = 42 g):
+Upload the bundled flow profile (target weight = 36 g):
 
 ```bash
 curl -sf -X POST http://localhost:8080/api/v1/machine/profile \
   -H 'Content-Type: application/json' \
   --data @assets/defaultProfiles/Flow_profile_for_straight_espresso.json
+```
+
+Set the matching workflow target that `BengleSawBridge` writes to firmware:
+
+```bash
+curl -sf -X PUT http://localhost:8080/api/v1/workflow \
+  -H 'Content-Type: application/json' \
+  --data '{"context":{"targetYield":36}}'
 ```
 
 Tare, then start the espresso shot:
@@ -76,20 +84,14 @@ curl -s -X PUT http://localhost:8080/api/v1/scale/tare
 curl -sX PUT http://localhost:8080/api/v1/machine/state/espresso
 ```
 
-Watch the machine snapshot stream — `MockDe1` simulates flow, `MockBengle` integrates flow into weight, `ShotController` projects `weight + flow * multiplier` against `targetYield` (42 g for this profile) and drives the machine to `idle` once the projection crosses the target:
+Watch the machine snapshot stream. `BengleSawBridge` reflects the workflow's 36 g target into the firmware SAW register. `MockBengle` models the firmware by integrating flow into weight and returning the machine to `idle` when that target is reached. `ShotSequencer` observes the machine transition instead of issuing a competing app-side stop:
 
 ```bash
 websocat --no-async-stdio -n -U -t --max-messages-rev 200 \
   ws://localhost:8080/ws/v1/machine/snapshot | jq -c '{state, substate}'
 ```
 
-Expected sequence ends with `state == "idle"` once the integrated scale crosses ~42 g (projection causes the cutoff slightly before the literal reading). Logs show:
-
-```bash
-sb-dev logs -n 60 --filter "ShotController\|target weight"
-```
-
-Expected log line: `Target weight 42.0g reached (projected: ...). Stopping shot.`
+Expected sequence ends with `state == "idle"` once the integrated scale reaches approximately 36 g. The transition originates from `MockBengle`, matching firmware-autonomous SAW.
 
 ### 5. No external scale connection ever happened
 
@@ -108,5 +110,5 @@ scripts/sb-dev.sh stop
 ## Notes
 
 - **Why no `--connect-scale`?** On Bengle, `ConnectionManager` skips the external-scale phase entirely (see `doc/DeviceManagement.md`). Passing `--connect-scale MockScale` will be ignored / overridden by the integrated-scale auto-attach.
-- **Target weight is profile-driven**, not a global default. The bundled `Flow_profile_for_straight_espresso.json` ships with `target_weight: 42.0`. Workflow target weight (when set via `/api/v1/workflow`) overrides per-run; this scenario relies on the profile value alone for simplicity.
-- **Stop is software SAW**, identical to the external-scale path — `ShotController` makes the stop decision; the integrated scale just sources weight via `BengleVirtualScale` instead of a BLE scale.
+- **Profile and workflow targets are set separately.** The bundled `Flow_profile_for_straight_espresso.json` ships with `target_weight: 36`. Uploading it configures the machine profile; the `/api/v1/workflow` update sets the firmware SAW target for this run.
+- **Stop is firmware-autonomous SAW.** Decaid writes `WorkflowContext.targetYield` to `EndOfShotWeight`; Bengle owns the stop decision and the resulting machine state propagates back to Decaid. `MockBengle` models that ownership in simulation.

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -391,10 +391,10 @@ paths:
       description: |
         Returns the optional capability surfaces the currently connected
         machine exposes. Plain DE1s return an empty list; Bengle returns
-        `["cupWarmer", "integratedScale"]` plus any future capabilities
-        as they ship. Skins should query this
-        endpoint once after connect to decide which UI to render and
-        which `/api/v1/machine/...` capability endpoints to call.
+        `["cupWarmer", "integratedScale", "ledStrip", "stopAtWeight"]`
+        plus any future capabilities as they ship. Skins should query this
+        endpoint once after connect to decide which UI to render and which
+        `/api/v1/machine/...` capability endpoints to call.
       tags: [Machine]
       responses:
         "200":

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -689,7 +689,7 @@ class UnifiedDe1 implements De1Interface {
   @protected
   Future<void> writeMmrScaled(MmrAddress addr, double value) async {
     _assertKind(addr, const {MmrValueKind.scaledFloat}, 'writeMmrScaled');
-    final scaled = (value * addr.writeScale).toInt();
+    final scaled = (value * addr.writeScale).round();
     if (addr is MMRItem) return _writeMMRInt(addr, scaled);
     final clamped = (addr.min != null && addr.max != null)
         ? scaled.clamp(addr.min!, addr.max!)

--- a/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart
@@ -219,6 +219,26 @@ void main() {
       expect(payload.getInt32(0, Endian.little), 500);
     });
 
+    test('writeMmrScaled rounds Bengle stop-at-weight writes', () async {
+      transport.writes.clear();
+      await de1.capWriteScaled(BengleScaleMmr.endOfShotWeight, 2.3);
+      final frame = transport.writes.firstWhere(
+        (write) => write.characteristicUUID == Endpoint.writeToMMR.uuid,
+      );
+      final payload = ByteData.sublistView(frame.data, 4, 8);
+      expect(payload.getInt32(0, Endian.little), 230);
+    });
+
+    test('plain DE1 scaled writes keep truncating', () async {
+      transport.writes.clear();
+      await de1.setSteamFlow(2.3);
+      final frame = transport.writes.firstWhere(
+        (write) => write.characteristicUUID == Endpoint.writeToMMR.uuid,
+      );
+      final payload = ByteData.sublistView(frame.data, 4, 8);
+      expect(payload.getInt32(0, Endian.little), 229);
+    });
+
     test(
       'notificationsFor(shotSample) routes to transport shotSample',
       () async {


### PR DESCRIPTION
## Summary

- Problem: protected capability MMR writes truncated scaled doubles, so a Bengle 2.3 g stop target could serialize as raw 229 instead of 230.
- Why it matters: firmware should receive the nearest representable scaled value; floating-point representation must not bias targets downward.
- What changed: round protected scaled writes, lock Bengle and private DE1 behavior with regressions, correct the capability description, and revise the MockBengle integrated-scale scenario for firmware-autonomous SAW.
- What did NOT change (scope boundary): no SAW range, readback, tare, or A013 work already delivered by #601; no public API shape or private DE1 serialization change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [x] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Related #462
- Related #601

## Root Cause (if bug fix)

- Root cause: `(value * scale).toInt()` truncates binary floating-point products such as `2.3 * 100`, which can be represented just below 230.
- Missing detection or guardrail: no regression distinguished the protected capability writer from the legacy private DE1 writer.
- Contributing context (if known): #601 established the current Bengle SAW path, leaving only this serialization residual from #462.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [x] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/unit/models/device/impl/de1/unified_de1/protected_surface_test.dart`
- Scenario the test should lock in: Bengle `endOfShotWeight = 2.3` writes raw 230 while plain DE1 `setSteamFlow(2.3)` remains raw 229.
- If no new test added, why not: N/A

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A - no docs affected

Only the existing OpenAPI operation description and existing regression scenario were stale; endpoint behavior and user-facing API documentation did not change.

## Security Impact (required)

- New or changed REST endpoints? (`Yes/No`): No
- New or changed WebSocket topics? (`Yes/No`): No
- New or changed network calls? (`Yes/No`): No
- BLE/USB surface changed? (`Yes/No`): Yes
- File system access changed? (`Yes/No`): No
- Plugin sandbox boundary changed? (`Yes/No`): No
- If any `Yes`, explain risk and mitigation: protected non-DE1 scaled MMR payloads now use nearest-integer rounding. Existing kind and range checks remain, and a regression proves the private DE1 path is unchanged.

## User-Visible Changes

Bengle scaled capability values are encoded to the nearest firmware unit. Capability documentation now lists `cupWarmer`, `integratedScale`, `ledStrip`, and `stopAtWeight`.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` - no remaining changes
- [x] `flutter analyze` - clean (no new warnings)
- [ ] `flutter test` - all pass
- [ ] `./scripts/fetch_dye2_plugin.sh` - DYE2 plugin installed into `assets/plugins/dye2.reaplugin/`

Focused tests: 15 passed. The full suite ran to completion; its only failure was the pre-existing Windows CRLF-sensitive assertion in `test/connect_result_schema_test.dart`.

The fetch script could not be rerun because WSL startup is denied and `jq` is unavailable in this Windows shell. The existing bundled DYE2 v0.1.4 manifest, API version, permissions, and `createPlugin` entry point were validated locally.

### Manual verification (if applicable)

- OS / platform tested: Windows
- Simulated devices? (`simulate=1`): Yes
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: ran the revised flow with a handler-level MockBengle smoke harness; capabilities were exactly `cupWarmer`, `integratedScale`, `ledStrip`, and `stopAtWeight`, and firmware-autonomous SAW returned the machine to `idle` at 36.17 g.
- Edge cases checked: raw 230 Bengle rounding, raw 229 private DE1 truncation, all four capabilities, autonomous idle transition.
- What you did **not** verify: real hardware or a native Windows live app. The local native build is blocked by VS2019/CMake and `universal_ble` runtime incompatibilities.

### Evidence

- [x] Test output (failing before + passing after)
- [x] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

Before the implementation change, the focused Bengle regression reported raw 229 instead of 230. Afterward all 15 focused tests passed.

## Compatibility & Migration

- Backward compatible? (`Yes/No`): Yes
- Config / env changes needed? (`Yes/No`): No
- Database migration needed? (`Yes/No`): No
- If any `No` or `Yes`, explain exact steps: no migration or configuration changes are required.

## Risks & Mitigations

- Risk: all protected non-DE1 scaled capability writes now round rather than truncate.
  - Mitigation: address kind/range handling remains unchanged, focused tests cover Bengle and legacy private DE1 behavior, and the full analyzer is clean.