### PR TITLE
fix steam documentation, add tests

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -6137,13 +6137,16 @@ components:
         targetTemperature:
           type: integer
           description: >
-            Target steam temperature in Celsius. Values below 135 disable steam;
-            values of 135 or greater enable it. Duration does not control whether
-            steam is enabled.
+            Target steam temperature in Celsius. Set to 0 to disable steam-heater
+            preheating. Decaid writes 0 to the machine when steam is disabled and
+            treats temperatures below the supported range as disabled. Supported
+            enabled ranges are 135–160 °C for DE1 and 135–165 °C for Bengle.
           example: 150
         duration:
           type: integer
-          description: Steam duration in seconds
+          description: >
+            Maximum steam operation duration in seconds. This does not control
+            steam-heater preheating.
           example: 50
         flow:
           type: number

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -6136,7 +6136,10 @@ components:
       properties:
         targetTemperature:
           type: integer
-          description: Target steam temperature in Celsius
+          description: >
+            Target steam temperature in Celsius. Values below 135 disable steam;
+            values of 135 or greater enable it. Duration does not control whether
+            steam is enabled.
           example: 150
         duration:
           type: integer

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -570,7 +570,7 @@ Update just the profile:
 - `duration` (integer): Steam duration in seconds
 - `flow` (number): Steam flow rate
 
-Steam is enabled when `targetTemperature` is 135 °C or higher. Set it below 135 °C to disable steam; `duration` does not control whether steam is enabled.
+Steam-heater enablement is encoded through `targetTemperature` alone. Set it to `0` to disable steam-heater preheating; Decaid writes `0` °C to the machine when steam is disabled and treats temperatures below the supported range as disabled. Supported enabled ranges are 135–160 °C for DE1 and 135–165 °C for Bengle. `duration` controls the maximum duration of a steaming operation and does not control steam-heater preheating.
 
 **HotWaterData:**
 - `targetTemperature` (integer): Target hot water temperature in Celsius

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -570,6 +570,8 @@ Update just the profile:
 - `duration` (integer): Steam duration in seconds
 - `flow` (number): Steam flow rate
 
+Steam is enabled when `targetTemperature` is 135 °C or higher. Set it below 135 °C to disable steam; `duration` does not control whether steam is enabled.
+
 **HotWaterData:**
 - `targetTemperature` (integer): Target hot water temperature in Celsius
 - `duration` (integer): Hot water dispensing duration in seconds

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -424,7 +424,7 @@ class De1Controller {
     double flowRate = await connectedDe1().getSteamFlow();
 
     return SteamFormSettings(
-      steamEnabled: shotSettings.targetSteamTemp >= 130,
+      steamEnabled: shotSettings.targetSteamTemp >= 135,
       targetTemp: shotSettings.targetSteamTemp,
       targetDuration: shotSettings.targetSteamDuration,
       targetFlow: flowRate,
@@ -542,7 +542,7 @@ class De1Controller {
     if (!rinseChanged && !steamChanged && !hotWaterChanged) return;
 
     final steam = SteamFormSettings(
-      steamEnabled: updated.steamSettings.duration > 0,
+      steamEnabled: updated.steamSettings.targetTemperature >= 135,
       targetTemp: updated.steamSettings.targetTemperature,
       targetDuration: updated.steamSettings.duration,
       targetFlow: updated.steamSettings.flow,

--- a/lib/src/controllers/de1_controller.defaults.dart
+++ b/lib/src/controllers/de1_controller.defaults.dart
@@ -15,7 +15,7 @@ extension Defaults on De1Controller {
     await _updateSteamSettingsFor(
       device,
       SteamFormSettings(
-        steamEnabled: steamSettings.targetTemperature >= 130,
+        steamEnabled: steamSettings.targetTemperature >= 135,
         targetTemp: steamSettings.targetTemperature,
         targetDuration: steamSettings.duration,
         targetFlow: steamSettings.flow,

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -450,6 +450,26 @@ void main() {
       );
     });
 
+    test('steam enablement follows target temperature, not duration', () async {
+      await _settleHandler(spy);
+      spy.updateShotSettingsCalls.clear();
+
+      final hotTargetResponse = await put({
+        'steamSettings': {'targetTemperature': 135, 'duration': 0},
+      });
+
+      expect(hotTargetResponse.statusCode, 200);
+      expect(spy.updateShotSettingsCalls.single.targetSteamTemp, 135);
+
+      spy.updateShotSettingsCalls.clear();
+      final disabledResponse = await put({
+        'steamSettings': {'targetTemperature': 134, 'duration': 30},
+      });
+
+      expect(disabledResponse.statusCode, 200);
+      expect(spy.updateShotSettingsCalls.single.targetSteamTemp, 0);
+    });
+
     test('no-op PUT (same values) issues no DE1 writes', () async {
       await _settleHandler(spy);
       final snapshot = workflowController.currentWorkflow;


### PR DESCRIPTION
## Summary

Make corrections to steam API documentation. Setting steam temp above 135C will enable steam heaters. 160C is maximum steam temperature (clamped in firmware)

## Linked Issue

Fixes #534 

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- verified in DE1 & Bengle fw sources

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- Updated Skins.md
- Minor corrections required in clients

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
