### PR TITLE
fix(scale): preserve preferred-scale reconnect backoff

### DIFF
--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -791,7 +791,7 @@ class ConnectionManager {
     required bool scaleOnly,
     required ConnectionAttemptPolicy policy,
   }) async {
-    _cancelScaleReacquisition();
+    _cancelScaleReacquisition(resetFailures: !scaleOnly);
     if (scaleOnly && _scaleReconnectBlockedByPowerMode) {
       _log.fine(
         'Skipping scale-only scan while machine is sleeping and scale '
@@ -1072,9 +1072,9 @@ class ConnectionManager {
     }
   }
 
-  void _cancelScaleReacquisition() {
+  void _cancelScaleReacquisition({bool resetFailures = true}) {
     unawaited(_scaleWatch.disarm());
-    _cancelPreferredScaleReconnect();
+    _cancelPreferredScaleReconnect(resetFailures: resetFailures);
   }
 
   Future<void> _connectScaleFromWatch(Scale scale) async {
@@ -1112,10 +1112,10 @@ class ConnectionManager {
         !_scaleReconnectBlockedByPowerMode;
   }
 
-  void _cancelPreferredScaleReconnect() {
+  void _cancelPreferredScaleReconnect({bool resetFailures = true}) {
     _preferredScaleReconnect?.cancel();
     _preferredScaleReconnect = null;
-    _scaleReconnectFailures = 0;
+    if (resetFailures) _scaleReconnectFailures = 0;
   }
 
   void _handleScaleDisconnected() {

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -2578,6 +2578,120 @@ void main() {
       });
     });
 
+    group('preferred scale fallback reconnect', () {
+      ConnectionManager buildFallbackManager() => ConnectionManager(
+        deviceScanner: mockScanner,
+        de1Controller: mockDe1Controller,
+        scaleController: mockScaleController,
+        settingsController: settingsController,
+      )..snapshotStalenessTimeout = const Duration(hours: 1);
+
+      List<Completer<void>> startFallbackRecovery(
+        FakeAsync async,
+        int expectedScans,
+      ) {
+        connectionManager = buildFallbackManager();
+        final scanCompleters = List.generate(
+          expectedScans,
+          (_) => Completer<void>(),
+        );
+        mockScanner.queuedScanCompleters.addAll(scanCompleters);
+        settingsController.setPreferredScaleId('missing-scale');
+        async.flushMicrotasks();
+        mockDe1Controller.de1Subject.add(_FakeDe1(deviceId: 'connected-de1'));
+        async.flushMicrotasks();
+        return scanCompleters;
+      }
+
+      void expectScanAfter(FakeAsync async, Duration delay, int expectedCalls) {
+        async.elapse(delay - const Duration(milliseconds: 1));
+        async.flushMicrotasks();
+        expect(mockScanner.scanCallCount, expectedCalls - 1);
+        async.elapse(const Duration(milliseconds: 1));
+        async.flushMicrotasks();
+        expect(mockScanner.scanCallCount, expectedCalls);
+      }
+
+      void completeScan(FakeAsync async, Completer<void> scan) {
+        scan.complete();
+        async.flushMicrotasks();
+      }
+
+      setUp(() async {
+        await connectionManager.dispose();
+      });
+
+      test('backs off consecutive failed scans and caps at 60 seconds', () {
+        fakeAsync((async) {
+          final scans = startFallbackRecovery(async, 6);
+          const retryDelays = [
+            Duration(seconds: 5),
+            Duration(seconds: 10),
+            Duration(seconds: 20),
+            Duration(seconds: 40),
+            Duration(seconds: 60),
+            Duration(seconds: 60),
+          ];
+
+          for (var index = 0; index < retryDelays.length; index++) {
+            expectScanAfter(async, retryDelays[index], index + 1);
+            completeScan(async, scans[index]);
+          }
+
+          connectionManager.dispose();
+          async.flushMicrotasks();
+        });
+      });
+
+      test('successful scale connection resets the backoff', () {
+        fakeAsync((async) {
+          final scans = startFallbackRecovery(async, 3);
+          expectScanAfter(async, const Duration(seconds: 5), 1);
+          completeScan(async, scans[0]);
+          expectScanAfter(async, const Duration(seconds: 10), 2);
+          completeScan(async, scans[1]);
+
+          mockScaleController.debugSetLastConnectedId('missing-scale');
+          mockScaleController.mockEmitConnectionState(
+            ConnectionState.connected,
+          );
+          mockScaleController.mockEmitConnectionState(
+            ConnectionState.disconnected,
+          );
+          async.flushMicrotasks();
+
+          expectScanAfter(async, const Duration(seconds: 5), 3);
+          completeScan(async, scans[2]);
+
+          connectionManager.dispose();
+          async.flushMicrotasks();
+        });
+      });
+
+      test('machine disconnect cancels and resets the backoff', () {
+        fakeAsync((async) {
+          final scans = startFallbackRecovery(async, 2);
+          expectScanAfter(async, const Duration(seconds: 5), 1);
+          completeScan(async, scans[0]);
+
+          mockDe1Controller.de1Subject.add(null);
+          async.flushMicrotasks();
+          async.elapse(const Duration(seconds: 10));
+          expect(mockScanner.scanCallCount, 1);
+
+          mockDe1Controller.de1Subject.add(
+            _FakeDe1(deviceId: 'reconnected-de1'),
+          );
+          async.flushMicrotasks();
+          expectScanAfter(async, const Duration(seconds: 5), 2);
+          completeScan(async, scans[1]);
+
+          connectionManager.dispose();
+          async.flushMicrotasks();
+        });
+      });
+    });
+
     group('background scale watch', () {
       const scaleId = 'pref-scale';
 


### PR DESCRIPTION
## Summary

What changed, and why?

- Preserve preferred-scale retry history when a scheduled `scaleOnly` scan takes ownership of reacquisition.
- Keep retry-history resets for successful connections, full connects, cancellation, and disposal.
- Add `fakeAsync` coverage for the 5 → 10 → 20 → 40 → 60-second cadence, the 60-second cap, and reset behavior.

## Linked Issue

Fixes #527

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- `dart format lib test`
- `flutter test test/controllers/connection_manager_test.dart` — 145 passed
- `flutter analyze` — no issues found
- `flutter test` — 3021 passed, 1 skipped
- No manual hardware testing; the affected fallback timing and reset behavior are covered with deterministic fake time.

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- Missing preferred scales on fallback platforms now retry after 5, 10, 20, 40, then 60 seconds instead of repeating every 5 seconds between scans.
- Android background `ScaleWatch`, APIs, migrations, specifications, documentation, and security behavior are unchanged.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
