### PR TITLE
fix(skins): restore brightness when skin view closes

### DIFF
--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -1444,7 +1444,8 @@ Returns to auto-managed wake-lock behavior based on machine state.
 **Wake-Lock Auto-Management:**
 - When no override is active, wake-lock is automatically enabled when the machine is connected and not sleeping, and disabled when the machine sleeps or disconnects.
 - Brightness is automatically restored to its pre-sleep value when the machine transitions from sleeping to idle.
-- When the embedded skin view closes, the host resets brightness to 100 (OS-managed) before returning to native UI.
+- When the embedded skin view closes, native UI becomes authoritative and the host resets brightness to 100 (OS-managed), overriding any active REST or WebSocket brightness request.
+- Clients that still require fixed brightness must request it again after the skin closes.
 
 **Low Battery Brightness Cap:**
 - When the `lowBatteryBrightnessLimit` setting is enabled (via `POST /api/v1/settings`) and battery drops below 30%, screen brightness is capped at 20.

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -1444,6 +1444,7 @@ Returns to auto-managed wake-lock behavior based on machine state.
 **Wake-Lock Auto-Management:**
 - When no override is active, wake-lock is automatically enabled when the machine is connected and not sleeping, and disabled when the machine sleeps or disconnects.
 - Brightness is automatically restored to its pre-sleep value when the machine transitions from sleeping to idle.
+- When the embedded skin view closes, the host resets brightness to 100 (OS-managed) before returning to native UI.
 
 **Low Battery Brightness Cap:**
 - When the `lowBatteryBrightnessLimit` setting is enabled (via `POST /api/v1/settings`) and battery drops below 30%, screen brightness is capped at 20.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -610,6 +610,7 @@ void main(List<String> args) async {
         decentAccountService: decentAccountService,
         accountTokensController: accountTokensController,
         batteryController: batteryController,
+        displayController: displayController,
       ),
     ),
   );
