### PR TITLE
feat(api): list bean batches across beans

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -2166,6 +2166,40 @@ paths:
         "500":
           description: Internal Server Error
 
+  /api/v1/bean-batches:
+    get:
+      summary: List all bean batches
+      description: Returns batches across all beans, optionally including archived ones.
+      tags: [Beans]
+      parameters:
+        - name: includeArchived
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: Include archived batches
+      responses:
+        "200":
+          description: Array of batches
+          headers:
+            ETag:
+              schema:
+                type: string
+              description: |
+                Strong entity tag derived from the response body. Echo back as
+                `If-None-Match` on subsequent requests for conditional GET.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/BeanBatch"
+        "304":
+          description: Not Modified — client's `If-None-Match` matched the current ETag.
+        "500":
+          description: Internal Server Error
+
   /api/v1/bean-batches/{id}:
     get:
       summary: Get a batch by ID

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -224,6 +224,7 @@ supplied values replace them. Explicit `null` for non-nullable fields returns
 | DELETE | `/api/v1/beans/:id` | Delete bean | |
 | GET | `/api/v1/beans/:id/batches` | List batches for a bean | |
 | POST | `/api/v1/beans/:id/batches` | Create batch | |
+| GET | `/api/v1/bean-batches` | List batches across all beans | |
 | GET | `/api/v1/bean-batches/:id` | Get batch | |
 | PUT | `/api/v1/bean-batches/:id` | Update batch | |
 | DELETE | `/api/v1/bean-batches/:id` | Delete batch | |

--- a/lib/src/services/database/daos/bean_dao.dart
+++ b/lib/src/services/database/daos/bean_dao.dart
@@ -66,6 +66,15 @@ class BeanDao extends DatabaseAccessor<AppDatabase> with _$BeanDaoMixin {
     return (delete(beans)..where((b) => b.id.equals(id))).go();
   }
 
