### PR TITLE
fix: report Bengle virtual scale as connected in device APIs

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -39,11 +39,12 @@ paths:
                     available:
                       type: boolean
                       description: >
-                        true if the device is currently present in discovery;
-                        false for a remembered device that is not present
-                        (reported with state "disconnected"). Remembered devices
-                        are those the user has connected to; they persist across
-                        restarts until forgotten via /api/v1/devices/forget.
+                        true if the device is currently present in discovery or
+                        is actively connected; false for a remembered device
+                        that is not present (reported with state "disconnected").
+                        Remembered devices are those the user has connected to;
+                        they persist across restarts until forgotten via
+                        /api/v1/devices/forget.
         "500":
           description: Internal Server Error
           content:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -121,6 +121,8 @@ paths:
         Accepts deviceId via JSON body (preferred) or query parameter (backward compatible).
         Device IDs may contain special characters (e.g. colons in BLE MAC addresses,
         slashes in serial port paths), so the JSON body approach avoids URL encoding issues.
+        Controller-owned inventory devices such as Bengle's integrated virtual scale
+        are not independent command targets and return 409.
       tags: [Devices]
       parameters:
         - name: deviceId
@@ -154,11 +156,13 @@ paths:
         "404":
           description: "Device not found"
         "409":
-          description: "Connection conflicts with another operation or a stale selection"
+          description: "Connection conflicts with another operation, a stale selection, or an inventory-only device"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeviceConnectResult"
+                oneOf:
+                  - $ref: "#/components/schemas/DeviceConnectResult"
+                  - $ref: "#/components/schemas/Error"
         "503":
           description: "Device transport currently unavailable"
           content:
@@ -177,6 +181,8 @@ paths:
       summary: Disconnect a specified device
       description: |
         Accepts deviceId via JSON body (preferred) or query parameter (backward compatible).
+        Controller-owned inventory devices such as Bengle's integrated virtual scale
+        follow their machine lifecycle and return 409.
       tags: [Devices]
       parameters:
         - name: deviceId
@@ -205,6 +211,12 @@ paths:
           description: "Missing deviceId"
         "404":
           description: "Device not found"
+        "409":
+          description: "Device is inventory-only and cannot be disconnected independently"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /api/v1/devices/wifi:
     get:

--- a/assets/api/websocket_v1.yml
+++ b/assets/api/websocket_v1.yml
@@ -849,7 +849,8 @@ components:
             connected; false for a remembered device that is not present
             (reported with state "disconnected"). Remembered devices persist
             across restarts until forgotten via the REST
-            /api/v1/devices/forget endpoint.
+            /api/v1/devices/forget endpoint. Availability does not imply command
+            ownership; controller-owned devices may be inventory-only.
           example: true
 
     DeviceConnectResult:
@@ -890,7 +891,11 @@ components:
           description: The command to execute.
         deviceId:
           type: string
-          description: Device identifier. Required for connect and disconnect commands.
+          description: >
+            Device identifier. Required for connect and disconnect commands.
+            Controller-owned inventory devices such as Bengle's integrated
+            virtual scale reject both commands because their lifecycle follows
+            the machine.
         connect:
           type: boolean
           description: Whether to scan first and automatically fill missing machine and scale slots without replacing connected devices (scan command only).

--- a/assets/api/websocket_v1.yml
+++ b/assets/api/websocket_v1.yml
@@ -845,10 +845,11 @@ components:
         available:
           type: boolean
           description: >
-            true if the device is currently present in discovery; false for a
-            remembered device that is not present (reported with state
-            "disconnected"). Remembered devices persist across restarts until
-            forgotten via the REST /api/v1/devices/forget endpoint.
+            true if the device is currently present in discovery or is actively
+            connected; false for a remembered device that is not present
+            (reported with state "disconnected"). Remembered devices persist
+            across restarts until forgotten via the REST
+            /api/v1/devices/forget endpoint.
           example: true
 
     DeviceConnectResult:

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -123,6 +123,12 @@ forgotten via `PUT /api/v1/devices/forget` (deviceId in the JSON body or
 `?deviceId=` query). The same `available` field is on each device in the
 `ws/v1/devices` snapshot.
 
