### PR TITLE
fix(profiles): make ID-changing updates atomic

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3021,7 +3021,11 @@ paths:
     
     put:
       summary: Update profile
-      description: Updates an existing profile. Cannot modify default profiles' content, only metadata.
+      description: |
+        Updates an existing profile. Cannot modify default profiles' content,
+        only metadata. Execution changes that produce a new profile ID replace
+        the old record atomically. If the target ID already exists, the update
+        is rejected and both records remain unchanged.
       tags: [Profiles]
       parameters:
         - name: id
@@ -3051,7 +3055,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProfileRecord'
         "400":
-          description: Bad Request (profile not found or cannot modify default profile)
+          description: Bad Request (profile not found, target ID already exists, or cannot modify default profile)
         "500":
           description: Internal Server Error
     

--- a/doc/AI_STORAGE_NOTES.md
+++ b/doc/AI_STORAGE_NOTES.md
@@ -51,6 +51,7 @@ Content-based hash IDs for deduplication. `ProfileController` manages the profil
 - Hash computed from profile content (`Profile.fromJson` → `computeHash`).
 - Deduplication: two profiles with identical content get the same hash ID.
 - `ProfileStorageService` interface with `DriftProfileStorageService` implementation.
+- ID-changing updates use `ProfileStorageService.replace`, which inserts the replacement and deletes the original in one Drift transaction. Target-ID collisions throw `ArgumentError` and leave both records unchanged.
 
 ### Legacy Profile Corpus Ingestion
 

--- a/doc/Profiles.md
+++ b/doc/Profiles.md
@@ -70,7 +70,8 @@ The implementation follows REA's standard layered architecture with clear separa
 **ProfileStorageService** (`lib/src/services/storage/profile_storage_service.dart`)
 - Abstract interface defining all storage operations
 - Allows swapping implementations (Drift/SQLite, or others)
-- Methods: `store`, `get`, `getAll`, `update`, `delete`, `getByParentId`, `storeAll`, `count`
+- Methods: `store`, `get`, `getAll`, `update`, `replace`, `delete`, `getByParentId`, `storeAll`, `count`
+- `replace` atomically stores an ID-changing replacement and removes the old record; an existing target ID rejects the update without changing either record
 
 **DriftProfileStorageService** (`lib/src/services/storage/drift_profile_storage.dart`)
 - Active implementation, backed by the shared Drift `AppDatabase` (SQLite)
@@ -85,7 +86,7 @@ The implementation follows REA's standard layered architecture with clear separa
 - Enforces default profile protection (cannot be deleted, only hidden; cannot modify execution fields)
 - Validates parent profile existence before creating children
 - **Automatic deduplication**: Identical profiles share the same hash-based ID
-- **Smart updates**: When execution fields change, old record is deleted and new one is stored with new hash
+- **Smart updates**: When execution fields change, the new hash record replaces the old record in one Drift transaction. A target-ID collision rejects the update and preserves both existing records
 - Profile lineage tracking via `getLineage()`
 - Import/export with detailed results (imported/skipped/failed counts)
 - Exposes `profileCount` stream for UI updates
