### PR TITLE
fix(skins): make Dashboard exit clear and reliable

### DIFF
--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -3320,7 +3320,7 @@ This shows "Back to MySkin" in the settings plugin's nav bar. When clicked, it n
 
 **Return to the dashboard:** Skin pages served on port 3000 load the tokenless `/__decent/skin-api.js` from an absolute same-origin URL, which exposes `window.decentApp.exitToDashboard()`. ReaPrime stores the account-proxy token in escaped page metadata that only the same-origin script reads. Token injection accepts loopback and IP addresses currently assigned to the device, including Ethernet and secondary adapters; arbitrary hostnames and stale addresses are rejected. If local interface enumeration is unavailable, the WiFi address cached for the server link is used as a fallback. The script response also uses `Cross-Origin-Resource-Policy: same-origin`. In the embedded webview the callback closes the skin and reveals the Decent dashboard. In an external browser it is a no-op. The script works with `script-src 'self'`; policies that reject all same-origin scripts, such as `script-src 'none'` or nonce-only policies without `'self'`, also reject this API.
 
-The embedded webview also shows a platform-specific navigation guide when a skin opens. On Windows, a persistent Dashboard button is overlaid in the top-right corner because WebView2 owns browser keyboard shortcuts. Disable or restore the guide in **Settings** under **General** with **Skin navigation guide**.
+The embedded webview also shows a platform-specific navigation guide when a skin opens. On Windows, choose **Back to Dashboard** from the system menu, available from the window icon or by right-clicking the title bar. Disable or restore the guide in **Settings** under **General** with **Skin navigation guide**.
 
 **Server control endpoints:**
 

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -3320,7 +3320,7 @@ This shows "Back to MySkin" in the settings plugin's nav bar. When clicked, it n
 
 **Return to the dashboard:** Skin pages served on port 3000 load the tokenless `/__decent/skin-api.js` from an absolute same-origin URL, which exposes `window.decentApp.exitToDashboard()`. ReaPrime stores the account-proxy token in escaped page metadata that only the same-origin script reads. Token injection accepts loopback and IP addresses currently assigned to the device, including Ethernet and secondary adapters; arbitrary hostnames and stale addresses are rejected. If local interface enumeration is unavailable, the WiFi address cached for the server link is used as a fallback. The script response also uses `Cross-Origin-Resource-Policy: same-origin`. In the embedded webview the callback closes the skin and reveals the Decent dashboard. In an external browser it is a no-op. The script works with `script-src 'self'`; policies that reject all same-origin scripts, such as `script-src 'none'` or nonce-only policies without `'self'`, also reject this API.
 
