### PR TITLE
fix(launcher): keep plugins destination visible

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -423,7 +423,6 @@ class _MyAppState extends State<MyApp> {
                         de1Controller: widget.de1Controller,
                         scaleController: widget.scaleController,
                         webUIService: widget.webUIService,
-                        pluginLoaderService: widget.pluginLoaderService,
                         batteryController: widget.batteryController,
                         decentAccountService: widget.decentAccountService,
                         isDegradedAndroid: _degradedAndroid,

--- a/lib/src/launcher/launcher_view.dart
+++ b/lib/src/launcher/launcher_view.dart
@@ -14,7 +14,6 @@ import 'package:reaprime/src/launcher/widgets/connect_device_hero_card.dart';
 import 'package:reaprime/src/launcher/widgets/destination_card.dart';
 import 'package:reaprime/src/launcher/widgets/skin_unavailable_card.dart';
 import 'package:reaprime/src/launcher/widgets/status_bar.dart';
-import 'package:reaprime/src/plugins/plugin_loader_service.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/services/account/decent_account_service.dart';
 import 'package:reaprime/src/settings/advanced_page.dart';
@@ -49,7 +48,6 @@ class LauncherView extends StatelessWidget {
     required this.de1Controller,
     required this.scaleController,
     required this.webUIService,
-    required this.pluginLoaderService,
     required this.connectionManager,
     required this.deviceController,
     required this.settingsController,
@@ -62,7 +60,6 @@ class LauncherView extends StatelessWidget {
   final De1Controller de1Controller;
   final ScaleController scaleController;
   final WebUIService webUIService;
-  final PluginLoaderService pluginLoaderService;
   final ConnectionManager connectionManager;
   final DeviceController deviceController;
   final SettingsController settingsController;
@@ -190,12 +187,11 @@ class LauncherView extends StatelessWidget {
           label: 'Account',
           route: AccountPage.routeName,
         ),
-      if (pluginLoaderService.availablePlugins.isNotEmpty)
-        _Destination(
-          icon: LucideIcons.puzzle,
-          label: 'Plugins',
-          route: '/plugins',
-        ),
+      _Destination(
+        icon: LucideIcons.puzzle,
+        label: 'Plugins',
+        route: '/plugins',
+      ),
       _Destination(
         icon: LucideIcons.wrench,
         label: 'Advanced',

--- a/lib/src/launcher/widgets/destination_card.dart
+++ b/lib/src/launcher/widgets/destination_card.dart
@@ -34,7 +34,7 @@ class DestinationCard extends StatelessWidget {
           onTap: onTap,
           child: SizedBox.expand(
             child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 16),
+              padding: const EdgeInsets.symmetric(horizontal: 8),
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/src/settings/plugins_settings_view.dart
+++ b/lib/src/settings/plugins_settings_view.dart
@@ -116,6 +116,7 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
   Map<String, PluginSource> _sources = {};
   bool _isLoading = true;
   bool _isCheckingUpdates = false;
+  String? _loadError;
 
   late final PluginSourceService _sourceService =
       widget.pluginSourceService ??
@@ -130,21 +131,36 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
   Future<void> _loadPlugins() async {
     setState(() {
       _isLoading = true;
+      _loadError = null;
     });
 
-    final plugins = widget.pluginLoaderService.availablePlugins;
-    _sourceService.seedBundledSources();
-    final sources = <String, PluginSource>{};
-    for (final plugin in plugins) {
-      final source = _sourceService.sourceFor(plugin.id);
-      if (source != null) sources[plugin.id] = source;
+    try {
+      await widget.pluginLoaderService.initialize();
+      if (!mounted) return;
+
+      final plugins = widget.pluginLoaderService.availablePlugins;
+      _sourceService.seedBundledSources();
+      final sources = <String, PluginSource>{};
+      for (final plugin in plugins) {
+        final source = _sourceService.sourceFor(plugin.id);
+        if (source != null) sources[plugin.id] = source;
+      }
+
+      setState(() {
+        _plugins = plugins;
+        _sources = sources;
+        _isLoading = false;
+      });
+    } catch (error, stackTrace) {
+      Logger(
+        'PluginsSettingsView',
+      ).warning('Failed to initialize plugins', error, stackTrace);
+      if (!mounted) return;
+      setState(() {
+        _loadError = error.toString();
+        _isLoading = false;
+      });
     }
-
-    setState(() {
-      _plugins = plugins;
-      _sources = sources;
-      _isLoading = false;
-    });
   }
 
   void _refreshPlugins() {
@@ -159,7 +175,7 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
         actions: [
           IconButton(
             icon: const Icon(LucideIcons.refreshCw),
-            onPressed: _refreshPlugins,
+            onPressed: _isLoading ? null : _refreshPlugins,
             tooltip: 'Refresh Plugins',
           ),
           IconButton(
@@ -170,13 +186,14 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
                     child: CircularProgressIndicator(strokeWidth: 2),
                   )
                 : const Icon(LucideIcons.cloudDownload),
-            onPressed: _isCheckingUpdates
+            onPressed: _isLoading || _loadError != null || _isCheckingUpdates
                 ? null
                 : () => _checkForPluginUpdates(context),
             tooltip: 'Check for updates',
           ),
           if (widget.allowInstall)
             PopupMenuButton<String>(
+              enabled: !_isLoading && _loadError == null,
               icon: const Icon(LucideIcons.plus),
               tooltip: 'Install Plugin',
               onSelected: (value) => _handleInstallAction(context, value),
@@ -205,6 +222,24 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
   Widget _buildPluginList() {
     if (_isLoading) {
       return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_loadError != null) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          spacing: 12,
+          children: [
+            const Icon(Icons.error_outline, size: 48),
+            const Text(
+              'Plugins unavailable',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+            ),
+            Text(_loadError!, textAlign: TextAlign.center),
+            ShadButton(onPressed: _refreshPlugins, child: const Text('Retry')),
+          ],
+        ),
+      );
     }
 
     if (_plugins.isEmpty) {

--- a/test/launcher/connect_hero_visibility_test.dart
+++ b/test/launcher/connect_hero_visibility_test.dart
@@ -4,6 +4,7 @@ import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/scan_state_guardian.dart';
 import 'package:reaprime/src/launcher/launcher_view.dart';
 import 'package:reaprime/src/launcher/widgets/connect_device_hero_card.dart';
+import 'package:reaprime/src/launcher/widgets/destination_card.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
@@ -91,5 +92,30 @@ void main() {
     await tester.pump();
 
     expect(find.text('Plugins'), findsOneWidget);
+  });
+
+  testWidgets('destination card fits the Pixel 8a grid cell', (tester) async {
+    tester.platformDispatcher.textScaleFactorTestValue = 1.15;
+    addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+
+    await tester.pumpWidget(
+      ShadApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox.square(
+              dimension: 111,
+              child: DestinationCard(
+                icon: LucideIcons.settings,
+                label: 'Advanced',
+                onTap: () {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
   });
 }

--- a/test/launcher/connect_hero_visibility_test.dart
+++ b/test/launcher/connect_hero_visibility_test.dart
@@ -4,8 +4,6 @@ import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/scan_state_guardian.dart';
 import 'package:reaprime/src/launcher/launcher_view.dart';
 import 'package:reaprime/src/launcher/widgets/connect_device_hero_card.dart';
-import 'package:reaprime/src/plugins/plugin_loader_service.dart';
-import 'package:reaprime/src/services/storage/hive_store_service.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
@@ -25,7 +23,6 @@ void main() {
   late MockBleDiscoveryService bleService;
   late SettingsController settingsController;
   late WebUIService webUIService;
-  late PluginLoaderService pluginLoaderService;
 
   setUp(() async {
     settingsController = SettingsController(MockSettingsService());
@@ -41,9 +38,6 @@ void main() {
     bleService = MockBleDiscoveryService();
     guardian = ScanStateGuardian(bleService: bleService);
     webUIService = WebUIService();
-    pluginLoaderService = PluginLoaderService(
-      kvStore: HiveStoreService(defaultNamespace: 'test-launcher-hero'),
-    );
   });
 
   tearDown(() {
@@ -57,7 +51,6 @@ void main() {
       de1Controller: de1Controller,
       scaleController: scaleController,
       webUIService: webUIService,
-      pluginLoaderService: pluginLoaderService,
       connectionManager: connectionManager,
       deviceController: DeviceController([]),
       settingsController: settingsController,
@@ -91,5 +84,12 @@ void main() {
     await tester.pump();
 
     expect(find.byType(ConnectDeviceHeroCard), findsNothing);
+  });
+
+  testWidgets('plugins destination is always visible', (tester) async {
+    await tester.pumpWidget(buildLauncher());
+    await tester.pump();
+
+    expect(find.text('Plugins'), findsOneWidget);
   });
 }

--- a/test/plugins/plugins_settings_view_sources_test.dart
+++ b/test/plugins/plugins_settings_view_sources_test.dart
@@ -13,6 +13,9 @@ class _FakeLoader extends Fake implements PluginLoaderService {
   final List<PluginManifest> plugins;
 
   @override
+  Future<void> initialize() async {}
+
+  @override
   List<PluginManifest> get availablePlugins => plugins;
 
   @override

--- a/test/plugins_settings_view_appstore_test.dart
+++ b/test/plugins_settings_view_appstore_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
@@ -6,12 +8,25 @@ import 'package:reaprime/src/plugins/plugin_manifest.dart';
 import 'package:reaprime/src/settings/plugins_settings_view.dart';
 
 class FakePluginLoaderService extends Fake implements PluginLoaderService {
-  FakePluginLoaderService({this.plugins = const [], this.settings = const {}});
+  FakePluginLoaderService({
+    List<PluginManifest> plugins = const [],
+    this.settings = const {},
+    Future<void>? initialization,
+  }) : plugins = List.of(plugins),
+       initialization = initialization ?? Future.value();
 
   final List<PluginManifest> plugins;
   final Map<String, dynamic> settings;
+  final Future<void> initialization;
   Map<String, dynamic>? savedSettings;
   int saveCallCount = 0;
+  int initializeCallCount = 0;
+
+  @override
+  Future<void> initialize() {
+    initializeCallCount++;
+    return initialization;
+  }
 
   @override
   List<PluginManifest> get availablePlugins => plugins;
@@ -82,6 +97,74 @@ void main() {
       expect(find.byTooltip('Install Plugin'), findsNothing);
       expect(find.byTooltip('Refresh Plugins'), findsOneWidget);
     });
+  });
+
+  testWidgets('waits for initialization before exposing discovered plugins', (
+    tester,
+  ) async {
+    final ready = Completer<void>();
+    fakePluginLoaderService = FakePluginLoaderService(
+      initialization: ready.future,
+    );
+
+    await tester.pumpWidget(
+      ShadApp(
+        home: PluginsSettingsView(pluginLoaderService: fakePluginLoaderService),
+      ),
+    );
+    await tester.pump();
+
+    expect(fakePluginLoaderService.initializeCallCount, 1);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    final installButton = find.byWidgetPredicate(
+      (widget) =>
+          widget is PopupMenuButton<String> &&
+          widget.tooltip == 'Install Plugin',
+    );
+    expect(
+      tester.widget<PopupMenuButton<String>>(installButton).enabled,
+      isFalse,
+    );
+
+    fakePluginLoaderService.plugins.add(
+      PluginManifest(
+        id: 'ready.reaplugin',
+        name: 'Ready Plugin',
+        author: 'Test',
+        description: 'Loaded after initialization',
+        version: '1.0.0',
+        apiVersion: 1,
+        permissions: {},
+        settings: {},
+        api: PluginApi(endpoints: []),
+      ),
+    );
+    ready.complete();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Ready Plugin'), findsOneWidget);
+    expect(
+      tester.widget<PopupMenuButton<String>>(installButton).enabled,
+      isTrue,
+    );
+  });
+
+  testWidgets('shows a retry state when initialization fails', (tester) async {
+    final failed = Completer<void>();
+    fakePluginLoaderService = FakePluginLoaderService(
+      initialization: failed.future,
+    );
+
+    await tester.pumpWidget(
+      ShadApp(
+        home: PluginsSettingsView(pluginLoaderService: fakePluginLoaderService),
+      ),
+    );
+    failed.completeError(StateError('scan failed'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Plugins unavailable'), findsOneWidget);
+    expect(find.widgetWithText(ShadButton, 'Retry'), findsOneWidget);
   });
 
   testWidgets('renders manifest permission wire names', (tester) async {


### PR DESCRIPTION
## Summary

What changed, and why?

- Keep the Plugins destination visible while bundled plugin discovery runs in the background.
- Remove the launcher's unused plugin-loader dependency; the Plugins screen owns loading and installation.
- Await loader initialization before reading discovery results or enabling plugin operations, with an explicit retry state on startup failure.
- Fit launcher destination cards on phone-sized grids and at the Pixel 8a's 1.15 text scale.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [x] Plugins / JS runtime
- [x] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs

## Linked Issues

Fixes #531

## Root Cause (if bug fix)

- Root cause: The launcher conditionally built the Plugins destination from a background discovery result but had no reactive state that could rebuild it.
- Missing detection or guardrail: The launcher widget test did not assert that Plugins remains reachable during startup or with an empty plugin list.
- Contributing context: The Plugins screen already owns empty-state and install behavior, but it previously read the loader cache before initialization completed.
- Physical-device review also found fixed vertical and horizontal card padding left too little room for labels on the Pixel 8a grid.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target tests or files: `test/launcher/connect_hero_visibility_test.dart` and `test/plugins_settings_view_appstore_test.dart`.
- Scenario the tests lock in: Plugins is visible before discovery completes; entering Plugins waits for initialization and shows discovered plugins without manual refresh; initialization failure offers Retry; destination cards fit a Pixel 8a grid cell at 1.15 text scale.
- If no new test added, why not: N/A; launcher, card, and Plugins widget regressions were added.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A - no public contract documentation changed

## Security Impact (required)

- New or changed REST endpoints? `No`.
- New or changed WebSocket topics? `No`.
- New or changed network calls? `No`.
- BLE/USB surface changed? `No`.
- File system access changed? `No`.
- Plugin sandbox boundary changed? `No`.
- If any `Yes`, explain risk and mitigation: N/A.

## User-Visible Changes

- The Plugins destination is available immediately after launch, before discovery finishes and when no plugins are installed.
- The Plugins screen waits for discovery before showing results or enabling actions, and offers Retry if initialization fails.
- Dashboard destination labels fit phone-sized cards without clipping or RenderFlex overflow.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` - no remaining candidate changes
- [x] `flutter analyze --no-pub` - no issues
- [x] Focused launcher tests - 4 passed
- [ ] `flutter test --no-pub` - 3,181 passed and 1 skipped; the existing Windows CRLF-sensitive AsyncAPI assertion failed
- [ ] `./scripts/fetch_dye2_plugin.sh` - not rerun for this local draft

### Manual verification (if applicable)

- OS / platform tested: Physical Pixel 8a (API 37) and Samsung Galaxy Tab A9+ (Android 15, 1920 x 1200), mirrored through Android Studio on Windows.
- Simulated devices? (`simulate=1`): `Yes`.
- Real hardware? (DE1/Bengle/scale): `No`, not applicable.
- What you personally verified and how: Computer Use confirmed that Plugins is present on both the Pixel and tablet launchers. On the Samsung tablet it opened a populated Plugins screen, refreshed back to populated content, and scrolled through cards without clipping or overlap.
- Pixel layout: The first run exposed a 27-pixel `RenderFlex` overflow in `destination_card.dart`. After reducing fixed padding, all seven destinations fit, `Advanced` stays on one line, and the live Flutter log reports no layout exception.
- Edge cases checked: Discovery pending, empty plugin list, loader initialization failure, refresh, Pixel-sized grid cell, and 1.15 text scale.
- What you did **not** verify: The live Retry presentation because the real bundled loader initialized successfully; the failure state remains covered by the focused widget test.

### Evidence

- [x] Test output (failing before + passing after)
- [x] Log snippets
- [x] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

Detailed evidence:

- The original launcher test found zero `Plugins` labels before the conditional destination was removed and passes afterward.
- Plugins screen widget tests hold initialization incomplete, then verify discovery appears without refresh, operations stay disabled while loading, and initialization failure offers Retry.
- The Pixel-sized destination-card test fails before the padding fix with a 31-pixel bottom overflow and passes afterward.
- `flutter test test/launcher/connect_hero_visibility_test.dart --no-pub` - 4 passed.
- `flutter analyze --no-pub` - no issues.
- Full `flutter test --no-pub` with the package-matched QuickJS DLL reached 3,181 passed and 1 skipped; only the existing line-ending-sensitive AsyncAPI assertion failed on the CRLF worktree.
- Physical Pixel 8a verification covered launcher navigation, populated Plugins inventory, refresh, scrolling, and card layout.
- Physical Samsung Galaxy Tab A9+ verification covered the 1920 x 1200 tablet layout, immediate Plugins visibility, populated inventory, refresh, and scrolling without clipping or overlap.
- `git diff --check` before commit - clean.

## Compatibility & Migration

- Backward compatible? `Yes`.
- Config / env changes needed? `No`.
- Database migration needed? `No`.
- Exact steps: None.

## Risks & Mitigations

- Risk: Users can open Plugins while discovery is pending.
  - Mitigation: The Plugins screen awaits the loader's deduplicated initialization before reading results or enabling operations.
- Risk: Reduced destination-card padding changes launcher spacing.
  - Mitigation: The content remains centered; the focused widget test and physical Pixel review cover the smallest observed grid cell.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
