### PR TITLE
feat(debug): add DE1 calibration controls

### DIFF
--- a/doc/plans/archive/de1-debug-calibration/2026-08-19-issue-620-debug-calibration.md
+++ b/doc/plans/archive/de1-debug-calibration/2026-08-19-issue-620-debug-calibration.md
@@ -1,0 +1,27 @@
+# Native DE1 calibration debug controls
+
+**Issue:** [decentespresso/decaid#620](https://github.com/decentespresso/decaid/issues/620)
+**Branch:** `odev/issue-620-debug-calibration`
+**Scope:** Native debug UI only. The typed calibration API from #613 remains the sole device boundary.
+
+## Findings
+
+- `De1Interface` already exposes typed current/factory reads and writes for flow, pressure, and temperature.
+- Writes are corrections described by the reported and measured pair. Initialize both write fields from the current calibration value so an unchanged write is a no-op and editing the measured field performs the documented absolute-set recipe.
+- `De1DebugView` already uses cards, Shad inputs/buttons, snackbars for status, and dialogs for failures.
+- Issue #620 has no acceptance label, so any prepared PR remains gated on maintainer acceptance.
+
+## Plan
+
+1. Add widget tests that pin all-target current/factory reads, write arguments, authoritative post-write refresh, invalid input handling, and device failures.
+2. Add one calibration card to the native debug view, backed directly by `De1Interface`.
+3. Keep one row per typed target with current/factory display and numeric reported/measured inputs.
+4. Use the existing snackbar/dialog conventions for validation, success, and device errors.
+5. Format changed Dart files, run focused tests, analyze, run the full suite, then archive this design note and prepare the local draft PR.
+
+## Non-goals
+
+- Physical calibration guidance.
+- Raw A012 or BLE handling.
+- REST or WebSocket changes.
+- New controller, service, or persistence layer.

--- a/lib/src/debug_feature/calibration_debug_card.dart
+++ b/lib/src/debug_feature/calibration_debug_card.dart
@@ -13,8 +13,6 @@ class CalibrationDebugCard extends StatefulWidget {
 
 class _CalibrationDebugCardState extends State<CalibrationDebugCard>
     with AutomaticKeepAliveClientMixin {
-  static const _fixedPointScale = 65536.0;
-
   final _reportedControllers = {
     for (final target in De1CalibrationTarget.values)
       target: TextEditingController(),
@@ -201,12 +199,6 @@ class _CalibrationDebugCardState extends State<CalibrationDebugCard>
       _showStatus('Enter valid reported and measured values');
       return;
     }
-    if (target != De1CalibrationTarget.temperature &&
-        (reported * _fixedPointScale).round() == 0) {
-      _showStatus('Reported value must be non-zero for flow and pressure');
-      return;
-    }
-
     setState(() => _writing = {target});
     try {
       await widget.machine.writeCalibration(

--- a/lib/src/debug_feature/calibration_debug_card.dart
+++ b/lib/src/debug_feature/calibration_debug_card.dart
@@ -13,6 +13,8 @@ class CalibrationDebugCard extends StatefulWidget {
 
 class _CalibrationDebugCardState extends State<CalibrationDebugCard>
     with AutomaticKeepAliveClientMixin {
+  static const _fixedPointScale = 65536.0;
+
   final _reportedControllers = {
     for (final target in De1CalibrationTarget.values)
       target: TextEditingController(),
@@ -197,6 +199,11 @@ class _CalibrationDebugCardState extends State<CalibrationDebugCard>
         !reported.isFinite ||
         !measured.isFinite) {
       _showStatus('Enter valid reported and measured values');
+      return;
+    }
+    if (target != De1CalibrationTarget.temperature &&
+        (reported * _fixedPointScale).round() == 0) {
+      _showStatus('Reported value must be non-zero for flow and pressure');
       return;
     }
 

--- a/lib/src/debug_feature/calibration_debug_card.dart
+++ b/lib/src/debug_feature/calibration_debug_card.dart
@@ -1,0 +1,288 @@
+import 'package:flutter/material.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class CalibrationDebugCard extends StatefulWidget {
+  const CalibrationDebugCard({super.key, required this.machine});
+
+  final De1Interface machine;
+
+  @override
+  State<CalibrationDebugCard> createState() => _CalibrationDebugCardState();
+}
+
+class _CalibrationDebugCardState extends State<CalibrationDebugCard>
+    with AutomaticKeepAliveClientMixin {
+  final _reportedControllers = {
+    for (final target in De1CalibrationTarget.values)
+      target: TextEditingController(),
+  };
+  final _measuredControllers = {
+    for (final target in De1CalibrationTarget.values)
+      target: TextEditingController(),
+  };
+
+  Map<De1CalibrationTarget, De1Calibration> _current = const {};
+  Map<De1CalibrationTarget, De1Calibration> _factory = const {};
+  Set<De1CalibrationTarget> _writing = const {};
+  var _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _refreshAll();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return ShadCard(
+      title: Row(
+        children: [
+          const Expanded(child: Text('Calibration')),
+          Tooltip(
+            message: 'Refresh calibration',
+            child: ShadButton.ghost(
+              size: ShadButtonSize.sm,
+              onPressed: _loading || _writing.isNotEmpty ? null : _refreshAll,
+              child: const Icon(LucideIcons.refreshCw, size: 16),
+            ),
+          ),
+        ],
+      ),
+      child: _loading
+          ? const Center(
+              child: SizedBox(
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            )
+          : Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                for (final (index, target)
+                    in De1CalibrationTarget.values.indexed) ...[
+                  if (index > 0) const Divider(height: 24),
+                  _buildTarget(target),
+                ],
+              ],
+            ),
+    );
+  }
+
+  Widget _buildTarget(De1CalibrationTarget target) {
+    final current = _current[target];
+    final factory = _factory[target];
+    final busy = _writing.isNotEmpty;
+    final theme = ShadTheme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(_targetLabel(target), style: theme.textTheme.small),
+        const SizedBox(height: 6),
+        Text(_valueLabel('Current', current), style: theme.textTheme.muted),
+        Text(_valueLabel('Factory', factory), style: theme.textTheme.muted),
+        const SizedBox(height: 8),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Expanded(
+              child: _buildInput(
+                label: 'Reported',
+                controller: _reportedControllers[target]!,
+                key: Key('calibration-reported-${target.name}'),
+                enabled: !busy,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: _buildInput(
+                label: 'Measured',
+                controller: _measuredControllers[target]!,
+                key: Key('calibration-measured-${target.name}'),
+                enabled: !busy,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Tooltip(
+              message:
+                  'Write ${_targetLabel(target).toLowerCase()} calibration',
+              child: ShadButton(
+                key: Key('calibration-write-${target.name}'),
+                size: ShadButtonSize.sm,
+                onPressed: busy ? null : () => _write(target),
+                child: _writing.contains(target)
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(LucideIcons.save, size: 16),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildInput({
+    required String label,
+    required TextEditingController controller,
+    required Key key,
+    required bool enabled,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: ShadTheme.of(context).textTheme.muted),
+        const SizedBox(height: 4),
+        ShadInput(
+          key: key,
+          controller: controller,
+          enabled: enabled,
+          keyboardType: const TextInputType.numberWithOptions(
+            signed: true,
+            decimal: true,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _refreshAll() async {
+    if (mounted) {
+      setState(() => _loading = true);
+    }
+    try {
+      final reads = await Future.wait([
+        for (final target in De1CalibrationTarget.values)
+          widget.machine.readCalibration(target),
+        for (final target in De1CalibrationTarget.values)
+          widget.machine.readCalibration(
+            target,
+            source: De1CalibrationSource.factory,
+          ),
+      ]);
+      if (!mounted) return;
+      final targetCount = De1CalibrationTarget.values.length;
+      final current = {
+        for (final value in reads.take(targetCount)) value.target: value,
+      };
+      final factory = {
+        for (final value in reads.skip(targetCount)) value.target: value,
+      };
+      setState(() {
+        _current = current;
+        _factory = factory;
+        _loading = false;
+      });
+      for (final value in current.values) {
+        _setInputValues(value);
+      }
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => _loading = false);
+      _showFailure('Calibration read failed', error);
+    }
+  }
+
+  Future<void> _write(De1CalibrationTarget target) async {
+    final reported = double.tryParse(_reportedControllers[target]!.text);
+    final measured = double.tryParse(_measuredControllers[target]!.text);
+    if (reported == null ||
+        measured == null ||
+        !reported.isFinite ||
+        !measured.isFinite) {
+      _showStatus('Enter valid reported and measured values');
+      return;
+    }
+
+    setState(() => _writing = {target});
+    try {
+      await widget.machine.writeCalibration(
+        De1Calibration(
+          target: target,
+          de1ReportedValue: reported,
+          measuredValue: measured,
+        ),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => _writing = const {});
+      _showFailure('Calibration write failed', error);
+      return;
+    }
+
+    try {
+      final current = await widget.machine.readCalibration(target);
+      if (!mounted) return;
+      setState(() {
+        _current = {..._current, target: current};
+        _writing = const {};
+      });
+      _setInputValues(current);
+      _showStatus('${_targetLabel(target)} calibration updated');
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => _writing = const {});
+      _showFailure('Calibration refresh failed', error);
+    }
+  }
+
+  void _setInputValues(De1Calibration calibration) {
+    _reportedControllers[calibration.target]!.text = calibration.measuredValue
+        .toString();
+    _measuredControllers[calibration.target]!.text = calibration.measuredValue
+        .toString();
+  }
+
+  void _showStatus(String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  void _showFailure(String title, Object error) {
+    showShadDialog(
+      context: context,
+      builder: (context) => ShadDialog(
+        title: Text(title),
+        actions: [
+          ShadButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+        child: Text(error.toString()),
+      ),
+    );
+  }
+
+  String _valueLabel(String source, De1Calibration? value) => value == null
+      ? '$source: unavailable'
+      : '$source: reported ${value.de1ReportedValue.toStringAsFixed(4)}, '
+            'measured ${value.measuredValue.toStringAsFixed(4)}';
+
+  String _targetLabel(De1CalibrationTarget target) => switch (target) {
+    De1CalibrationTarget.flow => 'Flow',
+    De1CalibrationTarget.pressure => 'Pressure',
+    De1CalibrationTarget.temperature => 'Temperature',
+  };
+
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  void dispose() {
+    for (final controller in _reportedControllers.values) {
+      controller.dispose();
+    }
+    for (final controller in _measuredControllers.values) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+}

--- a/lib/src/debug_feature/calibration_debug_card.dart
+++ b/lib/src/debug_feature/calibration_debug_card.dart
@@ -112,7 +112,9 @@ class _CalibrationDebugCardState extends State<CalibrationDebugCard>
               child: ShadButton(
                 key: Key('calibration-write-${target.name}'),
                 size: ShadButtonSize.sm,
-                onPressed: busy ? null : () => _write(target),
+                onPressed: busy || current == null
+                    ? null
+                    : () => _write(target),
                 child: _writing.contains(target)
                     ? const SizedBox(
                         width: 16,
@@ -157,23 +159,20 @@ class _CalibrationDebugCardState extends State<CalibrationDebugCard>
       setState(() => _loading = true);
     }
     try {
-      final reads = await Future.wait([
-        for (final target in De1CalibrationTarget.values)
-          widget.machine.readCalibration(target),
-        for (final target in De1CalibrationTarget.values)
-          widget.machine.readCalibration(
-            target,
-            source: De1CalibrationSource.factory,
-          ),
-      ]);
+      var current = const <De1CalibrationTarget, De1Calibration>{};
+      for (final target in De1CalibrationTarget.values) {
+        final value = await widget.machine.readCalibration(target);
+        current = {...current, value.target: value};
+      }
+      var factory = const <De1CalibrationTarget, De1Calibration>{};
+      for (final target in De1CalibrationTarget.values) {
+        final value = await widget.machine.readCalibration(
+          target,
+          source: De1CalibrationSource.factory,
+        );
+        factory = {...factory, value.target: value};
+      }
       if (!mounted) return;
-      final targetCount = De1CalibrationTarget.values.length;
-      final current = {
-        for (final value in reads.take(targetCount)) value.target: value,
-      };
-      final factory = {
-        for (final value in reads.skip(targetCount)) value.target: value,
-      };
       setState(() {
         _current = current;
         _factory = factory;
@@ -184,7 +183,11 @@ class _CalibrationDebugCardState extends State<CalibrationDebugCard>
       }
     } catch (error) {
       if (!mounted) return;
-      setState(() => _loading = false);
+      setState(() {
+        _current = const {};
+        _factory = const {};
+        _loading = false;
+      });
       _showFailure('Calibration read failed', error);
     }
   }
@@ -226,7 +229,13 @@ class _CalibrationDebugCardState extends State<CalibrationDebugCard>
       _showStatus('${_targetLabel(target)} calibration updated');
     } catch (error) {
       if (!mounted) return;
-      setState(() => _writing = const {});
+      setState(() {
+        _current = {
+          for (final entry in _current.entries)
+            if (entry.key != target) entry.key: entry.value,
+        };
+        _writing = const {};
+      });
       _showFailure('Calibration refresh failed', error);
     }
   }

--- a/lib/src/debug_feature/debug_item_details_view.dart
+++ b/lib/src/debug_feature/debug_item_details_view.dart
@@ -26,11 +26,12 @@ class De1DebugView extends StatefulWidget {
 
 class _De1DebugViewState extends State<De1DebugView> {
   var _lastDate = DateTime.now();
+  late final Future<void> _connection;
 
   @override
   void initState() {
     super.initState();
-    widget.machine.onConnect();
+    _connection = widget.machine.onConnect();
   }
 
   @override
@@ -99,7 +100,7 @@ class _De1DebugViewState extends State<De1DebugView> {
                 ],
               ),
               const SizedBox(height: 12),
-              CalibrationDebugCard(machine: widget.machine),
+              _buildCalibrationCard(),
             ],
           ),
         ),
@@ -119,8 +120,35 @@ class _De1DebugViewState extends State<De1DebugView> {
         const SizedBox(height: 12),
         _buildMachineInfoCard(theme),
         const SizedBox(height: 12),
-        CalibrationDebugCard(machine: widget.machine),
+        _buildCalibrationCard(),
       ],
+    );
+  }
+
+  Widget _buildCalibrationCard() {
+    return FutureBuilder<void>(
+      future: _connection,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return ShadCard(
+            title: const Text('Calibration'),
+            child: const Center(
+              child: SizedBox(
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            ),
+          );
+        }
+        if (snapshot.hasError) {
+          return const ShadCard(
+            title: Text('Calibration'),
+            child: Text('Machine connection failed'),
+          );
+        }
+        return CalibrationDebugCard(machine: widget.machine);
+      },
     );
   }
 

--- a/lib/src/debug_feature/debug_item_details_view.dart
+++ b/lib/src/debug_feature/debug_item_details_view.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:reaprime/src/debug_feature/calibration_debug_card.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/de1_rawmessage.dart';
@@ -74,29 +75,33 @@ class _De1DebugViewState extends State<De1DebugView> {
   }
 
   Widget _buildWideLayout(ShadThemeData theme) {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Column(
-          children: [
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Expanded(child: _buildShotSnapshotCard(theme)),
-                const SizedBox(width: 12),
-                Expanded(child: _buildShotSettingsCard(theme)),
-              ],
-            ),
-            const SizedBox(height: 12),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Expanded(child: _buildWaterLevelsCard(theme)),
-                const SizedBox(width: 12),
-                Expanded(child: _buildMachineInfoCard(theme)),
-              ],
-            ),
-          ],
+    return SingleChildScrollView(
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(child: _buildShotSnapshotCard(theme)),
+                  const SizedBox(width: 12),
+                  Expanded(child: _buildShotSettingsCard(theme)),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(child: _buildWaterLevelsCard(theme)),
+                  const SizedBox(width: 12),
+                  Expanded(child: _buildMachineInfoCard(theme)),
+                ],
+              ),
+              const SizedBox(height: 12),
+              CalibrationDebugCard(machine: widget.machine),
+            ],
+          ),
         ),
       ),
     );