-The embedded webview also shows a platform-specific navigation guide when a skin opens. Disable or restore it in **Settings** under **General** with **Skin navigation guide**.
+The embedded webview also shows a platform-specific navigation guide when a skin opens. On Windows, a persistent Dashboard button is overlaid in the top-right corner because WebView2 owns browser keyboard shortcuts. Disable or restore the guide in **Settings** under **General** with **Skin navigation guide**.
 
 **Server control endpoints:**
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -883,6 +883,37 @@ class _AppRootState extends State<AppRoot> {
   final Logger _log = Logger("AppRoot");
   Key _key = UniqueKey();
 
+  static const _windowChannel = MethodChannel('net.tadel.reaprime/window');
+
+  @override
+  void initState() {
+    super.initState();
+    if (Platform.isWindows) {
+      _windowChannel.setMethodCallHandler(_handleWindowMethod);
+    }
+  }
+
+  @override
+  void dispose() {
+    if (Platform.isWindows) {
+      _windowChannel.setMethodCallHandler(null);
+    }
+    super.dispose();
+  }
+
+  Future<void> _handleWindowMethod(MethodCall call) async {
+    if (call.method == 'backToDashboard') {
+      _backToDashboard();
+    }
+  }
+
+  void _backToDashboard() {
+    NavigationService.navigatorKey.currentState?.pushNamedAndRemoveUntil(
+      LauncherView.routeName,
+      (_) => false,
+    );
+  }
+
   Future<void> restart() async {
     _log.info("recreating App Root");
     setState(() {
@@ -1013,15 +1044,7 @@ class _AppRootState extends State<AppRoot> {
               LogicalKeyboardKey.keyD,
               meta: true,
             ),
-            onSelected: () {
-              final navigator = NavigationService.navigatorKey.currentState;
-              if (navigator != null) {
-                navigator.pushNamedAndRemoveUntil(
-                  LauncherView.routeName,
-                  (_) => false,
-                );
-              }
-            },
+            onSelected: _backToDashboard,
           ),
           if (widget.settingsController.enableSimulatedWebViews) ...[
             PlatformMenuItem(

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -273,7 +273,7 @@ class _MyAppState extends State<MyApp> {
     }
 
     _log.info('Navigating to SkinView');
-    navigator.pushNamed(SkinView.routeName);
+    SkinView.open(navigator);
   }
 
   @override

--- a/lib/src/device_discovery_feature/device_discovery_view.dart
+++ b/lib/src/device_discovery_feature/device_discovery_view.dart
@@ -149,8 +149,7 @@ class _DeviceDiscoveryState extends State<DeviceDiscoveryView> {
     if (!mounted) return;
 
     if (route == SkinView.routeName) {
-      Navigator.popAndPushNamed(context, LauncherView.routeName);
-      Navigator.of(context).pushNamed(SkinView.routeName);
+      SkinView.open(Navigator.of(context));
     } else {
       Navigator.popAndPushNamed(context, route);
     }

--- a/lib/src/home_feature/widgets/quick_settings_widget.dart
+++ b/lib/src/home_feature/widgets/quick_settings_widget.dart
@@ -195,7 +195,7 @@ class _QuickSettingsState extends State<QuickSettingsWidget> {
                           );
                           await launchUrl(url);
                         } else {
-                          Navigator.of(context).pushNamed(SkinView.routeName);
+                          SkinView.open(Navigator.of(context));
                         }
                       },
                     ),

--- a/lib/src/launcher/launcher_view.dart
+++ b/lib/src/launcher/launcher_view.dart
@@ -143,7 +143,7 @@ class LauncherView extends StatelessWidget {
       case LauncherSkinSlot.returnToSkin:
         return _ReturnToSkinButton(
           onTap: () {
-            Navigator.of(context).pushNamed(SkinView.routeName);
+            SkinView.open(Navigator.of(context));
           },
         );
       case LauncherSkinSlot.skinUnavailable:

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -11,6 +11,7 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/controllers/display_controller.dart';
 import 'package:reaprime/src/home_feature/widgets/quick_settings_widget.dart';
+import 'package:reaprime/src/launcher/launcher_view.dart';
 import 'package:reaprime/src/services/telemetry/boot_timing.dart';
 import 'package:reaprime/src/services/webview_compatibility_checker.dart';
 import 'package:reaprime/src/services/webview_log_service.dart';
@@ -25,7 +26,8 @@ String skinExitInstructions(TargetPlatform platform) {
   const purpose = 'Dashboard contains app settings and skin selection.';
   final navigation = switch (platform) {
     TargetPlatform.android =>
-      'Swipe inward from either screen edge or tap Android Back to open it.',
+      'Swipe inward from either screen edge to open it. With button '
+          'navigation, reveal the navigation bar and tap Back.',
     TargetPlatform.iOS => 'Swipe right from the left screen edge to open it.',
     TargetPlatform.macOS =>
       'Press ⌘D or use View → Back to Dashboard to open it.',
@@ -289,15 +291,27 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
     );
   }
 
+  void _exitToDashboard() {
+    Navigator.of(
+      context,
+    ).pushNamedAndRemoveUntil(LauncherView.routeName, (_) => false);
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        top: false,
-        bottom: false,
-        left: false,
-        right: false,
-        child: _buildBody(),
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) _exitToDashboard();
+      },
+      child: Scaffold(
+        body: SafeArea(
+          top: false,
+          bottom: false,
+          left: false,
+          right: false,
+          child: _buildBody(),
+        ),
       ),
     );
   }
@@ -396,9 +410,7 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
                   ),
                 ),
                 OutlinedButton.icon(
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                  },
+                  onPressed: _exitToDashboard,
                   icon: const Icon(Icons.dashboard),
                   label: const Text('Dashboard'),
                 ),
@@ -481,7 +493,7 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
         await launchUrl(url, mode: LaunchMode.externalApplication);
 
         if (mounted) {
-          Navigator.of(context).pop();
+          _exitToDashboard();
         }
       } else {
         _log.warning('Cannot launch URL: $url');
@@ -550,9 +562,7 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
               ),
               const SizedBox(height: 16),
               ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).pop();
-                },
+                onPressed: _exitToDashboard,
                 child: const Text('Go to Dashboard'),
               ),
             ],