+  Future<List<BeanBatche>> getAllBatches({bool includeArchived = false}) {
+    final query = select(beanBatches);
+    if (!includeArchived) {
+      query.where((b) => b.archived.equals(false));
+    }
+    query.orderBy([(b) => OrderingTerm.desc(b.updatedAt)]);
+    return query.get();
+  }
+
   Future<List<BeanBatche>> getBatchesForBean(
     String beanId, {
     bool includeArchived = false,

--- a/lib/src/services/database/daos/bean_dao.dart
+++ b/lib/src/services/database/daos/bean_dao.dart
@@ -69,7 +69,12 @@ class BeanDao extends DatabaseAccessor<AppDatabase> with _$BeanDaoMixin {
   Future<List<BeanBatche>> getAllBatches({bool includeArchived = false}) {
     final query = select(beanBatches);
     if (!includeArchived) {
-      query.where((b) => b.archived.equals(false));
+      final activeBeans = selectOnly(beans)
+        ..addColumns([beans.id])
+        ..where(beans.archived.equals(false));
+      query.where(
+        (b) => b.archived.equals(false) & b.beanId.isInQuery(activeBeans),
+      );
     }
     query.orderBy([(b) => OrderingTerm.desc(b.updatedAt)]);
     return query.get();

--- a/lib/src/services/storage/bean_storage_service.dart
+++ b/lib/src/services/storage/bean_storage_service.dart
@@ -8,6 +8,7 @@ abstract class BeanStorageService {
   Future<void> updateBean(Bean bean);
   Future<void> deleteBean(String id);
 
+  Future<List<BeanBatch>> getAllBatches({bool includeArchived = false});
   Future<List<BeanBatch>> getBatchesForBean(
     String beanId, {
     bool includeArchived = false,

--- a/lib/src/services/storage/drift_bean_storage.dart
+++ b/lib/src/services/storage/drift_bean_storage.dart
@@ -45,6 +45,16 @@ class DriftBeanStorageService implements BeanStorageService {
   }
 
   @override
+  Future<List<domain.BeanBatch>> getAllBatches({
+    bool includeArchived = false,
+  }) async {
+    final rows = await _db.beanDao.getAllBatches(
+      includeArchived: includeArchived,
+    );
+    return rows.map(BeanMapper.batchFromRow).toList();
+  }
+
+  @override
   Future<List<domain.BeanBatch>> getBatchesForBean(
     String beanId, {
     bool includeArchived = false,

--- a/lib/src/services/webserver/beans_handler.dart
+++ b/lib/src/services/webserver/beans_handler.dart
@@ -21,6 +21,7 @@ class BeansHandler {
 
     app.get('/api/v1/beans/<beanId>/batches', _getBatches);
     app.post('/api/v1/beans/<beanId>/batches', _createBatch);
+    app.get('/api/v1/bean-batches', _getAllBatches);
     app.get('/api/v1/bean-batches/<id>', _getBatch);
     app.put('/api/v1/bean-batches/<id>', _updateBatch);
     app.delete('/api/v1/bean-batches/<id>', _deleteBatch);
@@ -141,6 +142,20 @@ class BeansHandler {
       return jsonOkConditional(req, batches.map((b) => b.toJson()).toList());
     } catch (e, st) {
       _log.severe('Error getting batches for bean $beanId', e, st);
+      return jsonError({'error': e.toString()});
+    }
+  }
+
+  Future<Response> _getAllBatches(Request req) async {
+    try {
+      final includeArchived =
+          req.url.queryParameters['includeArchived'] == 'true';
+      final batches = await _storage.getAllBatches(
+        includeArchived: includeArchived,
+      );
+      return jsonOkConditional(req, batches.map((b) => b.toJson()).toList());
+    } catch (e, st) {
+      _log.severe('Error getting batches', e, st);
       return jsonError({'error': e.toString()});
     }
   }

--- a/test/data_export/bean_export_section_test.dart
+++ b/test/data_export/bean_export_section_test.dart
@@ -40,6 +40,12 @@ class MockBeanStorage implements BeanStorageService {
       beans.removeWhere((b) => b.id == id);
 
   @override
+  Future<List<BeanBatch>> getAllBatches({bool includeArchived = false}) async =>
+      throw StateError(
+        'getAllBatches must not be called during streaming export',
+      );
+
+  @override
   Future<List<BeanBatch>> getBatchesForBean(
     String beanId, {
     bool includeArchived = false,

--- a/test/database/bean_dao_test.dart
+++ b/test/database/bean_dao_test.dart
@@ -115,20 +115,22 @@ void main() {
   });
 
   group('BeanDao - BeanBatches', () {
-    test('lists batches across beans and filters archived', () async {
+    test('lists batches across beans and filters archived records', () async {
       await db.beanDao.insertBean(makeBean(id: 'bean-1'));
       await db.beanDao.insertBean(makeBean(id: 'bean-2'));
+      await db.beanDao.insertBean(makeBean(id: 'bean-3', archived: true));
       await db.beanDao.insertBatch(makeBatch(id: 'b1'));
       await db.beanDao.insertBatch(makeBatch(id: 'b2', beanId: 'bean-2'));
       await db.beanDao.insertBatch(
         makeBatch(id: 'b3', beanId: 'bean-2', archived: true),
       );
+      await db.beanDao.insertBatch(makeBatch(id: 'b4', beanId: 'bean-3'));
 
       final active = await db.beanDao.getAllBatches();
       expect(active.map((batch) => batch.id).toSet(), {'b1', 'b2'});
 
       final all = await db.beanDao.getAllBatches(includeArchived: true);
-      expect(all.map((batch) => batch.id).toSet(), {'b1', 'b2', 'b3'});
+      expect(all.map((batch) => batch.id).toSet(), {'b1', 'b2', 'b3', 'b4'});
     });
 
     test('inserts and retrieves batches for a bean', () async {

--- a/test/database/bean_dao_test.dart
+++ b/test/database/bean_dao_test.dart
@@ -115,6 +115,22 @@ void main() {
   });
 
   group('BeanDao - BeanBatches', () {
+    test('lists batches across beans and filters archived', () async {
+      await db.beanDao.insertBean(makeBean(id: 'bean-1'));
+      await db.beanDao.insertBean(makeBean(id: 'bean-2'));
+      await db.beanDao.insertBatch(makeBatch(id: 'b1'));
+      await db.beanDao.insertBatch(makeBatch(id: 'b2', beanId: 'bean-2'));
+      await db.beanDao.insertBatch(
+        makeBatch(id: 'b3', beanId: 'bean-2', archived: true),
+      );
+
+      final active = await db.beanDao.getAllBatches();
+      expect(active.map((batch) => batch.id).toSet(), {'b1', 'b2'});
+
+      final all = await db.beanDao.getAllBatches(includeArchived: true);
+      expect(all.map((batch) => batch.id).toSet(), {'b1', 'b2', 'b3'});
+    });
+
     test('inserts and retrieves batches for a bean', () async {
       await db.beanDao.insertBean(makeBean(id: 'bean-1'));
       await db.beanDao.insertBatch(makeBatch(id: 'batch-1'));

--- a/test/import/de1app_importer_test.dart
+++ b/test/import/de1app_importer_test.dart
@@ -179,6 +179,12 @@ class FakeBeanStorageService implements BeanStorageService {
   Future<void> deleteBean(String id) async => beans.remove(id);
 
   @override
+  Future<List<BeanBatch>> getAllBatches({bool includeArchived = false}) async =>
+      includeArchived
+      ? batches.values.toList()
+      : batches.values.where((batch) => !batch.archived).toList();
+
+  @override
   Future<List<BeanBatch>> getBatchesForBean(
     String beanId, {
     bool includeArchived = false,

--- a/test/webserver/beans_handler_test.dart
+++ b/test/webserver/beans_handler_test.dart
@@ -43,6 +43,12 @@ class MockBeanStorageService implements BeanStorageService {
   }
 
   @override
+  Future<List<BeanBatch>> getAllBatches({bool includeArchived = false}) async {
+    if (includeArchived) return List.of(batches);
+    return batches.where((b) => !b.archived).toList();
+  }
+
+  @override
   Future<List<BeanBatch>> getBatchesForBean(
     String beanId, {
     bool includeArchived = false,
@@ -407,6 +413,74 @@ void main() {
       expect(response.statusCode, 200);
       final body = jsonDecode(await response.readAsString()) as List;
       expect(body, hasLength(2));
+    });
+
+    test(
+      'GET /api/v1/bean-batches lists active batches across beans',
+      () async {
+        final otherBeanResponse = await sendPost('/api/v1/beans', {
+          'roaster': 'Tim Wendelboe',
+          'name': 'Karogoto',
+        });
+        final otherBeanId = jsonDecode(
+          await otherBeanResponse.readAsString(),
+        )['id'];
+        final first = jsonDecode(
+          await (await sendPost('/api/v1/beans/$beanId/batches', {
+            'roastLevel': 'light',
+          })).readAsString(),
+        );
+        final second = jsonDecode(
+          await (await sendPost('/api/v1/beans/$otherBeanId/batches', {
+            'roastLevel': 'medium',
+          })).readAsString(),
+        );
+        final archived = jsonDecode(
+          await (await sendPost('/api/v1/beans/$otherBeanId/batches', {
+            'roastLevel': 'dark',
+          })).readAsString(),
+        );
+        await sendPut('/api/v1/bean-batches/${archived['id']}', {
+          'archived': true,
+        });
+
+        final activeResponse = await sendGet('/api/v1/bean-batches');
+        expect(activeResponse.statusCode, 200);
+        final active = jsonDecode(await activeResponse.readAsString()) as List;
+        expect(active.map((batch) => batch['id']).toSet(), {
+          first['id'],
+          second['id'],
+        });
+
+        final allResponse = await sendGet(
+          '/api/v1/bean-batches?includeArchived=true',
+        );
+        final all = jsonDecode(await allResponse.readAsString()) as List;
+        expect(all.map((batch) => batch['id']).toSet(), {
+          first['id'],
+          second['id'],
+          archived['id'],
+        });
+      },
+    );
+
+    test('GET /api/v1/bean-batches supports conditional GET', () async {
+      await sendPost('/api/v1/beans/$beanId/batches', {'roastLevel': 'light'});
+
+      final response = await sendGet('/api/v1/bean-batches');
+      final etag = response.headers['etag'];
+      expect(etag, isNotNull);
+
+      final cached = await handler(
+        Request(
+          'GET',
+          Uri.parse('http://localhost/api/v1/bean-batches'),
+          headers: {'If-None-Match': etag!},
+        ),
+      );
+      expect(cached.statusCode, 304);
+      expect(cached.headers['etag'], etag);
+      expect(await cached.readAsString(), isEmpty);
     });
 
     test('GET /api/v1/bean-batches/<id> returns a specific batch', () async {

--- a/test/webserver/beans_handler_test.dart
+++ b/test/webserver/beans_handler_test.dart
@@ -45,7 +45,15 @@ class MockBeanStorageService implements BeanStorageService {
   @override
   Future<List<BeanBatch>> getAllBatches({bool includeArchived = false}) async {
     if (includeArchived) return List.of(batches);
-    return batches.where((b) => !b.archived).toList();
+    final activeBeanIds = beans
+        .where((bean) => !bean.archived)
+        .map((bean) => bean.id)
+        .toSet();
+    return batches
+        .where(
+          (batch) => !batch.archived && activeBeanIds.contains(batch.beanId),
+        )
+        .toList();
   }
 
   @override
@@ -416,7 +424,7 @@ void main() {
     });
 
     test(
-      'GET /api/v1/bean-batches lists active batches across beans',
+      'GET /api/v1/bean-batches filters archived batches and parent beans',
       () async {
         final otherBeanResponse = await sendPost('/api/v1/beans', {
           'roaster': 'Tim Wendelboe',
@@ -443,14 +451,12 @@ void main() {
         await sendPut('/api/v1/bean-batches/${archived['id']}', {
           'archived': true,
         });
+        await sendPut('/api/v1/beans/$otherBeanId', {'archived': true});
 
         final activeResponse = await sendGet('/api/v1/bean-batches');
         expect(activeResponse.statusCode, 200);
         final active = jsonDecode(await activeResponse.readAsString()) as List;
-        expect(active.map((batch) => batch['id']).toSet(), {
-          first['id'],
-          second['id'],
-        });
+        expect(active.map((batch) => batch['id']).toSet(), {first['id']});
 
         final allResponse = await sendGet(
           '/api/v1/bean-batches?includeArchived=true',


### PR DESCRIPTION
## Summary

What changed, and why?

- Add `GET /api/v1/bean-batches` so inventory clients can fetch batches for
  every bean with one request instead of one request and SQLite query per bean.
- Use one Drift query, preserve the existing default archived filter, accept
  `includeArchived=true`, and support the same conditional `ETag` behavior as
  the existing bean and per-bean batch collection routes.
- Exclude batches whose parent bean is archived from the default collection,
  matching the motivating beans-then-batches workflow.
- Keep the per-bean and single-batch routes unchanged. No speculative
  multi-ID filter or embedded-bean response was added.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [x] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [x] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [x] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

Fixes #564

> **Remaining validation before merge:** Maintainer review of the additive endpoint and a live API smoke with `curl`. No hardware is required.

## Root Cause (if bug fix)

N/A - this adds a bulk read route for existing bean-batch data.

## Regression Test Plan (if bug fix or refactor)

N/A - feature coverage in `test/webserver/beans_handler_test.dart` and
`test/database/bean_dao_test.dart` locks in cross-bean results, archived
batch and parent-bean filtering, one-query behavior, and conditional GET.

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [x] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A - no docs affected

## Security Impact (required)

- New or changed REST endpoints? `Yes`; adds read-only
  `GET /api/v1/bean-batches`.
- New or changed WebSocket topics? `No`.
- New or changed network calls? `No`.
- BLE/USB surface changed? `No`.
- File system access changed? `No`.
- Plugin sandbox boundary changed? `No`.
- Risk and mitigation: The route exposes only batch records already available
  through per-bean routes, remains read-only, excludes archived batches and
  parent beans by default, and supports `ETag` validation.

## User-Visible Changes

- API clients can fetch bean batches across all beans with one request instead
  of issuing one request per bean.
- Existing per-bean and single-batch routes and response objects are unchanged.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` - no remaining candidate changes
- [x] `flutter analyze` - clean
- [x] `flutter test` - 3,181 passed, 1 skipped
- [ ] `./scripts/fetch_dye2_plugin.sh` - not rerun for this local draft

### Manual verification (if applicable)

- OS / platform tested: Windows test host; live app did not launch.
- Simulated devices? (`simulate=1`): `No`; CMake stopped the build first.
- Real hardware? (DE1/Bengle/scale): `No`, not applicable.
- What you personally verified and how: Real Shelf handler and Drift DAO paths
  through integration tests.
- Edge cases checked: Archived batches, archived parent beans,
  `includeArchived=true`, cross-bean ordering, `ETag`, and `304 Not Modified`.
- What you did **not** verify: A live curl request against a running app.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

Detailed evidence:

- Regression-first handler tests failed with `404` before the route existed,
  then passed with cross-bean results, archived filtering, and `304` handling.
- The archived-parent regression exposed the inconsistent default collection
  before the follow-up and passes at the DAO and API-handler levels afterward.
- `flutter test test/webserver/beans_handler_test.dart test/database/bean_dao_test.dart` (36 passed)
- `flutter analyze` (no issues)
- `flutter test` with the package-matched QuickJS DLL on `PATH` and the
  repository's temporary LF normalization for the line-ending-sensitive
  AsyncAPI assertion (3,181 passed, 1 skipped)
- `git diff --cached --check` before commit (clean)
- Attempted `flutter run --no-pub -d windows --dart-define=simulate=1` for a
  live curl smoke. The local build stopped before launch because Flutter
  selected CMake 3.20 while the Firebase SDK requires CMake 3.22 or newer.

## Compatibility & Migration

- Backward compatible? `Yes`; this is an additive route.
- Config / env changes needed? `No`.
- Database migration needed? `No`; the existing `beanBatches` table is queried.
- Exact steps: None.

## Risks & Mitigations

- Risk: A bulk collection could add database or response overhead for large
  inventories.
  - Mitigation: Use one Drift query, keep archived batches and parent beans
    excluded by default, and support conditional requests with `ETag`.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->