+`available` describes inventory presence, not command ownership. A connected
+controller-owned device such as Bengle's integrated virtual scale is listed as
+available but is inventory-only: REST connect/disconnect returns 409 and the
+devices WebSocket returns an explicit error. Its lifecycle follows the Bengle
+machine; use the scale API for operations such as tare.
+
 **Manual WiFi scale endpoints.** Auto-discovered (DNS-SD) WiFi scales appear in
 `GET /api/v1/devices` like any other device and need no extra calls. The
 `/api/v1/devices/wifi` routes are only for *manually* entering a scale by IP or

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -116,11 +116,12 @@ and connection timeouts return 504. The devices WebSocket returns the same resul
 after each connect command.
 
 Each device entry carries an **`available`** boolean. `true` = currently present
-in discovery; `false` = a **remembered** device that isn't present (reported with
-`state: "disconnected"`). Devices the user connects to are remembered and persist
-across restarts, shown as unavailable when offline, until forgotten via
-`PUT /api/v1/devices/forget` (deviceId in the JSON body or `?deviceId=` query).
-The same `available` field is on each device in the `ws/v1/devices` snapshot.
+in discovery or actively connected; `false` = a **remembered** device that isn't
+present (reported with `state: "disconnected"`). Devices the user connects to are
+remembered and persist across restarts, shown as unavailable when offline, until
+forgotten via `PUT /api/v1/devices/forget` (deviceId in the JSON body or
+`?deviceId=` query). The same `available` field is on each device in the
+`ws/v1/devices` snapshot.
 
 **Manual WiFi scale endpoints.** Auto-discovered (DNS-SD) WiFi scales appear in
 `GET /api/v1/devices` like any other device and need no extra calls. The

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -715,10 +715,11 @@ of vanishing. Cross-transport (BLE/USB/WiFi) by construction.
   `{id, name, type}` off the connected device. A null emission (disconnect)
   does **not** forget — the device stays remembered.
 - **Availability:** computed at the API layer. `DevicesStateAggregator` /
-  `DevicesHandler` merge live devices (`available: true`) with remembered
-  devices that aren't present (`available: false`, `state: "disconnected"`) via
-  the shared `buildAvailabilityDeviceList`. The aggregator re-emits when the
-  registry changes. `DeviceController` itself stays live-only.
+  `DevicesHandler` merge discovered devices and the actively connected scale
+  (`available: true`) with remembered devices that aren't present
+  (`available: false`, `state: "disconnected"`) via the shared
+  `buildAvailabilityDeviceList`. The aggregator re-emits when the registry or
+  connected scale changes. `DeviceController` itself stays discovery-only.
 - **Forget:** `RememberedDevicesController.forget(id)`, exposed as
   `PUT /api/v1/devices/forget` (deviceId in body/query). A GUI Forget control
   lives in the web skin (separate repo), driven by this endpoint.
@@ -733,7 +734,9 @@ When a Bengle is the connected machine, its integrated scale is auto-attached
 to `ScaleController` as a virtual `BengleVirtualScale`. The integrated scale
 always wins on Bengle: external scale scanning is skipped entirely, and
 `preferredScaleId` is ignored while a Bengle is connected. Multi-scale
-support (external scale alongside the integrated scale) is on the roadmap.
+support (external scale alongside the integrated scale) is on the roadmap. The
+REST and WebSocket device inventories include the attached virtual scale even
+though it does not originate from `DeviceController` discovery.
 
 The confirmed Bengle application telemetry source is its 28-byte `0xA013`
 packet, consumed as the Bengle transport telemetry source and fanned out into

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -736,7 +736,9 @@ always wins on Bengle: external scale scanning is skipped entirely, and
 `preferredScaleId` is ignored while a Bengle is connected. Multi-scale
 support (external scale alongside the integrated scale) is on the roadmap. The
 REST and WebSocket device inventories include the attached virtual scale even