@@ -581,7 +591,7 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
       return CallbackShortcuts(
         bindings: {
           const SingleActivator(LogicalKeyboardKey.backspace, alt: true): () {
-            Navigator.of(context).pop();
+            _exitToDashboard();
           },
         },
         child: _buildWebViewStack(),
@@ -672,7 +682,7 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
               topLevelUri: _mainFrameUri,
             )) {
               _log.info('Skin requested dashboard');
-              if (mounted) Navigator.of(context).pop();
+              if (mounted) _exitToDashboard();
             } else {
               _log.warning('Rejected skin dashboard request');
             }

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -31,7 +31,8 @@ String skinExitInstructions(TargetPlatform platform) {
     TargetPlatform.iOS => 'Swipe right from the left screen edge to open it.',
     TargetPlatform.macOS =>
       'Press ⌘D or use View → Back to Dashboard to open it.',
-    TargetPlatform.windows => 'Press Alt+Backspace to open it.',
+    TargetPlatform.windows =>
+      'Use the Dashboard button in the top-right corner to open it.',
     TargetPlatform.linux ||
     TargetPlatform.fuchsia => 'Use system back navigation to open it.',
   };
@@ -217,6 +218,10 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
   }
 
   Future<void> _checkCompatibilityAndInit() async {
+    if (widget.webView != null) {
+      _isCheckingCompatibility = false;
+      return;
+    }
     _log.info('Checking WebView compatibility...');
 
     if (!Platform.isWindows) {
@@ -253,6 +258,8 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
       allowUniversalAccessFromFileURLs: false,
 
       useShouldOverrideUrlLoading: true,
+
+      browserAcceleratorKeysEnabled: !Platform.isWindows,
 
       cacheEnabled: false,
 
@@ -590,17 +597,6 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
       );
     }
 
-    if (Platform.isWindows) {
-      return CallbackShortcuts(
-        bindings: {
-          const SingleActivator(LogicalKeyboardKey.backspace, alt: true): () {
-            _exitToDashboard();
-          },
-        },
-        child: _buildWebViewStack(),
-      );
-    }
-
     return _buildWebViewStack();
   }
 
@@ -617,6 +613,28 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
               child: _buildWebView(simulatedDevice),
             ),
             if (_isLoading) const Center(child: CircularProgressIndicator()),
+            if (defaultTargetPlatform == TargetPlatform.windows)
+              Positioned(
+                top: 8,
+                right: 8,
+                child: Material(
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.surfaceContainer.withValues(alpha: 0.9),
+                  elevation: 2,
+                  borderRadius: BorderRadius.circular(8),
+                  child: IconButton(
+                    tooltip: 'Open Dashboard',
+                    onPressed: _exitToDashboard,
+                    icon: const Icon(Icons.dashboard),
+                    iconSize: 20,
+                    constraints: const BoxConstraints.tightFor(
+                      width: 40,
+                      height: 40,
+                    ),
+                  ),
+                ),
+              ),
           ],
         );
       },

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -91,12 +91,15 @@ class SkinView extends StatefulWidget {
     required this.webViewLogService,
     required this.deviceIp,
     required this.displayController,
+    this.webView,
   });
 
   final SettingsController settingsController;
   final WebViewLogService webViewLogService;
   final String deviceIp;
   final DisplayController displayController;
+  @visibleForTesting
+  final Widget? webView;
 
   static const routeName = '/skin';
 
@@ -621,6 +624,7 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
   }
 
   Widget _buildWebView(SimulatedWebViewDevice? simulatedDevice) {
+    if (widget.webView != null) return widget.webView!;
     return InAppWebView(
       key: ValueKey(simulatedDevice?.id ?? 'native-webview'),
       initialUrlRequest: URLRequest(url: WebUri(_skinUrl)),

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -32,7 +32,8 @@ String skinExitInstructions(TargetPlatform platform) {
     TargetPlatform.macOS =>
       'Press ⌘D or use View → Back to Dashboard to open it.',
     TargetPlatform.windows =>
-      'Use the Dashboard button in the top-right corner to open it.',
+      'Open the Windows system menu from the window icon or by right-clicking '
+          'the title bar, then choose Back to Dashboard.',
     TargetPlatform.linux ||
     TargetPlatform.fuchsia => 'Use system back navigation to open it.',
   };
@@ -620,28 +621,6 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
               child: _buildWebView(simulatedDevice),
             ),
             if (_isLoading) const Center(child: CircularProgressIndicator()),
-            if (defaultTargetPlatform == TargetPlatform.windows)
-              Positioned(
-                top: 8,
-                right: 8,
-                child: Material(
-                  color: Theme.of(
-                    context,
-                  ).colorScheme.surfaceContainer.withValues(alpha: 0.9),
-                  elevation: 2,
-                  borderRadius: BorderRadius.circular(8),
-                  child: IconButton(
-                    tooltip: 'Open Dashboard',
-                    onPressed: _exitToDashboard,
-                    icon: const Icon(Icons.dashboard),
-                    iconSize: 20,
-                    constraints: const BoxConstraints.tightFor(
-                      width: 40,
-                      height: 40,
-                    ),
-                  ),
-                ),
-              ),
           ],
         );
       },

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -104,6 +104,11 @@ class SkinView extends StatefulWidget {
 
   static const routeName = '/skin';
 
+  static Future<T?> open<T>(NavigatorState navigator) {
+    navigator.pushNamedAndRemoveUntil(LauncherView.routeName, (_) => false);
+    return navigator.pushNamed<T>(routeName);
+  }
+
   @override
   State<SkinView> createState() => _SkinViewState();
 }