@@ -253,7 +254,7 @@ Content-Type: application/json
 }
 ```
 
-Note: Cannot modify the `profile` field of default profiles (only metadata).
+Note: Cannot modify the `profile` field of default profiles (only metadata). If execution changes produce a new ID, replacement is atomic. If that ID already exists, the update is rejected and both profiles remain unchanged.
 
 Response: Updated `ProfileRecord` (200) or error (400/404)
 

--- a/lib/src/controllers/profile_controller.dart
+++ b/lib/src/controllers/profile_controller.dart
@@ -234,8 +234,7 @@ class ProfileController {
         'This creates a new profile. Consider using parentId for versioning.',
       );
 
-      await _storage.delete(existing.id);
-      await _storage.store(updated);
+      await _storage.replace(existing.id, updated);
     } else {
       await _storage.update(updated);
     }

--- a/lib/src/services/storage/drift_profile_storage.dart
+++ b/lib/src/services/storage/drift_profile_storage.dart
@@ -38,6 +38,23 @@ class DriftProfileStorageService implements ProfileStorageService {
   }
 
   @override
+  Future<void> replace(String oldId, domain.ProfileRecord replacement) {
+    return _db.transaction(() async {
+      if (!await _db.profileDao.profileExists(oldId)) {
+        throw ArgumentError('Profile not found: $oldId');
+      }
+      if (await _db.profileDao.profileExists(replacement.id)) {
+        throw ArgumentError('Profile already exists: ${replacement.id}');
+      }
+
+      await _db.profileDao.insertProfile(
+        ProfileMapper.toCompanion(replacement),
+      );
+      await _db.profileDao.deleteProfile(oldId);
+    });
+  }
+
+  @override
   Future<void> delete(String id) {
     return _db.profileDao.deleteProfile(id);
   }

--- a/lib/src/services/storage/profile_storage_service.dart
+++ b/lib/src/services/storage/profile_storage_service.dart
@@ -11,6 +11,8 @@ abstract class ProfileStorageService {
 
   Future<void> update(ProfileRecord record);
 
+  Future<void> replace(String oldId, ProfileRecord replacement);
+
   Future<void> delete(String id);
 
   Future<bool> exists(String id);

--- a/test/controllers/profile_controller_update_test.dart
+++ b/test/controllers/profile_controller_update_test.dart
@@ -1,0 +1,171 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/profile_controller.dart';
+import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/data/profile_record.dart';
+import 'package:reaprime/src/services/storage/profile_storage_service.dart';
+
+class _ProfileStorage implements ProfileStorageService {
+  final records = <String, ProfileRecord>{};
+  String? failStoreForId;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> store(ProfileRecord record) async {
+    if (record.id == failStoreForId) {
+      throw StateError('store failed');
+    }
+    if (records.containsKey(record.id)) {
+      throw ArgumentError('Profile already exists: ${record.id}');
+    }
+    records[record.id] = record;
+  }
+
+  @override
+  Future<ProfileRecord?> get(String id) async => records[id];
+
+  @override
+  Future<List<ProfileRecord>> getAll({Visibility? visibility}) async => records
+      .values
+      .where((record) => visibility == null || record.visibility == visibility)
+      .toList();
+
+  @override
+  Future<void> update(ProfileRecord record) async {
+    if (!records.containsKey(record.id)) {
+      throw ArgumentError('Profile not found: ${record.id}');
+    }
+    records[record.id] = record;
+  }
+
+  @override
+  Future<void> replace(String oldId, ProfileRecord replacement) async {
+    if (!records.containsKey(oldId)) {
+      throw ArgumentError('Profile not found: $oldId');
+    }
+    if (records.containsKey(replacement.id)) {
+      throw ArgumentError('Profile already exists: ${replacement.id}');
+    }
+    if (replacement.id == failStoreForId) {
+      throw StateError('store failed');
+    }
+
+    records[replacement.id] = replacement;
+    records.remove(oldId);
+  }
+
+  @override
+  Future<void> delete(String id) async => records.remove(id);
+
+  @override
+  Future<bool> exists(String id) async => records.containsKey(id);
+
+  @override
+  Future<List<String>> getAllIds() async => records.keys.toList();
+
+  @override
+  Future<List<ProfileRecord>> getByParentId(String parentId) async =>
+      records.values.where((record) => record.parentId == parentId).toList();
+
+  @override
+  Future<void> storeAll(List<ProfileRecord> records) async {
+    for (final record in records) {
+      await store(record);
+    }
+  }
+
+  @override
+  Future<void> clear() async => records.clear();
+
+  @override
+  Future<int> count({Visibility? visibility}) async =>
+      (await getAll(visibility: visibility)).length;
+}
+
+Profile _profile({required double tankTemperature, String title = 'Profile'}) {
+  return Profile(
+    version: '2',
+    title: title,
+    author: 'Test',
+    notes: '',
+    beverageType: BeverageType.espresso,
+    steps: const [],
+    tankTemperature: tankTemperature,
+    targetVolumeCountStart: 0,
+  );
+}
+
+void main() {
+  group('ProfileController.update', () {
+    late _ProfileStorage storage;
+    late ProfileController controller;
+    late ProfileRecord original;
+
+    setUp(() async {
+      storage = _ProfileStorage();
+      controller = ProfileController(storage: storage);
+      original = ProfileRecord.create(profile: _profile(tankTemperature: 93));
+      await storage.store(original);
+    });
+
+    tearDown(() => controller.dispose());
+
+    test('replaces a profile when execution changes its ID', () async {
+      final replacement = _profile(tankTemperature: 94);
+
+      final updated = await controller.update(
+        original.id,
+        profile: replacement,
+      );
+
+      expect(updated.id, isNot(original.id));
+      expect(await storage.get(original.id), isNull);
+      expect(await storage.get(updated.id), updated);
+    });
+
+    test('keeps the original when storing the replacement fails', () async {
+      final replacement = _profile(tankTemperature: 94);
+      final replacementId = ProfileRecord.create(profile: replacement).id;
+      storage.failStoreForId = replacementId;
+
+      await expectLater(
+        controller.update(original.id, profile: replacement),
+        throwsStateError,
+      );
+
+      expect(await storage.get(original.id), original);
+      expect(await storage.get(replacementId), isNull);
+    });
+
+    test(
+      'rejects a target ID collision without changing either profile',
+      () async {
+        final target = ProfileRecord.create(
+          profile: _profile(tankTemperature: 94, title: 'Target'),
+        );
+        await storage.store(target);
+
+        await expectLater(
+          controller.update(original.id, profile: target.profile),
+          throwsArgumentError,
+        );
+
+        expect(await storage.get(original.id), original);
+        expect(await storage.get(target.id), target);
+      },
+    );
+
+    test('updates metadata without changing the profile ID', () async {
+      final updated = await controller.update(
+        original.id,
+        profile: original.profile.copyWith(title: 'Renamed'),
+      );
+
+      expect(updated.id, original.id);
+      expect(updated.profile.title, 'Renamed');
+      expect(await storage.get(original.id), updated);
+      expect(storage.records, hasLength(1));
+    });
+  });
+}

--- a/test/data_export/profile_export_section_test.dart
+++ b/test/data_export/profile_export_section_test.dart
@@ -49,6 +49,12 @@ class MockProfileStorage implements ProfileStorageService {
   }
 
   @override
+  Future<void> replace(String oldId, ProfileRecord replacement) async {
+    records[replacement.id] = replacement;
+    records.remove(oldId);
+  }
+
+  @override
   Future<void> delete(String id) async => records.remove(id);
 
   @override

--- a/test/import/de1app_importer_test.dart
+++ b/test/import/de1app_importer_test.dart
@@ -120,6 +120,12 @@ class FakeProfileStorageService implements ProfileStorageService {
       profiles[record.id] = record;
 
   @override
+  Future<void> replace(String oldId, ProfileRecord replacement) async {
+    profiles[replacement.id] = replacement;
+    profiles.remove(oldId);
+  }
+
+  @override
   Future<void> delete(String id) async => profiles.remove(id);
 
   @override

--- a/test/profile_test.dart
+++ b/test/profile_test.dart
@@ -40,6 +40,12 @@ class MockProfileStorage implements ProfileStorageService {
   }
 
   @override
+  Future<void> replace(String oldId, ProfileRecord replacement) async {
+    _storage[replacement.id] = replacement;
+    _storage.remove(oldId);
+  }
+
+  @override
   Future<void> delete(String id) async {
     _storage.remove(id);
   }

--- a/test/profiles/default_profiles_migration_test.dart
+++ b/test/profiles/default_profiles_migration_test.dart
@@ -24,6 +24,12 @@ class InMemoryProfileStorage implements ProfileStorageService {
   Future<void> update(ProfileRecord record) async =>
       records[record.id] = record;
   @override
+  Future<void> replace(String oldId, ProfileRecord replacement) async {
+    records[replacement.id] = replacement;
+    records.remove(oldId);
+  }
+
+  @override
   Future<void> delete(String id) async => records.remove(id);
   @override
   Future<bool> exists(String id) async => records.containsKey(id);

--- a/test/services/storage/drift_profile_storage_test.dart
+++ b/test/services/storage/drift_profile_storage_test.dart
@@ -1,0 +1,87 @@
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/data/profile_record.dart' as domain;
+import 'package:reaprime/src/services/database/database.dart';
+import 'package:reaprime/src/services/storage/drift_profile_storage.dart';
+
+Profile _profile(double tankTemperature) {
+  return Profile(
+    version: '2',
+    title: 'Profile',
+    author: 'Test',
+    notes: '',
+    beverageType: BeverageType.espresso,
+    steps: [
+      ProfileStepPressure(
+        name: 'pour',
+        transition: TransitionType.fast,
+        volume: 100,
+        seconds: 30,
+        temperature: 93,
+        sensor: TemperatureSensor.coffee,
+        pressure: 9,
+      ),
+    ],
+    tankTemperature: tankTemperature,
+    targetVolumeCountStart: 0,
+  );
+}
+
+void main() {
+  late AppDatabase database;
+  late DriftProfileStorageService storage;
+  late domain.ProfileRecord original;
+
+  setUp(() async {
+    database = AppDatabase(NativeDatabase.memory());
+    storage = DriftProfileStorageService(database);
+    original = domain.ProfileRecord.create(profile: _profile(93));
+    await storage.store(original);
+  });
+
+  tearDown(() => database.close());
+
+  test('atomically replaces an ID-changing profile', () async {
+    final replacement = original.copyWith(profile: _profile(94));
+
+    await storage.replace(original.id, replacement);
+
+    expect(await storage.get(original.id), isNull);
+    expect(await storage.get(replacement.id), replacement);
+  });
+
+  test('rolls back when storing the replacement fails', () async {
+    final replacement = original.copyWith(
+      profile: _profile(94),
+      metadata: {'unsupported': Object()},
+    );
+
+    await expectLater(
+      storage.replace(original.id, replacement),
+      throwsA(isA<JsonUnsupportedObjectError>()),
+    );
+
+    expect(await storage.get(original.id), original);
+    expect(await storage.get(replacement.id), isNull);
+  });
+
+  test(
+    'rejects a target ID collision without changing either profile',
+    () async {
+      final target = domain.ProfileRecord.create(profile: _profile(94));
+      await storage.store(target);
+      final replacement = original.copyWith(profile: target.profile);
+
+      await expectLater(
+        storage.replace(original.id, replacement),
+        throwsArgumentError,
+      );
+
+      expect(await storage.get(original.id), original);
+      expect(await storage.get(target.id), target);
+    },
+  );
+}

--- a/test/services/webserver/profile_handler_create_test.dart
+++ b/test/services/webserver/profile_handler_create_test.dart
@@ -24,6 +24,12 @@ class _StubStorage implements ProfileStorageService {
   Future<void> update(ProfileRecord record) async =>
       _records[record.id] = record;
   @override
+  Future<void> replace(String oldId, ProfileRecord replacement) async {
+    _records[replacement.id] = replacement;
+    _records.remove(oldId);
+  }
+
+  @override
   Future<void> delete(String id) async => _records.remove(id);
   @override
   Future<bool> exists(String id) async => _records.containsKey(id);

--- a/test/services/webserver/profile_handler_defaults_test.dart
+++ b/test/services/webserver/profile_handler_defaults_test.dart
@@ -20,6 +20,9 @@ class _StubStorage implements ProfileStorageService {
   @override
   Future<void> update(ProfileRecord record) async {}
   @override
+  Future<void> replace(String oldId, ProfileRecord replacement) async {}
+
+  @override
   Future<void> delete(String id) async {}
   @override
   Future<bool> exists(String id) async => false;

--- a/test/services/webserver/profile_handler_export_test.dart
+++ b/test/services/webserver/profile_handler_export_test.dart
@@ -25,6 +25,9 @@ class _StubStorage implements ProfileStorageService {
   Future<void> update(ProfileRecord record) async {}
 
   @override
+  Future<void> replace(String oldId, ProfileRecord replacement) async {}
+
+  @override
   Future<void> delete(String id) async {}
 
   @override


### PR DESCRIPTION
## Summary

What changed, and why?

- add an atomic profile replacement operation backed by one Drift transaction
- preserve the original profile on replacement failure and reject target-ID collisions without changing either record
- cover ID-changing success/failure/collision and same-ID updates; document the storage and REST contracts

## Linked Issue

Fixes #553

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- `flutter analyze` — no issues
- `flutter test test/controllers/profile_controller_update_test.dart test/services/storage/drift_profile_storage_test.dart` — 7 passed
- `flutter test` — 3,081 passed, 1 skipped

## Impact

ID-changing `PUT /api/v1/profiles/{id}` updates are now atomic. A target-ID collision returns the existing 400 error shape and leaves both profiles unchanged. Same-ID updates are unchanged. No database migration is required. OpenAPI and profile/storage documentation are updated.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