-though it does not originate from `DeviceController` discovery.
+though it does not originate from `DeviceController` discovery. It is
+inventory-only in the devices API: connect and disconnect commands reject its
+ID because its lifecycle follows the Bengle machine.
 
 The confirmed Bengle application telemetry source is its 28-byte `0xA013`
 packet, consumed as the Bengle transport telemetry source and fanned out into

--- a/lib/src/services/webserver/devices_handler.dart
+++ b/lib/src/services/webserver/devices_handler.dart
@@ -37,8 +37,8 @@ class DevicesStateAggregator {
 
   void _start() {
     _subscriptions.add(
-      _controller.deviceStream.skip(1).listen((devices) {
-        _updateDeviceSubscriptions(devices);
+      _controller.deviceStream.skip(1).listen((_) {
+        _updateDeviceSubscriptions(_inventoryDevices());
         _emitState();
       }),
     );
@@ -57,6 +57,13 @@ class DevicesStateAggregator {
       _connectionManager.status.skip(1).listen((_) => _emitState()),
     );
 
+    _subscriptions.add(
+      _connectionManager.scaleController.connectionState.skip(1).listen((_) {
+        _updateDeviceSubscriptions(_inventoryDevices());
+        _emitState();
+      }),
+    );
+
     final remembered = _rememberedController;
     if (remembered != null) {
       _subscriptions.add(
@@ -64,7 +71,7 @@ class DevicesStateAggregator {
       );
     }
 
-    _updateDeviceSubscriptions(_controller.devices);
+    _updateDeviceSubscriptions(_inventoryDevices());
 
     _emitState(immediate: true);
   }
@@ -115,8 +122,10 @@ class DevicesStateAggregator {
   }
 
   Future<Map<String, dynamic>> _buildSnapshot() async {
+    final devices = _inventoryDevices();
+    _updateDeviceSubscriptions(devices);
     final devList = await buildAvailabilityDeviceList(
-      _controller.devices,
+      devices,
       _rememberedController?.remembered ?? const [],
       preferredScaleId: _preferredScaleId?.call(),
     );
@@ -157,6 +166,11 @@ class DevicesStateAggregator {
     };
     return snapshot;
   }
+
+  List<Device> _inventoryDevices() => _devicesForInventory(
+    _controller.devices,
+    _connectionManager.scaleController,
+  );
 
   void dispose() {
     _debounceTimer?.cancel();
@@ -247,7 +261,10 @@ class DevicesHandler {
 
   Future<List<Map<String, dynamic>>> _deviceList() async {
     return buildAvailabilityDeviceList(
-      _controller.devices,
+      _devicesForInventory(
+        _controller.devices,
+        _connectionManager.scaleController,
+      ),
       _rememberedController?.remembered ?? const [],
       preferredScaleId: _preferredScaleId?.call(),
     );
@@ -533,6 +550,23 @@ class DevicesHandler {
           : '${device.name} failed to connect.',
       suggestion: 'Check that the device is available and try again.',
     );
+  }
+}
+
+List<Device> _devicesForInventory(
+  List<Device> discoveredDevices,
+  ScaleController scaleController,
+) {
+  try {
+    final connectedScale = scaleController.connectedScale();
+    if (discoveredDevices.any(
+      (device) => device.deviceId == connectedScale.deviceId,
+    )) {
+      return discoveredDevices;
+    }
+    return [...discoveredDevices, connectedScale];
+  } on DeviceNotConnectedException {
+    return discoveredDevices;
   }
 }
 

--- a/lib/src/services/webserver/devices_handler.dart
+++ b/lib/src/services/webserver/devices_handler.dart
@@ -314,6 +314,8 @@ class DevicesHandler {
     }
     final device = devices.firstWhereOrNull((e) => e.deviceId == deviceId);
     if (device == null) {
+      final error = _inventoryOnlyCommandError(deviceId);
+      if (error != null) return jsonConflict({'error': error});
       return jsonNotFound({'error': 'Device not found: $deviceId'});
     }
     final result = await _connectDevice(device);
@@ -335,6 +337,8 @@ class DevicesHandler {
     }
     final device = devices.firstWhereOrNull((e) => e.deviceId == deviceId);
     if (device == null) {
+      final error = _inventoryOnlyCommandError(deviceId);
+      if (error != null) return jsonConflict({'error': error});
       return jsonNotFound({'error': 'Device not found: $deviceId'});
     }
     _connectionManager.markExpectingDisconnect(device.deviceId);
@@ -428,7 +432,13 @@ class DevicesHandler {
           (e) => e.deviceId == deviceId,
         );
         if (device == null) {
-          socket.sink.add(jsonEncode({'error': 'Device not found: $deviceId'}));
+          socket.sink.add(
+            jsonEncode({
+              'error':
+                  _inventoryOnlyCommandError(deviceId) ??
+                  'Device not found: $deviceId',
+            }),
+          );
           return;
         }
         await _sendConnectResult(device, socket);
@@ -445,7 +455,13 @@ class DevicesHandler {
           (e) => e.deviceId == deviceId,
         );
         if (device == null) {
-          socket.sink.add(jsonEncode({'error': 'Device not found: $deviceId'}));
+          socket.sink.add(
+            jsonEncode({
+              'error':
+                  _inventoryOnlyCommandError(deviceId) ??
+                  'Device not found: $deviceId',
+            }),
+          );
           return;
         }
         _connectionManager.markExpectingDisconnect(device.deviceId);
@@ -456,6 +472,16 @@ class DevicesHandler {
       default:
         socket.sink.add(jsonEncode({'error': 'Unknown command: $command'}));
     }
+  }
+
+  String? _inventoryOnlyCommandError(String deviceId) {
+    final inventoryOnly = _devicesForInventory(
+      const [],
+      _connectionManager.scaleController,
+    ).any((device) => device.deviceId == deviceId);
+    return inventoryOnly
+        ? 'Device is inventory-only and cannot be controlled here: $deviceId'
+        : null;
   }
 
   Future<void> _sendConnectResult(

--- a/test/devices_handler_test.dart
+++ b/test/devices_handler_test.dart
@@ -9,6 +9,8 @@ import 'package:reaprime/src/controllers/connection_manager.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle_virtual_scale.dart';
+import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/services/webserver_service.dart';
 
@@ -411,9 +413,10 @@ void main() {
       });
 
       test('returns a connected scale that is outside discovery', () async {
-        await scaleController.connectToScale(
-          TestScale(deviceId: 'bengle-internal-machine', name: 'Bengle scale'),
-        );
+        final bengle = MockBengle();
+        await bengle.onConnect();
+        addTearDown(bengle.onDisconnect);
+        await scaleController.connectToScale(BengleVirtualScale(bengle));
 
         final response = await sendGet('/api/v1/devices');
         expect(response.statusCode, 200);
@@ -421,12 +424,33 @@ void main() {
         expect(body, [
           {
             'name': 'Bengle scale',
-            'id': 'bengle-internal-machine',
+            'id': 'bengle-internal-MockBengle',
             'state': 'connected',
             'type': 'scale',
             'available': true,
           },
         ]);
+      });
+
+      test('rejects machine-managed scale commands explicitly', () async {
+        final bengle = MockBengle();
+        await bengle.onConnect();
+        addTearDown(bengle.onDisconnect);
+        final scale = BengleVirtualScale(bengle);
+        await scaleController.connectToScale(scale);
+
+        for (final operation in ['connect', 'disconnect']) {
+          final response = await sendPut(
+            '/api/v1/devices/$operation',
+            body: jsonEncode({'deviceId': scale.deviceId}),
+          );
+          expect(response.statusCode, 409);
+          expect(jsonDecode(await response.readAsString()), {
+            'error':
+                'Device is inventory-only and cannot be controlled here: '
+                '${scale.deviceId}',
+          });
+        }
       });
     });
   });

--- a/test/devices_handler_test.dart
+++ b/test/devices_handler_test.dart
@@ -409,6 +409,25 @@ void main() {
         expect(body[0]['name'], 'Test Scale');
         expect(body[0]['type'], 'scale');
       });