@@ -309,20 +314,22 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
+    final view = Scaffold(
+      body: SafeArea(
+        top: false,
+        bottom: false,
+        left: false,
+        right: false,
+        child: _buildBody(),
+      ),
+    );
+    if (defaultTargetPlatform == TargetPlatform.iOS) return view;
     return PopScope(
       canPop: false,
       onPopInvokedWithResult: (didPop, _) {
         if (!didPop) _exitToDashboard();
       },
-      child: Scaffold(
-        body: SafeArea(
-          top: false,
-          bottom: false,
-          left: false,
-          right: false,
-          child: _buildBody(),
-        ),
-      ),
+      child: view,
     );
   }
 

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
@@ -19,6 +20,21 @@ import 'package:reaprime/src/webui_support/webui_service.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 enum SkinNavDecision { exitDashboard, allow, openExternal, block }
+
+String skinExitInstructions(TargetPlatform platform) {
+  const purpose = 'Dashboard contains app settings and skin selection.';
+  final navigation = switch (platform) {
+    TargetPlatform.android =>
+      'Swipe inward from either screen edge or tap Android Back to open it.',
+    TargetPlatform.iOS => 'Swipe right from the left screen edge to open it.',
+    TargetPlatform.macOS =>
+      'Press ⌘D or use View → Back to Dashboard to open it.',
+    TargetPlatform.windows => 'Press Alt+Backspace to open it.',
+    TargetPlatform.linux ||
+    TargetPlatform.fuchsia => 'Use system back navigation to open it.',
+  };
+  return '$purpose $navigation';
+}
 
 SkinNavDecision classifySkinNavigation(Uri? url) {
   if (url == null) return SkinNavDecision.block;
@@ -253,24 +269,9 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
   }
 
   void _showExitInstructions() {
-    String instructions;
-
-    if (Platform.isIOS) {
-      instructions =
-          'Swipe right from the left side of the screen to return to Dashboard';
-    } else if (Platform.isAndroid) {
-      instructions = 'Use system back button to return to Dashboard';
-    } else if (Platform.isMacOS) {
-      instructions = 'Press ⌘D or use View → Back to Dashboard to return';
-    } else if (Platform.isWindows) {
-      instructions = 'Press Alt+Backspace to return to Dashboard';
-    } else {
-      instructions = 'Use back navigation to return to Dashboard';
-    }
-
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text(instructions),
+        content: Text(skinExitInstructions(defaultTargetPlatform)),
         duration: const Duration(seconds: 10),
         behavior: SnackBarBehavior.floating,
         margin: const EdgeInsets.all(16),

--- a/lib/src/skin_selector/skin_selector_page.dart
+++ b/lib/src/skin_selector/skin_selector_page.dart
@@ -721,7 +721,7 @@ class _SkinSelectorPageState extends State<SkinSelectorPage>
     if (Platform.isLinux) {
       await _openWebUIInBrowser();
     } else {
-      await Navigator.of(context).pushNamed(SkinView.routeName);
+      await SkinView.open(Navigator.of(context));
     }
   }
 

--- a/test/skin_selector_go_to_skin_test.dart
+++ b/test/skin_selector_go_to_skin_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:reaprime/src/launcher/launcher_view.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/skin_feature/skin_view.dart';
 import 'package:reaprime/src/skin_selector/skin_selector_page.dart';
