### PR TITLE
fix(api): support tri-state partial updates

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -1198,8 +1198,11 @@ paths:
 
         Each HTTP request is an independent mutation. Requests are processed in FIFO order,
         and partial request bodies are deep-merged against the workflow state when that request
-        reaches the front of the queue. The server does not debounce or combine separate
-        requests. Machine side effects from workflow PUT requests do not execute concurrently,
+        reaches the front of the queue. Omitted steam-setting fields keep their current values;
+        supplied values replace them. Steam settings are non-nullable, so explicit `null` for
+        `steamSettings` or any of its fields returns `400`.
+        The server does not debounce or combine separate requests. Machine side effects from
+        workflow PUT requests do not execute concurrently,
         so a request may wait behind an in-flight machine operation. Each response describes
         the workflow resulting from that request. High-frequency clients should throttle input
         on the client side rather than relying on server-side debounce.
@@ -1231,7 +1234,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/WorkflowRequest"
+              $ref: "#/components/schemas/WorkflowPatch"
             examples:
               updateContext:
                 summary: Update dose and grinder via context (recommended)
@@ -1917,7 +1920,10 @@ paths:
           description: Internal Server Error
     put:
       summary: Update a bean
-      description: Updates an existing bean. Pass only the fields to change.
+      description: |
+        Updates an existing bean. Omitted fields preserve their current values,
+        explicit `null` clears nullable fields, and supplied values replace them.
+        Explicit `null` for a non-nullable field returns `400`.
       tags: [Beans]
       parameters:
         - name: id
@@ -2184,7 +2190,10 @@ paths:
           description: Internal Server Error
     put:
       summary: Update a batch
-      description: Updates an existing batch. Pass only the fields to change.
+      description: |
+        Updates an existing batch. Omitted fields preserve their current values,
+        explicit `null` clears nullable fields, and supplied values replace them.
+        Explicit `null` for a non-nullable field returns `400`.
       tags: [Beans]
       parameters:
         - name: id
@@ -2458,7 +2467,10 @@ paths:
           description: Internal Server Error
     put:
       summary: Update a grinder
-      description: Updates an existing grinder. Pass only the fields to change.
+      description: |
+        Updates an existing grinder. Omitted fields preserve their current values,
+        explicit `null` clears nullable fields, and supplied values replace them.
+        Explicit `null` for a non-nullable field returns `400`.
       tags: [Grinders]
       parameters:
         - name: id
@@ -3115,10 +3127,13 @@ paths:
     put:
       summary: Update profile
       description: |
-        Updates an existing profile. Cannot modify default profiles' content,
-        only metadata. Execution changes that produce a new profile ID replace
-        the old record atomically. If the target ID already exists, the update
-        is rejected and both records remain unchanged.
+        Updates an existing profile. Omitted fields preserve their current values;
+        `metadata: null` clears metadata; supplied metadata replaces it. The profile
+        itself is non-nullable, so `profile: null` returns `400`.
+        Cannot modify default profiles' content, only metadata. Execution changes
+        that produce a new profile ID replace the old record atomically. If the
+        target ID already exists, the update is rejected and both records remain
+        unchanged.
       tags: [Profiles]
       parameters:
         - name: id
@@ -3136,10 +3151,10 @@ paths:
               properties:
                 profile:
                   $ref: '#/components/schemas/Profile'
-                  nullable: true
                 metadata:
                   type: object
                   nullable: true
+                  description: Set to `null` to clear stored profile metadata.
       responses:
         "200":
           description: Profile updated successfully
@@ -6340,6 +6355,29 @@ components:
             Machine settings active when the shot was pulled — recorded onto the
             shot, ignored on apply.
 
+    WorkflowPatch:
+      type: object
+      description: |
+        Partial workflow update. Omitted fields preserve their current values.
+        Fields in `steamSettings` are non-nullable and reject explicit `null`.
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        profile:
+          $ref: "#/components/schemas/Profile"
+        context:
+          $ref: "#/components/schemas/WorkflowContext"
+        steamSettings:
+          $ref: "#/components/schemas/SteamSettingsPatch"
+        hotWaterData:
+          $ref: "#/components/schemas/HotWaterData"
+        rinseData:
+          $ref: "#/components/schemas/RinseData"
+        machine:
+          $ref: "#/components/schemas/WorkflowMachine"
+
     WorkflowMachine:
       type: object
       description: >
@@ -6353,6 +6391,21 @@ components:
           description: >
             The DE1's flow-estimation calibration (calibration_flow_multiplier)
             active when the shot was pulled.
