### PR TITLE
feat(plugins): support enum settings

### DIFF
--- a/assets/plugins/time-to-ready.reaplugin/manifest.json
+++ b/assets/plugins/time-to-ready.reaplugin/manifest.json
@@ -32,7 +32,7 @@
         },
         "status": {
           "type": "enum",
-          "values": "reached | insufficient_data | not_heating | heating",
+          "values": ["reached", "insufficient_data", "not_heating", "heating"],
           "description": "current plugin heating state"
         }
       },

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -37,6 +37,12 @@ A Decaid plugin consists of two required files:
       "type": "string",
       "secure": false,
       "description": "Setting description"
+    },
+    "Roast": {
+      "type": "enum",
+      "values": "Light | Medium | Dark",
+      "default": "Medium",
+      "description": "Roast degree"
     }
   },
   "api": [
@@ -66,7 +72,7 @@ A Decaid plugin consists of two required files:
   - `events.shots`: Receive `shotStored` and `shotUpdated`
   - `proxy.decent_api`: Send read requests through `host.decentProxy`
   - `proxy.decent_api.write`: Send allowlisted write requests through `host.decentProxy`
-- **settings**: User-configurable options with `type` (`string`, `number`, `boolean`) and optional `secure` flag for credentials such as passwords. Secure values use platform credential storage, are supplied in memory to `onLoad(settings)`, and are never returned by the REST API.
+- **settings**: User-configurable options with `type` (`string`, `number`, `boolean`, `enum`) and optional `secure` flag for credentials such as passwords. Enum `values` are separated by `|`. Secure values use platform credential storage, are supplied in memory to `onLoad(settings)`, and are never returned by the REST API.
 - **api**: HTTP and WebSocket endpoints exposed by the plugin
 
 Unknown permission names make the manifest invalid. Calls without their required

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -40,7 +40,7 @@ A Decaid plugin consists of two required files:
     },
     "Roast": {
       "type": "enum",
-      "values": "Light | Medium | Dark",
+      "values": ["Light", "Medium", "Dark"],
       "default": "Medium",
       "description": "Roast degree"
     }
@@ -72,7 +72,7 @@ A Decaid plugin consists of two required files:
   - `events.shots`: Receive `shotStored` and `shotUpdated`
   - `proxy.decent_api`: Send read requests through `host.decentProxy`
   - `proxy.decent_api.write`: Send allowlisted write requests through `host.decentProxy`
-- **settings**: User-configurable options with `type` (`string`, `number`, `boolean`, `enum`) and optional `secure` flag for credentials such as passwords. Enum `values` are separated by `|`. Secure values use platform credential storage, are supplied in memory to `onLoad(settings)`, and are never returned by the REST API.
+- **settings**: User-configurable options with `type` (`string`, `number`, `boolean`, `enum`) and optional `secure` flag for credentials such as passwords. Enum `values` are a JSON array of strings. Secure values use platform credential storage, are supplied in memory to `onLoad(settings)`, and are never returned by the REST API.
 - **api**: HTTP and WebSocket endpoints exposed by the plugin
 
 Unknown permission names make the manifest invalid. Calls without their required

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -973,10 +973,20 @@ class PluginLoaderService {
       return;
     }
 