@@ -91,6 +92,12 @@ Future<void> _pumpPage(WidgetTester tester, WebUIService service) async {
   await tester.pumpWidget(
     ShadApp(
       onGenerateRoute: (settings) {
+        if (settings.name == LauncherView.routeName) {
+          return MaterialPageRoute<void>(
+            settings: settings,
+            builder: (_) => const Scaffold(body: Text('Dashboard')),
+          );
+        }
         if (settings.name == SkinView.routeName) {
           return MaterialPageRoute<void>(
             settings: settings,

--- a/test/unit/skin_feature/skin_navigation_test.dart
+++ b/test/unit/skin_feature/skin_navigation_test.dart
@@ -1,7 +1,12 @@
-import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/launcher/launcher_view.dart';
+import 'package:reaprime/src/services/webview_log_service.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/skin_feature/skin_view.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
+
+import '../../helpers/mock_settings_service.dart';
 
 void main() {
   test('skin exit guide explains Android navigation and Dashboard purpose', () {
@@ -9,8 +14,49 @@ void main() {
 
     expect(instructions, contains('settings and skin selection'));
     expect(instructions, contains('Swipe inward from either screen edge'));
-    expect(instructions, contains('Android Back'));
+    expect(instructions, contains('reveal the navigation bar'));
+    expect(instructions, contains('tap Back'));
   });
+
+  testWidgets(
+    'system back exits directly to Dashboard from the skin selector',
+    (tester) async {
+      tester.view.physicalSize = const Size(1600, 900);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      final navigatorKey = GlobalKey<NavigatorState>();
+      final webViewLogService = WebViewLogService(logDirectoryPath: '.');
+      addTearDown(webViewLogService.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navigatorKey,
+          home: const Scaffold(body: Text('Dashboard')),
+          routes: {
+            LauncherView.routeName: (_) =>
+                const Scaffold(body: Text('Dashboard')),
+            '/skins-test': (_) => const Scaffold(body: Text('Skins')),
+            SkinView.routeName: (_) => SkinView(
+              settingsController: SettingsController(MockSettingsService()),
+              webViewLogService: webViewLogService,
+              deviceIp: '127.0.0.1',
+            ),
+          },
+        ),
+      );
+      navigatorKey.currentState!.pushNamed('/skins-test');
+      await tester.pumpAndSettle();
+      navigatorKey.currentState!.pushNamed(SkinView.routeName);
+      await tester.pump();
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Dashboard'), findsOneWidget);
+      expect(find.text('Skins'), findsNothing);
+    },
+  );
 
   group('classifySkinNavigation', () {
     test('allows localhost:3000 and its sub-paths', () {

--- a/test/unit/skin_feature/skin_navigation_test.dart
+++ b/test/unit/skin_feature/skin_navigation_test.dart
@@ -1,13 +1,33 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/display_controller.dart';
 import 'package:reaprime/src/launcher/launcher_view.dart';
 import 'package:reaprime/src/services/webview_log_service.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/skin_feature/skin_view.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
 
+import '../../helpers/mock_de1_controller.dart';
 import '../../helpers/mock_settings_service.dart';
+
+DisplayController _createDisplayController(
+  SettingsController settingsController,
+) {
+  return DisplayController(
+    de1Controller: MockDe1Controller(controller: DeviceController(const [])),
+    settingsController: settingsController,
+    setBrightness: (_) async {},
+    resetBrightness: () async {},
+    enableWakeLock: () async {},
+    disableWakeLock: () async {},
+    platformSupport: const DisplayPlatformSupport(
+      brightness: false,
+      wakeLock: false,
+    ),
+  );
+}
 
 void main() {
   test('skin exit guide explains Android navigation and Dashboard purpose', () {
@@ -37,7 +57,10 @@ void main() {
     addTearDown(tester.view.resetDevicePixelRatio);
     final navigatorKey = GlobalKey<NavigatorState>();
     final webViewLogService = WebViewLogService(logDirectoryPath: '.');
+    final settingsController = SettingsController(MockSettingsService());
+    final displayController = _createDisplayController(settingsController);
     addTearDown(webViewLogService.dispose);
+    addTearDown(displayController.dispose);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -48,9 +71,10 @@ void main() {
               const Scaffold(body: Text('Dashboard')),
           '/skins-test': (_) => const Scaffold(body: Text('Skins')),
           SkinView.routeName: (_) => SkinView(
-            settingsController: SettingsController(MockSettingsService()),
+            settingsController: settingsController,
             webViewLogService: webViewLogService,
             deviceIp: '127.0.0.1',
+            displayController: displayController,
             webView: const SizedBox.expand(key: Key('webview')),
           ),
         },
@@ -91,7 +115,10 @@ void main() {
     addTearDown(tester.view.resetDevicePixelRatio);
     final navigatorKey = GlobalKey<NavigatorState>();
     final webViewLogService = WebViewLogService(logDirectoryPath: '.');
+    final settingsController = SettingsController(MockSettingsService());
+    final displayController = _createDisplayController(settingsController);
     addTearDown(webViewLogService.dispose);
+    addTearDown(displayController.dispose);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -102,9 +129,10 @@ void main() {
               const Scaffold(body: Text('Dashboard')),
           '/skins-test': (_) => const Scaffold(body: Text('Skins')),
           SkinView.routeName: (_) => SkinView(
-            settingsController: SettingsController(MockSettingsService()),
+            settingsController: settingsController,
             webViewLogService: webViewLogService,
             deviceIp: '127.0.0.1',
+            displayController: displayController,
             webView: const SizedBox.expand(key: Key('webview')),
           ),
         },

--- a/test/unit/skin_feature/skin_navigation_test.dart
+++ b/test/unit/skin_feature/skin_navigation_test.dart
@@ -19,14 +19,16 @@ void main() {
     expect(instructions, contains('tap Back'));
   });
 
-  test('skin exit guide points Windows users to the Dashboard button', () {
+  test('skin exit guide points Windows users to the system menu', () {
     final instructions = skinExitInstructions(TargetPlatform.windows);
 
-    expect(instructions, contains('Dashboard button'));
+    expect(instructions, contains('Windows system menu'));
+    expect(instructions, contains('Back to Dashboard'));
     expect(instructions, isNot(contains('Alt+Backspace')));
+    expect(instructions, isNot(contains('Alt+Space')));
   });
 
-  testWidgets('system back and Windows button exit directly to Dashboard', (
+  testWidgets('system back exits directly to Dashboard without an overlay', (
     tester,
   ) async {
     tester.view.physicalSize = const Size(1600, 900);
@@ -77,11 +79,7 @@ void main() {
       tester.getSize(find.byKey(const Key('webview'))),
       const Size(1600, 900),
     );
-    await tester.tap(find.byTooltip('Open Dashboard'));
-    await tester.pumpAndSettle();
-
-    expect(find.text('Dashboard'), findsOneWidget);
-    expect(find.text('Skins'), findsNothing);
+    expect(find.byTooltip('Open Dashboard'), findsNothing);
   });
 
   testWidgets('iOS edge swipe exits directly to Dashboard', (tester) async {

--- a/test/unit/skin_feature/skin_navigation_test.dart
+++ b/test/unit/skin_feature/skin_navigation_test.dart
@@ -56,7 +56,7 @@ void main() {
     );
     navigatorKey.currentState!.pushNamed('/skins-test');
     await tester.pumpAndSettle();
-    navigatorKey.currentState!.pushNamed(SkinView.routeName);
+    SkinView.open(navigatorKey.currentState!);
     await tester.pump();
 
     await tester.binding.handlePopRoute();
@@ -68,7 +68,7 @@ void main() {
     debugDefaultTargetPlatformOverride = TargetPlatform.windows;
     navigatorKey.currentState!.pushNamed('/skins-test');
     await tester.pumpAndSettle();
-    navigatorKey.currentState!.pushNamed(SkinView.routeName);
+    SkinView.open(navigatorKey.currentState!);
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
     debugDefaultTargetPlatformOverride = null;
@@ -82,6 +82,49 @@ void main() {
 
     expect(find.text('Dashboard'), findsOneWidget);
     expect(find.text('Skins'), findsNothing);
+  });
+
+  testWidgets('iOS edge swipe exits directly to Dashboard', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+    tester.view.physicalSize = const Size(1600, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final navigatorKey = GlobalKey<NavigatorState>();
+    final webViewLogService = WebViewLogService(logDirectoryPath: '.');
+    addTearDown(webViewLogService.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: const Scaffold(body: Text('Dashboard')),
+        routes: {
+          LauncherView.routeName: (_) =>
+              const Scaffold(body: Text('Dashboard')),
+          '/skins-test': (_) => const Scaffold(body: Text('Skins')),
+          SkinView.routeName: (_) => SkinView(
+            settingsController: SettingsController(MockSettingsService()),
+            webViewLogService: webViewLogService,
+            deviceIp: '127.0.0.1',
+            webView: const SizedBox.expand(key: Key('webview')),
+          ),
+        },
+      ),
+    );
+    navigatorKey.currentState!.pushNamed('/skins-test');
+    await tester.pumpAndSettle();
+    SkinView.open(navigatorKey.currentState!);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    await tester.dragFrom(const Offset(1, 450), const Offset(800, 0));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Dashboard'), findsOneWidget);
+    expect(find.text('Skins'), findsNothing);
+    expect(find.byType(SkinView), findsNothing);
+    debugDefaultTargetPlatformOverride = null;
   });
 
   group('classifySkinNavigation', () {

--- a/test/unit/skin_feature/skin_navigation_test.dart
+++ b/test/unit/skin_feature/skin_navigation_test.dart
@@ -41,6 +41,7 @@ void main() {
               settingsController: SettingsController(MockSettingsService()),
               webViewLogService: webViewLogService,
               deviceIp: '127.0.0.1',
+              webView: const SizedBox.shrink(),
             ),
           },
         ),

--- a/test/unit/skin_feature/skin_navigation_test.dart
+++ b/test/unit/skin_feature/skin_navigation_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/launcher/launcher_view.dart';
@@ -18,46 +19,70 @@ void main() {
     expect(instructions, contains('tap Back'));
   });
 
-  testWidgets(
-    'system back exits directly to Dashboard from the skin selector',
-    (tester) async {
-      tester.view.physicalSize = const Size(1600, 900);
-      tester.view.devicePixelRatio = 1;
-      addTearDown(tester.view.resetPhysicalSize);
-      addTearDown(tester.view.resetDevicePixelRatio);
-      final navigatorKey = GlobalKey<NavigatorState>();
-      final webViewLogService = WebViewLogService(logDirectoryPath: '.');
-      addTearDown(webViewLogService.dispose);
+  test('skin exit guide points Windows users to the Dashboard button', () {
+    final instructions = skinExitInstructions(TargetPlatform.windows);
 
-      await tester.pumpWidget(
-        MaterialApp(
-          navigatorKey: navigatorKey,
-          home: const Scaffold(body: Text('Dashboard')),
-          routes: {
-            LauncherView.routeName: (_) =>
-                const Scaffold(body: Text('Dashboard')),
-            '/skins-test': (_) => const Scaffold(body: Text('Skins')),
-            SkinView.routeName: (_) => SkinView(
-              settingsController: SettingsController(MockSettingsService()),
-              webViewLogService: webViewLogService,
-              deviceIp: '127.0.0.1',
-              webView: const SizedBox.shrink(),
-            ),
-          },
-        ),
-      );
-      navigatorKey.currentState!.pushNamed('/skins-test');
-      await tester.pumpAndSettle();
-      navigatorKey.currentState!.pushNamed(SkinView.routeName);
-      await tester.pump();
+    expect(instructions, contains('Dashboard button'));
+    expect(instructions, isNot(contains('Alt+Backspace')));
+  });
 
-      await tester.binding.handlePopRoute();
-      await tester.pumpAndSettle();
+  testWidgets('system back and Windows button exit directly to Dashboard', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1600, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final navigatorKey = GlobalKey<NavigatorState>();
+    final webViewLogService = WebViewLogService(logDirectoryPath: '.');
+    addTearDown(webViewLogService.dispose);
 
-      expect(find.text('Dashboard'), findsOneWidget);
-      expect(find.text('Skins'), findsNothing);
-    },
-  );
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: const Scaffold(body: Text('Dashboard')),
+        routes: {
+          LauncherView.routeName: (_) =>
+              const Scaffold(body: Text('Dashboard')),
+          '/skins-test': (_) => const Scaffold(body: Text('Skins')),
+          SkinView.routeName: (_) => SkinView(
+            settingsController: SettingsController(MockSettingsService()),
+            webViewLogService: webViewLogService,
+            deviceIp: '127.0.0.1',
+            webView: const SizedBox.expand(key: Key('webview')),
+          ),
+        },
+      ),
+    );
+    navigatorKey.currentState!.pushNamed('/skins-test');
+    await tester.pumpAndSettle();
+    navigatorKey.currentState!.pushNamed(SkinView.routeName);
+    await tester.pump();
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Dashboard'), findsOneWidget);
+    expect(find.text('Skins'), findsNothing);
+
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    navigatorKey.currentState!.pushNamed('/skins-test');
+    await tester.pumpAndSettle();
+    navigatorKey.currentState!.pushNamed(SkinView.routeName);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    debugDefaultTargetPlatformOverride = null;
+
+    expect(
+      tester.getSize(find.byKey(const Key('webview'))),
+      const Size(1600, 900),
+    );
+    await tester.tap(find.byTooltip('Open Dashboard'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Dashboard'), findsOneWidget);
+    expect(find.text('Skins'), findsNothing);
+  });
 
   group('classifySkinNavigation', () {
     test('allows localhost:3000 and its sub-paths', () {

--- a/test/unit/skin_feature/skin_navigation_test.dart
+++ b/test/unit/skin_feature/skin_navigation_test.dart
@@ -1,8 +1,17 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/skin_feature/skin_view.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
 
 void main() {
+  test('skin exit guide explains Android navigation and Dashboard purpose', () {
+    final instructions = skinExitInstructions(TargetPlatform.android);
+
+    expect(instructions, contains('settings and skin selection'));
+    expect(instructions, contains('Swipe inward from either screen edge'));
+    expect(instructions, contains('Android Back'));
+  });
+
   group('classifySkinNavigation', () {
     test('allows localhost:3000 and its sub-paths', () {
       expect(

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -2,7 +2,14 @@
 
 #include <optional>
 
+#include <flutter/method_channel.h>
+#include <flutter/standard_method_codec.h>
+
 #include "flutter/generated_plugin_registrant.h"
+
+namespace {
+constexpr UINT kBackToDashboardCommand = 0x1FF0;
+}
 
 FlutterWindow::FlutterWindow(const flutter::DartProject& project)
     : project_(project) {}
@@ -22,6 +29,12 @@ bool FlutterWindow::OnCreate() {
     return false;
   }
   RegisterPlugins(flutter_controller_->engine());
+  HMENU system_menu = GetSystemMenu(GetHandle(), FALSE);
+  if (system_menu != nullptr) {
+    AppendMenu(system_menu, MF_SEPARATOR, 0, nullptr);
+    AppendMenu(system_menu, MF_STRING, kBackToDashboardCommand,
+               L"Back to Dashboard");
+  }
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
 
   flutter_controller_->engine()->SetNextFrameCallback([&]() {
@@ -45,6 +58,18 @@ LRESULT
 FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
                               WPARAM const wparam,
                               LPARAM const lparam) noexcept {
+  if (message == WM_SYSCOMMAND &&
+      (wparam & 0xFFF0) == kBackToDashboardCommand) {
+    if (flutter_controller_) {
+      flutter::MethodChannel<flutter::EncodableValue> channel(
+          flutter_controller_->engine()->messenger(),
+          "net.tadel.reaprime/window",
+          &flutter::StandardMethodCodec::GetInstance());
+      channel.InvokeMethod("backToDashboard", nullptr);
+    }
+    return 0;
+  }
+
   if (flutter_controller_) {
     std::optional<LRESULT> result =
         flutter_controller_->HandleTopLevelWindowProc(hwnd, message, wparam,


### PR DESCRIPTION
## Summary

- Explain that Dashboard contains app settings and skin selection.
- Normalize every SkinView entry so Dashboard is directly underneath it, then route explicit exits directly to Dashboard. This preserves the native iOS left-edge back gesture.
- On Windows, disable WebView2 browser accelerator keys and add **Back to Dashboard** to the native Windows system menu.
- Keep the skin at its full viewport size with no overlaid Dashboard control.
- Document the Windows navigation control.

## Linked Issue

Fixes #427

## Verification

- `flutter test --no-pub test/unit/skin_feature/skin_navigation_test.dart` (14 passed, including a real iOS edge-drag gesture and Windows no-overlay coverage)
- `flutter analyze --no-pub` (no issues)
- `flutter test --no-pub` with the package-matched QuickJS DLL on `PATH` (3,181 passed, 1 skipped)
- Windows CMake/Visual Studio 2022 Debug build completed successfully.
- Computer Use and manual user verification confirmed **Back to Dashboard** appears in the native Windows system menu and opens Dashboard.
- The Windows guide says to use the system menu from the window icon or title bar and does not advertise a Dashboard keyboard shortcut.
- Samsung Galaxy Tab A9+ (Android 15, 1920 x 1200): the skin used the full display; the navigation guide correctly described Dashboard, edge swipes, and button-navigation Back; Android system Back opened Dashboard directly rather than returning to the Skins page.

## Impact

- Windows users get a reliable Dashboard exit while the WebView owns keyboard focus.
- The skin retains its full viewport with no overlaid control covering skin content.
- Android keeps the full skin viewport and relies on native Back/edge navigation. iOS retains Flutter's native interactive left-edge pop gesture.
- Windows WebView2 browser-specific accelerator keys are disabled. Page input shortcuts remain owned by the page/WebView.
- `doc/Skins.md` describes the Windows behavior. No API, storage, BLE/USB, migration, or plugin sandbox changes.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
