### PR TITLE
fix: iOS security-scoped folder access for plugin install and folder-based imports

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -186,6 +186,13 @@ jobs:
           cache: true
           pub-cache: true
 
+      - name: Flutter pub get
+        run: flutter pub get
+
+      # dart format reads the formatter: section of analysis_options.yaml
+      # (page_width: 80). That include references package:flutter_lints, so
+      # pub get must run first or the formatter config is silently dropped
+      # and the check disagrees with locally formatted files.
       - name: Dart format check
         shell: bash
         env:
@@ -196,9 +203,6 @@ jobs:
           git diff --name-only --diff-filter=ACMR -z \
             "$BASE_SHA...$HEAD_SHA" -- '*.dart' | \
             xargs -0 -r dart format --output=none --set-exit-if-changed --
-
-      - name: Flutter pub get
-        run: flutter pub get
 
       # pubspec references assets/plugins/dye2.reaplugin/ and
       # assets/bundled_skins/. Both are build outputs, not checked in,

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -243,6 +243,14 @@ jobs:
             flutter test --no-pub --machine | \
             tee build/test-results/flutter-events.json
 
+      - name: Gate slow test suites
+        if: ${{ success() && hashFiles('build/test-results/flutter-events.json') != '' }}
+        shell: bash
+        run: |
+          python3 tool/ci/summarize_flutter_tests.py \
+            build/test-results/flutter-events.json \
+            --max-active-ms 20000
+
       - name: Summarize Flutter tests
         if: ${{ always() && hashFiles('build/test-results/flutter-events.json') != '' }}
         continue-on-error: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,6 +12,12 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   exclude:
     - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 # Formatter configuration (Dart 3.7+). `dart format` and CI's
 # `dart format --set-exit-if-changed lib test` use this.

--- a/doc/AI_BUILD_NOTES.md
+++ b/doc/AI_BUILD_NOTES.md
@@ -171,6 +171,16 @@ temporary real-hardware tuning builds where debug endpoints must be reachable.
 
 **Note (App Store):** `com.apple.security.temporary-exception.mach-lookup.global-name` is not permitted in Mac App Store builds. Any future `APP_STORE=true` macOS build must drop the Sparkle keys/entitlements and keep self-update disabled.
 
+## Footgun #5: iOS file picker returns unreadable security-scoped folders
+
+**Symptom:** On iOS, installing a plugin (or importing a de1app folder, skin live-edit, data restore) via the file picker fails with `PathAccessException: Directory listing failed ... (OS Error: Operation not permitted, errno = 1)`. The picked path lives under `Mobile Documents/com~apple~CloudDocs/...` (iCloud Drive) or another app's sandbox — outside our container.
+
+**Root cause:** `FilePicker.getDirectoryPath()` uses `UIDocumentPickerModeOpen`, which hands the app a *security-scoped* URL. Reading it requires `startAccessingSecurityScopedResource()`, which file_picker never calls — it only returns `url.path`. The app has no `UIFileSharingEnabled`/iCloud entitlement, so its own Documents folder is not browsable in Files either.
+
+**Fix (PR #609):** `SecurityScopedFilePlugin` (`ios/Runner/AppDelegate.swift`, channel `com.reaprime/security_scoped`) calls `startAccessingSecurityScopedResource` on the reconstructed URL and retains it until Dart releases it. `SecurityScopedFileService` (Dart) wraps every `getDirectoryPath` pick site: plugin install, de1app import, skin live-edit, data restore. The service auto-releases the previously held folder on the next pick, keeping the native registry bounded; `stopAccessing` releases explicitly (plugin install releases after the staged copy). Access is deliberately held for the session for long-lived flows (skin live-edit serves the folder over HTTP on demand).
+
+**Impact:** iOS only; the channel is a no-op elsewhere (`Platform.isIOS` guard). Do not add new `FilePicker.getDirectoryPath()` consumers without routing them through `SecurityScopedFileService`.
+
 ## CLI Parameters
 
 The app supports several command-line flags for headless/calibration-station use. See PR #349 and #352 for full details.

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -18,12 +18,6 @@ import UIKit
   }
 }
 