+
+      test('returns a connected scale that is outside discovery', () async {
+        await scaleController.connectToScale(
+          TestScale(deviceId: 'bengle-internal-machine', name: 'Bengle scale'),
+        );
+
+        final response = await sendGet('/api/v1/devices');
+        expect(response.statusCode, 200);
+        final body = jsonDecode(await response.readAsString()) as List;
+        expect(body, [
+          {
+            'name': 'Bengle scale',
+            'id': 'bengle-internal-machine',
+            'state': 'connected',
+            'type': 'scale',
+            'available': true,
+          },
+        ]);
+      });
     });
   });
 

--- a/test/devices_ws_test.dart
+++ b/test/devices_ws_test.dart
@@ -11,6 +11,8 @@ import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle_virtual_scale.dart';
+import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/services/webserver_service.dart';
 
@@ -132,10 +134,10 @@ void main() {
     });
 
     test('tracks a connected scale that is outside discovery', () async {
-      final scale = TestScale(
-        deviceId: 'bengle-internal-machine',
-        name: 'Bengle scale',
-      );
+      final bengle = MockBengle();
+      await bengle.onConnect();
+      addTearDown(bengle.onDisconnect);
+      final scale = BengleVirtualScale(bengle);
       await scaleController.connectToScale(scale);
 
       final (channel, messages) = connectWs();
@@ -152,7 +154,16 @@ void main() {
 
       expect((connected['devices'] as List).single['available'], true);
 
-      scale.setConnectionState(ConnectionState.disconnected);
+      channel.sink.add(
+        jsonEncode({'command': 'disconnect', 'deviceId': scale.deviceId}),
+      );
+      expect(await waitForError(messages), {
+        'error':
+            'Device is inventory-only and cannot be controlled here: '
+            '${scale.deviceId}',
+      });
+
+      await bengle.onDisconnect();
 
       final disconnected = await messages
           .where(

--- a/test/devices_ws_test.dart
+++ b/test/devices_ws_test.dart
@@ -131,6 +131,43 @@ void main() {
       await channel.sink.close();
     });
 
+    test('tracks a connected scale that is outside discovery', () async {
+      final scale = TestScale(
+        deviceId: 'bengle-internal-machine',
+        name: 'Bengle scale',
+      );
+      await scaleController.connectToScale(scale);
+
+      final (channel, messages) = connectWs();
+      final connected = await messages
+          .where(
+            (message) => (message['devices'] as List).any(
+              (device) =>
+                  device['id'] == scale.deviceId &&
+                  device['state'] == 'connected',
+            ),
+          )
+          .first
+          .timeout(Duration(seconds: 2));
+
+      expect((connected['devices'] as List).single['available'], true);
+
+      scale.setConnectionState(ConnectionState.disconnected);
+
+      final disconnected = await messages
+          .where(
+            (message) => (message['devices'] as List).every(
+              (device) => device['id'] != scale.deviceId,
+            ),
+          )
+          .first
+          .timeout(Duration(seconds: 2));
+
+      expect(disconnected['devices'], isEmpty);
+
+      await channel.sink.close();
+    });
+
     test('emits update when device is added', () async {
       final (channel, messages) = connectWs();
 


### PR DESCRIPTION
## Summary

What changed, and why?

- Include the scale currently owned by `ScaleController` in the REST and
  WebSocket device inventories when it is absent from discovery. This makes a
  connected `BengleVirtualScale` visible as connected and available.
- Rebuild WebSocket snapshots when the scale-controller connection state
  changes, including removal or remembered-offline state after disconnect.
- Reject REST and WebSocket connect/disconnect commands for inventory-only
  devices explicitly instead of reporting their listed IDs as not found.
- Update the REST, WebSocket, API, and device-management contracts for the
  clarified `available` and command-ownership meanings.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [x] REST API / handlers
- [x] WebSocket API
- [ ] Machine state / shot logic
- [x] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

Fixes #630

> **Remaining hardware validation before merge:** Verify REST and WebSocket inventory transitions with a physical Bengle and its virtual scale.

## Root Cause (if bug fix)

- Root cause: Device inventories were built only from `DeviceController`
  discovery, while a `BengleVirtualScale` can be connected and owned solely by
  `ScaleController`.
- Missing detection or guardrail: REST and WebSocket coverage did not exercise
  a real `BengleVirtualScale` absent from discovery or its command contract.
- Contributing context: The two controllers intentionally have different
  ownership responsibilities.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/devices_handler_test.dart` and
  `test/devices_ws_test.dart`.
- Scenario the test should lock in: A connected Bengle virtual scale appears
  once as connected and available when discovery does not contain it, while
  connect/disconnect commands return an explicit inventory-only error.
- If no new test added, why not: N/A; regression tests were added first.

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [x] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [x] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A - no docs affected

## Security Impact (required)

- New or changed REST endpoints? `Yes`, inventory inclusion changed.
- New or changed WebSocket topics? `Yes`, inventory inclusion changed.
- New or changed network calls? `No`.
- BLE/USB surface changed? `No`.
- File system access changed? `No`.
- Plugin sandbox boundary changed? `No`.
- Risk and mitigation: The APIs expose no new class of device data; they merge
  an already connected scale by ID, reject independent lifecycle commands, and
  integration tests cover de-duplication and offline transitions.

## User-Visible Changes

- `GET /api/v1/devices` and `/ws/v1/devices` now report an actively connected
  scale even when it did not originate from discovery.
- `available: true` now explicitly means present in discovery or actively
  connected. Remembered offline devices remain unavailable and disconnected.
- Inventory-only devices return REST 409 or an explicit WebSocket error for
  connect/disconnect because their lifecycle belongs to another controller.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` - no remaining candidate changes
- [x] `flutter analyze` - clean
- [x] `flutter test` - 3,181 passed, 1 skipped
- [ ] `./scripts/fetch_dye2_plugin.sh` - not rerun for this local draft

### Manual verification (if applicable)

- OS / platform tested: Windows test host; live app launched.
- Simulated devices? (`simulate=1`): `Yes`.
- Real hardware? (DE1/Bengle/scale): `No`.
- What you personally verified and how: Computer Use confirmed the live Devices
  inventory renders MockBengle under machines and Mock Scale under scales; real
  Shelf and WebSocket handler paths remain covered by integration tests.
- Edge cases checked: Missing discovery entry, both command transports,
  disconnect, remembered-offline state, and duplicate prevention.
- What you did **not** verify: Physical Bengle behavior or command execution
  against Bengle hardware.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

Detailed evidence:

- Regression-first proof: before the implementation, the new REST test returned
  an empty list and the new WebSocket test timed out.
- Follow-up regression proof: the real Bengle command tests failed with REST
  404 and WebSocket `Device not found` before the inventory-only contract fix.
- `dart format --output=none --set-exit-if-changed lib/src/services/webserver/devices_handler.dart test/devices_handler_test.dart test/devices_ws_test.dart`
- `flutter test --no-pub test/connect_result_schema_test.dart test/devices_handler_test.dart test/devices_ws_test.dart` (61 passed)
- `flutter analyze --no-pub` (no issues)
- `flutter test --no-pub` with the package-matched QuickJS DLL on `PATH`
  (3,181 passed, 1 skipped)
- Flutter's default Windows path still selected CMake 3.20, but the unchanged
  source built with installed CMake 3.28 and Visual Studio 2022. Computer Use
  verified the simulated device inventory; changed REST and WebSocket paths
  remain exercised through real Shelf and WebSocket handler integration tests.

## Compatibility & Migration

- Backward compatible? `Yes`; existing objects and routes are unchanged. The
  newly exposed inventory-only IDs now return explicit 409 instead of 404.
- Config / env changes needed? `No`.
- Database migration needed? `No`.
- Exact steps: None.

## Risks & Mitigations

- Risk: A controller-owned scale could be emitted twice or remain available
  after disconnect.
  - Mitigation: Merge by device ID and rebuild on scale-controller state
    changes; REST and WebSocket tests cover both cases.
- Risk: Clients may treat `available` as permission to send lifecycle commands.
  - Mitigation: Specs and docs separate presence from command ownership, and
    both command transports return an explicit inventory-only error.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->