### PR TITLE
fix(api): rebind sensor snapshot sockets

### DIFF
--- a/assets/api/websocket_v1.yml
+++ b/assets/api/websocket_v1.yml
@@ -102,7 +102,12 @@ channels:
       shotStateEvent:
         $ref: '#/components/messages/ShotStateEvent'
   SensorSnapshot:
-    description: Real-time sensor snapshot updates for a specific sensor.
+    description: >
+      Real-time sensor snapshot updates for a specific sensor. An open socket
+      follows replacement sensor instances with the same id and stays open
+      during a transient removal, resuming when that id returns. No status
+      frame is emitted while the sensor is absent. Opening the socket for an id
+      that is not present still returns an error frame and closes the socket.
     address: ws/v1/sensors/{id}/snapshot
     parameters:
       id:

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -489,7 +489,7 @@ All WebSocket endpoints are on port 8080 at `/ws/v1/...`. See [`assets/api/webso
 | `/ws/v1/machine/raw` | Raw BLE characteristic data. Re-binds across a machine reconnect; writes go to the currently-bound machine. | Hex-encoded bytes |
 | `/ws/v1/machine/shotState` | Shot sequencer state + decision feed: why a step advanced, why the shot stopped. Replays the latest frame on connect; idle between shots; not gated on a connected machine. | `event` (`state`\|`decision`\|`terminal`), `shotId`, shot phase, machine context, `decision {kind, reason, details, data}` |
 | `/ws/v1/devices` | Device discovery + `ConnectionManager` status (phase, found devices, ambiguity, errors). Also accepts `scan`/`connect`/`disconnect` commands. | Device list, `connectionStatus` |
-| `/ws/v1/sensors/:id/snapshot` | Sensor data stream | Sensor-specific |
+| `/ws/v1/sensors/:id/snapshot` | Sensor data stream. Re-binds across replacement or transient removal/re-add of the same sensor ID. | Sensor-specific |
 | `/ws/v1/plugins/:id/:endpoint` | Plugin WebSocket proxy | Plugin-specific |
 | `/ws/v1/logs` | App log stream | Timestamped log entries |
 | `/ws/v1/webview/logs` | WebView console log stream | WebView console messages |
@@ -524,6 +524,16 @@ For clients this means:
 Machine sockets opened before the first machine connection behave like any later disconnected gap:
 the socket stays open and remains silent until a machine attaches. No error or status frame is emitted
 on the typed telemetry sockets.
+
+### Sensor sockets follow replacement
+
+An open `/ws/v1/sensors/:id/snapshot` socket follows the current sensor instance for its ID. When that
+sensor is replaced, the server cancels the old data subscription and binds the socket to the replacement.
+During a transient removal the socket stays open and silent, then resumes when the same ID returns. The
+channel remains sensor-data-only and emits no connection status frames.
+
+The initial lookup is unchanged: opening a socket for an ID that is not present returns
+`{"error":"not found"}` and closes the socket.
 
 ### `shotState` events
 

--- a/lib/src/controllers/sensor_controller.dart
+++ b/lib/src/controllers/sensor_controller.dart
@@ -4,12 +4,15 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/sensor.dart';
+import 'package:rxdart/rxdart.dart';
 
 class SensorController {
   final DeviceController _deviceController;
 
   final Map<String, Sensor> _discovered = {};
   final Map<String, Sensor> _bridgeRegistered = {};
+  final BehaviorSubject<Map<String, Sensor>> _sensorRegistry =
+      BehaviorSubject.seeded(const {});
 
   final Logger _log = Logger("SensorController");
 
@@ -28,6 +31,7 @@ class SensorController {
     _discovered
       ..clear()
       ..addEntries(sensors.map((s) => MapEntry(s.deviceId, s)));
+    _publishSensors();
     await Future.wait(sensors.map((s) => s.onConnect()));
   }
 
@@ -39,6 +43,7 @@ class SensorController {
     }
     _bridgeRegistered[id] = sensor;
     if (!identical(existing, sensor)) {
+      _publishSensors();
       await sensor.onConnect();
     }
   }
@@ -46,14 +51,21 @@ class SensorController {
   Future<void> unregister(String deviceId) async {
     final removed = _bridgeRegistered.remove(deviceId);
     if (removed != null) {
+      _publishSensors();
       await removed.disconnect();
     }
   }
 
-  Map<String, Sensor> get sensors => {..._discovered, ..._bridgeRegistered};
+  Map<String, Sensor> get sensors =>
+      Map.unmodifiable({..._discovered, ..._bridgeRegistered});
+
+  Stream<Map<String, Sensor>> get sensorRegistry => _sensorRegistry.stream;
+
+  void _publishSensors() => _sensorRegistry.add(sensors);
 
   void dispose() {
     _deviceStreamSubscription?.cancel();
     _deviceStreamSubscription = null;
+    _sensorRegistry.close();
   }
 }

--- a/lib/src/services/webserver/sensors_handler.dart
+++ b/lib/src/services/webserver/sensors_handler.dart
@@ -58,15 +58,55 @@ final class SensorsHandler {
         return;
       }
 
-      final sub = sensor.data.listen((snapshot) {
-        _log.finest("received snapshot: $snapshot");
-        socket.sink.add(jsonEncode(snapshot));
-      }, onError: (e, st) => log.severe('send error', e, st));
+      Sensor? attached;
+      StreamSubscription<dynamic>? dataSub;
+      StreamSubscription<dynamic>? registrySub;
+      StreamSubscription<dynamic>? socketSub;
+      var disposed = false;
 
-      socket.stream.listen(
+      void detach() {
+        final sub = dataSub;
+        dataSub = null;
+        attached = null;
+        sub?.cancel();
+      }
+
+      void dispose({bool closeSocket = false}) {
+        if (disposed) return;
+        disposed = true;
+        registrySub?.cancel();
+        registrySub = null;
+        socketSub?.cancel();
+        socketSub = null;
+        detach();
+        if (closeSocket) socket.sink.close();
+      }
+
+      void bind(Map<String, Sensor> registry) {
+        final current = registry[id];
+        if (identical(current, attached)) return;
+        detach();
+        if (current == null) return;
+        attached = current;
+        dataSub = current.data.listen((snapshot) {
+          _log.finest("received snapshot: $snapshot");
+          socket.sink.add(jsonEncode(snapshot));
+        }, onError: (e, st) => log.severe('send error', e, st));
+      }
+
+      bind(_controller.sensors);
+      registrySub = _controller.sensorRegistry.listen(
+        bind,
+        onDone: () => dispose(closeSocket: true),
+        onError: (Object e, StackTrace st) {
+          log.severe('sensor registry error', e, st);
+          dispose(closeSocket: true);
+        },
+      );
+      socketSub = socket.stream.listen(
         (msg) {},
-        onDone: sub.cancel,
-        onError: (_, _) => sub.cancel(),
+        onDone: dispose,
+        onError: (_, _) => dispose(),
       );
     })(req);
   }

--- a/test/webserver/sensors_handler_rebind_ws_test.dart
+++ b/test/webserver/sensors_handler_rebind_ws_test.dart
@@ -1,0 +1,222 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/sensor_controller.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/device_implementation.dart';
+import 'package:reaprime/src/models/device/sensor.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:shelf/shelf_io.dart' as io;
+import 'package:shelf_plus/shelf_plus.dart';
+import 'package:web_socket_channel/io.dart';
+
+import '../helpers/mock_device_discovery_service.dart';
+
+class _StreamingSensor implements Sensor {
+  _StreamingSensor(this.deviceId) {
+    _data = StreamController<Map<String, dynamic>>.broadcast(
+      onListen: () => listenCount++,
+      onCancel: () => cancelCount++,
+    );
+  }
+
+  @override
+  final String deviceId;
+
+  late final StreamController<Map<String, dynamic>> _data;
+  int listenCount = 0;
+  int cancelCount = 0;
+
+  bool get hasListener => _data.hasListener;
+
+  void emit(String value) => _data.add({'value': value});
+
+  Future<void> dispose() => _data.close();
+
+  @override
+  String get name => 'Streaming Sensor';
+
+  @override
+  DeviceType get type => DeviceType.sensor;
+
+  @override
+  DeviceImplementation get implementation => DeviceImplementation.sensorBasket;
+
+  @override
+  TransportType get transportType => TransportType.unknown;
+
+  @override
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.connected);
+
+  @override
+  Stream<Map<String, dynamic>> get data => _data.stream;
+
+  @override
+  SensorInfo get info => SensorInfo(
+    name: 'Streaming Sensor',
+    vendor: 'test',
+    dataChannels: [],
+    commands: [],
+  );
+
+  @override
+  Future<Map<String, dynamic>> execute(
+    String commandId,
+    Map<String, dynamic>? parameters,
+  ) async => const {};
+
+  @override
+  Future<void> onConnect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+}
+
+void main() {
+  late SensorController sensorController;
+  late MockDeviceDiscoveryService discovery;
+  late HttpServer server;
+  final sensors = <_StreamingSensor>[];
+
+  setUp(() async {
+    discovery = MockDeviceDiscoveryService();
+    final deviceController = DeviceController([discovery]);
+    await deviceController.initialize();
+    sensorController = SensorController(controller: deviceController);
+
+    final app = Router().plus;
+    SensorsHandler(controller: sensorController).addRoutes(app);
+    server = await io.serve(app.call, 'localhost', 0);
+  });
+
+  tearDown(() async {
+    await server.close(force: true);
+    sensorController.dispose();
+    await Future.wait(sensors.map((sensor) => sensor.dispose()));
+    sensors.clear();
+  });
+
+  _StreamingSensor sensor(String id) {
+    final value = _StreamingSensor(id);
+    sensors.add(value);
+    return value;
+  }
+
+  Future<void> settle([int turns = 6]) async {
+    for (var i = 0; i < turns; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+    }
+  }
+
+  (IOWebSocketChannel, List<Map<String, dynamic>>) connect(String id) {
+    final uri = Uri.parse(
+      'ws://localhost:${server.port}/ws/v1/sensors/$id/snapshot',
+    );
+    final channel = IOWebSocketChannel.connect(uri);
+    final received = <Map<String, dynamic>>[];
+    channel.stream.listen(
+      (message) =>
+          received.add(jsonDecode(message.toString()) as Map<String, dynamic>),
+    );
+    return (channel, received);
+  }
+
+  test('rebinds to a replacement sensor with the same id', () async {
+    final first = sensor('probe-1');
+    await sensorController.register(first);
+    final (channel, received) = connect(first.deviceId);
+    await settle();
+
+    final replacement = sensor(first.deviceId);
+    await sensorController.register(replacement);
+    await settle();
+
+    received.clear();
+    first.emit('old');
+    replacement.emit('new');
+    await settle();
+
+    expect(received, [
+      const {'value': 'new'},
+    ]);
+    expect(first.hasListener, isFalse);
+    expect(replacement.listenCount, 1);
+    await channel.sink.close();
+  });
+
+  test('stays open across removal and re-add of the requested id', () async {
+    final first = sensor('probe-2');
+    discovery.addDevice(first);
+    await settle();
+    final (channel, received) = connect(first.deviceId);
+    await settle();
+
+    discovery.removeDevice(first.deviceId);
+    await settle();
+    expect(first.hasListener, isFalse);
+
+    final replacement = sensor(first.deviceId);
+    discovery.addDevice(replacement);
+    await settle();
+    replacement.emit('restored');
+    await settle();
+
+    expect(received.map((frame) => frame['value']), contains('restored'));
+    await channel.sink.close();
+  });
+
+  test('ignores unrelated registry changes', () async {
+    final requested = sensor('probe-3');
+    await sensorController.register(requested);
+    final (channel, received) = connect(requested.deviceId);
+    await settle();
+
+    await sensorController.register(sensor('other'));
+    await settle();
+    requested.emit('once');
+    await settle();
+
+    expect(requested.listenCount, 1);
+    expect(requested.cancelCount, 0);
+    expect(received, [
+      const {'value': 'once'},
+    ]);
+    await channel.sink.close();
+  });
+
+  test(
+    'releases data and registry subscriptions when the socket closes',
+    () async {
+      final first = sensor('probe-4');
+      await sensorController.register(first);
+      final (channel, _) = connect(first.deviceId);
+      await settle();
+
+      await channel.sink.close();
+      await settle();
+      expect(first.hasListener, isFalse);
+
+      final replacement = sensor(first.deviceId);
+      await sensorController.register(replacement);
+      await settle();
+      expect(replacement.listenCount, 0);
+    },
+  );
+
+  test('preserves the initial not-found response', () async {
+    final uri = Uri.parse(
+      'ws://localhost:${server.port}/ws/v1/sensors/missing/snapshot',
+    );
+    final channel = IOWebSocketChannel.connect(uri);
+
+    expect(
+      await channel.stream.first.timeout(const Duration(seconds: 2)),
+      jsonEncode({'error': 'not found'}),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

What changed, and why?

- Publish immutable sensor-registry snapshots whenever discovery or bridge
  registration changes the current sensor instances.
- Rebind an open sensor snapshot WebSocket when its requested ID is replaced,
  keep it open during a transient removal, and cancel all subscriptions when
  the socket or registry closes.
- Preserve the existing initial not-found response and document the reconnect
  behavior in the AsyncAPI contract and API guide.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [x] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

Fixes #554

## Root Cause (if bug fix)

- Root cause: A sensor snapshot socket captured one sensor instance at connect
  time and never observed later registry replacement or removal/re-add.
- Missing detection or guardrail: WebSocket tests covered initial binding only,
  not sensor identity stability across registry updates.
- Contributing context: Sensor IDs are stable while adapter instances can be
  replaced during discovery and bridge registration.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/webserver/sensors_handler_rebind_ws_test.dart`.
- Scenario the test should lock in: An open socket rebinds exactly once after
  replacement or transient removal/re-add and releases every subscription.
- If no new test added, why not: N/A; five regression scenarios were added.

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [x] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A - no docs affected

## Security Impact (required)

- New or changed REST endpoints? `No`.
- New or changed WebSocket topics? `Yes`; the existing sensor snapshot topic
  now follows registry replacement and removal/re-add.
- New or changed network calls? `No`.
- BLE/USB surface changed? `No`.
- File system access changed? `No`.
- Plugin sandbox boundary changed? `No`.
- Risk and mitigation: The wire payload and initial authorization/error surface
  are unchanged; subscription cancellation tests guard against duplicate data
  and leaked listeners.

## User-Visible Changes

- Existing sensor snapshot sockets resume after a sensor object is replaced or
  temporarily removed and re-added under the same ID.
- The payload remains sensor-data-only, and the initial missing-ID error is
  unchanged.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` - no remaining candidate changes
- [x] `flutter analyze` - clean
- [x] `flutter test` - 3,183 passed, 1 skipped
- [ ] `./scripts/fetch_dye2_plugin.sh` - not rerun for this local draft

### Manual verification (if applicable)

- OS / platform tested: Windows test host; live app did not launch.
- Simulated devices? (`simulate=1`): `No`; CMake stopped the build first.
- Real hardware? (DE1/Bengle/scale): `No`.
- What you personally verified and how: Real WebSocket handler behavior with
  test sensor registry changes.
- Edge cases checked: Replacement, removal/re-add, unrelated changes, initial
  missing ID, socket close, and registry close.
- What you did **not** verify: A live WebSocket client against a running app.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

Detailed evidence:

- Regression-first WebSocket tests failed against the original one-shot
  binding, then passed for replacement, removal/re-add, unrelated registry
  changes, socket cleanup, and initial not-found behavior.
- `flutter test test/webserver/sensors_handler_rebind_ws_test.dart` (5 passed)
- Focused affected test set (29 passed)
- `flutter analyze` (no issues)
- `flutter test` with the package-matched QuickJS DLL on `PATH` and temporary
  LF normalization for the line-ending-sensitive AsyncAPI assertion (3,183
  passed, 1 skipped)
- `git diff --cached --check` before commit (clean)
- Attempted `flutter run --no-pub -d windows --dart-define=simulate=1` for a
  live WebSocket smoke. The local build stopped before launch because Flutter
  selected CMake 3.20 while the Firebase SDK requires CMake 3.22 or newer.

## Compatibility & Migration

- Backward compatible? `Yes`; the topic and payload schema are unchanged.
- Config / env changes needed? `No`.
- Database migration needed? `No`.
- Exact steps: None.

## Risks & Mitigations

- Risk: Registry churn could create duplicate frames or leaked subscriptions.
  - Mitigation: Publish immutable snapshots, rebind only when the matching
    instance changes, and cancel listeners on socket and registry closure.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->