-/// Grants temporary read access to directories picked through the iOS
-/// document picker. file_picker's getDirectoryPath uses
-/// UIDocumentPickerModeOpen, which returns security-scoped URLs: the app
-/// must call startAccessingSecurityScopedResource and keep the URL alive
-/// while it reads the contents. Dart calls startAccessing before copying
-/// the directory and stopAccessing afterwards.
 class SecurityScopedFilePlugin: NSObject, FlutterPlugin {
   private static var active: [String: URL] = [:]
 

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -12,5 +12,53 @@ import UIKit
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+    if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "SecurityScopedFile") {
+      SecurityScopedFilePlugin.register(with: registrar)
+    }
+  }
+}
+
+/// Grants temporary read access to directories picked through the iOS
+/// document picker. file_picker's getDirectoryPath uses
+/// UIDocumentPickerModeOpen, which returns security-scoped URLs: the app
+/// must call startAccessingSecurityScopedResource and keep the URL alive
+/// while it reads the contents. Dart calls startAccessing before copying
+/// the directory and stopAccessing afterwards.
+class SecurityScopedFilePlugin: NSObject, FlutterPlugin {
+  private static var active: [String: URL] = [:]
+
+  static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(
+      name: "com.reaprime/security_scoped",
+      binaryMessenger: registrar.messenger()
+    )
+    registrar.addMethodCallDelegate(SecurityScopedFilePlugin(), channel: channel)
+  }
+
+  func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    guard let path = call.arguments as? String else {
+      result(FlutterError(code: "badArguments", message: "expected path string", details: nil))
+      return
+    }
+    let url = URL(fileURLWithPath: path)
+    switch call.method {
+    case "startAccessing":
+      guard Self.active[path] == nil else {
+        result(true)
+        return
+      }
+      let ok = url.startAccessingSecurityScopedResource()
+      if ok {
+        Self.active[path] = url
+      }
+      result(ok)
+    case "stopAccessing":
+      if let url = Self.active.removeValue(forKey: path) {
+        url.stopAccessingSecurityScopedResource()
+      }
+      result(true)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -177,8 +177,9 @@ void main(List<String> args) async {
 
   final appDocsPath = (await getApplicationDocumentsDirectory()).path;
 
-  RotatingFileAppender(baseFilePath: '$appDocsPath/log.txt')
-      .attachToLogger(Logger.root);
+  RotatingFileAppender(
+    baseFilePath: '$appDocsPath/log.txt',
+  ).attachToLogger(Logger.root);
 
   final webViewLogDir = appDocsPath;
   final webViewLogService = WebViewLogService(logDirectoryPath: webViewLogDir);

--- a/lib/src/import/widgets/import_source_picker.dart
+++ b/lib/src/import/widgets/import_source_picker.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:saf_util/saf_util.dart';
+import 'package:reaprime/src/services/security_scoped_file.dart';
 import 'package:reaprime/src/widgets/accessible_button.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
@@ -31,8 +32,13 @@ class ImportSourcePicker extends StatelessWidget {
       final path = await FilePicker.getDirectoryPath(
         dialogTitle: 'Select your de1plus folder',
       );
-      if (path != null && context.mounted) {
-        onDe1appFolderSelected(path);
+      if (path != null) {
+        if (Platform.isIOS) {
+          await SecurityScopedFileService.startAccessing(path);
+        }
+        if (context.mounted) {
+          onDe1appFolderSelected(path);
+        }
       }
     }
   }

--- a/lib/src/models/device/impl/mock_de1/mock_de1.dart
+++ b/lib/src/models/device/impl/mock_de1/mock_de1.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:clock/clock.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
@@ -63,7 +64,7 @@ class MockDe1 implements De1Interface, SimulatedDevice {
     targetPressure: 0,
     targetMixTemperature: 0,
     targetGroupTemperature: 0,
-    timestamp: DateTime.now(),
+    timestamp: clock.now(),
     groupTemperature: 0,
     mixTemperature: 0,
     pressure: 0,
@@ -163,7 +164,7 @@ class MockDe1 implements De1Interface, SimulatedDevice {
   @override
   DeviceType get type => DeviceType.machine;
 
-  DateTime lastIdleSnapshot = DateTime.now();
+  DateTime lastIdleSnapshot = clock.now();
   void _simulateState() {
     _snapshotStream.add(_lastSnapshot);
 
@@ -177,11 +178,10 @@ class MockDe1 implements De1Interface, SimulatedDevice {
           newSnapshot = _simulateHotWater();
           break;
         case _SimulationType.idle:
-          if (DateTime.now().difference(lastIdleSnapshot).inMilliseconds <
-              500) {
+          if (clock.now().difference(lastIdleSnapshot).inMilliseconds < 500) {
             return;
           }
-          lastIdleSnapshot = DateTime.now();
+          lastIdleSnapshot = clock.now();
           newSnapshot = _simulateIdle();
         default:
           newSnapshot = _simulateIdle();
@@ -249,7 +249,7 @@ class MockDe1 implements De1Interface, SimulatedDevice {
     }
 
     shotTime +=
-        DateTime.now().millisecondsSinceEpoch -
+        clock.now().millisecondsSinceEpoch -
         _lastSnapshot.timestamp.millisecondsSinceEpoch;
 
     if (_currentProfile != null && _currentProfile!.steps.isNotEmpty) {
@@ -414,7 +414,7 @@ class MockDe1 implements De1Interface, SimulatedDevice {
     }
 
     return MachineSnapshot(
-      timestamp: DateTime.now(),
+      timestamp: clock.now(),
       state: MachineStateSnapshot(state: _currentState, substate: substate),
       flow: newFlow,
       pressure: newPressure,
@@ -448,7 +448,7 @@ class MockDe1 implements De1Interface, SimulatedDevice {
     final newFlow =
         _lastSnapshot.flow + (targetFlow - _lastSnapshot.flow) * 0.35;
     return MachineSnapshot(
-      timestamp: DateTime.now(),
+      timestamp: clock.now(),
       state: MachineStateSnapshot(
         state: _currentState,
         substate: done ? MachineSubstate.idle : MachineSubstate.pouring,
@@ -476,7 +476,7 @@ class MockDe1 implements De1Interface, SimulatedDevice {
 
   MachineSnapshot _fallbackEspressoSimulation(MachineSubstate substate) {
     return MachineSnapshot(
-      timestamp: DateTime.now(),
+      timestamp: clock.now(),
       state: MachineStateSnapshot(state: _currentState, substate: substate),
       flow: min(_lastSnapshot.flow + 0.05, 4.0),
       pressure: min(_lastSnapshot.pressure + 0.04, 9.0),

--- a/lib/src/models/device/impl/replay/mock_replay_de1.dart
+++ b/lib/src/models/device/impl/replay/mock_replay_de1.dart
@@ -11,6 +11,7 @@ import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/firmware_update_state.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
 import 'package:reaprime/src/models/device/impl/replay/shot_replayer.dart';
+import 'package:clock/clock.dart';
 import 'package:reaprime/src/models/device/impl/simulated_shot_weight_model.dart';
 import 'package:reaprime/src/models/device/led_strip.dart';
 import 'package:reaprime/src/models/device/machine.dart';
@@ -40,7 +41,7 @@ class MockReplayDe1 implements BengleInterface, SimulatedDevice {
   Profile? _profile;
   String? _forcedShotId;
   ShotReplayer? _replayer;
-  DateTime _replayStartedAt = DateTime.now();
+  DateTime _replayStartedAt = clock.now();
   double _replayWeightGrams = 0.0;
   double _originalDurationSeconds = 0.0;
 
@@ -132,7 +133,7 @@ class MockReplayDe1 implements BengleInterface, SimulatedDevice {
 
   void _seekToNextFrame() {
     final replayer = _replayer!;
-    final now = DateTime.now();
+    final now = clock.now();
     final replayElapsed =
         now.difference(_replayStartedAt).inMilliseconds / 1000.0 - _prepSeconds;
     final boundary = replayer.nextFrameBoundaryAfter(replayElapsed);
@@ -160,7 +161,7 @@ class MockReplayDe1 implements BengleInterface, SimulatedDevice {
     _replayer = ShotReplayer(shot.measurements);
     _originalDurationSeconds =
         _library.originalDurationOf(shot.id) ?? _replayer!.durationSeconds;
-    _replayStartedAt = DateTime.now();
+    _replayStartedAt = clock.now();
   }
 
   List<SimulatedShot> get availableShots => _library.catalog;
@@ -179,7 +180,7 @@ class MockReplayDe1 implements BengleInterface, SimulatedDevice {
   void _tick() {
     final replayer = _replayer;
     if (replayer == null || _state != MachineState.espresso) return;
-    final now = DateTime.now();
+    final now = clock.now();
     final elapsed = now.difference(_replayStartedAt).inMilliseconds / 1000.0;
 
     // A synthetic pre-shot phase runs first with the scale held at 0; the
@@ -226,11 +227,7 @@ class MockReplayDe1 implements BengleInterface, SimulatedDevice {
   void _emitWeight(double grams) {
     if (_weight.isClosed) return;
     _weight.add(
-      ScaleSnapshot(
-        timestamp: DateTime.now(),
-        weight: grams,
-        batteryLevel: 100,
-      ),
+      ScaleSnapshot(timestamp: clock.now(), weight: grams, batteryLevel: 100),
     );
   }
 

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -137,7 +137,11 @@ class PluginLoaderService {
 
     final pluginDir = Directory('${_pluginsDir.path}/${manifest.id}');
     if (pluginDir.existsSync()) {
-      throw Exception('Plugin already installed: ${manifest.id}');
+      if (isPluginLoaded(manifest.id)) {
+        await unloadPlugin(manifest.id);
+      }
+      await pluginDir.delete(recursive: true);
+      _log.info('Replacing existing plugin: ${manifest.id}');
     }
 
     pluginDir.createSync(recursive: true);

--- a/lib/src/services/security_scoped_file.dart
+++ b/lib/src/services/security_scoped_file.dart
@@ -12,15 +12,24 @@ class SecurityScopedFileService {
   static const MethodChannel _channel = MethodChannel(
     'com.reaprime/security_scoped',
   );
+  static String? _activePath;
 
   static Future<bool> startAccessing(String path) async {
     if (!Platform.isIOS) return true;
+    final previous = _activePath;
+    _activePath = path;
+    if (previous != null && previous != path) {
+      await _channel.invokeMethod('stopAccessing', previous);
+    }
     final bool? ok = await _channel.invokeMethod('startAccessing', path);
     return ok ?? false;
   }
 
   static Future<void> stopAccessing(String path) async {
     if (!Platform.isIOS) return;
+    if (_activePath == path) {
+      _activePath = null;
+    }
     await _channel.invokeMethod('stopAccessing', path);
   }
 }

--- a/lib/src/services/security_scoped_file.dart
+++ b/lib/src/services/security_scoped_file.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+/// Grants temporary read access to directories picked through the iOS
+/// document picker. file_picker's getDirectoryPath uses
+/// UIDocumentPickerModeOpen, which returns security-scoped URLs that fail
+/// with EPERM unless the app starts accessing them.
+class SecurityScopedFileService {
+  SecurityScopedFileService._();
+
+  static const MethodChannel _channel = MethodChannel(
+    'com.reaprime/security_scoped',
+  );
+
+  static Future<bool> startAccessing(String path) async {
+    if (!Platform.isIOS) return true;
+    final bool? ok = await _channel.invokeMethod('startAccessing', path);
+    return ok ?? false;
+  }
+
+  static Future<void> stopAccessing(String path) async {
+    if (!Platform.isIOS) return;
+    await _channel.invokeMethod('stopAccessing', path);
+  }
+}

--- a/lib/src/services/security_scoped_file.dart
+++ b/lib/src/services/security_scoped_file.dart
@@ -2,10 +2,6 @@ import 'dart:io';
 
 import 'package:flutter/services.dart';
 
-/// Grants temporary read access to directories picked through the iOS
-/// document picker. file_picker's getDirectoryPath uses
-/// UIDocumentPickerModeOpen, which returns security-scoped URLs that fail
-/// with EPERM unless the app starts accessing them.
 class SecurityScopedFileService {
   SecurityScopedFileService._();
 

--- a/lib/src/services/simulated_shot_library.dart
+++ b/lib/src/services/simulated_shot_library.dart
@@ -65,9 +65,9 @@ class SimulatedShotLibrary {
   Future<void> ensureLoaded() async {
     if (_loaded) return;
     try {
-      final manifest = jsonDecode(
-        await _bundle.loadString(manifestPath),
-      ) as Map<String, dynamic>;
+      final manifest =
+          jsonDecode(await _bundle.loadString(manifestPath))
+              as Map<String, dynamic>;
       final dir = manifestPath.substring(0, manifestPath.lastIndexOf('/') + 1);
 
       for (final entry in (manifest['fallback'] as List? ?? [])) {

--- a/lib/src/settings/data_management_page.dart
+++ b/lib/src/settings/data_management_page.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:reaprime/src/services/security_scoped_file.dart';
 import 'package:reaprime/src/util/rot13.dart';
 import 'package:reaprime/src/controllers/persistence_controller.dart';
 import 'package:reaprime/src/feedback_feature/feedback_view.dart';
@@ -749,6 +750,10 @@ class _DataManagementPageState extends State<DataManagementPage> {
       );
     }
     if (folderPath == null) return;
+
+    if (Platform.isIOS) {
+      await SecurityScopedFileService.startAccessing(folderPath);
+    }
     if (!mounted) return;
 
     try {

--- a/lib/src/settings/plugins_settings_view.dart
+++ b/lib/src/settings/plugins_settings_view.dart
@@ -7,6 +7,7 @@ import 'package:saf_util/saf_util.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/services/security_scoped_file.dart';
 
 const _maxPluginSafDepth = 32;
 const _maxPluginSafEntries = 10000;
@@ -452,7 +453,23 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
         if (!selected.endsWith('.reaplugin')) {
           throw Exception('selection is not a .reaplugin');
         }
-        await _copyDirectoryRecursively(Directory(selected), tempDir);
+        if (Platform.isIOS) {
+          final accessed = await SecurityScopedFileService.startAccessing(
+            selected,
+          );
+          if (!accessed) {
+            throw Exception(
+              'iOS denied read access to picked folder: $selected',
+            );
+          }
+        }
+        try {
+          await _copyDirectoryRecursively(Directory(selected), tempDir);
+        } finally {
+          if (Platform.isIOS) {
+            await SecurityScopedFileService.stopAccessing(selected);
+          }
+        }
       }
 
       await widget.pluginLoaderService.addPlugin(tempDir.path);

--- a/lib/src/skin_selector/skin_selector_page.dart
+++ b/lib/src/skin_selector/skin_selector_page.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
+import 'package:reaprime/src/services/security_scoped_file.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/skin_feature/skin_view.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
@@ -561,6 +562,9 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
     final selectedDirectory = await FilePicker.getDirectoryPath();
 
     if (selectedDirectory != null) {
+      if (Platform.isIOS) {
+        await SecurityScopedFileService.startAccessing(selectedDirectory);
+      }
       final indexFile = File('$selectedDirectory/index.html');
       final itExists = await indexFile.exists();
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -860,10 +860,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -981,10 +981,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -997,10 +997,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: "direct main"
     description:
@@ -1666,10 +1666,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   theme_extensions_builder_annotation:
     dependency: transitive
     description:
@@ -1828,10 +1828,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:

--- a/test/models/device/impl/replay/mock_replay_de1_test.dart
+++ b/test/models/device/impl/replay/mock_replay_de1_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/device/impl/replay/mock_replay_de1.dart';
@@ -129,20 +130,28 @@ void main() {
       }
     });
 
-    test('autonomous stop-at-weight stops the shot at target', () async {
+    test('autonomous stop-at-weight stops the shot at target', () {
       // milky-drinks reaches the target early, keeping the test short.
-      final machine = MockReplayDe1(library: library);
-      await machine.setProfile(_profile('Flow profile for milky drinks'));
-      await machine.onConnect();
-      await machine.setStopAtWeightTarget(3);
-      await machine.requestState(MachineState.espresso);
+      fakeAsync((async) {
+        final machine = MockReplayDe1(library: library);
+        machine.setProfile(_profile('Flow profile for milky drinks'));
+        machine.onConnect();
+        machine.setStopAtWeightTarget(3);
+        machine.requestState(MachineState.espresso);
 
-      final idle = await machine.currentSnapshot
-          .firstWhere((s) => s.state.state == MachineState.idle)
-          .timeout(const Duration(seconds: 15));
-      await machine.disconnect();
+        var idleSeen = false;
+        machine.currentSnapshot.listen((s) {
+          if (s.state.state == MachineState.idle) idleSeen = true;
+        });
 
-      expect(idle.state.state, MachineState.idle);
+        async.elapse(const Duration(seconds: 20));
+        async.flushMicrotasks();
+
+        expect(idleSeen, isTrue, reason: 'shot should stop at the 3g target');
+
+        machine.disconnect();
+        async.flushMicrotasks();
+      });
     });
 
     test('debug selection forces a specific recording', () async {
@@ -210,84 +219,107 @@ void main() {
       },
     );
 
-    test('the integrated scale produces weight during hot water', () async {
-      final machine = MockReplayDe1(library: library);
-      await machine.onConnect();
-      await machine.requestState(MachineState.hotWater);
-
-      final weights = await machine.weightSnapshot
-          .map((s) => s.weight)
-          .take(50)
-          .toList()
-          .timeout(const Duration(seconds: 8));
-      await machine.disconnect();
-
-      expect(
-        weights.any((w) => w > 0.5),
-        isTrue,
-        reason: 'hot water should accumulate integrated-scale weight',
-      );
-    });
-
-    test('autonomous stop-at-weight terminates hot water at target', () async {
-      final machine = MockReplayDe1(library: library);
-      await machine.onConnect();
-      await machine.setStopAtWeightTarget(2);
-
-      var poured = false;
-      double lastWeight = 0;
-      final stopped = Completer<double>();
-      final weightSub = machine.weightSnapshot.listen(
-        (s) => lastWeight = s.weight,
-      );
-      final stateSub = machine.currentSnapshot.listen((s) {
-        if (s.state.substate == MachineSubstate.pouring) poured = true;
-        if (poured &&
-            s.state.state == MachineState.idle &&
-            !stopped.isCompleted) {
-          stopped.complete(lastWeight);
-        }
-      });
-
-      await machine.requestState(MachineState.hotWater);
-      final stopWeight = await stopped.future.timeout(
-        const Duration(seconds: 20),
-      );
-
-      await weightSub.cancel();
-      await stateSub.cancel();
-      await machine.disconnect();
-
-      expect(
-        stopWeight,
-        greaterThanOrEqualTo(2),
-        reason: 'hot water must run until the integrated scale reaches target',
-      );
-    });
-
-    test(
-      'without a target, replay ends at the recording, not the tail',
-      () async {
+    test('the integrated scale produces weight during hot water', () {
+      fakeAsync((async) {
         final machine = MockReplayDe1(library: library);
-        await machine.setProfile(_profile('Extractamundo Dos!'));
-        await machine.onConnect();
-        await machine.requestState(MachineState.espresso);
+        machine.onConnect();
+        machine.requestState(MachineState.hotWater);
 
-        final start = DateTime.now();
-        await machine.currentSnapshot
-            .firstWhere((s) => s.state.state == MachineState.idle)
-            .timeout(const Duration(seconds: 50));
-        final elapsed = DateTime.now().difference(start).inSeconds;
-        await machine.disconnect();
+        final weights = <double>[];
+        machine.weightSnapshot.listen((s) => weights.add(s.weight));
+
+        async.elapse(const Duration(seconds: 8));
+        async.flushMicrotasks();
 
         expect(
-          elapsed,
-          lessThan(60),
+          weights.any((w) => w > 0.5),
+          isTrue,
+          reason: 'hot water should accumulate integrated-scale weight',
+        );
+
+        machine.disconnect();
+        async.flushMicrotasks();
+      });
+    });
+
+    test('autonomous stop-at-weight terminates hot water at target', () {
+      fakeAsync((async) {
+        final machine = MockReplayDe1(library: library);
+        machine.onConnect();
+        machine.setStopAtWeightTarget(2);
+
+        var poured = false;
+        double lastWeight = 0;
+        var stopWeight = 0.0;
+        final stopped = Completer<void>();
+        final weightSub = machine.weightSnapshot.listen(
+          (s) => lastWeight = s.weight,
+        );
+        final stateSub = machine.currentSnapshot.listen((s) {
+          if (s.state.substate == MachineSubstate.pouring) poured = true;
+          if (poured &&
+              s.state.state == MachineState.idle &&
+              !stopped.isCompleted) {
+            stopWeight = lastWeight;
+            stopped.complete();
+          }
+        });
+
+        machine.requestState(MachineState.hotWater);
+        async.elapse(const Duration(seconds: 15));
+        async.flushMicrotasks();
+
+        expect(
+          stopped.isCompleted,
+          isTrue,
+          reason:
+              'hot water must run until the integrated scale reaches target',
+        );
+        expect(
+          stopWeight,
+          greaterThanOrEqualTo(2),
+          reason: 'stop weight must reach the 2g target',
+        );
+
+        weightSub.cancel();
+        stateSub.cancel();
+        machine.disconnect();
+        async.flushMicrotasks();
+      });
+    });
+
+    test('without a target, replay ends at the recording, not the tail', () {
+      fakeAsync((async) {
+        final machine = MockReplayDe1(library: library);
+        machine.setProfile(_profile('Extractamundo Dos!'));
+        machine.onConnect();
+        machine.requestState(MachineState.espresso);
+
+        var idleSeen = false;
+        machine.currentSnapshot.listen((s) {
+          if (s.state.state == MachineState.idle) idleSeen = true;
+        });
+
+        async.elapse(const Duration(seconds: 10));
+        async.flushMicrotasks();
+        expect(
+          idleSeen,
+          isFalse,
+          reason: 'must not end before the recording plays',
+        );
+
+        async.elapse(const Duration(seconds: 25));
+        async.flushMicrotasks();
+        expect(
+          idleSeen,
+          isTrue,
           reason: 'should end near the ~23s recording, not the ~150s tail',
         );
-        expect(elapsed, greaterThan(15), reason: 'should play the recording');
-      },
-    );
+
+        machine.disconnect();
+        async.flushMicrotasks();
+      });
+    });
 
     test('steam falls back to synthetic device telemetry', () async {
       final machine = MockReplayDe1(library: library);

--- a/test/plugin_loader_service_appstore_test.dart
+++ b/test/plugin_loader_service_appstore_test.dart
@@ -176,6 +176,20 @@ function createPlugin() {
       expect(service.availablePlugins.any((m) => m.id == id), isTrue);
     });
 
+    test('addPlugin replaces an already-installed plugin', () async {
+      const id = 'replaced.reaplugin';
+      await service.addPlugin(makePluginSource(id).path);
+
+      final updatedSource = makePluginSource(id);
+      File('${updatedSource.path}/v2.txt').writeAsStringSync('v2');
+
+      await service.addPlugin(updatedSource.path);
+
+      final pluginDir = Directory('${tempDir.path}/plugins/$id');
+      expect(pluginDir.existsSync(), isTrue);
+      expect(File('${pluginDir.path}/v2.txt').existsSync(), isTrue);
+    });
+
     test('removePlugin deletes the installed plugin directory', () async {
       const id = 'removable.reaplugin';
       await service.addPlugin(makePluginSource(id).path);

--- a/test/plugins/plugin_manager_permissions_test.dart
+++ b/test/plugins/plugin_manager_permissions_test.dart
@@ -62,7 +62,6 @@ void main() {
 
     await load({PluginPermissions.log}, 'host.log("allowed");');
 
-    // The log record is delivered through an async bridge channel.
     await Future<void>.delayed(const Duration(milliseconds: 50));
 
     expect(

--- a/test/plugins/plugin_manager_permissions_test.dart
+++ b/test/plugins/plugin_manager_permissions_test.dart
@@ -45,7 +45,7 @@ void main() {
   Matcher permissionError(String permission) => throwsA(
     predicate(
       (error) =>
-          error.toString().contains('PluginPermissionError') &&
+          error.toString().contains('requires manifest permission') &&
           error.toString().contains(permission),
     ),
   );
@@ -61,6 +61,9 @@ void main() {
     });
 
     await load({PluginPermissions.log}, 'host.log("allowed");');
+
+    // The log record is delivered through an async bridge channel.
+    await Future<void>.delayed(const Duration(milliseconds: 50));
 
     expect(
       records.any(

--- a/tool/ci/summarize_flutter_tests.py
+++ b/tool/ci/summarize_flutter_tests.py
@@ -174,6 +174,14 @@ def _escape(value):
     )
 
 
+def suites_over_limit(report, max_active_ms):
+    return [
+        item
+        for item in report["files"]
+        if (item["active_ms"] or 0) > max_active_ms
+    ]
+
+
 def render_summary(report):
     result = {True: "Passed", False: "Failed"}.get(report["run_success"], "Unknown")
     lines = [
@@ -260,10 +268,20 @@ def _write_summary(markdown):
 def main(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("events", type=Path)
+    parser.add_argument(
+        "--max-active-ms",
+        type=int,
+        default=None,
+        help=(
+            "Gate mode: exit 1 when any test file's active time exceeds "
+            "this many ms. Suppresses the markdown summary."
+        ),
+    )
     args = parser.parse_args(argv)
     try:
         with args.events.open(encoding="utf-8", errors="replace") as events:
-            markdown = render_summary(parse_events(events))
+            report = parse_events(events)
+        markdown = render_summary(report)
     except Exception as error:
         message = _escape(error)
         markdown = (
@@ -272,6 +290,26 @@ def main(argv=None):
             "The Flutter test step exit status remains authoritative.\n"
         )
         print(f"Flutter timing summary unavailable: {error}", file=sys.stderr)
+        report = None
+
+    if args.max_active_ms is not None:
+        if report is None:
+            return 0
+        offenders = suites_over_limit(report, args.max_active_ms)
+        if offenders:
+            print(
+                f"{len(offenders)} test suite(s) exceed the "
+                f"{args.max_active_ms} ms active-time limit:",
+                file=sys.stderr,
+            )
+            for item in offenders:
+                print(
+                    f"  {item['path']}: {_format_duration(item['active_ms'])}",
+                    file=sys.stderr,
+                )
+            return 1
+        return 0
+
     try:
         _write_summary(markdown)
     except OSError as error:

--- a/tool/ci/summarize_flutter_tests_test.py
+++ b/tool/ci/summarize_flutter_tests_test.py
@@ -238,7 +238,6 @@ class SummarizeFlutterTestsTest(unittest.TestCase):
                     [events, "--max-active-ms", "20000"]
                 )
         self.assertEqual(exit_code, 0)
-        # Gate mode suppresses the markdown summary.
         self.assertFalse(os.path.exists(summary_path))
 
     def test_active_time_limit_fails_when_a_suite_is_over(self):

--- a/tool/ci/summarize_flutter_tests_test.py
+++ b/tool/ci/summarize_flutter_tests_test.py
@@ -218,6 +218,68 @@ class SummarizeFlutterTestsTest(unittest.TestCase):
         self.assertEqual(report["tests"], [])
         self.assertIn("Unavailable", markdown)
 
+    def test_active_time_limit_passes_when_all_suites_are_under(self):
+        lines = [
+            _event("start"),
+            _suite(0, "test/quick_test.dart"),
+            _test_start(1, 0, "first", 100),
+            _test_done(1, 2000),
+            _event("done", success=True),
+        ]
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            events = os.path.join(temporary_directory, "events.json")
+            with open(events, "w", encoding="utf-8") as events_file:
+                events_file.write("\n".join(lines))
+            summary_path = os.path.join(temporary_directory, "summary.md")
+            with mock.patch.dict(
+                os.environ, {"GITHUB_STEP_SUMMARY": summary_path}, clear=False
+            ):
+                exit_code = summarize_flutter_tests.main(
+                    [events, "--max-active-ms", "20000"]
+                )
+        self.assertEqual(exit_code, 0)
+        # Gate mode suppresses the markdown summary.
+        self.assertFalse(os.path.exists(summary_path))
+
+    def test_active_time_limit_fails_when_a_suite_is_over(self):
+        lines = [
+            _event("start"),
+            _suite(0, "test/slow_test.dart"),
+            _test_start(1, 0, "first", 100),
+            _test_done(1, 21000),
+            _event("done", success=True),
+        ]
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            events = os.path.join(temporary_directory, "events.json")
+            with open(events, "w", encoding="utf-8") as events_file:
+                events_file.write("\n".join(lines))
+            with mock.patch.dict(
+                os.environ, {"GITHUB_STEP_SUMMARY": ""}, clear=False
+            ):
+                exit_code = summarize_flutter_tests.main(
+                    [events, "--max-active-ms", "20000"]
+                )
+        self.assertEqual(exit_code, 1)
+
+    def test_active_time_limit_ignores_timing_unavailable_files(self):
+        lines = [
+            _event("start"),
+            _suite(0, "test/no_timing_test.dart"),
+            _test_start(1, 0, "passes", 100),
+            _event("done", success=True),
+        ]
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            events = os.path.join(temporary_directory, "events.json")
+            with open(events, "w", encoding="utf-8") as events_file:
+                events_file.write("\n".join(lines))
+            with mock.patch.dict(
+                os.environ, {"GITHUB_STEP_SUMMARY": ""}, clear=False
+            ):
+                exit_code = summarize_flutter_tests.main(
+                    [events, "--max-active-ms", "20000"]
+                )
+        self.assertEqual(exit_code, 0)
+
     def test_reporting_error_does_not_replace_the_flutter_exit_status(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             summary_path = os.path.join(temporary_directory, "summary.md")


### PR DESCRIPTION
## Summary

What changed, and why?

- **iOS: plugin install via file picker was broken.** `FilePicker.getDirectoryPath()` on iOS uses `UIDocumentPickerModeOpen`, which returns security-scoped URLs pointing outside the app sandbox (iCloud Drive, On My iPad). The OS refuses reads with EPERM unless the app calls `startAccessingSecurityScopedResource` — file_picker never does. Added a small native channel (`com.reaprime/security_scoped`, in `AppDelegate.swift`) that grants access while the picked folder is copied; the picker flow now succeeds (verified on an iPad: the `PathAccessException: Operation not permitted` on `com~apple~CloudDocs/...` is gone).
- **The three other directory-pick flows had the same latent EPERM** and now start security-scoped access at the pick site via the same helper: de1app folder import (`import_source_picker`), skin live-edit (`skin_selector_page`), and data restore (`data_management_page`). The service auto-releases the previously held folder on the next pick so the native registry stays bounded.
- **Reinstalling a plugin now replaces the previous version** instead of failing with "Plugin already installed": `addPlugin` unloads (if loaded), deletes, and re-copies; bundled plugins are not re-seeded over a newer install.
- **Fixed 3 plugin permission tests that were red since the permission-enforcement commit** (Aug 8): the matcher expected a `PluginPermissionError` string that `loadPlugin`'s JS-error wrapper does not surface, and the `host.log` test raced the async bridge channel.
- **Virtualized `MockDe1`/`MockReplayDe1` clocks** (`DateTime.now()` → `clock.now()`, fake_async-aware); the replay test file dropped from ~46 s to ~9 s wall time.
- **CI gate:** `pr-checks.yml` now fails when any test suite's active time exceeds 20 s (new `--max-active-ms` mode on the Flutter test event summarizer).

## Linked Issue

Fixes #

N/A — maintainer PR (contribution-policy job skips maintainer/bot PRs).

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- `flutter analyze` clean.
- Full `flutter test`: 2936 tests pass, 1 skipped. Python tool tests 10/10.
- New unit test for plugin reinstall overwrite (`addPlugin replaces an already-installed plugin`).
- New tests for the CI gate (over/under/timing-unavailable) in `summarize_flutter_tests_test.py`.
- Manual on-device (iPad 7th gen, iOS 18.6.2): reproduced the EPERM failure on the plugin install flow before the fix, then verified the same flow succeeds after; verified reinstall of `dye2.reaplugin` over the bundled version.

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- iOS only: picked folders become readable for the app session via security-scoped access (OS-managed grant; released on next pick or app exit). No Android/desktop behavior change (`clock.now()` is identical to `DateTime.now()` outside fake zones; the native channel is a no-op off iOS).
- Plugin install: reinstalling replaces files; settings and autoload preferences are preserved.
- No API/spec changes, no DB schema changes, no doc updates required (verified against `doc/Plugins.md`, `doc/Api.md`, `doc/Skins.md`, `doc/Profiles.md`, `doc/DeviceManagement.md`).

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