@@ -113,6 +118,8 @@ class _De1DebugViewState extends State<De1DebugView> {
         _buildWaterLevelsCard(theme),
         const SizedBox(height: 12),
         _buildMachineInfoCard(theme),
+        const SizedBox(height: 12),
+        CalibrationDebugCard(machine: widget.machine),
       ],
     );
   }

--- a/lib/src/models/device/de1_interface.dart
+++ b/lib/src/models/device/de1_interface.dart
@@ -244,6 +244,10 @@ enum De1CalibrationTarget {
 enum De1CalibrationSource { current, factory }
 
 final class De1Calibration {
+  static const fixedPointScale = 65536.0;
+  static const minValue = -32768.0;
+  static const maxValueExclusive = 32768.0;
+
   final De1CalibrationTarget target;
   final double de1ReportedValue;
   final double measuredValue;
@@ -253,6 +257,32 @@ final class De1Calibration {
     required this.de1ReportedValue,
     required this.measuredValue,
   });
+
+  void validateForWrite() {
+    _validateValue(de1ReportedValue, 'de1ReportedValue');
+    _validateValue(measuredValue, 'measuredValue');
+    if (target != De1CalibrationTarget.temperature &&
+        (de1ReportedValue * fixedPointScale).round() == 0) {
+      throw ArgumentError.value(
+        de1ReportedValue,
+        'de1ReportedValue',
+        'must not encode as zero for flow or pressure',
+      );
+    }
+  }
+
+  static void _validateValue(double value, String name) {
+    if (!value.isFinite) {
+      throw ArgumentError.value(value, name, 'must be finite');
+    }
+    if (value < minValue || value >= maxValueExclusive) {
+      throw ArgumentError.value(
+        value,
+        name,
+        'outside the signed Q16.16 range -32768..32767.9999',
+      );
+    }
+  }
 
   @override
   bool operator ==(Object other) =>

--- a/lib/src/models/device/impl/de1/unified_de1/calibration_codec.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/calibration_codec.dart
@@ -43,20 +43,22 @@ final class De1CalibrationCodec {
   static Uint8List encodeWrite(De1Calibration calibration) {
     _checkFinite(calibration.de1ReportedValue, 'de1ReportedValue');
     _checkFinite(calibration.measuredValue, 'measuredValue');
+    final reported = _encodeQ16_16Signed(calibration.de1ReportedValue);
+    final measured = _encodeQ16_16Signed(calibration.measuredValue);
+    if (calibration.target != De1CalibrationTarget.temperature &&
+        reported == 0) {
+      throw ArgumentError.value(
+        calibration.de1ReportedValue,
+        'de1ReportedValue',
+        'must not encode as zero for flow or pressure',
+      );
+    }
     final bytes = ByteData(packetLength);
     bytes.setUint32(0, _writeWriteKey, Endian.big);
     bytes.setUint8(4, writeCommand);
     bytes.setUint8(5, calibration.target.wireValue);
-    bytes.setInt32(
-      6,
-      _encodeQ16_16Signed(calibration.de1ReportedValue),
-      Endian.big,
-    );
-    bytes.setInt32(
-      10,
-      _encodeQ16_16Signed(calibration.measuredValue),
-      Endian.big,
-    );
+    bytes.setInt32(6, reported, Endian.big);
+    bytes.setInt32(10, measured, Endian.big);
     return bytes.buffer.asUint8List();
   }
 

--- a/lib/src/models/device/impl/de1/unified_de1/calibration_codec.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/calibration_codec.dart
@@ -21,11 +21,10 @@ final class De1CalibrationCodec {
 
   static const int _readWriteKey = 1;
   static const int _writeWriteKey = 0xCAFEF00D;
-  static const double _fixedPointScale = 65536.0;
 
   /// Signed Q16.16 representable range (S32P16).
-  static const double minValue = -32768.0;
-  static const double maxValueExclusive = 32768.0;
+  static const double minValue = De1Calibration.minValue;
+  static const double maxValueExclusive = De1Calibration.maxValueExclusive;
 
   static Uint8List encodeRead(
     De1CalibrationTarget target, {
@@ -41,18 +40,9 @@ final class De1CalibrationCodec {
   }
 
   static Uint8List encodeWrite(De1Calibration calibration) {
-    _checkFinite(calibration.de1ReportedValue, 'de1ReportedValue');
-    _checkFinite(calibration.measuredValue, 'measuredValue');
+    calibration.validateForWrite();
     final reported = _encodeQ16_16Signed(calibration.de1ReportedValue);
     final measured = _encodeQ16_16Signed(calibration.measuredValue);
-    if (calibration.target != De1CalibrationTarget.temperature &&
-        reported == 0) {
-      throw ArgumentError.value(
-        calibration.de1ReportedValue,
-        'de1ReportedValue',
-        'must not encode as zero for flow or pressure',
-      );
-    }
     final bytes = ByteData(packetLength);
     bytes.setUint32(0, _writeWriteKey, Endian.big);
     bytes.setUint8(4, writeCommand);
@@ -90,24 +80,11 @@ final class De1CalibrationCodec {
     }
   }
 
-  static int _encodeQ16_16Signed(double value) {
-    if (value < minValue || value >= maxValueExclusive) {
-      throw ArgumentError.value(
-        value,
-        'value',
-        'outside the signed Q16.16 range -32768..32767.9999',
-      );
-    }
-    return (value * _fixedPointScale).round();
-  }
+  static int _encodeQ16_16Signed(double value) =>
+      (value * De1Calibration.fixedPointScale).round();
 
-  static double _decodeQ16_16Signed(int raw) => raw / _fixedPointScale;
-
-  static void _checkFinite(double value, String name) {
-    if (!value.isFinite) {
-      throw ArgumentError.value(value, name, 'must be finite');
-    }
-  }
+  static double _decodeQ16_16Signed(int raw) =>
+      raw / De1Calibration.fixedPointScale;
 }
 
 final class De1CalibrationPacket {

--- a/lib/src/models/device/impl/mock_de1/mock_de1.dart
+++ b/lib/src/models/device/impl/mock_de1/mock_de1.dart
@@ -604,6 +604,7 @@ class MockDe1 implements De1Interface, SimulatedDevice {
 
   @override
   Future<void> writeCalibration(De1Calibration calibration) async {
+    calibration.validateForWrite();
     // Writes are corrections, not sets, matching the DE1 firmware:
     // flow/pressure multiply by measured/reported, temperature adds the
     // difference.

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -572,7 +572,6 @@ class De1Handler {
             ),
           );
         } on ArgumentError catch (e) {
-          // Out-of-range values (outside signed Q16.16) are client errors.
           return jsonBadRequest({'error': e.toString()});
         }
         return jsonAccepted();

--- a/test/debug_feature/debug_item_details_view_test.dart
+++ b/test/debug_feature/debug_item_details_view_test.dart
@@ -311,6 +311,44 @@ void main() {
       expect(find.text('Exception: write failed'), findsOneWidget);
     });
 
+    testWidgets('invalidates a target when write verification fails', (
+      tester,
+    ) async {
+      final machine = _CalibrationDe1();
+      await pumpView(tester, machine);
+      final write = find.byKey(const Key('calibration-write-flow'));
+      await tester.ensureVisible(write);
+      machine.failReads = true;
+
+      await tester.tap(write);
+      await tester.pumpAndSettle();
+
+      expect(machine.writes, hasLength(1));
+      expect(find.text('Calibration refresh failed'), findsOneWidget);
+      expect(find.text('Current: unavailable'), findsOneWidget);
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+      await tester.tap(write, warnIfMissed: false);
+      await tester.pumpAndSettle();
+      expect(machine.writes, hasLength(1));
+    });
+
+    testWidgets('failed refresh invalidates values and stops reading', (
+      tester,
+    ) async {
+      final machine = _CalibrationDe1();
+      await pumpView(tester, machine);
+      machine.failReads = true;
+
+      await tester.tap(find.byIcon(LucideIcons.refreshCw));
+      await tester.pumpAndSettle();
+
+      expect(machine.reads, hasLength(7));
+      expect(find.text('Current: unavailable'), findsNWidgets(3));
+      expect(find.text('Factory: unavailable'), findsNWidgets(3));
+      expect(find.text('Calibration read failed'), findsOneWidget);
+    });
+
     testWidgets('fits narrow and wide debug layouts', (tester) async {
       tester.view.devicePixelRatio = 1;
       addTearDown(tester.view.resetDevicePixelRatio);

--- a/test/debug_feature/debug_item_details_view_test.dart
+++ b/test/debug_feature/debug_item_details_view_test.dart
@@ -270,31 +270,6 @@ void main() {
       );
     });
 
-    testWidgets('rejects multiplicative reported values that encode as zero', (
-      tester,
-    ) async {
-      final machine = _CalibrationDe1();
-      await pumpView(tester, machine);
-
-      for (final (target, value) in const [
-        (De1CalibrationTarget.flow, '0'),
-        (De1CalibrationTarget.pressure, '0.000001'),
-      ]) {
-        final reported = find.byKey(Key('calibration-reported-${target.name}'));
-        final write = find.byKey(Key('calibration-write-${target.name}'));
-        await tester.ensureVisible(write);
-        await tester.enterText(reported, value);
-        await tester.tap(write);
-        await tester.pumpAndSettle();
-      }
-
-      expect(machine.writes, isEmpty);
-      expect(
-        find.text('Reported value must be non-zero for flow and pressure'),
-        findsOneWidget,
-      );
-    });
-
     testWidgets('permits a zero reported value for temperature', (
       tester,
     ) async {

--- a/test/debug_feature/debug_item_details_view_test.dart
+++ b/test/debug_feature/debug_item_details_view_test.dart
@@ -1,7 +1,78 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
 import 'package:reaprime/src/debug_feature/debug_item_details_view.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+import '../helpers/test_de1.dart';
+
+class _CalibrationDe1 extends TestDe1 {
+  var reads = <(De1CalibrationTarget, De1CalibrationSource)>[];
+  var writes = <De1Calibration>[];
+  var failReads = false;
+  var failWrites = false;
+
+  var current = <De1CalibrationTarget, De1Calibration>{
+    De1CalibrationTarget.flow: const De1Calibration(
+      target: De1CalibrationTarget.flow,
+      de1ReportedValue: 1,
+      measuredValue: 1.1,
+    ),
+    De1CalibrationTarget.pressure: const De1Calibration(
+      target: De1CalibrationTarget.pressure,
+      de1ReportedValue: 1,
+      measuredValue: 0.9,
+    ),
+    De1CalibrationTarget.temperature: const De1Calibration(
+      target: De1CalibrationTarget.temperature,
+      de1ReportedValue: 0,
+      measuredValue: -0.25,
+    ),
+  };
+
+  final factory = <De1CalibrationTarget, De1Calibration>{
+    for (final target in De1CalibrationTarget.values)
+      target: De1Calibration(
+        target: target,
+        de1ReportedValue: target == De1CalibrationTarget.temperature ? 0 : 1,
+        measuredValue: target == De1CalibrationTarget.temperature ? 0 : 1,
+      ),
+  };
+
+  @override
+  Future<De1Calibration> readCalibration(
+    De1CalibrationTarget target, {
+    De1CalibrationSource source = De1CalibrationSource.current,
+  }) async {
+    reads = [...reads, (target, source)];
+    if (failReads) throw Exception('read failed');
+    return source == De1CalibrationSource.current
+        ? current[target]!
+        : factory[target]!;
+  }
+
+  @override
+  Future<void> writeCalibration(De1Calibration calibration) async {
+    if (failWrites) throw Exception('write failed');
+    writes = [...writes, calibration];
+    final previous = current[calibration.target]!.measuredValue;
+    final measuredValue = calibration.target == De1CalibrationTarget.temperature
+        ? previous + (calibration.measuredValue - calibration.de1ReportedValue)
+        : previous * calibration.measuredValue / calibration.de1ReportedValue;
+    current = {
+      ...current,
+      calibration.target: De1Calibration(
+        target: calibration.target,
+        de1ReportedValue: calibration.target == De1CalibrationTarget.temperature
+            ? 0
+            : 1,
+        measuredValue: measuredValue,
+      ),
+    };
+  }
+}
 
 void main() {
   group('debugViewTitle', () {
@@ -11,6 +82,175 @@ void main() {
 
     test('returns Bengle label for a BengleInterface', () {
       expect(debugViewTitle(MockBengle()), equals('Bengle Details'));
+    });
+  });
+
+  group('DE1 calibration controls', () {
+    Future<void> pumpView(
+      WidgetTester tester,
+      _CalibrationDe1 machine, {
+      bool scrollToCalibration = true,
+    }) async {
+      await tester.pumpWidget(
+        ScaffoldMessenger(
+          child: ShadApp(
+            home: De1DebugView(key: ValueKey(machine), machine: machine),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      if (scrollToCalibration) {
+        await tester.scrollUntilVisible(
+          find.text('Calibration'),
+          400,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.pumpAndSettle();
+      }
+    }
+
+    testWidgets('reads current and factory values for every target', (
+      tester,
+    ) async {
+      final machine = _CalibrationDe1();
+
+      await pumpView(tester, machine);
+
+      expect(find.text('Calibration'), findsOneWidget);
+      expect(find.text('Flow'), findsAtLeastNWidgets(1));
+      expect(find.text('Pressure'), findsAtLeastNWidgets(1));
+      expect(find.text('Temperature'), findsAtLeastNWidgets(1));
+      expect(machine.reads.toSet(), {
+        for (final target in De1CalibrationTarget.values)
+          (target, De1CalibrationSource.current),
+        for (final target in De1CalibrationTarget.values)
+          (target, De1CalibrationSource.factory),
+      });
+      expect(
+        find.text('Current: reported 1.0000, measured 1.1000'),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Factory: reported 1.0000, measured 1.0000'),
+        findsNWidgets(2),
+      );
+    });
+
+    testWidgets('writes entered values and refreshes the current value', (
+      tester,
+    ) async {
+      final machine = _CalibrationDe1();
+      await pumpView(tester, machine);
+      final reported = find.byKey(const Key('calibration-reported-flow'));
+      final measured = find.byKey(const Key('calibration-measured-flow'));
+      final write = find.byKey(const Key('calibration-write-flow'));
+      await tester.ensureVisible(write);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(reported, '1.2');
+      await tester.enterText(measured, '1.5');
+      await tester.tap(write);
+      await tester.pumpAndSettle();
+
+      expect(machine.writes, [
+        const De1Calibration(
+          target: De1CalibrationTarget.flow,
+          de1ReportedValue: 1.2,
+          measuredValue: 1.5,
+        ),
+      ]);
+      expect(
+        machine.reads
+            .where(
+              (read) =>
+                  read.$1 == De1CalibrationTarget.flow &&
+                  read.$2 == De1CalibrationSource.current,
+            )
+            .length,
+        2,
+      );
+      expect(
+        find.text('Current: reported 1.0000, measured 1.3750'),
+        findsOneWidget,
+      );
+      expect(find.text('Flow calibration updated'), findsOneWidget);
+    });
+
+    testWidgets('writing unchanged controls preserves the calibration', (
+      tester,
+    ) async {
+      final machine = _CalibrationDe1();
+      await pumpView(tester, machine);
+      final write = find.byKey(const Key('calibration-write-flow'));
+      await tester.ensureVisible(write);
+      await tester.pumpAndSettle();
+
+      await tester.tap(write);
+      await tester.pumpAndSettle();
+
+      expect(
+        machine.writes.single,
+        const De1Calibration(
+          target: De1CalibrationTarget.flow,
+          de1ReportedValue: 1.1,
+          measuredValue: 1.1,
+        ),
+      );
+      expect(
+        find.text('Current: reported 1.0000, measured 1.1000'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('rejects invalid values without writing', (tester) async {
+      final machine = _CalibrationDe1();
+      await pumpView(tester, machine);
+      final reported = find.byKey(const Key('calibration-reported-flow'));
+      final write = find.byKey(const Key('calibration-write-flow'));
+      await tester.ensureVisible(write);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(reported, 'not-a-number');
+      await tester.tap(write);
+      await tester.pumpAndSettle();
+
+      expect(machine.writes, isEmpty);
+      expect(
+        find.text('Enter valid reported and measured values'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows device read and write failures', (tester) async {
+      final readFailure = _CalibrationDe1()..failReads = true;
+      await pumpView(tester, readFailure, scrollToCalibration: false);
+      expect(find.text('Calibration read failed'), findsOneWidget);
+      expect(find.text('Exception: read failed'), findsOneWidget);
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      final writeFailure = _CalibrationDe1()..failWrites = true;
+      await pumpView(tester, writeFailure);
+      final write = find.byKey(const Key('calibration-write-flow'));
+      await tester.ensureVisible(write);
+      await tester.pumpAndSettle();
+      await tester.tap(write);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Calibration write failed'), findsOneWidget);
+      expect(find.text('Exception: write failed'), findsOneWidget);
+    });
+
+    testWidgets('fits narrow and wide debug layouts', (tester) async {
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.resetPhysicalSize);
+
+      for (final size in const [Size(360, 800), Size(1200, 800)]) {
+        tester.view.physicalSize = size;
+        await pumpView(tester, _CalibrationDe1());
+        expect(tester.takeException(), isNull);
+      }
     });
   });
 }

--- a/test/debug_feature/debug_item_details_view_test.dart
+++ b/test/debug_feature/debug_item_details_view_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
@@ -74,6 +76,28 @@ class _CalibrationDe1 extends TestDe1 {
   }
 }
 
+class _DelayedCalibrationDe1 extends _CalibrationDe1 {
+  final _connection = Completer<void>();
+  var _connected = false;
+
+  @override
+  Future<void> onConnect() async {
+    await _connection.future;
+    _connected = true;
+  }
+
+  @override
+  Future<De1Calibration> readCalibration(
+    De1CalibrationTarget target, {
+    De1CalibrationSource source = De1CalibrationSource.current,
+  }) {
+    if (!_connected) throw StateError('read before connection');
+    return super.readCalibration(target, source: source);
+  }
+
+  void completeConnection() => _connection.complete();
+}
+
 void main() {
   group('debugViewTitle', () {
     test('returns DE1 label for a non-Bengle De1Interface', () {
@@ -134,6 +158,31 @@ void main() {
         find.text('Factory: reported 1.0000, measured 1.0000'),
         findsNWidgets(2),
       );
+    });
+
+    testWidgets('waits for connection before reading calibration', (
+      tester,
+    ) async {
+      final machine = _DelayedCalibrationDe1();
+
+      await tester.pumpWidget(
+        ScaffoldMessenger(
+          child: ShadApp(home: De1DebugView(machine: machine)),
+        ),
+      );
+      await tester.pump();
+      await tester.scrollUntilVisible(
+        find.text('Calibration'),
+        400,
+        scrollable: find.byType(Scrollable).first,
+      );
+
+      expect(machine.reads, isEmpty);
+
+      machine.completeConnection();
+      await tester.pumpAndSettle();
+
+      expect(machine.reads, hasLength(6));
     });
 
     testWidgets('writes entered values and refreshes the current value', (
@@ -219,6 +268,52 @@ void main() {
         find.text('Enter valid reported and measured values'),
         findsOneWidget,
       );
+    });
+
+    testWidgets('rejects multiplicative reported values that encode as zero', (
+      tester,
+    ) async {
+      final machine = _CalibrationDe1();
+      await pumpView(tester, machine);
+
+      for (final (target, value) in const [
+        (De1CalibrationTarget.flow, '0'),
+        (De1CalibrationTarget.pressure, '0.000001'),
+      ]) {
+        final reported = find.byKey(Key('calibration-reported-${target.name}'));
+        final write = find.byKey(Key('calibration-write-${target.name}'));
+        await tester.ensureVisible(write);
+        await tester.enterText(reported, value);
+        await tester.tap(write);
+        await tester.pumpAndSettle();
+      }
+
+      expect(machine.writes, isEmpty);
+      expect(
+        find.text('Reported value must be non-zero for flow and pressure'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('permits a zero reported value for temperature', (
+      tester,
+    ) async {
+      final machine = _CalibrationDe1();
+      await pumpView(tester, machine);
+
+      final temperatureReported = find.byKey(
+        const Key('calibration-reported-temperature'),
+      );
+      final temperatureWrite = find.byKey(
+        const Key('calibration-write-temperature'),
+      );
+      await tester.ensureVisible(temperatureWrite);
+      await tester.enterText(temperatureReported, '0');
+      await tester.tap(temperatureWrite);
+      await tester.pumpAndSettle();
+
+      expect(machine.writes.single.target, De1CalibrationTarget.temperature);
+      expect(machine.writes.single.de1ReportedValue, 0);
     });
 
     testWidgets('shows device read and write failures', (tester) async {

--- a/test/unit/models/device/impl/de1/unified_de1/calibration_api_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/calibration_api_test.dart
@@ -5,6 +5,7 @@ import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/calibration_codec.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
 import 'package:reaprime/src/models/errors.dart';
 
 import '../../../../../../helpers/fake_ble_transport.dart';
@@ -200,6 +201,34 @@ void main() {
       // notification is required or awaited.
       await future;
       expect(completed, isTrue);
+    },
+  );
+
+  test(
+    'real and simulated writes reject multiplicative encoded zero',
+    () async {
+      final mock = MockDe1();
+      for (final calibration in const [
+        De1Calibration(
+          target: De1CalibrationTarget.flow,
+          de1ReportedValue: 0,
+          measuredValue: 1,
+        ),
+        De1Calibration(
+          target: De1CalibrationTarget.pressure,
+          de1ReportedValue: 0.000001,
+          measuredValue: 1,
+        ),
+      ]) {
+        await expectLater(
+          de1.writeCalibration(calibration),
+          throwsArgumentError,
+        );
+        await expectLater(
+          mock.writeCalibration(calibration),
+          throwsArgumentError,
+        );
+      }
     },
   );
 

--- a/test/unit/models/device/impl/de1/unified_de1/calibration_codec_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/calibration_codec_test.dart
@@ -153,6 +153,37 @@ void main() {
       );
     });
 
+    test('rejects multiplicative reported values that encode as zero', () {
+      for (final calibration in const [
+        De1Calibration(
+          target: De1CalibrationTarget.flow,
+          de1ReportedValue: 0,
+          measuredValue: 1,
+        ),
+        De1Calibration(
+          target: De1CalibrationTarget.pressure,
+          de1ReportedValue: 0.000001,
+          measuredValue: 1,
+        ),
+      ]) {
+        expect(
+          () => De1CalibrationCodec.encodeWrite(calibration),
+          throwsArgumentError,
+        );
+      }
+
+      expect(
+        De1CalibrationCodec.encodeWrite(
+          const De1Calibration(
+            target: De1CalibrationTarget.temperature,
+            de1ReportedValue: 0,
+            measuredValue: 1,
+          ),
+        ),
+        hasLength(De1CalibrationCodec.packetLength),
+      );
+    });
+
     test('rejects values outside the fixed-point ranges', () {
       expect(
         () => De1CalibrationCodec.encodeWrite(


### PR DESCRIPTION
## Summary

What changed, and why?

- Add native debug controls for reading the current and factory flow, pressure,
  and temperature calibration values through the existing typed `De1Interface`.
- Let a technician submit reported and measured values for each target, then
  re-read the machine so the UI shows the value the DE1 accepted.
- Keep the calibration state alive while scrolling and make the wide debug view
  scrollable so the new controls remain usable at narrow and wide widths.
- Wait for machine connection setup before creating the calibration controls; the shared A012 codec rejects flow or pressure divisors that encode as zero in Q16.16 for every caller.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [x] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs

## Linked Issues

Fixes #620

> **Remaining hardware validation before merge:** Validate calibration reads and writes on a physical DE1. Incorrect calibration can affect machine readings.

## Root Cause (if bug fix)

N/A - this exposes existing typed calibration operations in the native debug UI.

## Regression Test Plan (if bug fix or refactor)

N/A - feature coverage lives in
`test/debug_feature/debug_item_details_view_test.dart` and locks in reads,
writes, connection gating, refresh, failures, and
responsive layouts.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A - no docs affected

## Security Impact (required)

- New or changed REST endpoints? `No`.
- New or changed WebSocket topics? `No`.
- New or changed network calls? `No`.
- BLE/USB surface changed? `Yes`; existing typed calibration reads and writes
  are now reachable from the native debug UI.
- File system access changed? `No`.
- Plugin sandbox boundary changed? `No`.
- Risk and mitigation: Bad calibration can affect machine readings. Controls
  remain in the debug screen, wait for machine setup, use the typed `De1Interface`, validate zero wire divisors once in the shared codec, and re-read the accepted value after writes.

## User-Visible Changes

- The DE1 debug screen shows current and factory flow, pressure, and
  temperature calibration values and can write corrections.
- Both inputs start at the current value; an unchanged submission is a no-op.
- Calibration controls stay unavailable until machine connection setup
  completes, and unsafe zero flow/pressure divisors are rejected by the shared machine codec.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` - no remaining candidate changes
- [x] `flutter analyze` - clean
- [x] `flutter test` - 3,187 passed, 1 skipped
- [ ] `./scripts/fetch_dye2_plugin.sh` - not rerun for this local draft

### Manual verification (if applicable)

- OS / platform tested: Windows test host; live app launched.
- Simulated devices? (`simulate=1`): `Yes`.
- Real hardware? (DE1/Bengle/scale): `No`.
- What you personally verified and how: Computer Use opened MockDe1 details,
  waited for live calibration reads, and confirmed the flow, pressure, and
  temperature controls fit and scroll coherently at 1268 by 795.
- Edge cases checked: Delayed connection, zero and sub-LSB flow/pressure
  divisors, temperature zero, unchanged values, invalid input, read/write
  failures, post-write refresh, scrolling, and retained state.
- What you did **not** verify: Calibration reads or writes on a physical DE1.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

Detailed evidence:

- Regression-first codec coverage checks zero and sub-LSB flow/pressure divisors while permitting temperature zero. Widget coverage checks delayed connection setup, all current and factory
  reads, write arguments, post-write refresh, failures, and responsive layouts.
- `flutter test --no-pub test/debug_feature/debug_item_details_view_test.dart`
  (11 passed).
- Widget, calibration codec/transport/API, Bengle scale calibration, and REST
  calibration tests passed together (81 tests).
- `flutter analyze --no-pub` (no issues).
- `flutter test --no-pub` with the package-matched QuickJS DLL on `PATH`
  (3,187 passed, 1 skipped).
- No DE1 was available for a hardware calibration smoke test.
- Review follow-up commit c04d8594 moved zero-divisor validation into De1CalibrationCodec. The codec and widget suites passed 28 tests, and flutter analyze was clean.
- The Windows full suite reached 3,185 passed and 1 skipped; the two failures were the existing CRLF-sensitive AsyncAPI assertion and the ignored bundled-skin fixture not entering Flutter's cached asset bundle.

## Compatibility & Migration

- Backward compatible? `Yes`; the change adds controls to an existing debug
  surface and reuses the current typed API.
- Config / env changes needed? `No`.
- Database migration needed? `No`.
- Exact steps: None.

## Risks & Mitigations

- Risk: An incorrect technician entry can miscalibrate the DE1.
  - Mitigation: Require physical-DE1 validation before merge; wait for connection setup,
    validate zero wire divisors once in the shared codec, retain typed writes, and re-read after writes.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->