### PR TITLE
feat(api): log client IP and scrub serial from exported logs

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -452,6 +452,7 @@ class _MyAppState extends State<MyApp> {
                       return DataManagementPage(
                         controller: widget.settingsController,
                         persistenceController: widget.persistenceController,
+                        de1Controller: widget.de1Controller,
                         profileStorageService: widget.profileStorageService,
                         beanStorageService: widget.beanStorage,
                         grinderStorageService: widget.grinderStorage,

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -21,7 +21,10 @@ class De1Controller {
   Workflow? defaultWorkflow;
 
   De1Interface? _de1;
+  final Set<String> _seenSerials = {};
   final Logger _log = Logger("De1Controller");
+
+  List<String> get seenSerials => List.unmodifiable(_seenSerials);
 
   final BehaviorSubject<De1Interface?> _de1Controller = BehaviorSubject.seeded(
     null,
@@ -195,6 +198,18 @@ class De1Controller {
     );
   }
 
+  void _recordSerial(De1Interface device) {
+    final String serial;
+    try {
+      serial = device.machineInfo.serialNumber;
+    } catch (_) {
+      return;
+    }
+    if (serial.isNotEmpty && serial != '0') {
+      _seenSerials.add(serial);
+    }
+  }
+
   void _onDisconnect() {
     _log.info("resetting de1");
     _connectionGeneration++;
@@ -224,6 +239,7 @@ class De1Controller {
 
     _log.info("Initializing DE1 data");
     _dataInitialized = true;
+    _recordSerial(device);
 
     try {
       _subscriptions.add(device.shotSettings.listen(_shotSettingsUpdate));

--- a/lib/src/feedback_feature/feedback_view.dart
+++ b/lib/src/feedback_feature/feedback_view.dart
@@ -12,17 +12,27 @@ import 'package:url_launcher/url_launcher.dart';
 
 const _maxScreenshots = 2;
 
-void showFeedbackDialog(BuildContext context, {required String githubToken}) {
+void showFeedbackDialog(
+  BuildContext context, {
+  required String githubToken,
+  required List<String> Function() serialNumbers,
+}) {
   showShadDialog(
     context: context,
-    builder: (context) => FeedbackDialog(githubToken: githubToken),
+    builder: (context) =>
+        FeedbackDialog(githubToken: githubToken, serialNumbers: serialNumbers),
   );
 }
 
 class FeedbackDialog extends StatefulWidget {
   final String githubToken;
+  final List<String> Function() serialNumbers;
 
-  const FeedbackDialog({super.key, required this.githubToken});
+  const FeedbackDialog({
+    super.key,
+    required this.githubToken,
+    required this.serialNumbers,
+  });
 
   @override
   State<FeedbackDialog> createState() => _FeedbackDialogState();
@@ -44,7 +54,10 @@ class _FeedbackDialogState extends State<FeedbackDialog> {
   @override
   void initState() {
     super.initState();
-    _service = FeedbackService(githubToken: widget.githubToken);
+    _service = FeedbackService(
+      githubToken: widget.githubToken,
+      currentSerialNumbers: widget.serialNumbers,
+    );
     _controller = FeedbackController(service: _service);
     _controller.addListener(_onControllerChanged);
   }

--- a/lib/src/services/feedback_service.dart
+++ b/lib/src/services/feedback_service.dart
@@ -10,10 +10,12 @@ import 'package:path_provider/path_provider.dart';
 import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/models/feedback/feedback_request.dart';
 import 'package:reaprime/src/models/feedback/feedback_result.dart';
+import 'package:reaprime/src/services/telemetry/anonymization.dart';
 
 class FeedbackService {
   final String _githubToken;
   final String _repo;
+  final String? Function()? _currentSerialNumber;
   final Logger _log = Logger('FeedbackService');
 
   static const String _githubApiBase = 'https://api.github.com';
@@ -21,8 +23,10 @@ class FeedbackService {
   FeedbackService({
     required String githubToken,
     String repo = 'decentespresso/decaid',
+    String? Function()? currentSerialNumber,
   }) : _githubToken = githubToken,
-       _repo = repo;
+       _repo = repo,
+       _currentSerialNumber = currentSerialNumber;
 
   bool get isConfigured => _githubToken.isNotEmpty;
 
@@ -167,7 +171,7 @@ class FeedbackService {
       final docs = await getApplicationDocumentsDirectory();
       final logFile = File('${docs.path}/log.txt');
       if (await logFile.exists()) {
-        return await logFile.readAsString();
+        return _scrubSensitive(await logFile.readAsString());
       }
       _log.info('No log file found');
       return null;
@@ -182,7 +186,7 @@ class FeedbackService {
       final docs = await getApplicationDocumentsDirectory();
       final logFile = File('${docs.path}/webview_console.log');
       if (await logFile.exists()) {
-        return await logFile.readAsString();
+        return _scrubSensitive(await logFile.readAsString());
       }
       _log.info('No webview log file found');
       return null;
@@ -190,6 +194,16 @@ class FeedbackService {
       _log.warning('Failed to read webview log file', e);
       return null;
     }
+  }
+
+  String _scrubSensitive(String content) {
+    final serial = _currentSerialNumber?.call();
+    return Anonymization.scrubString(
+      content,
+      sensitiveStrings: [
+        if (serial != null && serial.isNotEmpty && serial != '0') serial,
+      ],
+    );
   }
 
   Future<Uint8List> _scaleImageToMaxSize(

--- a/lib/src/services/feedback_service.dart
+++ b/lib/src/services/feedback_service.dart
@@ -15,7 +15,7 @@ import 'package:reaprime/src/services/telemetry/anonymization.dart';
 class FeedbackService {
   final String _githubToken;
   final String _repo;
-  final String? Function()? _currentSerialNumber;
+  final List<String> Function() _currentSerialNumbers;
   final Logger _log = Logger('FeedbackService');
 
   static const String _githubApiBase = 'https://api.github.com';
@@ -23,10 +23,10 @@ class FeedbackService {
   FeedbackService({
     required String githubToken,
     String repo = 'decentespresso/decaid',
-    String? Function()? currentSerialNumber,
+    required List<String> Function() currentSerialNumbers,
   }) : _githubToken = githubToken,
        _repo = repo,
-       _currentSerialNumber = currentSerialNumber;
+       _currentSerialNumbers = currentSerialNumbers;
 
   bool get isConfigured => _githubToken.isNotEmpty;
 
@@ -197,12 +197,9 @@ class FeedbackService {
   }
 
   String _scrubSensitive(String content) {
-    final serial = _currentSerialNumber?.call();
     return Anonymization.scrubString(
       content,
-      sensitiveStrings: [
-        if (serial != null && serial.isNotEmpty && serial != '0') serial,
-      ],
+      sensitiveStrings: _currentSerialNumbers(),
     );
   }
 

--- a/lib/src/services/telemetry/anonymization.dart
+++ b/lib/src/services/telemetry/anonymization.dart
@@ -64,6 +64,16 @@ class Anonymization {
       scrubbed = scrubbed.replaceAll(sensitive, anonymizeSerial(sensitive));
     }
 
+    final serialFieldPattern = RegExp(
+      r'serialNumber"?\s*:\s*"?([0-9A-Za-z._-]{3,})',
+      caseSensitive: false,
+    );
+    scrubbed = scrubbed.replaceAllMapped(serialFieldPattern, (match) {
+      return match
+          .group(0)!
+          .replaceFirst(match.group(1)!, anonymizeSerial(match.group(1)!));
+    });
+
     final macPattern = RegExp(r'([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}');
     scrubbed = scrubbed.replaceAllMapped(macPattern, (match) {
       return anonymizeMac(match.group(0)!);

--- a/lib/src/services/telemetry/anonymization.dart
+++ b/lib/src/services/telemetry/anonymization.dart
@@ -27,6 +27,13 @@ class Anonymization {
     return 'ip_${hash.toString().substring(0, 16)}';
   }
 
+  static String anonymizeSerial(String serialNumber) {
+    final bytes = utf8.encode('$_salt:serial:$serialNumber');
+    final hash = sha256.convert(bytes);
+
+    return 'serial_${hash.toString().substring(0, 16)}';
+  }
+
   static String anonymize(String input) {
     final macPattern = RegExp(r'^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$');
     if (macPattern.hasMatch(input)) {
@@ -46,8 +53,16 @@ class Anonymization {
     return input;
   }
 
-  static String scrubString(String text) {
+  static String scrubString(
+    String text, {
+    List<String> sensitiveStrings = const [],
+  }) {
     var scrubbed = text;
+
+    for (final sensitive in sensitiveStrings) {
+      if (sensitive.length < 3) continue;
+      scrubbed = scrubbed.replaceAll(sensitive, anonymizeSerial(sensitive));
+    }
 
     final macPattern = RegExp(r'([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}');
     scrubbed = scrubbed.replaceAllMapped(macPattern, (match) {

--- a/lib/src/services/telemetry/anonymization.dart
+++ b/lib/src/services/telemetry/anonymization.dart
@@ -74,6 +74,17 @@ class Anonymization {
       return anonymizeIp(match.group(0)!);
     });
 
+    final ipv6Pattern = RegExp(
+      r'(?<![\dA-Fa-f:])(?:'
+      r'(?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?::(?:[0-9A-Fa-f]{1,4}:)*[0-9A-Fa-f]{1,4}'
+      r'|'
+      r'[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4}){3,}'
+      r')(?![\dA-Fa-f:])',
+    );
+    scrubbed = scrubbed.replaceAllMapped(ipv6Pattern, (match) {
+      return anonymizeIp(match.group(0)!);
+    });
+
     return scrubbed;
   }
 }

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -220,6 +220,8 @@ Future<void> startWebServer(
       githubToken: rot13(
         const String.fromEnvironment('GITHUB_FEEDBACK_TOKEN', defaultValue: ''),
       ),
+      currentSerialNumber: () =>
+          de1Controller.connectedDe1OrNull?.machineInfo.serialNumber,
     ),
   );
 
@@ -463,13 +465,7 @@ Handler _init(
 
   final handler = const Pipeline()
       .addMiddleware(accountProxyCorsMiddleware(accountProxyAllowedOrigins))
-      .addMiddleware(
-        logRequests(
-          logger: (msg, isError) {
-            isError ? log.warning(msg) : log.info(msg);
-          },
-        ),
-      )
+      .addMiddleware(logRequestsWithClientIp())
       .addMiddleware(
         corsHeaders(
           headers: {
@@ -489,6 +485,59 @@ Handler _init(
       .addHandler(app.call);
 
   return handler;
+}
+
+const _shelfConnectionInfoKey = 'shelf.io.connection_info';
+
+Middleware logRequestsWithClientIp({
+  void Function(String message, bool isError)? logger,
+}) {
+  final write =
+      logger ?? (msg, isError) => isError ? log.warning(msg) : log.info(msg);
+
+  return (innerHandler) {
+    return (request) {
+      final startTime = DateTime.now();
+      final watch = Stopwatch()..start();
+      final ip = clientIpFromRequest(request);
+
+      return Future.sync(() => innerHandler(request)).then(
+        (response) {
+          write(
+            '${startTime.toIso8601String()} '
+            '${watch.elapsed.toString().padLeft(15)} '
+            '${request.method.padRight(7)} $ip '
+            '[${response.statusCode}] '
+            '${request.requestedUri.path}'
+            '${_formatQuery(request.requestedUri.query)}',
+            false,
+          );
+          return response;
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          if (error is HijackException) throw error;
+
+          write(
+            '${startTime.toIso8601String()} ${request.method} $ip '
+            '${request.requestedUri.path}'
+            '${_formatQuery(request.requestedUri.query)} error: $error',
+            true,
+          );
+
+          throw error;
+        },
+      );
+    };
+  };
+}
+
+String clientIpFromRequest(Request request) {
+  final info = request.context[_shelfConnectionInfoKey];
+  return info is HttpConnectionInfo ? info.remoteAddress.address : '-';
+}
+
+String _formatQuery(String query) {
+  return query.isEmpty ? '' : '?$query';
 }
 
 Set<String> accountProxyCorsAllowedOrigins(WebUIService webUIService) {

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -73,6 +73,7 @@ import 'package:reaprime/src/models/device/transport/ble_timeout_exception.dart'
 import 'package:shelf/shelf_io.dart' as io;
 import 'package:shelf_web_socket/shelf_web_socket.dart' as sws;
 import 'package:shelf_cors_headers/shelf_cors_headers.dart';
+import 'package:stack_trace/stack_trace.dart';
 import 'package:reaprime/src/models/device/de1_rawmessage.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
 import 'package:reaprime/src/services/feedback_service.dart';
@@ -220,8 +221,7 @@ Future<void> startWebServer(
       githubToken: rot13(
         const String.fromEnvironment('GITHUB_FEEDBACK_TOKEN', defaultValue: ''),
       ),
-      currentSerialNumber: () =>
-          de1Controller.connectedDe1OrNull?.machineInfo.serialNumber,
+      currentSerialNumbers: () => de1Controller.seenSerials,
     ),
   );
 
@@ -517,10 +517,17 @@ Middleware logRequestsWithClientIp({
         onError: (Object error, StackTrace stackTrace) {
           if (error is HijackException) throw error;
 
+          var chain = Chain.forTrace(stackTrace)
+              .foldFrames((frame) => frame.isCore || frame.package == 'shelf')
+              .terse;
+
           write(
-            '${startTime.toIso8601String()} ${request.method} $ip '
+            '${startTime.toIso8601String()} '
+            '${watch.elapsed.toString().padLeft(15)} '
+            '${request.method.padRight(7)} $ip '
             '${request.requestedUri.path}'
-            '${_formatQuery(request.requestedUri.query)} error: $error',
+            '${_formatQuery(request.requestedUri.query)}\n'
+            '$error\n$chain',
             true,
           );
 

--- a/lib/src/settings/data_management_page.dart
+++ b/lib/src/settings/data_management_page.dart
@@ -11,6 +11,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:reaprime/src/services/security_scoped_file.dart';
 import 'package:reaprime/src/util/rot13.dart';
 import 'package:reaprime/src/controllers/persistence_controller.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/feedback_feature/feedback_view.dart';
 import 'package:reaprime/src/import/de1app_importer.dart';
 import 'package:reaprime/src/import/saf_folder_copier.dart';
@@ -47,6 +48,7 @@ class DataManagementPage extends StatefulWidget {
     super.key,
     required this.controller,
     required this.persistenceController,
+    required this.de1Controller,
     this.profileStorageService,
     this.beanStorageService,
     this.grinderStorageService,
@@ -57,6 +59,7 @@ class DataManagementPage extends StatefulWidget {
 
   final SettingsController controller;
   final PersistenceController persistenceController;
+  final De1Controller de1Controller;
   final ProfileStorageService? profileStorageService;
   final BeanStorageService? beanStorageService;
   final GrinderStorageService? grinderStorageService;
@@ -258,6 +261,7 @@ class _DataManagementPageState extends State<DataManagementPage> {
                   defaultValue: '',
                 ),
               ),
+              serialNumbers: () => widget.de1Controller.seenSerials,
             ),
             child: const Text("Send Feedback"),
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1623,7 +1623,7 @@ packages:
     source: hosted
     version: "0.44.5"
   stack_trace:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: stack_trace
       sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1130,7 +1130,7 @@ packages:
     source: hosted
     version: "2.2.1"
   path_provider_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: path_provider_platform_interface
       sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   permission_handler: ^12.0.0+1
   rxdart: ^0.28.0
   shelf: ^1.0.0
+  stack_trace: ^1.12.0
   shelf_web_socket: ^3.0.0
   shelf_router: ^1.1.4
   battery_plus: ^7.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -160,6 +160,7 @@ dev_dependencies:
   # Test-only: mock url_launcher for the skin "Go to skin" button. Already
   # present transitively via url_launcher; declared so the test imports resolve.
   plugin_platform_interface: ^2.1.8
+  path_provider_platform_interface: ^2.1.2
   url_launcher_platform_interface: ^2.3.2
   hive_ce_generator: ^1.10.0
   drift_dev: ^2.24.0

--- a/test/controllers/de1_controller_test.dart
+++ b/test/controllers/de1_controller_test.dart
@@ -73,6 +73,56 @@ void main() {
     });
   });
 
+  group('seenSerials', () {
+    test('retains serials after the device disconnects', () async {
+      await runZonedGuarded(() async {
+        final deviceController = DeviceController([
+          MockDeviceDiscoveryService(),
+        ]);
+        await deviceController.initialize();
+        final de1Controller = De1Controller(controller: deviceController);
+        final testDe1 = TestDe1(serialNumber: '123456');
+
+        await de1Controller.connectToDe1(testDe1);
+        testDe1.emitShotSettings(_emptyShotSettings());
+        await Future<void>.delayed(Duration.zero);
+        expect(de1Controller.seenSerials, contains('123456'));
+
+        testDe1.setConnectionState(ConnectionState.disconnected);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(de1Controller.seenSerials, contains('123456'));
+
+        testDe1.dispose();
+      }, (_, _) {});
+    });
+
+    test('accumulates serials across device switches', () async {
+      await runZonedGuarded(() async {
+        final deviceController = DeviceController([
+          MockDeviceDiscoveryService(),
+        ]);
+        await deviceController.initialize();
+        final de1Controller = De1Controller(controller: deviceController);
+
+        final first = TestDe1(serialNumber: '111111');
+        await de1Controller.connectToDe1(first);
+        first.emitShotSettings(_emptyShotSettings());
+        await Future<void>.delayed(Duration.zero);
+
+        final second = TestDe1(serialNumber: '222222');
+        await de1Controller.connectToDe1(second);
+        second.emitShotSettings(_emptyShotSettings());
+        await Future<void>.delayed(Duration.zero);
+
+        expect(de1Controller.seenSerials, containsAll(['111111', '222222']));
+
+        first.dispose();
+        second.dispose();
+      }, (_, _) {});
+    });
+  });
+
   group('initial shot settings', () {
     test('missing initial settings do not block initialization', () async {
       final deviceController = DeviceController([MockDeviceDiscoveryService()]);

--- a/test/helpers/test_de1.dart
+++ b/test/helpers/test_de1.dart
@@ -13,10 +13,14 @@ import 'package:rxdart/rxdart.dart';
 class TestDe1 implements De1Interface {
   final String _deviceId;
   final String _name;
+  final String serialNumber;
 
-  TestDe1({String deviceId = 'test-de1', String name = 'TestDe1'})
-    : _deviceId = deviceId,
-      _name = name;
+  TestDe1({
+    String deviceId = 'test-de1',
+    String name = 'TestDe1',
+    this.serialNumber = '1',
+  }) : _deviceId = deviceId,
+       _name = name;
   final BehaviorSubject<MachineSnapshot> snapshotSubject =
       BehaviorSubject.seeded(
         MachineSnapshot(
@@ -100,7 +104,7 @@ class TestDe1 implements De1Interface {
   MachineInfo get machineInfo => MachineInfo(
     version: '1',
     model: '1',
-    serialNumber: '1',
+    serialNumber: serialNumber,
     groupHeadControllerPresent: false,
     extra: {},
   );

--- a/test/services/feedback_service_test.dart
+++ b/test/services/feedback_service_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:reaprime/src/models/feedback/feedback_request.dart';
+import 'package:reaprime/src/services/feedback_service.dart';
+
+class _FakePathProvider extends Fake
+    with MockPlatformInterfaceMixin
+    implements PathProviderPlatform {
+  _FakePathProvider(this.docsDir);
+
+  final Directory docsDir;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => docsDir.path;
+}
+
+void main() {
+  test('scrubs serials from logs when the serial provider is empty', () async {
+    final tempDir = Directory.systemTemp.createTempSync(
+      'feedback_service_test',
+    );
+    addTearDown(() => tempDir.deleteSync(recursive: true));
+
+    PathProviderPlatform.instance = _FakePathProvider(tempDir);
+
+    File('${tempDir.path}/log.txt').writeAsStringSync(
+      'device connected {"machineInfo":{"serialNumber":"SN123456"}}\n'
+      'another line serialNumber: SN999888\n',
+    );
+
+    final service = FeedbackService(
+      githubToken: 'token',
+      currentSerialNumbers: () => const [],
+    );
+
+    final report = await service.generateHtmlReport(
+      FeedbackRequest(
+        description: 'test',
+        type: FeedbackType.bug,
+        includeLogs: true,
+        includeSystemInfo: false,
+      ),
+    );
+
+    expect(report, isNot(contains('SN123456')));
+    expect(report, isNot(contains('SN999888')));
+    expect(report, contains('serial_'));
+  });
+}

--- a/test/services/telemetry/anonymization_test.dart
+++ b/test/services/telemetry/anonymization_test.dart
@@ -40,6 +40,16 @@ void main() {
       expect(out, contains('ip_'));
     });
 
+    test('scrubs serialNumber log fields without a serial provider', () {
+      final out = Anonymization.scrubString(
+        '{"machineInfo":{"serialNumber":"SN123456"}} '
+        'serialNumber: SN999888',
+      );
+      expect(out, isNot(contains('SN123456')));
+      expect(out, isNot(contains('SN999888')));
+      expect(out, contains('serial_'));
+    });
+
     test('leaves timestamps and bare colons untouched', () {
       final out = Anonymization.scrubString(
         'at 10:30:00 request 2025-05-14T10:30:00.123Z',

--- a/test/services/telemetry/anonymization_test.dart
+++ b/test/services/telemetry/anonymization_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/telemetry/anonymization.dart';
+
+void main() {
+  group('Anonymization.scrubString', () {
+    test('redacts a machine serial number', () {
+      final out = Anonymization.scrubString(
+        'Info: {serialNumber: 123456} Machine serial 123456',
+        sensitiveStrings: ['123456'],
+      );
+      expect(out, isNot(contains('123456')));
+      expect(out, contains('serial_'));
+    });
+
+    test('leaves short serials untouched', () {
+      final out = Anonymization.scrubString(
+        'serial 12',
+        sensitiveStrings: ['12'],
+      );
+      expect(out, contains('12'));
+    });
+
+    test('still scrubs mac and ip addresses', () {
+      final out = Anonymization.scrubString(
+        'mac AA:BB:CC:DD:EE:FF ip 192.168.1.50',
+      );
+      expect(out, isNot(contains('AA:BB:CC:DD:EE:FF')));
+      expect(out, isNot(contains('192.168.1.50')));
+    });
+  });
+
+  group('Anonymization.anonymizeSerial', () {
+    test('is deterministic and prefixed', () {
+      final a = Anonymization.anonymizeSerial('123456');
+      final b = Anonymization.anonymizeSerial('123456');
+      expect(a, b);
+      expect(a, startsWith('serial_'));
+    });
+  });
+}

--- a/test/services/telemetry/anonymization_test.dart
+++ b/test/services/telemetry/anonymization_test.dart
@@ -27,6 +27,26 @@ void main() {
       expect(out, isNot(contains('AA:BB:CC:DD:EE:FF')));
       expect(out, isNot(contains('192.168.1.50')));
     });
+
+    test('scrubs ipv6 addresses', () {
+      final out = Anonymization.scrubString(
+        'loopback ::1 link-local fe80::1234:abcd '
+        '2001:db8::1 full 2001:db8:0:1:1:1:1:1',
+      );
+      expect(out, isNot(contains('::1')));
+      expect(out, isNot(contains('fe80::1234:abcd')));
+      expect(out, isNot(contains('2001:db8::1')));
+      expect(out, isNot(contains('2001:db8:0:1:1:1:1:1')));
+      expect(out, contains('ip_'));
+    });
+
+    test('leaves timestamps and bare colons untouched', () {
+      final out = Anonymization.scrubString(
+        'at 10:30:00 request 2025-05-14T10:30:00.123Z',
+      );
+      expect(out, contains('10:30:00'));
+      expect(out, isNot(contains('ip_')));
+    });
   });
 
   group('Anonymization.anonymizeSerial', () {

--- a/test/services/webserver/request_log_middleware_test.dart
+++ b/test/services/webserver/request_log_middleware_test.dart
@@ -94,6 +94,8 @@ void main() {
       expect(messages.single, startsWith('true:'));
       expect(messages.single, contains('10.0.0.9'));
       expect(messages.single, contains('/api/v1/scale/tare'));
+      expect(messages.single, contains('boom'));
+      expect(messages.single, contains('logRequestsWithClientIp'));
     });
   });
 }

--- a/test/services/webserver/request_log_middleware_test.dart
+++ b/test/services/webserver/request_log_middleware_test.dart
@@ -43,11 +43,12 @@ void main() {
   group('logRequestsWithClientIp', () {
     test('logs the client ip and status code', () async {
       final messages = <String>[];
-      final handler = logRequestsWithClientIp(
-        logger: (msg, isError) => messages.add(msg),
-      )((Request request) async {
-        return Response.ok('ok');
-      });
+      final handler =
+          logRequestsWithClientIp(logger: (msg, isError) => messages.add(msg))((
+            Request request,
+          ) async {
+            return Response.ok('ok');
+          });
 
       final request = Request(
         'GET',
@@ -70,11 +71,12 @@ void main() {
 
     test('logs errors with the client ip', () async {
       final messages = <String>[];
-      final handler = logRequestsWithClientIp(
-        logger: (msg, isError) => messages.add('$isError:$msg'),
-      )((Request request) async {
-        throw StateError('boom');
-      });
+      final handler =
+          logRequestsWithClientIp(
+            logger: (msg, isError) => messages.add('$isError:$msg'),
+          )((Request request) async {
+            throw StateError('boom');
+          });
 
       final request = Request(
         'POST',

--- a/test/services/webserver/request_log_middleware_test.dart
+++ b/test/services/webserver/request_log_middleware_test.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+class _FakeConnectionInfo implements HttpConnectionInfo {
+  final InternetAddress _remote;
+
+  _FakeConnectionInfo(this._remote);
+
+  @override
+  InternetAddress get remoteAddress => _remote;
+
+  @override
+  int get remotePort => 0;
+
+  @override
+  int get localPort => 0;
+}
+
+void main() {
+  group('clientIpFromRequest', () {
+    test('returns - when no connection info is present', () {
+      final request = Request('GET', Uri.parse('http://localhost/'));
+      expect(clientIpFromRequest(request), '-');
+    });
+
+    test('returns the remote address from connection info', () {
+      final request = Request(
+        'GET',
+        Uri.parse('http://localhost/'),
+        context: {
+          'shelf.io.connection_info': _FakeConnectionInfo(
+            InternetAddress('192.168.1.50'),
+          ),
+        },
+      );
+      expect(clientIpFromRequest(request), '192.168.1.50');
+    });
+  });
+
+  group('logRequestsWithClientIp', () {
+    test('logs the client ip and status code', () async {
+      final messages = <String>[];
+      final handler = logRequestsWithClientIp(
+        logger: (msg, isError) => messages.add(msg),
+      )((Request request) async {
+        return Response.ok('ok');
+      });
+
+      final request = Request(
+        'GET',
+        Uri.parse('http://localhost/api/v1/info'),
+        context: {
+          'shelf.io.connection_info': _FakeConnectionInfo(
+            InternetAddress('10.0.0.7'),
+          ),
+        },
+      );
+
+      final response = await handler(request);
+
+      expect(response.statusCode, 200);
+      expect(messages, hasLength(1));
+      expect(messages.single, contains('10.0.0.7'));
+      expect(messages.single, contains('/api/v1/info'));
+      expect(messages.single, contains('[200]'));
+    });
+
+    test('logs errors with the client ip', () async {
+      final messages = <String>[];
+      final handler = logRequestsWithClientIp(
+        logger: (msg, isError) => messages.add('$isError:$msg'),
+      )((Request request) async {
+        throw StateError('boom');
+      });
+
+      final request = Request(
+        'POST',
+        Uri.parse('http://localhost/api/v1/scale/tare'),
+        context: {
+          'shelf.io.connection_info': _FakeConnectionInfo(
+            InternetAddress('10.0.0.9'),
+          ),
+        },
+      );
+
+      await expectLater(handler(request), throwsStateError);
+
+      expect(messages, hasLength(1));
+      expect(messages.single, startsWith('true:'));
+      expect(messages.single, contains('10.0.0.9'));
+      expect(messages.single, contains('/api/v1/scale/tare'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Two changes addressing API observability and log-export privacy:

- **Client IP in API logs** — replaced shelf's `logRequests` with a middleware that includes the client's remote address, so API call logs show who is sending what (e.g. the rogue tare from the related issue).
- **Sensitive info scrubbing on log export** — the in-app feedback flow now scrubs the machine serial number (and already-scrubbed MAC/IP) from `log.txt` and `webview_console.log` before uploading to a gist or building the HTML report.

## Linked Issue

Fixes #500

## Verification

- `flutter analyze` clean.
- New unit tests: `test/services/telemetry/anonymization_test.dart` (serial scrubbing), `test/services/webserver/request_log_middleware_test.dart` (IP extraction + logging).
- Full `flutter test`: 3185 passed, 1 skipped, 0 failures.

## Impact

- API access-log lines now include the client IP (cosmetic change to log format).
- Exported feedback logs no longer contain the machine serial number.
- No API/spec, DB, or endpoint changes.