+
+    SteamSettingsPatch:
+      type: object
+      description: Partial steam-settings update; omitted fields are preserved and `null` is rejected.
+      properties:
+        targetTemperature:
+          type: integer
+        duration:
+          type: integer
+        flow:
+          type: number
+          format: double
+        stopAtTemperature:
+          type: number
+          format: double
 
     SteamSettings:
       type: object

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -178,6 +178,10 @@ in-app stop will trigger on.
 | POST | `/api/v1/profiles/import` | Import profiles from JSON | |
 | POST | `/api/v1/profiles/restore/:filename` | Restore a bundled default by manifest filename | |
 
+Profile updates use tri-state patch semantics: omitting `metadata` preserves it,
+`metadata: null` clears it, and an object replaces it. The profile itself is
+non-nullable; `profile: null` returns `400`.
+
 ### Workflow
 
 | Method | Path | Description | Handler |
@@ -188,7 +192,9 @@ in-app stop will trigger on.
 Each `PUT /api/v1/workflow` is one independent mutation. Requests run in FIFO order without
 cross-request or cross-client coalescing. Partial updates are deep-merged against the latest
 workflow state when each request executes, and each response contains that request's resulting
-workflow. Requests may wait behind machine I/O; the server does not debounce high-frequency
+workflow. Omitted steam-setting fields are preserved and supplied values replace them. The
+`steamSettings` object and all of its fields are non-nullable; explicit `null` returns `400`.
+Requests may wait behind machine I/O; the server does not debounce high-frequency
 input, so clients should throttle controls themselves. Bodies larger than 1 MiB return `413`,
 requests beyond the eight-entry active/queued limit return `429`, and requests waiting more
 than 30 seconds for execution return `503` without being applied. Machine-write failures
@@ -203,6 +209,11 @@ workflow change never touches the DE1 directly — the Bengle bridge applies it
 asynchronously — so it commits even while no machine is connected.
 
 ### Beans
+
+Bean, bean-batch, and grinder updates use tri-state patch semantics: omitted
+fields preserve stored values, explicit `null` clears nullable fields, and
+supplied values replace them. Explicit `null` for non-nullable fields returns
+`400`.
 
 | Method | Path | Description | Handler |
 |--------|------|-------------|---------|