-    for (final key in settings.keys) {
-      if (!manifestSettings.containsKey(key)) {
+    for (final entry in settings.entries) {
+      if (!manifestSettings.containsKey(entry.key)) {
         throw PluginSettingsValidationException(
-          'Setting "$key" not defined in plugin manifest',
+          'Setting "${entry.key}" not defined in plugin manifest',
+        );
+      }
+      if (entry.value == null || _isSecureState(entry.value)) continue;
+      final schema = manifestSettings[entry.key];
+      final enumValues = parsePluginEnumValues(entry.key, schema);
+      if (schema is Map &&
+          schema['type'] == 'enum' &&
+          !enumValues.contains(entry.value)) {
+        throw PluginSettingsValidationException(
+          'Setting "${entry.key}" must be one of: ${enumValues.join(', ')}',
         );
       }
     }

--- a/lib/src/plugins/plugin_manifest.dart
+++ b/lib/src/plugins/plugin_manifest.dart
@@ -1,5 +1,16 @@
 import 'package:collection/collection.dart';
 
+List<String> parsePluginEnumValues(String key, dynamic schema) {
+  if (schema is! Map || schema['type'] != 'enum') return const [];
+  final values = schema['values'];
+  if (values is! List || values.any((value) => value is! String)) {
+    throw FormatException(
+      'Enum setting "$key" values must be a JSON array of strings',
+    );
+  }
+  return List<String>.unmodifiable(values.cast<String>());
+}
+
 class PluginManifest {
   final String id;
   final String name;
@@ -24,6 +35,10 @@ class PluginManifest {
   });
 
   factory PluginManifest.fromJson(Map<String, dynamic> json) {
+    final settings = Map<String, dynamic>.from(json['settings'] ?? {});
+    for (final entry in settings.entries) {
+      parsePluginEnumValues(entry.key, entry.value);
+    }
     return PluginManifest(
       id: json['id'],
       name: json['name'],
@@ -32,7 +47,7 @@ class PluginManifest {
       version: json['version'],
       apiVersion: json['apiVersion'],
       permissions: PluginPermissionsFromJson.fromJson(json['permissions']),
-      settings: json['settings'] ?? {},
+      settings: settings,
       api: PluginApi.fromJsonList(json['api']),
     );
   }

--- a/lib/src/settings/plugins_settings_view.dart
+++ b/lib/src/settings/plugins_settings_view.dart
@@ -851,6 +851,26 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
     }
 
     final Map<String, dynamic> newSettings = Map.from(settings);
+    final enumValuesByKey = <String, List<String>>{
+      for (final entry in settingsSchema.entries)
+        if (entry.value['type'] == 'enum' &&
+            entry.value['secure'] != true &&
+            entry.value['values'] is String)
+          entry.key: (entry.value['values'] as String)
+              .split('|')
+              .map((value) => value.trim())
+              .where((value) => value.isNotEmpty)
+              .toList(growable: false),
+    };
+    for (final entry in enumValuesByKey.entries) {
+      if (entry.value.contains(newSettings[entry.key])) continue;
+      final defaultValue = settingsSchema[entry.key]?['default'];
+      if (entry.value.contains(defaultValue)) {
+        newSettings[entry.key] = defaultValue;
+      } else {
+        newSettings.remove(entry.key);
+      }
+    }
     if (context.mounted == false) {
       return;
     }
@@ -881,17 +901,9 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
                   final schema = entry.value;
                   final currentValue = newSettings[key];
                   final defaultValue = schema['default'];
-                  final enumValues = schema['values'] is String
-                      ? (schema['values'] as String)
-                            .split('|')
-                            .map((value) => value.trim())
-                            .where((value) => value.isNotEmpty)
-                            .toList()
-                      : const <String>[];
+                  final enumValues = enumValuesByKey[key] ?? const <String>[];
                   final selectedEnumValue = enumValues.contains(currentValue)
                       ? currentValue as String
-                      : enumValues.contains(defaultValue)
-                      ? defaultValue as String
                       : null;
                   final secureDraft = secureDrafts[key];
                   final secureValueIsSet =

--- a/lib/src/settings/plugins_settings_view.dart
+++ b/lib/src/settings/plugins_settings_view.dart
@@ -863,12 +863,15 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
               .toList(growable: false),
     };
     for (final entry in enumValuesByKey.entries) {
-      if (entry.value.contains(newSettings[entry.key])) continue;
+      if (!newSettings.containsKey(entry.key) ||
+          entry.value.contains(newSettings[entry.key])) {
+        continue;
+      }
       final defaultValue = settingsSchema[entry.key]?['default'];
       if (entry.value.contains(defaultValue)) {
         newSettings[entry.key] = defaultValue;
       } else {
-        newSettings.remove(entry.key);
+        newSettings[entry.key] = null;
       }
     }
     if (context.mounted == false) {
@@ -904,6 +907,8 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
                   final enumValues = enumValuesByKey[key] ?? const <String>[];
                   final selectedEnumValue = enumValues.contains(currentValue)
                       ? currentValue as String
+                      : enumValues.contains(defaultValue)
+                      ? defaultValue as String
                       : null;
                   final secureDraft = secureDrafts[key];
                   final secureValueIsSet =

--- a/lib/src/settings/plugins_settings_view.dart
+++ b/lib/src/settings/plugins_settings_view.dart
@@ -881,6 +881,18 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
                   final schema = entry.value;
                   final currentValue = newSettings[key];
                   final defaultValue = schema['default'];
+                  final enumValues = schema['values'] is String
+                      ? (schema['values'] as String)
+                            .split('|')
+                            .map((value) => value.trim())
+                            .where((value) => value.isNotEmpty)
+                            .toList()
+                      : const <String>[];
+                  final selectedEnumValue = enumValues.contains(currentValue)
+                      ? currentValue as String
+                      : enumValues.contains(defaultValue)
+                      ? defaultValue as String
+                      : null;
                   final secureDraft = secureDrafts[key];
                   final secureValueIsSet =
                       secureDraft != null &&
@@ -990,6 +1002,29 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
                                 });
                               }
                             },
