### PR TITLE
chore(ci): remove download guidance from release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -794,30 +794,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Prepend download guidance to release notes
-        env:
-          VERSION: ${{ needs.release-metadata.outputs.version }}
-        run: |
-          cat > notes-header.md <<EOF
-          ## Downloads
-
-          Every file below is covered by \`decaid-${VERSION}-SHA256SUMS.txt\`.
-
-          - **macOS** — \`decaid-macos-${VERSION}.dmg\` (signed and notarized; drag Decaid to Applications). The \`decaid-macos-${VERSION}.zip\` remains the portable build used for auto-update.
-          - **Windows x64** — \`decaid-windows-x64-${VERSION}.zip\` (portable; extract the whole ZIP and run \`Decaid.exe\`; the build is unsigned).
-          - **Linux x86_64** — \`decaid-linux-x86_64-${VERSION}.AppImage\` (chmod +x and run; no installation needed).
-          - **Linux ARM64** — \`decaid-linux-aarch64-${VERSION}.AppImage\`.
-          - **Linux portable archives** — \`decaid-linux-x64-${VERSION}.tar.gz\` and \`decaid-linux-arm64-${VERSION}.tar.gz\`.
-          - **Android** — \`decaid-android-${VERSION}.apk\`. **iOS** — unsigned \`decaid-ios-unsigned-${VERSION}.ipa\`.
-
-          **Stable URLs** — every file above also ships as a \`-latest\` alias, so \`https://github.com/decentespresso/decaid/releases/latest/download/decaid-android-latest.apk\` (and \`decaid-macos-latest.dmg\`, \`decaid-linux-x86_64-latest.AppImage\`, ...) always points at the newest stable release. The aliases are covered by \`decaid-latest-SHA256SUMS.txt\`.
-
-          See \`doc/RELEASE.md\` for install and verification instructions.
-
-          EOF
-          cat notes-header.md release-notes.md > combined-notes.md
-          mv combined-notes.md release-notes.md
-
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary

What changed, and why?

- Removed the "Prepend download guidance to release notes" step from `create-release` (introduced in `66a5f69c`). The Downloads block duplicated the asset list GitHub already renders on every release, and the Stable URLs / checksum pointers live in `doc/RELEASE.md`. Release notes are now the generated changelog only.

## Linked Issue

N/A — maintainer cleanup PR (no issue exists for this; maintainer PRs may write N/A per the template).

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- `actionlint -shellcheck='' .github/workflows/release.yml` — clean.
- `git diff --check` — clean.
- No remaining references to `notes-header.md` / `combined-notes.md` in the workflow; `release-notes.md` still flows from the generate step into `body_path` on Create Release.
- Download URLs, checksums, and stable `-latest` aliases remain documented in `doc/RELEASE.md`.

## Impact

- Release bodies lose the prepended Downloads block; changelog stands alone. No functional change to artifact upload, checksums, appcast, or aliases.
- None beyond release-note cosmetics.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