--- a/doc/Profiles.md
+++ b/doc/Profiles.md
@@ -254,7 +254,9 @@ Content-Type: application/json
 }
 ```
 
-Note: Cannot modify the `profile` field of default profiles (only metadata). If execution changes produce a new ID, replacement is atomic. If that ID already exists, the update is rejected and both profiles remain unchanged.
+Omitted fields are preserved. Set `metadata` to `null` to clear stored metadata, or pass an object to replace it. The `profile` field is non-nullable; explicit `null` returns 400.
+
+Cannot modify the `profile` field of default profiles (only metadata). If execution changes produce a new ID, replacement is atomic. If that ID already exists, the update is rejected and both profiles remain unchanged.
 
 Response: Updated `ProfileRecord` (200) or error (400/404)
 

--- a/lib/src/controllers/profile_controller.dart
+++ b/lib/src/controllers/profile_controller.dart
@@ -216,6 +216,7 @@ class ProfileController {
     String id, {
     Profile? profile,
     Map<String, dynamic>? metadata,
+    bool metadataPresent = false,
   }) async {
     final existing = await _storage.get(id);
     if (existing == null) {
@@ -226,7 +227,11 @@ class ProfileController {
       throw ArgumentError('Cannot modify default profile content');
     }
 
-    final updated = existing.copyWith(profile: profile, metadata: metadata);
+    final updated = existing.copyWith(
+      profile: profile,
+      metadata: metadata,
+      clearMetadata: metadataPresent && metadata == null,
+    );
 
     if (updated.id != existing.id) {
       _log.warning(

--- a/lib/src/models/data/profile_record.dart
+++ b/lib/src/models/data/profile_record.dart
@@ -100,6 +100,7 @@ class ProfileRecord extends Equatable {
     DateTime? createdAt,
     DateTime? updatedAt,
     Map<String, dynamic>? metadata,
+    bool clearMetadata = false,
   }) {
     final newProfile = profile ?? this.profile;
     final hashes = ProfileHash.calculateAll(newProfile);
@@ -114,7 +115,7 @@ class ProfileRecord extends Equatable {
       isDefault: isDefault ?? this.isDefault,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? DateTime.now(),
-      metadata: metadata ?? this.metadata,
+      metadata: clearMetadata ? null : metadata ?? this.metadata,
     );
   }
 

--- a/lib/src/services/webserver/beans_handler.dart
+++ b/lib/src/services/webserver/beans_handler.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/data/bean.dart';
 import 'package:reaprime/src/services/storage/bean_storage_service.dart';
+import 'package:reaprime/src/services/webserver/json_patch.dart';
 import 'package:reaprime/src/services/webserver/json_response.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
@@ -91,25 +92,21 @@ class BeansHandler {
       final body = await req.body.asString;
       final json = jsonDecode(body) as Map<String, dynamic>;
 
-      final updated = existing.copyWith(
-        roaster: json['roaster'] as String?,
-        name: json['name'] as String?,
-        species: json['species'] as String?,
-        decaf: json['decaf'] as bool?,
-        decafProcess: json['decafProcess'] as String?,
-        country: json['country'] as String?,
-        region: json['region'] as String?,
-        producer: json['producer'] as String?,
-        variety: (json['variety'] as List?)?.cast<String>(),
-        altitude: (json['altitude'] as List?)?.cast<int>(),
-        processing: json['processing'] as String?,
-        notes: json['notes'] as String?,
-        archived: json['archived'] as bool?,
-        extras: json['extras'] as Map<String, dynamic>?,
-      );
+      rejectExplicitNulls(json, const ['roaster', 'name', 'decaf', 'archived']);
+      final updated = Bean.fromJson({
+        ...existing.toJson(),
+        ...json,
+        'id': existing.id,
+        'createdAt': existing.createdAt.toIso8601String(),
+        'updatedAt': DateTime.now().toIso8601String(),
+      });
 
       await _storage.updateBean(updated);
       return jsonOk(updated.toJson());
+    } on FormatException catch (e) {
+      return jsonBadRequest({'error': e.toString()});
+    } on TypeError catch (e) {
+      return jsonBadRequest({'error': e.toString()});
     } catch (e, st) {
       _log.severe('Error updating bean $id', e, st);
       return jsonError({'error': e.toString()});
@@ -211,40 +208,22 @@ class BeansHandler {
       final body = await req.body.asString;
       final json = jsonDecode(body) as Map<String, dynamic>;
 
-      final updated = existing.copyWith(
-        roastDate: json['roastDate'] != null
-            ? DateTime.parse(json['roastDate'] as String)
-            : null,
-        roastLevel: json['roastLevel'] as String?,
-        harvestDate: json['harvestDate'] as String?,
-        qualityScore: (json['qualityScore'] as num?)?.toDouble(),
-        price: (json['price'] as num?)?.toDouble(),
-        currency: json['currency'] as String?,
-        weight: (json['weight'] as num?)?.toDouble(),
-        weightRemaining: (json['weightRemaining'] as num?)?.toDouble(),
-        buyDate: json['buyDate'] != null
-            ? DateTime.parse(json['buyDate'] as String)
-            : null,
-        openDate: json['openDate'] != null
-            ? DateTime.parse(json['openDate'] as String)
-            : null,
-        bestBeforeDate: json['bestBeforeDate'] != null
-            ? DateTime.parse(json['bestBeforeDate'] as String)
-            : null,
-        freezeDate: json['freezeDate'] != null
-            ? DateTime.parse(json['freezeDate'] as String)
-            : null,
-        unfreezeDate: json['unfreezeDate'] != null
-            ? DateTime.parse(json['unfreezeDate'] as String)
-            : null,
-        frozen: json['frozen'] as bool?,
-        archived: json['archived'] as bool?,
-        notes: json['notes'] as String?,
-        extras: json['extras'] as Map<String, dynamic>?,
-      );
+      rejectExplicitNulls(json, const ['frozen', 'archived']);
+      final updated = BeanBatch.fromJson({
+        ...existing.toJson(),
+        ...json,
+        'id': existing.id,
+        'beanId': existing.beanId,
+        'createdAt': existing.createdAt.toIso8601String(),
+        'updatedAt': DateTime.now().toIso8601String(),
+      });
 
       await _storage.updateBatch(updated);
       return jsonOk(updated.toJson());
+    } on FormatException catch (e) {
+      return jsonBadRequest({'error': e.toString()});
+    } on TypeError catch (e) {
+      return jsonBadRequest({'error': e.toString()});
     } catch (e, st) {
       _log.severe('Error updating batch $id', e, st);
       return jsonError({'error': e.toString()});

--- a/lib/src/services/webserver/beans_handler.dart
+++ b/lib/src/services/webserver/beans_handler.dart
@@ -93,6 +93,11 @@ class BeansHandler {
       final json = jsonDecode(body) as Map<String, dynamic>;
 
       rejectExplicitNulls(json, const ['roaster', 'name', 'decaf', 'archived']);
+      validatePatchFieldTypes(
+        json,
+        integerListFields: const ['altitude'],
+        stringListFields: const ['variety'],
+      );
       final updated = Bean.fromJson({
         ...existing.toJson(),
         ...json,
@@ -209,6 +214,15 @@ class BeansHandler {
       final json = jsonDecode(body) as Map<String, dynamic>;
 
       rejectExplicitNulls(json, const ['frozen', 'archived']);
+      validatePatchFieldTypes(
+        json,
+        numberFields: const [
+          'qualityScore',
+          'price',
+          'weight',
+          'weightRemaining',
+        ],
+      );
       final updated = BeanBatch.fromJson({
         ...existing.toJson(),
         ...json,

--- a/lib/src/services/webserver/grinders_handler.dart
+++ b/lib/src/services/webserver/grinders_handler.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/data/grinder.dart';
 import 'package:reaprime/src/services/storage/grinder_storage_service.dart';
+import 'package:reaprime/src/services/webserver/json_patch.dart';
 import 'package:reaprime/src/services/webserver/json_response.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
@@ -87,26 +88,21 @@ class GrindersHandler {
       final body = await req.body.asString;
       final json = jsonDecode(body) as Map<String, dynamic>;
 
-      final updated = existing.copyWith(
-        model: json['model'] as String?,
-        burrs: json['burrs'] as String?,
-        burrSize: (json['burrSize'] as num?)?.toDouble(),
-        burrType: json['burrType'] as String?,
-        notes: json['notes'] as String?,
-        archived: json['archived'] as bool?,
-        settingType: json['settingType'] != null
-            ? GrinderSettingType.fromString(json['settingType'] as String)
-            : null,
-        settingValues: (json['settingValues'] as List?)?.cast<String>(),
-        settingSmallStep: (json['settingSmallStep'] as num?)?.toDouble(),
-        settingBigStep: (json['settingBigStep'] as num?)?.toDouble(),
-        rpmSmallStep: (json['rpmSmallStep'] as num?)?.toDouble(),
-        rpmBigStep: (json['rpmBigStep'] as num?)?.toDouble(),
-        extras: json['extras'] as Map<String, dynamic>?,
-      );
+      rejectExplicitNulls(json, const ['model', 'archived', 'settingType']);
+      final updated = Grinder.fromJson({
+        ...existing.toJson(),
+        ...json,
+        'id': existing.id,
+        'createdAt': existing.createdAt.toIso8601String(),
+        'updatedAt': DateTime.now().toIso8601String(),
+      });
 
       await _storage.updateGrinder(updated);
       return jsonOk(updated.toJson());
+    } on FormatException catch (e) {
+      return jsonBadRequest({'error': e.toString()});
+    } on TypeError catch (e) {
+      return jsonBadRequest({'error': e.toString()});
     } catch (e, st) {
       _log.severe('Error updating grinder $id', e, st);
       return jsonError({'error': e.toString()});

--- a/lib/src/services/webserver/grinders_handler.dart
+++ b/lib/src/services/webserver/grinders_handler.dart
@@ -89,6 +89,17 @@ class GrindersHandler {
       final json = jsonDecode(body) as Map<String, dynamic>;
 
       rejectExplicitNulls(json, const ['model', 'archived', 'settingType']);
+      validatePatchFieldTypes(
+        json,
+        numberFields: const [
+          'burrSize',
+          'settingSmallStep',
+          'settingBigStep',
+          'rpmSmallStep',
+          'rpmBigStep',
+        ],
+        stringListFields: const ['settingValues'],
+      );
       final updated = Grinder.fromJson({
         ...existing.toJson(),
         ...json,

--- a/lib/src/services/webserver/json_patch.dart
+++ b/lib/src/services/webserver/json_patch.dart
@@ -8,3 +8,39 @@ void rejectExplicitNulls(
     }
   }
 }
+
+void validatePatchFieldTypes(
+  Map<String, dynamic> patch, {
+  Iterable<String> numberFields = const [],
+  Iterable<String> integerListFields = const [],
+  Iterable<String> stringListFields = const [],
+}) {
+  _validateFields(patch, numberFields, (value) => value is num, 'a number');
+  _validateFields(
+    patch,
+    integerListFields,
+    (value) => value is List && value.every((item) => item is int),
+    'an array of integers',
+  );
+  _validateFields(
+    patch,
+    stringListFields,
+    (value) => value is List && value.every((item) => item is String),
+    'an array of strings',
+  );
+}
+
+void _validateFields(
+  Map<String, dynamic> patch,
+  Iterable<String> fields,
+  bool Function(Object value) isValid,
+  String expectedType,
+) {
+  for (final field in fields) {
+    final value = patch[field];
+    if (!patch.containsKey(field) || value == null) continue;
+    if (!isValid(value)) {
+      throw FormatException('Field "$field" must be $expectedType or null');
+    }
+  }
+}

--- a/lib/src/services/webserver/json_patch.dart
+++ b/lib/src/services/webserver/json_patch.dart
@@ -1,0 +1,10 @@
+void rejectExplicitNulls(
+  Map<String, dynamic> patch,
+  Iterable<String> nonNullableFields,
+) {
+  for (final field in nonNullableFields) {
+    if (patch.containsKey(field) && patch[field] == null) {
+      throw FormatException('Field "$field" cannot be null');
+    }
+  }
+}

--- a/lib/src/services/webserver/profile_handler.dart
+++ b/lib/src/services/webserver/profile_handler.dart
@@ -139,7 +139,11 @@ class ProfileHandler {
 
       Profile? profile;
       if (json.containsKey('profile')) {
-        profile = Profile.fromJson(json['profile'] as Map<String, dynamic>);
+        final profileJson = json['profile'];
+        if (profileJson == null) {
+          throw const FormatException('Field "profile" cannot be null');
+        }
+        profile = Profile.fromJson(profileJson as Map<String, dynamic>);
       }
 
       final metadata = json['metadata'] as Map<String, dynamic>?;
@@ -148,12 +152,15 @@ class ProfileHandler {
         id,
         profile: profile,
         metadata: metadata,
+        metadataPresent: json.containsKey('metadata'),
       );
 
       return jsonOk(record.toJson());
     } on ArgumentError catch (e) {
       return jsonBadRequest({'error': 'Invalid request', 'message': '$e'});
     } on FormatException catch (e) {
+      return jsonBadRequest({'error': 'Invalid request', 'message': '$e'});
+    } on TypeError catch (e) {
       return jsonBadRequest({'error': 'Invalid request', 'message': '$e'});
     } catch (e, st) {
       log.severe('Error in _handleUpdate', e, st);

--- a/lib/src/services/webserver/workflow_handler.dart
+++ b/lib/src/services/webserver/workflow_handler.dart
@@ -8,6 +8,7 @@ import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/models/data/json_utils.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/errors.dart';
+import 'package:reaprime/src/services/webserver/json_patch.dart';
 import 'package:reaprime/src/services/webserver/json_response.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
@@ -156,6 +157,18 @@ class WorkflowHandler {
 
   Future<Response> _applyUpdate(Map<String, dynamic> merge) async {
     try {
+      rejectExplicitNulls(merge, const ['steamSettings']);
+      if (merge['steamSettings'] case final Map<String, dynamic> settings) {
+        rejectExplicitNulls(settings, const [
+          'targetTemperature',
+          'duration',
+          'flow',
+          'stopAtTemperature',
+        ]);
+      } else if (merge.containsKey('steamSettings')) {
+        throw const FormatException('Field "steamSettings" must be an object');
+      }
+
       while (true) {
         final oldWorkflow = _controller.currentWorkflow;
         final revision = _controller.revision;

--- a/test/services/webserver/profile_handler_create_test.dart
+++ b/test/services/webserver/profile_handler_create_test.dart
@@ -51,6 +51,7 @@ class _StubStorage implements ProfileStorageService {
 }
 
 void main() {
+  late ProfileController controller;
   late Handler handler;
 
   Future<Response> postProfile(Map<String, dynamic> body) async {
@@ -63,8 +64,18 @@ void main() {
     );
   }
 
+  Future<Response> putProfile(String id, Map<String, dynamic> body) async {
+    return await handler(
+      Request(
+        'PUT',
+        Uri.parse('http://localhost/api/v1/profiles/$id'),
+        body: jsonEncode(body),
+      ),
+    );
+  }
+
   setUp(() {
-    final controller = ProfileController(storage: _StubStorage());
+    controller = ProfileController(storage: _StubStorage());
     final profileHandler = ProfileHandler(controller: controller);
     final app = Router().plus;
     profileHandler.addRoutes(app);
@@ -158,5 +169,48 @@ void main() {
         expect(response.statusCode, 400);
       },
     );
+  });
+
+  group('PUT /api/v1/profiles/<id>', () {
+    test('applies tri-state metadata semantics', () async {
+      final createResponse = await postProfile({
+        'profile': profileWithoutMetadata(),
+        'metadata': {'source': 'import'},
+      });
+      final created =
+          jsonDecode(await createResponse.readAsString())
+              as Map<String, dynamic>;
+      final id = created['id'] as String;
+
+      final preserved = await putProfile(id, {});
+      expect(jsonDecode(await preserved.readAsString())['metadata'], {
+        'source': 'import',
+      });
+
+      final cleared = await putProfile(id, {'metadata': null});
+      expect(jsonDecode(await cleared.readAsString())['metadata'], isNull);
+
+      final replaced = await putProfile(id, {
+        'metadata': {'source': 'user'},
+      });
+      expect(jsonDecode(await replaced.readAsString())['metadata'], {
+        'source': 'user',
+      });
+    });
+
+    test('rejects explicit null for the non-nullable profile', () async {
+      final createResponse = await postProfile({
+        'profile': profileWithoutMetadata(),
+      });
+      final created =
+          jsonDecode(await createResponse.readAsString())
+              as Map<String, dynamic>;
+
+      final response = await putProfile(created['id'] as String, {
+        'profile': null,
+      });
+
+      expect(response.statusCode, 400);
+    });
   });
 }

--- a/test/webserver/beans_handler_test.dart
+++ b/test/webserver/beans_handler_test.dart
@@ -212,6 +212,37 @@ void main() {
       expect(body['roaster'], 'Sey');
     });
 
+    test('PUT /api/v1/beans/<id> applies tri-state patch semantics', () async {
+      final createRes = await sendPost('/api/v1/beans', {
+        'roaster': 'Sey',
+        'name': 'Gichathaini',
+        'country': 'Kenya',
+      });
+      final created = jsonDecode(await createRes.readAsString());
+      final id = created['id'];
+
+      final preserved = await sendPut('/api/v1/beans/$id', {
+        'name': 'Gichathaini AA',
+      });
+      expect(jsonDecode(await preserved.readAsString())['country'], 'Kenya');
+
+      final cleared = await sendPut('/api/v1/beans/$id', {'country': null});
+      expect(
+        (jsonDecode(await cleared.readAsString()) as Map).containsKey(
+          'country',
+        ),
+        isFalse,
+      );
+
+      final replaced = await sendPut('/api/v1/beans/$id', {
+        'country': 'Ethiopia',
+      });
+      expect(jsonDecode(await replaced.readAsString())['country'], 'Ethiopia');
+
+      final rejected = await sendPut('/api/v1/beans/$id', {'roaster': null});
+      expect(rejected.statusCode, 400);
+    });
+
     test('PUT /api/v1/beans/<id> returns 404 for missing bean', () async {
       final response = await sendPut('/api/v1/beans/nonexistent', {
         'name': 'Test',
@@ -414,12 +445,17 @@ void main() {
         expect(DateTime.parse(fetched['unfreezeDate']), unfreezeDate);
         expect(fetched['roastLevel'], 'light');
 
-        await sendPut('/api/v1/bean-batches/${batch.id}', {'freezeDate': null});
-        final nullDateResponse = await sendGet(
+        final clearResponse = await sendPut(
           '/api/v1/bean-batches/${batch.id}',
+          {'freezeDate': null},
         );
-        final afterNullDate = jsonDecode(await nullDateResponse.readAsString());
-        expect(DateTime.parse(afterNullDate['freezeDate']), freezeDate);
+        final cleared = jsonDecode(await clearResponse.readAsString()) as Map;
+        expect(cleared.containsKey('freezeDate'), isFalse);
+
+        final rejected = await sendPut('/api/v1/bean-batches/${batch.id}', {
+          'frozen': null,
+        });
+        expect(rejected.statusCode, 400);
       },
     );
 

--- a/test/webserver/beans_handler_test.dart
+++ b/test/webserver/beans_handler_test.dart
@@ -243,6 +243,41 @@ void main() {
       expect(rejected.statusCode, 400);
     });
 
+    test(
+      'PUT /api/v1/beans/<id> rejects malformed lists without mutation',
+      () async {
+        final createRes = await sendPost('/api/v1/beans', {
+          'roaster': 'Sey',
+          'name': 'Gichathaini',
+          'variety': ['Heirloom'],
+          'altitude': [1800, 2200],
+        });
+        final created = jsonDecode(await createRes.readAsString());
+        final id = created['id'];
+
+        for (final patch in [
+          {
+            'altitude': ['1800', 2200],
+          },
+          {
+            'altitude': [1800.5, 2200],
+          },
+          {
+            'variety': [1],
+          },
+        ]) {
+          final response = await sendPut('/api/v1/beans/$id', patch);
+          expect(response.statusCode, 400, reason: '$patch');
+
+          final stored = jsonDecode(
+            await (await sendGet('/api/v1/beans/$id')).readAsString(),
+          );
+          expect(stored['altitude'], [1800, 2200], reason: '$patch');
+          expect(stored['variety'], ['Heirloom'], reason: '$patch');
+        }
+      },
+    );
+
     test('PUT /api/v1/beans/<id> returns 404 for missing bean', () async {
       final response = await sendPut('/api/v1/beans/nonexistent', {
         'name': 'Test',
@@ -456,6 +491,52 @@ void main() {
           'frozen': null,
         });
         expect(rejected.statusCode, 400);
+      },
+    );
+
+    test(
+      'PUT /api/v1/bean-batches/<id> rejects malformed numbers without mutation',
+      () async {
+        final createRes = await sendPost('/api/v1/beans/$beanId/batches', {
+          'qualityScore': 87.5,
+          'price': 18.5,
+          'weight': 250.0,
+        });
+        final created = jsonDecode(await createRes.readAsString());
+        final batchId = created['id'];
+        const expected = {
+          'qualityScore': 87.5,
+          'price': 18.5,
+          'weight': 250.0,
+          'weightRemaining': 250.0,
+        };
+
+        for (final field in expected.keys) {
+          final patch = {field: 'oops'};
+          final response = await sendPut(
+            '/api/v1/bean-batches/$batchId',
+            patch,
+          );
+          expect(response.statusCode, 400, reason: '$patch');
+
+          final stored = jsonDecode(
+            await (await sendGet(
+              '/api/v1/bean-batches/$batchId',
+            )).readAsString(),
+          );
+          for (final entry in expected.entries) {
+            expect(stored[entry.key], entry.value, reason: '$patch');
+          }
+        }
+
+        final numericString = await sendPut('/api/v1/bean-batches/$batchId', {
+          'price': '12.5',
+        });
+        expect(numericString.statusCode, 400);
+        final stored = jsonDecode(
+          await (await sendGet('/api/v1/bean-batches/$batchId')).readAsString(),
+        );
+        expect(stored['price'], 18.5);
       },
     );
 

--- a/test/webserver/grinders_handler_test.dart
+++ b/test/webserver/grinders_handler_test.dart
@@ -194,6 +194,62 @@ void main() {
       },
     );
 
+    test(
+      'PUT /api/v1/grinders/<id> rejects malformed values without mutation',
+      () async {
+        final createRes = await sendPost('/api/v1/grinders', {
+          'model': 'Niche Zero',
+          'burrSize': 63.0,
+          'settingValues': ['Fine', 'Coarse'],
+          'settingSmallStep': 0.1,
+          'settingBigStep': 1.0,
+          'rpmSmallStep': 10.0,
+          'rpmBigStep': 100.0,
+        });
+        final created = jsonDecode(await createRes.readAsString());
+        final id = created['id'];
+        const expected = {
+          'burrSize': 63.0,
+          'settingSmallStep': 0.1,
+          'settingBigStep': 1.0,
+          'rpmSmallStep': 10.0,
+          'rpmBigStep': 100.0,
+        };
+
+        for (final field in expected.keys) {
+          final patch = {field: 'oops'};
+          final response = await sendPut('/api/v1/grinders/$id', patch);
+          expect(response.statusCode, 400, reason: '$patch');
+
+          final stored = jsonDecode(
+            await (await sendGet('/api/v1/grinders/$id')).readAsString(),
+          );
+          for (final entry in expected.entries) {
+            expect(stored[entry.key], entry.value, reason: '$patch');
+          }
+          expect(stored['settingValues'], ['Fine', 'Coarse']);
+        }
+
+        for (final patch in [
+          {'burrSize': '63.0'},
+          {
+            'settingValues': [1],
+          },
+        ]) {
+          final response = await sendPut('/api/v1/grinders/$id', patch);
+          expect(response.statusCode, 400, reason: '$patch');
+
+          final stored = jsonDecode(
+            await (await sendGet('/api/v1/grinders/$id')).readAsString(),
+          );
+          for (final entry in expected.entries) {
+            expect(stored[entry.key], entry.value, reason: '$patch');
+          }
+          expect(stored['settingValues'], ['Fine', 'Coarse']);
+        }
+      },
+    );
+
     test('PUT /api/v1/grinders/<id> returns 404 for missing grinder', () async {
       final response = await sendPut('/api/v1/grinders/nonexistent', {
         'model': 'Test',

--- a/test/webserver/grinders_handler_test.dart
+++ b/test/webserver/grinders_handler_test.dart
@@ -155,6 +155,45 @@ void main() {
       expect(body['notes'], 'Upgraded burrs');
     });
 
+    test(
+      'PUT /api/v1/grinders/<id> applies tri-state patch semantics',
+      () async {
+        final createRes = await sendPost('/api/v1/grinders', {
+          'model': 'Niche Zero',
+          'notes': 'Original burrs',
+        });
+        final created = jsonDecode(await createRes.readAsString());
+        final id = created['id'];
+
+        final preserved = await sendPut('/api/v1/grinders/$id', {
+          'burrType': 'conical',
+        });
+        expect(
+          jsonDecode(await preserved.readAsString())['notes'],
+          'Original burrs',
+        );
+
+        final cleared = await sendPut('/api/v1/grinders/$id', {'notes': null});
+        expect(
+          (jsonDecode(await cleared.readAsString()) as Map).containsKey(
+            'notes',
+          ),
+          isFalse,
+        );
+
+        final replaced = await sendPut('/api/v1/grinders/$id', {
+          'notes': 'Upgraded burrs',
+        });
+        expect(
+          jsonDecode(await replaced.readAsString())['notes'],
+          'Upgraded burrs',
+        );
+
+        final rejected = await sendPut('/api/v1/grinders/$id', {'model': null});
+        expect(rejected.statusCode, 400);
+      },
+    );
+
     test('PUT /api/v1/grinders/<id> returns 404 for missing grinder', () async {
       final response = await sendPut('/api/v1/grinders/nonexistent', {
         'model': 'Test',

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -480,6 +480,52 @@ void main() {
       expect(spy.updateShotSettingsCalls.single.targetSteamTemp, 0);
     });
 
+    test('steam settings preserve, replace, and reject null values', () async {
+      await _settleHandler(spy);
+      final initial = workflowController.currentWorkflow.steamSettings;
+
+      final updatedDuration = initial.duration + 1;
+      final replaced = await put({
+        'steamSettings': {'duration': updatedDuration},
+      });
+      expect(replaced.statusCode, 200);
+      final body = jsonDecode(await replaced.readAsString());
+      expect(body['steamSettings']['duration'], updatedDuration);
+      expect(
+        body['steamSettings']['targetTemperature'],
+        initial.targetTemperature,
+      );
+      expect(body['steamSettings']['flow'], initial.flow);
+      expect(
+        body['steamSettings']['stopAtTemperature'],
+        initial.stopAtTemperature,
+      );
+
+      for (final patch in [
+        {'steamSettings': null},
+        {
+          'steamSettings': {'targetTemperature': null},
+        },
+        {
+          'steamSettings': {'duration': null},
+        },
+        {
+          'steamSettings': {'flow': null},
+        },
+        {
+          'steamSettings': {'stopAtTemperature': null},
+        },
+      ]) {
+        final rejected = await put(patch);
+        expect(rejected.statusCode, 400, reason: '$patch');
+      }
+
+      expect(
+        workflowController.currentWorkflow.steamSettings.duration,
+        updatedDuration,
+      );
+    });
+
     test('no-op PUT (same values) issues no DE1 writes', () async {
       await _settleHandler(spy);
       final snapshot = workflowController.currentWorkflow;


### PR DESCRIPTION
## Summary

What changed, and why?

- distinguish omitted fields from explicit `null` in bean, bean-batch, grinder, and profile metadata updates
- reject explicit `null` for non-nullable profile and steam-setting fields with `400`
- strictly validate HTTP numeric/list patch values before permissive import parsers can coerce them
- document tri-state partial-update semantics in OpenAPI and API/profile docs

## Linked Issue

Fixes #556

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- `dart format --output=none --set-exit-if-changed` on changed Dart files
- focused handler/controller tests: 82 passed
- `flutter analyze` — no issues
- `flutter test` — 3,121 passed, 1 skipped
- parsed `assets/api/rest_v1.yml` with PyYAML
- simulated macOS REST smoke with MockDe1 across bean, batch, grinder, profile metadata, and workflow steam settings; repeated after hot reload
- Drift-backed REST smoke proving malformed bean altitude/variety, batch numeric, and grinder numeric/list patches return `400` without mutation

## Impact

Affected partial-update endpoints now preserve omitted fields, clear nullable fields on explicit `null`, and return `400` for explicit `null` on non-nullable fields. Supplied numeric/list values must match the OpenAPI types; malformed strings and list elements are rejected before persistence. OpenAPI and user-facing API/profile documentation are updated. No database migration or security impact.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