@@ -825,6 +826,7 @@ class AppRoot extends StatefulWidget {
   final DecentAccountService? decentAccountService;
   final AccountTokensController? accountTokensController;
   final BatteryController? batteryController;
+  final DisplayController displayController;
 
   const AppRoot({
     super.key,
@@ -850,6 +852,7 @@ class AppRoot extends StatefulWidget {
     this.decentAccountService,
     this.accountTokensController,
     this.batteryController,
+    required this.displayController,
   });
 
   static void restart(BuildContext context) {
@@ -908,6 +911,7 @@ class _AppRootState extends State<AppRoot> {
         decentAccountService: widget.decentAccountService,
         accountTokensController: widget.accountTokensController,
         batteryController: widget.batteryController,
+        displayController: widget.displayController,
       ),
     );
 

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -8,6 +8,7 @@ import 'package:reaprime/main.dart';
 import 'package:reaprime/src/controllers/account_tokens_controller.dart';
 import 'package:reaprime/src/controllers/connection_manager.dart';
 import 'package:reaprime/src/controllers/de1_state_manager.dart';
+import 'package:reaprime/src/controllers/display_controller.dart';
 import 'package:reaprime/src/controllers/persistence_controller.dart';
 import 'package:reaprime/src/controllers/presence_controller.dart';
 import 'package:reaprime/src/controllers/presence_navigator_observer.dart';
@@ -87,6 +88,7 @@ class MyApp extends StatefulWidget {
     required this.webUIStorage,
     required this.webViewLogService,
     required this.presenceController,
+    required this.displayController,
     required this.connectionManager,
     required this.scanStateGuardian,
     this.updateCheckService,
@@ -111,6 +113,7 @@ class MyApp extends StatefulWidget {
   final WebUIStorage webUIStorage;
   final WebViewLogService webViewLogService;
   final PresenceController presenceController;
+  final DisplayController displayController;
   final ConnectionManager connectionManager;
   final ScanStateGuardian scanStateGuardian;
   final UpdateCheckService? updateCheckService;
@@ -491,6 +494,8 @@ class _MyAppState extends State<MyApp> {
                         settingsController: widget.settingsController,
                         webViewLogService: widget.webViewLogService,
                         deviceIp: widget.webUIService.deviceIp(),
+                        restoreBrightness: () =>
+                            widget.displayController.setBrightness(100),
                       );
                     default:
                       return OnboardingView(

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -494,8 +494,7 @@ class _MyAppState extends State<MyApp> {
                         settingsController: widget.settingsController,
                         webViewLogService: widget.webViewLogService,
                         deviceIp: widget.webUIService.deviceIp(),
-                        restoreBrightness: () =>
-                            widget.displayController.setBrightness(100),
+                        displayController: widget.displayController,
                       );
                     default:
                       return OnboardingView(

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -69,11 +69,13 @@ class SkinView extends StatefulWidget {
     required this.settingsController,
     required this.webViewLogService,
     required this.deviceIp,
+    required this.restoreBrightness,
   });
 
   final SettingsController settingsController;
   final WebViewLogService webViewLogService;
   final String deviceIp;
+  final Future<void> Function() restoreBrightness;
 
   static const routeName = '/skin';
 
@@ -113,6 +115,7 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
   @override
   void dispose() {
     _log.fine("disposing");
+    unawaited(widget.restoreBrightness());
     _blankPageTimer?.cancel();
     _blankPageTimer = null;
     final controller = _webViewController;

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/build_info.dart';
+import 'package:reaprime/src/controllers/display_controller.dart';
 import 'package:reaprime/src/home_feature/widgets/quick_settings_widget.dart';
 import 'package:reaprime/src/services/telemetry/boot_timing.dart';
 import 'package:reaprime/src/services/webview_compatibility_checker.dart';
@@ -69,13 +70,13 @@ class SkinView extends StatefulWidget {
     required this.settingsController,
     required this.webViewLogService,
     required this.deviceIp,
-    required this.restoreBrightness,
+    required this.displayController,
   });
 
   final SettingsController settingsController;
   final WebViewLogService webViewLogService;
   final String deviceIp;
-  final Future<void> Function() restoreBrightness;
+  final DisplayController displayController;
 
   static const routeName = '/skin';
 
@@ -115,7 +116,7 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
   @override
   void dispose() {
     _log.fine("disposing");
-    unawaited(widget.restoreBrightness());
+    unawaited(widget.displayController.setBrightness(100));
     _blankPageTimer?.cancel();
     _blankPageTimer = null;
     final controller = _webViewController;

--- a/test/unit/skin_feature/skin_view_brightness_test.dart
+++ b/test/unit/skin_feature/skin_view_brightness_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/webview_log_service.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/skin_feature/skin_view.dart';
+
+import '../../helpers/mock_settings_service.dart';
+
+void main() {
+  testWidgets('removing the skin view restores OS-managed brightness', (
+    tester,
+  ) async {
+    var restoreCalls = 0;
+    final logs = WebViewLogService(logDirectoryPath: '.');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SkinView(
+          settingsController: SettingsController(MockSettingsService()),
+          webViewLogService: logs,
+          deviceIp: '127.0.0.1',
+          restoreBrightness: () async {
+            restoreCalls++;
+          },
+        ),
+      ),
+    );
+    await tester.pumpWidget(const SizedBox.shrink());
+
+    expect(restoreCalls, 1);
+    logs.dispose();
+  });
+}

--- a/test/unit/skin_feature/skin_view_brightness_test.dart
+++ b/test/unit/skin_feature/skin_view_brightness_test.dart
@@ -1,33 +1,61 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/display_controller.dart';
 import 'package:reaprime/src/services/webview_log_service.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/skin_feature/skin_view.dart';
 
+import '../../helpers/mock_de1_controller.dart';
 import '../../helpers/mock_settings_service.dart';
 
 void main() {
-  testWidgets('removing the skin view restores OS-managed brightness', (
-    tester,
-  ) async {
-    var restoreCalls = 0;
-    final logs = WebViewLogService(logDirectoryPath: '.');
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: SkinView(
-          settingsController: SettingsController(MockSettingsService()),
-          webViewLogService: logs,
-          deviceIp: '127.0.0.1',
-          restoreBrightness: () async {
-            restoreCalls++;
-          },
+  testWidgets(
+    'native UI overrides other brightness requests when skin closes',
+    (tester) async {
+      final logs = WebViewLogService(logDirectoryPath: '.');
+      final de1Controller = MockDe1Controller(
+        controller: DeviceController(const []),
+      );
+      final settingsController = SettingsController(MockSettingsService());
+      var resetCalls = 0;
+      final displayController = DisplayController(
+        de1Controller: de1Controller,
+        settingsController: settingsController,
+        setBrightness: (_) async {},
+        resetBrightness: () async {
+          resetCalls++;
+        },
+        enableWakeLock: () async {},
+        disableWakeLock: () async {},
+        platformSupport: const DisplayPlatformSupport(
+          brightness: true,
+          wakeLock: false,
         ),
-      ),
-    );
-    await tester.pumpWidget(const SizedBox.shrink());
+      );
+      addTearDown(() {
+        displayController.dispose();
+        logs.dispose();
+      });
 
-    expect(restoreCalls, 1);
-    logs.dispose();
-  });
+      await displayController.setBrightness(40);
+      expect(displayController.currentState.requestedBrightness, 40);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SkinView(
+            settingsController: settingsController,
+            webViewLogService: logs,
+            deviceIp: '127.0.0.1',
+            displayController: displayController,
+          ),
+        ),
+      );
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+
+      expect(displayController.currentState.requestedBrightness, 100);
+      expect(resetCalls, 1);
+    },
+  );
 }


### PR DESCRIPTION
## Summary

What changed, and why?

- Give the embedded `SkinView` the production `DisplayController` and restore
  OS-managed brightness through `setBrightness(100)` when the view is removed.
- Define native UI as the brightness authority after skin exit, overriding any
  active REST or WebSocket fixed-brightness request.
- Document that clients must request fixed brightness again after skin exit.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [x] WebUI skins
- [ ] Plugins / JS runtime
- [x] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

Fixes #621

> Android tablet brightness restoration is validated. No additional hardware test is required for this display-lifecycle change.

## Root Cause (if bug fix)

- Root cause: Skin-requested brightness outlived the embedded `SkinView`; the
  view did not own the production controller needed to restore OS-managed
  brightness when it closed.
- Missing detection or guardrail: There was no widget lifecycle test for
  brightness cleanup on `SkinView` removal.
- Contributing context: Display WebSocket cleanup cannot own this because one
  client disconnect must not reset another client's brightness.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/unit/skin_feature/skin_view_brightness_test.dart`.
- Scenario the test should lock in: Removing `SkinView` while another client
  requests brightness 40 replaces that request with 100 and resets platform
  brightness exactly once.
- If no new test added, why not: N/A; a lifecycle regression test was added.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [x] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A - no docs affected

## Security Impact (required)

- New or changed REST endpoints? `No`.
- New or changed WebSocket topics? `No`.
- New or changed network calls? `No`.
- BLE/USB surface changed? `No`.
- File system access changed? `No`.
- Plugin sandbox boundary changed? `No`.
- If any `Yes`, explain risk and mitigation: N/A.

## User-Visible Changes

- Leaving the embedded skin now discards any skin-requested fixed brightness
  and returns the display to OS-managed brightness.
- An unrelated display WebSocket disconnect still cannot reset another
  client's brightness.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` - no remaining candidate changes
- [x] `flutter analyze` - clean
- [x] `flutter test` - 3,179 passed, 1 skipped
- [ ] `./scripts/fetch_dye2_plugin.sh` - not rerun for this local draft

### Manual verification (if applicable)

- OS / platform tested: Windows test host and physical Samsung Galaxy Tab A9+ (Android 15, 1920 x 1200).
- Simulated devices? (`simulate=1`): `Yes`.
- Real hardware? (DE1/Bengle/scale): `No`; physical Android tablet only.
- What you personally verified and how: Computer Use confirmed the skin ran on the Samsung tablet and Android Back removed the embedded SkinView. A REST request fixed brightness at 10%; Android then reported a 0.1 window brightness override. Leaving the skin cleared Decaid's physical override and returned brightness control to Android; adaptive brightness remained low in the current lighting.
- Edge cases checked: View removal while a competing client requests fixed
  brightness, and separation from WebSocket client cleanup.
- What you did **not** verify: Real DE1, Bengle, or scale hardware; not applicable to display brightness cleanup.

### Evidence

- [x] Test output (failing before + passing after)
- [x] Log snippets
- [x] Screenshot / recording (UI changes)
- [x] curl / websocat output (API changes)

Detailed evidence:

- Regression-first proof: the new lifecycle test failed before implementation
  because `SkinView` had no host brightness restore hook.
- `flutter test --no-pub test/unit/skin_feature/skin_view_brightness_test.dart test/controllers/display_controller_test.dart`
  (41 passed).
- `dart format --output=none --set-exit-if-changed lib/main.dart lib/src/app.dart lib/src/skin_feature/skin_view.dart test/unit/skin_feature/skin_view_brightness_test.dart`
- `flutter analyze --no-pub` (no issues).
- `flutter test --no-pub` with the package-matched QuickJS DLL on `PATH`
  (3,179 passed, 1 skipped).
- Samsung Galaxy Tab A9+ physical smoke test: `PUT /api/v1/display/brightness` with `10` returned requested and applied brightness 10. Android `dumpsys display` reported `screenBrightnessOverride=0.1`, `reason=override`, and `OverrideBrightnessStrategy`.
- After Android Back removed SkinView, Decaid reported requested and applied brightness 100. Android reported `screenBrightnessOverride=NaN`, `reason=automatic`, and `InvalidBrightnessStrategy`; automatic-brightness mode remained enabled. The panel did not visibly brighten because Android selected approximately 4% for the current lighting.
- Computer Use confirmed the supported skin-to-Dashboard bridge removes the
  live SkinView and renders the native launcher on Windows.

## Compatibility & Migration

- Backward compatible? `Yes`.
- Config / env changes needed? `No`.
- Database migration needed? `No`.
- Exact steps: None.

## Risks & Mitigations

- Risk: A REST or WebSocket client may expect fixed brightness to survive after
  the skin UI is gone.
  - Mitigation: The documented authority boundary makes native UI authoritative
    on skin exit; clients can request fixed brightness again afterward.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->