+                          )
+                        else if (schema['type'] == 'enum')
+                          ShadSelect<String>(
+                            initialValue: selectedEnumValue,
+                            enabled: enumValues.isNotEmpty,
+                            placeholder: const Text('Select a value...'),
+                            selectedOptionBuilder: (context, value) =>
+                                Text(value),
+                            onChanged: (value) {
+                              if (value != null) {
+                                setState(() {
+                                  newSettings[key] = value;
+                                });
+                              }
+                            },
+                            options: enumValues
+                                .map(
+                                  (value) => ShadOption<String>(
+                                    value: value,
+                                    child: Text(value),
+                                  ),
+                                )
+                                .toList(),
                           )
                         else
                           ShadInput(

--- a/lib/src/settings/plugins_settings_view.dart
+++ b/lib/src/settings/plugins_settings_view.dart
@@ -853,14 +853,8 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
     final Map<String, dynamic> newSettings = Map.from(settings);
     final enumValuesByKey = <String, List<String>>{
       for (final entry in settingsSchema.entries)
-        if (entry.value['type'] == 'enum' &&
-            entry.value['secure'] != true &&
-            entry.value['values'] is String)
-          entry.key: (entry.value['values'] as String)
-              .split('|')
-              .map((value) => value.trim())
-              .where((value) => value.isNotEmpty)
-              .toList(growable: false),
+        if (entry.value['type'] == 'enum' && entry.value['secure'] != true)
+          entry.key: parsePluginEnumValues(entry.key, entry.value),
     };
     for (final entry in enumValuesByKey.entries) {
       if (!newSettings.containsKey(entry.key) ||

--- a/test/plugin_loader_service_appstore_test.dart
+++ b/test/plugin_loader_service_appstore_test.dart
@@ -311,6 +311,46 @@ function createPlugin() {
       });
     });
 
