### PR TITLE
fix: restore AtomHeart Eclair BLE reliability

### DIFF
--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -196,6 +196,8 @@ An awake Decent Scale connection requires a recognised FFF4 status or weight fra
 
 Acaia parsing is frame-bounded. Payload lengths above 64 bytes and impossible lengths for known settings or weight events trigger header resynchronization; complete unsupported frames are consumed whole so embedded `EF DD` bytes cannot become top-level frames. Only accepted settings, weight, or timer frames refresh liveness. Event 11 selector 5 carries weight, while selector 7 is timer data. Connection readiness requires a decoded valid weight rather than an arbitrary notification.
 
+AtomHeart Eclair uses service `B905EAEA-2E63-0E04-7582-7913F10D8F81`, data/status characteristic `AD736C5F-BBC9-1F96-D304-CB5D5F41E160`, and command characteristic `4F9A45BA-8E1B-4E07-E157-0814D393B968`. Its connection remains `connecting` until a valid checksummed `0x57` weight frame arrives. Silence for 800 ms resets the notification subscription at most twice; a third silent window tears down the transport so ConnectionManager owns recovery. Timer reset/start/stop commands are `520101`, `530101`, and `450101`; tare remains `540101`.
+
 Scale maintenance uses self-scheduling one-shot timers and owns each asynchronous operation before scheduling another cycle. Do not perform asynchronous BLE writes directly from `Timer.periodic`; that permits overlap and leaves failures unowned. Decent notification recovery remains single-flight across connection generations, so reconnect waits for an unresolved prior subscription operation.
 
 Three reusable idioms from the comms-harden effort:

--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -198,6 +198,8 @@ Acaia parsing is frame-bounded. Payload lengths above 64 bytes and impossible le
 
 AtomHeart Eclair uses service `B905EAEA-2E63-0E04-7582-7913F10D8F81`, data/status characteristic `AD736C5F-BBC9-1F96-D304-CB5D5F41E160`, and command characteristic `4F9A45BA-8E1B-4E07-E157-0814D393B968`. Its connection remains `connecting` until a valid checksummed `0x57` weight frame arrives. Silence for 800 ms resets the notification subscription at most twice; a third silent window tears down the transport so ConnectionManager owns recovery. Timer reset/start/stop commands are `520101`, `530101`, and `450101`; tare remains `540101`.
 
+The Eclair weight frame is fixed at exactly 10 bytes: `0x57` header, four little-endian weight bytes in milligrams, four timer bytes, and one XOR checksum over bytes 1 to 8. Accept only that exact width. A shorter frame makes the last payload byte double as the checksum, so `57 00 00 00 00 00 00 00 00` would otherwise XOR-validate as a zero-weight snapshot and satisfy the readiness gate.
+
 Scale maintenance uses self-scheduling one-shot timers and owns each asynchronous operation before scheduling another cycle. Do not perform asynchronous BLE writes directly from `Timer.periodic`; that permits overlap and leaves failures unowned. Decent notification recovery remains single-flight across connection generations, so reconnect waits for an unresolved prior subscription operation.
 
 Three reusable idioms from the comms-harden effort:

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -664,7 +664,7 @@ Future<void> connectToDe1(De1Interface de1Interface) async {
 
 **Note:** ScaleController does **not** auto-connect. Connection decisions are made by `ConnectionManager`. ScaleController only handles the mechanics of connecting to a specific scale.
 
-Device implementations define their own readiness gate before `ScaleController` adopts them. Acaia requires its first structurally valid weight frame. An awake Decent Scale connection requires a recognised FFF4 status or weight frame, retrying the subscription and status probe once after two seconds. A deliberately sleeping reconnect restores the subscription while remaining dark and defers readiness verification until wake. Successful GATT setup or arbitrary notifications alone are not connected readiness. A mute transport is torn down without powering off the scale, and normal ConnectionManager recovery remains responsible for retrying.
+Device implementations define their own readiness gate before `ScaleController` adopts them. Acaia requires its first structurally valid weight frame. AtomHeart Eclair likewise waits for its first valid weight frame, with two bounded notification re-subscriptions before a silent connection is rejected. An awake Decent Scale connection requires a recognised FFF4 status or weight frame, retrying the subscription and status probe once after two seconds. A deliberately sleeping reconnect restores the subscription while remaining dark and defers readiness verification until wake. Successful GATT setup or arbitrary notifications alone are not connected readiness. A mute transport is torn down without powering off the scale, and normal ConnectionManager recovery remains responsible for retrying.
 
 **Connection Flow:**
 ```dart

--- a/lib/src/models/device/impl/atomheart/atomheart_scale.dart
+++ b/lib/src/models/device/impl/atomheart/atomheart_scale.dart
@@ -16,11 +16,13 @@ class AtomheartScale implements Scale {
   final Logger _log = Logger('AtomheartScale');
 
   static final BleServiceIdentifier serviceIdentifier =
-      BleServiceIdentifier.long('b905eaea-6c7e-4f73-b43d-2cdfcab29570');
+      BleServiceIdentifier.long('b905eaea-2e63-0e04-7582-7913f10d8f81');
   static final BleServiceIdentifier dataCharacteristic =
-      BleServiceIdentifier.long('b905eaeb-6c7e-4f73-b43d-2cdfcab29570');
+      BleServiceIdentifier.long('ad736c5f-bbc9-1f96-d304-cb5d5f41e160');
   static final BleServiceIdentifier commandCharacteristic =
-      BleServiceIdentifier.long('b905eaec-6c7e-4f73-b43d-2cdfcab29570');
+      BleServiceIdentifier.long('4f9a45ba-8e1b-4e07-e157-0814d393b968');
+
+  static const _notificationAttempts = 3;
 
   final String _deviceId;
 
@@ -28,10 +30,15 @@ class AtomheartScale implements Scale {
       StreamController.broadcast();
 
   final BLETransport _transport;
+  final Duration _notificationTimeout;
+  Completer<void>? _firstValidFrame;
 
-  AtomheartScale({required BLETransport transport})
-    : _transport = transport,
-      _deviceId = transport.id;
+  AtomheartScale({
+    required BLETransport transport,
+    Duration notificationTimeout = const Duration(milliseconds: 800),
+  }) : _transport = transport,
+       _notificationTimeout = notificationTimeout,
+       _deviceId = transport.id;
 
   @override
   Stream<ScaleSnapshot> get currentSnapshot => _streamController.stream;
@@ -49,7 +56,7 @@ class AtomheartScale implements Scale {
   @override
   String get name => "Atomheart Eclair";
 
-  final StreamController<ConnectionState> _connectionStateController =
+  final BehaviorSubject<ConnectionState> _connectionStateController =
       BehaviorSubject.seeded(ConnectionState.discovered);
 
   @override
@@ -58,7 +65,8 @@ class AtomheartScale implements Scale {
 
   @override
   Future<void> onConnect() async {
-    if (await _transport.connectionState.first == ConnectionState.connected) {
+    if (_connectionStateController.value == ConnectionState.connected &&
+        await _transport.connectionState.first == ConnectionState.connected) {
       return;
     }
     _connectionStateController.add(ConnectionState.connecting);
@@ -82,7 +90,10 @@ class AtomheartScale implements Scale {
           'Discovered services: $services',
         );
       }
-      await _registerNotifications();
+      await _confirmNotifications();
+      if (_connectionStateController.value != ConnectionState.connecting) {
+        throw const DeviceNotConnectedException.scale();
+      }
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
       _log.warning('Connect failed: $e');
@@ -130,17 +141,17 @@ class AtomheartScale implements Scale {
 
   @override
   Future<void> startTimer() async {
-    await _safeWrite(Uint8List.fromList([0x43, 0x01, 0x01]));
+    await _safeWrite(Uint8List.fromList([0x53, 0x01, 0x01]));
   }
 
   @override
   Future<void> stopTimer() async {
-    await _safeWrite(Uint8List.fromList([0x43, 0x00, 0x00]));
+    await _safeWrite(Uint8List.fromList([0x45, 0x01, 0x01]));
   }
 
   @override
   Future<void> resetTimer() async {
-    await tare();
+    await _safeWrite(Uint8List.fromList([0x52, 0x01, 0x01]));
   }
 
   Future<void> _registerNotifications() async {
@@ -149,6 +160,35 @@ class AtomheartScale implements Scale {
       dataCharacteristic.long,
       _parseNotification,
     );
+  }
+
+  Future<void> _confirmNotifications() async {
+    final firstValidFrame = Completer<void>();
+    _firstValidFrame = firstValidFrame;
+    try {
+      for (var attempt = 0; attempt < _notificationAttempts; attempt++) {
+        if (attempt == 0) {
+          await _registerNotifications();
+        } else {
+          await _transport.resetSubscription(
+            serviceIdentifier.long,
+            dataCharacteristic.long,
+            _parseNotification,
+          );
+        }
+        if (firstValidFrame.isCompleted) return;
+        try {
+          await firstValidFrame.future.timeout(_notificationTimeout);
+          return;
+        } on TimeoutException {
+          if (attempt == _notificationAttempts - 1) rethrow;
+        }
+      }
+    } finally {
+      if (identical(_firstValidFrame, firstValidFrame)) {
+        _firstValidFrame = null;
+      }
+    }
   }
 
   static ScaleSnapshot? parseFrame(List<int> data) {
@@ -187,6 +227,10 @@ class AtomheartScale implements Scale {
     final snapshot = parseFrame(data);
     if (snapshot != null) {
       _streamController.add(snapshot);
+      final firstValidFrame = _firstValidFrame;
+      if (firstValidFrame != null && !firstValidFrame.isCompleted) {
+        firstValidFrame.complete();
+      }
     }
   }
 }

--- a/lib/src/models/device/impl/atomheart/atomheart_scale.dart
+++ b/lib/src/models/device/impl/atomheart/atomheart_scale.dart
@@ -23,6 +23,7 @@ class AtomheartScale implements Scale {
       BleServiceIdentifier.long('4f9a45ba-8e1b-4e07-e157-0814d393b968');
 
   static const _notificationAttempts = 3;
+  static const _frameLength = 10;
 
   final String _deviceId;
 
@@ -192,7 +193,7 @@ class AtomheartScale implements Scale {
   }
 
   static ScaleSnapshot? parseFrame(List<int> data) {
-    if (data.length < 9) return null;
+    if (data.length != _frameLength) return null;
     if (data[0] != 0x57) return null;
 
     var xorResult = 0;

--- a/test/atomheart_scale_test.dart
+++ b/test/atomheart_scale_test.dart
@@ -34,6 +34,35 @@ void main() {
       expect(AtomheartScale.parseFrame([0x57, 0x01]), isNull);
     });
 
+    test('parseFrame rejects a truncated nine byte frame', () {
+      expect(
+        AtomheartScale.parseFrame([
+          0x57,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+        ]),
+        isNull,
+      );
+    });
+
+    test('parseFrame rejects a frame longer than the Eclair frame', () {
+      final payload = [0xDC, 0x05, 0x00, 0x00, 0x88, 0x13, 0x00, 0x00, 0x00];
+      var xor = 0;
+      for (var b in payload) {
+        xor ^= b;
+      }
+      final data = [0x57, ...payload, xor & 0xFF];
+
+      expect(data.length, 11);
+      expect(AtomheartScale.parseFrame(data), isNull);
+    });
+
     test('parseFrame returns null for wrong header', () {
       final payload = [0xDC, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
       var xor = 0;

--- a/test/unit/models/atomheart_scale_reliability_test.dart
+++ b/test/unit/models/atomheart_scale_reliability_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/impl/atomheart/atomheart_scale.dart';
+import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -172,6 +173,33 @@ void main() {
 
     expect(await scale.connectionState.first, ConnectionState.connected);
     expect((await snapshot).weight, closeTo(1.5, 0.001));
+    await transport.dispose();
+  });
+
+  test('a truncated frame does not satisfy the readiness gate', () async {
+    final transport = _RecordingTransport();
+    final scale = AtomheartScale(
+      transport: transport,
+      notificationTimeout: const Duration(seconds: 30),
+    );
+    final snapshots = <ScaleSnapshot>[];
+    final snapshotSub = scale.currentSnapshot.listen(snapshots.add);
+    final connection = scale.onConnect();
+
+    await transport.firstSubscription.future;
+    transport.emit([0x57, 0, 0, 0, 0, 0, 0, 0, 0]);
+    await pumpEventQueue();
+
+    expect(snapshots, isEmpty);
+    expect(await scale.connectionState.first, ConnectionState.connecting);
+    expect(transport.resetSubscriptionCalls, 0);
+
+    transport.emit(_weightFrame(weightMg: 1500, timerMs: 5000));
+    await connection;
+
+    expect(await scale.connectionState.first, ConnectionState.connected);
+    expect(snapshots.single.weight, closeTo(1.5, 0.001));
+    await snapshotSub.cancel();
     await transport.dispose();
   });
 

--- a/test/unit/models/atomheart_scale_reliability_test.dart
+++ b/test/unit/models/atomheart_scale_reliability_test.dart
@@ -1,0 +1,256 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/atomheart/atomheart_scale.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:rxdart/rxdart.dart';
+
+class _RecordingTransport extends BLETransport {
+  final BehaviorSubject<ConnectionState> states = BehaviorSubject.seeded(
+    ConnectionState.discovered,
+  );
+  final Completer<void> firstSubscription = Completer<void>();
+  final List<({String service, String characteristic, List<int> data})> writes =
+      [];
+
+  List<String> services = [AtomheartScale.serviceIdentifier.long];
+  Object? connectError;
+  Object? discoveryError;
+  Object? subscriptionError;
+  int subscribeCalls = 0;
+  int resetSubscriptionCalls = 0;
+  int disconnectCalls = 0;
+  String? subscribedService;
+  String? subscribedCharacteristic;
+  void Function(Uint8List)? notificationCallback;
+
+  @override
+  String get id => 'eclair-test';
+
+  @override
+  String get name => 'Eclair';
+
+  @override
+  Stream<ConnectionState> get connectionState => states.stream;
+
+  @override
+  Future<ConnectionState> getConnectionState() async => states.value;
+
+  @override
+  Future<void> connect() async {
+    if (connectError case final error?) throw error;
+    states.add(ConnectionState.connected);
+  }
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCalls++;
+    states.add(ConnectionState.disconnected);
+  }
+
+  @override
+  Future<List<String>> discoverServices() async {
+    if (discoveryError case final error?) throw error;
+    return services;
+  }
+
+  @override
+  Future<void> subscribe(
+    String serviceUUID,
+    String characteristicUUID,
+    void Function(Uint8List) callback,
+  ) async {
+    subscribeCalls++;
+    _recordSubscription(serviceUUID, characteristicUUID, callback);
+  }
+
+  @override
+  Future<void> resetSubscription(
+    String serviceUUID,
+    String characteristicUUID,
+    void Function(Uint8List) callback,
+  ) async {
+    resetSubscriptionCalls++;
+    _recordSubscription(serviceUUID, characteristicUUID, callback);
+  }
+
+  void _recordSubscription(
+    String serviceUUID,
+    String characteristicUUID,
+    void Function(Uint8List) callback,
+  ) {
+    if (!firstSubscription.isCompleted) firstSubscription.complete();
+    if (subscriptionError case final error?) throw error;
+    subscribedService = serviceUUID;
+    subscribedCharacteristic = characteristicUUID;
+    notificationCallback = callback;
+  }
+
+  void emit(List<int> data) => notificationCallback!(Uint8List.fromList(data));
+
+  @override
+  Future<Uint8List> read(
+    String serviceUUID,
+    String characteristicUUID, {
+    Duration? timeout,
+  }) async => Uint8List(0);
+
+  @override
+  Future<void> write(
+    String serviceUUID,
+    String characteristicUUID,
+    Uint8List data, {
+    bool withResponse = true,
+    Duration? timeout,
+  }) async {
+    writes.add((
+      service: serviceUUID,
+      characteristic: characteristicUUID,
+      data: data.toList(),
+    ));
+  }
+
+  @override
+  Future<void> setTransportPriority(bool prioritized) async {}
+
+  @override
+  Future<void> dispose() async {
+    await states.close();
+  }
+}
+
+void main() {
+  test('uses the current Eclair GATT contract', () async {
+    expect(
+      AtomheartScale.serviceIdentifier.long,
+      'b905eaea-2e63-0e04-7582-7913f10d8f81',
+    );
+    expect(
+      AtomheartScale.dataCharacteristic.long,
+      'ad736c5f-bbc9-1f96-d304-cb5d5f41e160',
+    );
+    expect(
+      AtomheartScale.commandCharacteristic.long,
+      '4f9a45ba-8e1b-4e07-e157-0814d393b968',
+    );
+
+    final transport = _RecordingTransport();
+    final scale = AtomheartScale(
+      transport: transport,
+      notificationTimeout: const Duration(seconds: 1),
+    );
+    final connection = scale.onConnect();
+
+    await transport.firstSubscription.future;
+    expect(transport.subscribedService, AtomheartScale.serviceIdentifier.long);
+    expect(
+      transport.subscribedCharacteristic,
+      AtomheartScale.dataCharacteristic.long,
+    );
+
+    transport.emit(_weightFrame(weightMg: 1500, timerMs: 5000));
+    await connection;
+    await transport.dispose();
+  });
+
+  test('stays connecting until the first valid weight frame', () async {
+    final transport = _RecordingTransport();
+    final scale = AtomheartScale(
+      transport: transport,
+      notificationTimeout: const Duration(seconds: 1),
+    );
+    final snapshot = scale.currentSnapshot.first;
+    final connection = scale.onConnect();
+
+    await transport.firstSubscription.future;
+    expect(await scale.connectionState.first, ConnectionState.connecting);
+
+    transport.emit(_weightFrame(weightMg: 1500, timerMs: 5000));
+    await connection;
+
+    expect(await scale.connectionState.first, ConnectionState.connected);
+    expect((await snapshot).weight, closeTo(1.5, 0.001));
+    await transport.dispose();
+  });
+
+  test('silent notifications retry twice and then disconnect', () async {
+    final transport = _RecordingTransport();
+    final scale = AtomheartScale(
+      transport: transport,
+      notificationTimeout: const Duration(milliseconds: 5),
+    );
+
+    await scale.onConnect();
+
+    expect(transport.subscribeCalls, 1);
+    expect(transport.resetSubscriptionCalls, 2);
+    expect(transport.disconnectCalls, 1);
+    expect(await scale.connectionState.first, ConnectionState.disconnected);
+    await transport.dispose();
+  });
+
+  for (final stage in ['connect', 'service discovery', 'subscription']) {
+    test('$stage failure ends disconnected', () async {
+      final transport = _RecordingTransport();
+      switch (stage) {
+        case 'connect':
+          transport.connectError = StateError('connect failed');
+        case 'service discovery':
+          transport.discoveryError = StateError('discovery failed');
+        case 'subscription':
+          transport.subscriptionError = StateError('subscription failed');
+      }
+      final scale = AtomheartScale(
+        transport: transport,
+        notificationTimeout: const Duration(milliseconds: 5),
+      );
+
+      await scale.onConnect();
+
+      expect(await scale.connectionState.first, ConnectionState.disconnected);
+      expect(transport.disconnectCalls, 1);
+      await transport.dispose();
+    });
+  }
+
+  test(
+    'writes current tare and timer opcodes to the command characteristic',
+    () async {
+      final transport = _RecordingTransport();
+      final scale = AtomheartScale(transport: transport);
+
+      await scale.tare();
+      await scale.resetTimer();
+      await scale.startTimer();
+      await scale.stopTimer();
+
+      expect(transport.writes.map((write) => write.service).toSet(), {
+        AtomheartScale.serviceIdentifier.long,
+      });
+      expect(transport.writes.map((write) => write.characteristic).toSet(), {
+        AtomheartScale.commandCharacteristic.long,
+      });
+      expect(transport.writes.map((write) => write.data).toList(), [
+        [0x54, 0x01, 0x01],
+        [0x52, 0x01, 0x01],
+        [0x53, 0x01, 0x01],
+        [0x45, 0x01, 0x01],
+      ]);
+      await transport.dispose();
+    },
+  );
+}
+
+List<int> _weightFrame({required int weightMg, required int timerMs}) {
+  final payload = ByteData(8)
+    ..setInt32(0, weightMg, Endian.little)
+    ..setUint32(4, timerMs, Endian.little);
+  final bytes = payload.buffer.asUint8List();
+  var checksum = 0;
+  for (final byte in bytes) {
+    checksum ^= byte;
+  }
+  return [0x57, ...bytes, checksum & 0xff];
+}

--- a/test/unit/services/device_matcher_test.dart
+++ b/test/unit/services/device_matcher_test.dart
@@ -83,6 +83,13 @@ void main() {
       mockTransport = _MockBLETransport();
     });
 
+    test('Eclair scan filter uses the current service UUID', () {
+      final services = DeviceMatcher.serviceUuidsFor(DeviceType.scale);
+
+      expect(services, contains('b905eaea-2e63-0e04-7582-7913f10d8f81'));
+      expect(services, isNot(contains('b905eaea-6c7e-4f73-b43d-2cdfcab29570')));
+    });
+
     test('exact match for Decent Scale', () async {
       final device = await DeviceMatcher.match(
         transport: mockTransport,


### PR DESCRIPTION
## Summary

What changed, and why?

- Replace the Decenza-style UUIDs with the current AtomHeart Eclair service,
  data/status, and command characteristics, and update scale discovery.
- Send the timer reset, start, and stop opcodes used by current Eclair firmware.
- Keep the scale `connecting` until a valid checksummed weight frame arrives.
  Reset a silent notification subscription at most twice, then disconnect so
  normal ConnectionManager recovery can retry.
- Document the Eclair protocol and readiness behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [x] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

Fixes #629

> **Remaining hardware validation before merge:** Reproduce the Android connection path on a current-firmware AtomHeart Eclair and verify service discovery, notifications, recovery, and timer controls.

## Root Cause (if bug fix)

- Root cause: The AtomHeart implementation used Decenza-style UUIDs and timer
  opcodes and marked the link ready before receiving a valid Eclair frame.
- Missing detection or guardrail: Tests asserted neither current Eclair UUIDs
  nor the first-valid-frame readiness boundary.
- Contributing context: The issue log may also contain a native GATT timeout
  outside the protocol layer; hardware validation remains mandatory.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/unit/models/atomheart_scale_reliability_test.dart`
  and `test/unit/services/device_matcher_test.dart`.
- Scenario the test should lock in: Current UUID matching, timer opcodes,
  checksummed first-frame readiness, bounded notification reset, and disconnect.
- If no new test added, why not: N/A; regression tests were added first.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [x] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A - no docs affected

`doc/AI_BLE_NOTES.md` is also updated with the protocol constraint.

## Security Impact (required)

- New or changed REST endpoints? `No`.
- New or changed WebSocket topics? `No`.
- New or changed network calls? `No`.
- BLE/USB surface changed? `Yes`, Eclair UUIDs, timer writes, and readiness
  recovery changed.
- File system access changed? `No`.
- Plugin sandbox boundary changed? `No`.
- Risk and mitigation: Writes are limited to documented Eclair timer opcodes;
  notification recovery is checksummed, bounded to two resets, then fails
  closed through normal disconnect recovery.

## User-Visible Changes

- Current Eclair firmware is discovered through its actual service UUID and is
  reported connected only after usable scale data arrives.
- Timer controls use the current Eclair protocol. A silent subscribed link
  fails closed after three 800 ms windows instead of appearing ready.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` - no remaining candidate changes
- [x] `flutter analyze` - clean
- [x] `flutter test` - 3,186 passed, 1 skipped
- [ ] `./scripts/fetch_dye2_plugin.sh` - not rerun for this local draft

### Manual verification (if applicable)

- OS / platform tested: Not applicable to the changed behavior.
- Simulated devices? (`simulate=1`): `No`.
- Real hardware? (DE1/Bengle/scale): `No`; no Eclair was available.
- What you personally verified and how: Protocol, matcher, readiness, and
  recovery behavior through focused tests.
- Edge cases checked: Invalid/silent frames, bounded resubscription, timer
  reset/start/stop, and disconnect.
- What you did **not** verify: Current-firmware Eclair behavior on the
  reporter's Android tablet. This PR has no meaningful changed visual surface,
  so desktop Computer Use cannot validate its BLE protocol behavior.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

Detailed evidence:

- Regression-first proof: the focused tests failed against the old UUIDs,
  timer opcodes, immediate-ready behavior, and missing silent-link recovery.
- `dart format --output=none --set-exit-if-changed lib/src/models/device/impl/atomheart/atomheart_scale.dart test/unit/models/atomheart_scale_reliability_test.dart test/unit/services/device_matcher_test.dart`
- Focused AtomHeart scale and device-matcher suite (49 passed).
- `flutter analyze --no-pub` (no issues).
- `flutter test --no-pub` with the package-matched QuickJS DLL on `PATH`
  (3,186 passed, 1 skipped).
- No Eclair hardware was available locally. A current-firmware Eclair and the
  reporter's Android tablet remain required to validate native connection,
  service discovery, notification recovery, and timer controls end to end.

## Compatibility & Migration

- Backward compatible? `Yes` for supported current Eclair firmware; devices
  advertising only the obsolete Decenza-style UUID are no longer misidentified.
- Config / env changes needed? `No`.
- Database migration needed? `No`.
- Exact steps: None.

## Risks & Mitigations

- Risk: The issue's field failure may occur before this protocol code, or a
  current device may behave differently from the captured protocol.
  - Mitigation: Require hardware validation before merge; validate service discovery,
    notifications, recovery, and timer controls on an Eclair before publishing.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->