+    test('enum settings reject values outside the manifest array', () async {
+      const id = 'enum.reaplugin';
+      await service.addPlugin(
+        makePluginSource(
+          id,
+          settings: {
+            'Roast': {
+              'type': 'enum',
+              'values': ['Light', 'Medium', 'Dark'],
+            },
+          },
+        ).path,
+      );
+
+      await service.savePluginSettings(id, {'Roast': 'Light'});
+      await expectLater(
+        service.savePluginSettings(id, {'Roast': 'Obsolete'}),
+        throwsA(isA<PluginSettingsValidationException>()),
+      );
+
+      expect(await service.pluginSettings(id), {'Roast': 'Light'});
+
+      await service.savePluginSettings(id, {'Roast': null});
+      expect(await service.pluginSettings(id), isEmpty);
+    });
+
+    test('rejects pipe-delimited enum manifest values', () async {
+      await expectLater(
+        service.addPlugin(
+          makePluginSource(
+            'invalid-enum.reaplugin',
+            settings: {
+              'Roast': {'type': 'enum', 'values': 'Light | Medium | Dark'},
+            },
+          ).path,
+        ),
+        throwsFormatException,
+      );
+    });
+
     test(
       'a mixed patch updates, preserves, and clears settings at once',
       () async {

--- a/test/plugins_settings_view_appstore_test.dart
+++ b/test/plugins_settings_view_appstore_test.dart
@@ -113,6 +113,54 @@ void main() {
     expect(find.text('proxyDecentApi'), findsNothing);
   });
 
+  testWidgets('selects and saves enum settings', (tester) async {
+    final manifest = PluginManifest(
+      id: 'enum.reaplugin',
+      name: 'Enum Plugin',
+      author: 'Test',
+      description: 'Test plugin',
+      version: '1.0.0',
+      apiVersion: 1,
+      permissions: {},
+      settings: {
+        'Roast': {
+          'type': 'enum',
+          'values': 'Light | Medium | Dark',
+          'default': 'Medium',
+        },
+      },
+      api: PluginApi(endpoints: []),
+    );
+    fakePluginLoaderService = FakePluginLoaderService(
+      plugins: [manifest],
+      settings: {'Roast': 'Light'},
+    );
+
+    await tester.pumpWidget(
+      ShadApp(
+        builder: (_, child) => ScaffoldMessenger(child: child!),
+        home: PluginsSettingsView(
+          pluginLoaderService: fakePluginLoaderService,
+          allowInstall: false,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.widgetWithText(ShadButton, 'Settings'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ShadSelect<String>), findsOneWidget);
+    expect(find.text('Light'), findsOneWidget);
+    await tester.tap(find.byType(ShadSelect<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(ShadOption<String>, 'Dark'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(ShadButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(fakePluginLoaderService.savedSettings, {'Roast': 'Dark'});
+  });
+
   PluginManifest secureManifest() => PluginManifest(
     id: 'secure.reaplugin',
     name: 'Secure Plugin',

--- a/test/plugins_settings_view_appstore_test.dart
+++ b/test/plugins_settings_view_appstore_test.dart
@@ -113,7 +113,7 @@ void main() {
     expect(find.text('proxyDecentApi'), findsNothing);
   });
 
-  PluginManifest enumManifest() => PluginManifest(
+  PluginManifest enumManifest({bool includeDefault = true}) => PluginManifest(
     id: 'enum.reaplugin',
     name: 'Enum Plugin',
     author: 'Test',
@@ -125,7 +125,7 @@ void main() {
       'Roast': {
         'type': 'enum',
         'values': 'Light | Medium | Dark',
-        'default': 'Medium',
+        if (includeDefault) 'default': 'Medium',
       },
     },
     api: PluginApi(endpoints: []),
@@ -133,10 +133,11 @@ void main() {
 
   Future<void> openEnumSettingsDialog(
     WidgetTester tester,
-    Map<String, dynamic> settings,
-  ) async {
+    Map<String, dynamic> settings, {
+    bool includeDefault = true,
+  }) async {
     fakePluginLoaderService = FakePluginLoaderService(
-      plugins: [enumManifest()],
+      plugins: [enumManifest(includeDefault: includeDefault)],
       settings: settings,
     );
 
@@ -179,6 +180,29 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(fakePluginLoaderService.savedSettings, {'Roast': 'Medium'});
+  });
+
+  testWidgets('clears an invalid enum setting without a valid default', (
+    tester,
+  ) async {
+    await openEnumSettingsDialog(tester, {
+      'Roast': 'Obsolete',
+    }, includeDefault: false);
+
+    await tester.tap(find.widgetWithText(ShadButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(fakePluginLoaderService.savedSettings, {'Roast': null});
+  });
+
+  testWidgets('does not persist an untouched enum default', (tester) async {
+    await openEnumSettingsDialog(tester, {});
+
+    expect(find.text('Medium'), findsOneWidget);
+    await tester.tap(find.widgetWithText(ShadButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(fakePluginLoaderService.savedSettings, isEmpty);
   });
 
   PluginManifest secureManifest() => PluginManifest(

--- a/test/plugins_settings_view_appstore_test.dart
+++ b/test/plugins_settings_view_appstore_test.dart
@@ -124,7 +124,7 @@ void main() {
     settings: {
       'Roast': {
         'type': 'enum',
-        'values': 'Light | Medium | Dark',
+        'values': ['Light', 'Medium', 'Dark'],
         if (includeDefault) 'default': 'Medium',
       },
     },

--- a/test/plugins_settings_view_appstore_test.dart
+++ b/test/plugins_settings_view_appstore_test.dart
@@ -113,27 +113,31 @@ void main() {
     expect(find.text('proxyDecentApi'), findsNothing);
   });
 
-  testWidgets('selects and saves enum settings', (tester) async {
-    final manifest = PluginManifest(
-      id: 'enum.reaplugin',
-      name: 'Enum Plugin',
-      author: 'Test',
-      description: 'Test plugin',
-      version: '1.0.0',
-      apiVersion: 1,
-      permissions: {},
-      settings: {
-        'Roast': {
-          'type': 'enum',
-          'values': 'Light | Medium | Dark',
-          'default': 'Medium',
-        },
+  PluginManifest enumManifest() => PluginManifest(
+    id: 'enum.reaplugin',
+    name: 'Enum Plugin',
+    author: 'Test',
+    description: 'Test plugin',
+    version: '1.0.0',
+    apiVersion: 1,
+    permissions: {},
+    settings: {
+      'Roast': {
+        'type': 'enum',
+        'values': 'Light | Medium | Dark',
+        'default': 'Medium',
       },
-      api: PluginApi(endpoints: []),
-    );
+    },
+    api: PluginApi(endpoints: []),
+  );
+
+  Future<void> openEnumSettingsDialog(
+    WidgetTester tester,
+    Map<String, dynamic> settings,
+  ) async {
     fakePluginLoaderService = FakePluginLoaderService(
-      plugins: [manifest],
-      settings: {'Roast': 'Light'},
+      plugins: [enumManifest()],
+      settings: settings,
     );
 
     await tester.pumpWidget(
@@ -148,6 +152,10 @@ void main() {
     await tester.pump();
     await tester.tap(find.widgetWithText(ShadButton, 'Settings'));
     await tester.pumpAndSettle();
+  }
+
+  testWidgets('selects and saves enum settings', (tester) async {
+    await openEnumSettingsDialog(tester, {'Roast': 'Light'});
 
     expect(find.byType(ShadSelect<String>), findsOneWidget);
     expect(find.text('Light'), findsOneWidget);
@@ -159,6 +167,18 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(fakePluginLoaderService.savedSettings, {'Roast': 'Dark'});
+  });
+
+  testWidgets('replaces an invalid enum setting with its valid default', (
+    tester,
+  ) async {
+    await openEnumSettingsDialog(tester, {'Roast': 'Obsolete'});
+
+    expect(find.text('Medium'), findsOneWidget);
+    await tester.tap(find.widgetWithText(ShadButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(fakePluginLoaderService.savedSettings, {'Roast': 'Medium'});
   });
 
   PluginManifest secureManifest() => PluginManifest(


### PR DESCRIPTION
## Summary

What changed, and why?

- Render plugin settings declared as `enum` with a select control.
- Normalize only stale stored enum values before saving, using a valid manifest default or an explicit deletion tombstone.
- Define enum `values` as a JSON array of strings and share one parser between manifest loading, service validation, and the settings UI.
- Reject non-null enum settings outside the manifest's declared values in `PluginLoaderService`, including non-UI callers.

## Linked Issue

Fixes #255

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- `flutter test --no-pub test/plugin_loader_service_appstore_test.dart test/plugins_settings_view_appstore_test.dart` (42 passed)
- `flutter analyze --no-pub` (no issues)
- `flutter test --no-pub` (3,220 passed, 1 skipped; the known Windows CRLF-sensitive AsyncAPI schema assertion failed, while CI/Linux uses LF)

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- Plugin manifests can expose `enum` settings as a fixed-choice selector. Enum manifests use JSON string arrays, and invalid values are rejected at the service boundary. No migration or security impact.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->