### PR TITLE
Fix HDS USB protocol compatibility

### DIFF
--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -84,6 +84,7 @@ Discovery services are responsible for scanning and creating device instances. E
   - `lib/src/services/serial/serial_service_android.dart` (Android)
   - `lib/src/services/serial/serial_service.dart` (factory)
 - **Discovery:** Enumerates serial ports, probes for device identification
+- **HDS USB readiness:** `HDSSerial` enables the 10 Hz OpenScale binary stream and remains `connecting` until a checksum-valid weight frame arrives. Its buffered decoder accepts fragmented/coalesced frames mixed with firmware text; only valid weight frames refresh the watchdog.
 
   DE1-family detection uses product names and the normal protocol probe:
   1. Exact `productName == "DE1"` creates `UnifiedDe1`; exact

--- a/lib/src/models/device/impl/decent_scale/protocol.dart
+++ b/lib/src/models/device/impl/decent_scale/protocol.dart
@@ -1,0 +1,7 @@
+import 'dart:typed_data';
+
+Uint8List buildDecentScaleCommand(List<int> commandBytes) {
+  final bytes = <int>[0x03, ...commandBytes];
+  final checksum = bytes.fold(0, (value, byte) => value ^ byte);
+  return Uint8List.fromList([...bytes, checksum]);
+}

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 import 'dart:math';
-import 'dart:typed_data';
 
 import 'package:reaprime/src/models/device/ble_service_identifier.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:reaprime/src/models/device/impl/decent_scale/protocol.dart';
 import 'package:reaprime/src/services/serial/serial_service_desktop.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:reaprime/src/models/device/device.dart';
@@ -56,16 +56,6 @@ class DecentScale implements Scale, TransportHandoffScale {
     : _deviceId = transport.id,
       _device = transport;
 
-  static Uint8List _buildCommand(List<int> commandBytes) {
-    final bytes = <int>[0x03, ...commandBytes];
-    int xor = 0;
-    for (final b in bytes) {
-      xor ^= b;
-    }
-    bytes.add(xor);
-    return Uint8List.fromList(bytes);
-  }
-
   Future<bool> _writeCommand(
     List<int> commandBytes, {
     Duration? timeout,
@@ -75,7 +65,7 @@ class DecentScale implements Scale, TransportHandoffScale {
       await _device.write(
         serviceIdentifier.long,
         writeCharacteristic.long,
-        _buildCommand(commandBytes),
+        buildDecentScaleCommand(commandBytes),
         timeout: timeout,
         withResponse: withResponse,
       );

--- a/lib/src/models/device/impl/decent_scale/scale_serial.dart
+++ b/lib/src/models/device/impl/decent_scale/scale_serial.dart
@@ -119,14 +119,16 @@ class HDSSerial implements Scale, TransportHandoffScale {
     );
 
     try {
-      await _transport.writeHexCommand(Uint8List.fromList(_enableCommand));
-      await initialization.future.timeout(
-        _initializationTimeout,
-        onTimeout: () => throw const EndpointUnavailableException(
-          'HDS USB weight stream',
+      await Future.wait<void>([
+        _transport.writeHexCommand(Uint8List.fromList(_enableCommand)),
+        initialization.future.timeout(
           _initializationTimeout,
+          onTimeout: () => throw const EndpointUnavailableException(
+            'HDS USB weight stream',
+            _initializationTimeout,
+          ),
         ),
-      );
+      ], eagerError: true);
     } catch (_) {
       if (identical(_initialization, initialization)) {
         _initialization = null;

--- a/lib/src/models/device/impl/decent_scale/scale_serial.dart
+++ b/lib/src/models/device/impl/decent_scale/scale_serial.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
+import 'package:reaprime/src/models/device/impl/decent_scale/protocol.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
@@ -13,7 +14,9 @@ class HDSSerial implements Scale, TransportHandoffScale {
   late Logger _log;
   final SerialTransport _transport;
 
-  static const _enableCommand = [0x03, 0x20, 0x01];
+  static const _enableCommand = [0x03, 0x20, 0x01, 0x01];
+  static const _initializationTimeout = Duration(seconds: 2);
+  static const _weightFrameLength = 7;
   static const _watchdogInterval = Duration(seconds: 2);
   static const _warningTicks = 3;
   static const _disconnectTicks = 6;
@@ -43,8 +46,10 @@ class HDSSerial implements Scale, TransportHandoffScale {
 
   bool _isDisconnecting = false;
   Timer? _watchdogTimer;
+  Completer<bool>? _initialization;
   int _ticksSinceLastData = 0;
   bool _retryAttempted = false;
+  final List<int> _inputBuffer = [];
 
   @override
   disconnect() async {
@@ -52,11 +57,15 @@ class HDSSerial implements Scale, TransportHandoffScale {
     _isDisconnecting = true;
     final uptimeSec = _watchdogTotalTicks * _watchdogInterval.inSeconds;
     _log.info(
-      "disconnecting (totalFrames=$_totalFrames, uptime=${uptimeSec}s)",
+      "disconnecting (rawChunks=$_rawChunks, rawBytes=$_rawBytes, validWeightFrames=$_validWeightFrames, invalidFrames=$_invalidFrames, checksumFailures=$_checksumFailures, uptime=${uptimeSec}s)",
     );
     try {
       _watchdogTimer?.cancel();
       _watchdogTimer = null;
+      if (_initialization case final initialization?
+          when !initialization.isCompleted) {
+        initialization.complete(false);
+      }
       _connectionSubject.add(ConnectionState.disconnected);
       _transportSubscription?.cancel();
       await _transport.disconnect();
@@ -74,14 +83,25 @@ class HDSSerial implements Scale, TransportHandoffScale {
   String get name => "Half Decent Scale (USB)";
 
   StreamSubscription<Uint8List>? _transportSubscription;
-  int _totalFrames = 0;
+  int _rawChunks = 0;
+  int _rawBytes = 0;
+  int _validWeightFrames = 0;
+  int _invalidFrames = 0;
+  int _checksumFailures = 0;
 
   @override
   Future<void> onConnect() async {
     _log.info("on connect (id=$deviceId, transport=${_transport.name})");
-    _totalFrames = 0;
+    _rawChunks = 0;
+    _rawBytes = 0;
+    _validWeightFrames = 0;
+    _invalidFrames = 0;
+    _checksumFailures = 0;
+    _inputBuffer.clear();
     _connectionSubject.add(ConnectionState.connecting);
     await _transport.connect();
+    final initialization = Completer<bool>();
+    _initialization = initialization;
     _transportSubscription = _transport.rawStream.listen(
       onData,
       onError: (error) {
@@ -94,6 +114,17 @@ class HDSSerial implements Scale, TransportHandoffScale {
     );
 
     await _transport.writeHexCommand(Uint8List.fromList(_enableCommand));
+    final initialized = await initialization.future.timeout(
+      _initializationTimeout,
+      onTimeout: () => false,
+    );
+    if (identical(_initialization, initialization)) {
+      _initialization = null;
+    }
+    if (!initialized) {
+      await disconnect();
+      throw TimeoutException('HDS USB weight stream initialization timed out');
+    }
     _startWatchdog();
     _connectionSubject.add(ConnectionState.connected);
   }
@@ -113,21 +144,21 @@ class HDSSerial implements Scale, TransportHandoffScale {
         final uptimeMin =
             (_watchdogTotalTicks * _watchdogInterval.inSeconds) ~/ 60;
         _log.fine(
-          "heartbeat: ${uptimeMin}m uptime, $_totalFrames frames received",
+          "heartbeat: ${uptimeMin}m uptime, $_validWeightFrames valid weight frames received",
         );
       }
 
       if (_ticksSinceLastData >= _disconnectTicks) {
         _log.severe(
           "No data for ${_disconnectTicks * _watchdogInterval.inSeconds}s "
-          "(totalFrames=$_totalFrames, uptime=${_watchdogTotalTicks * _watchdogInterval.inSeconds}s), disconnecting",
+          "(validWeightFrames=$_validWeightFrames, uptime=${_watchdogTotalTicks * _watchdogInterval.inSeconds}s), disconnecting",
         );
         disconnect();
       } else if (_ticksSinceLastData >= _warningTicks && !_retryAttempted) {
         _retryAttempted = true;
         _log.warning(
           "No data for ${_warningTicks * _watchdogInterval.inSeconds}s "
-          "(totalFrames=$_totalFrames), resending enable command",
+          "(validWeightFrames=$_validWeightFrames), resending enable command",
         );
         _transport.writeHexCommand(Uint8List.fromList(_enableCommand));
       }
@@ -136,11 +167,9 @@ class HDSSerial implements Scale, TransportHandoffScale {
 
   @override
   Future<void> tare() async {
-    Uint8List cmd = Uint8List(5);
-    cmd[0] = 0x03;
-    cmd[1] = 0x0F;
-
-    await _transport.writeHexCommand(cmd);
+    await _transport.writeHexCommand(
+      buildDecentScaleCommand([0x0F, 0x00, 0x00, 0x00, 0x01]),
+    );
   }
 
   @override
@@ -173,24 +202,69 @@ class HDSSerial implements Scale, TransportHandoffScale {
   DeviceType get type => DeviceType.scale;
 
   void onData(Uint8List data) {
+    _rawChunks++;
+    _rawBytes += data.length;
+    _inputBuffer.addAll(data);
+    _decodeWeightFrames();
+  }
+
+  void _decodeWeightFrames() {
+    while (_inputBuffer.length >= 2) {
+      final start = _weightFrameStart();
+      if (start < 0) {
+        final trailingStart = _inputBuffer.last == 0x03;
+        _inputBuffer.removeRange(
+          0,
+          _inputBuffer.length - (trailingStart ? 1 : 0),
+        );
+        return;
+      }
+      if (start > 0) {
+        _inputBuffer.removeRange(0, start);
+      }
+      if (_inputBuffer.length < _weightFrameLength) {
+        return;
+      }
+
+      final frame = _inputBuffer.sublist(0, _weightFrameLength);
+      final checksum = frame.take(6).fold(0, (value, byte) => value ^ byte);
+      if (checksum != frame[6]) {
+        _checksumFailures++;
+        _invalidFrames++;
+        _inputBuffer.removeAt(0);
+        continue;
+      }
+
+      _inputBuffer.removeRange(0, _weightFrameLength);
+      _handleWeightFrame(frame);
+    }
+  }
+
+  int _weightFrameStart() {
+    for (var i = 0; i < _inputBuffer.length - 1; i++) {
+      if (_inputBuffer[i] == 0x03 && _inputBuffer[i + 1] == 0xCE) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  void _handleWeightFrame(List<int> data) {
     _ticksSinceLastData = 0;
     _retryAttempted = false;
-    _totalFrames++;
-    try {
-      _log.finest("got message: $data");
-    } catch (_) {}
-    if (data.length < 5 || data[0] != 0x03 || data[1] != 0xCE) {
-      _log.finest("data is not weight data (len=${data.length})");
-      return;
+    _validWeightFrames++;
+    if (_initialization case final initialization?
+        when !initialization.isCompleted) {
+      initialization.complete(true);
     }
-    var d = ByteData(2);
-    d.setInt8(0, data[2]);
-    d.setInt8(1, data[3]);
-    var weight = d.getInt16(0) / 10;
+    final unsignedWeight = (data[2] << 8) | data[3];
+    final signedWeight = unsignedWeight >= 0x8000
+        ? unsignedWeight - 0x10000
+        : unsignedWeight;
     _snapshotHandler.add(
       ScaleSnapshot(
         timestamp: DateTime.now(),
-        weight: weight,
+        weight: signedWeight / 10,
         batteryLevel: 100,
       ),
     );

--- a/lib/src/models/device/impl/decent_scale/scale_serial.dart
+++ b/lib/src/models/device/impl/decent_scale/scale_serial.dart
@@ -48,6 +48,8 @@ class HDSSerial implements Scale, TransportHandoffScale {
   bool _isDisconnecting = false;
   Timer? _watchdogTimer;
   Completer<void>? _initialization;
+  bool _enableWriteComplete = false;
+  bool _initialWeightReceived = false;
   int _ticksSinceLastData = 0;
   bool _retryAttempted = false;
   final List<int> _inputBuffer = [];
@@ -99,6 +101,8 @@ class HDSSerial implements Scale, TransportHandoffScale {
     _invalidFrames = 0;
     _checksumFailures = 0;
     _inputBuffer.clear();
+    _enableWriteComplete = false;
+    _initialWeightReceived = false;
     _connectionSubject.add(ConnectionState.connecting);
     await _transport.connect();
     final initialization = Completer<void>();
@@ -119,14 +123,24 @@ class HDSSerial implements Scale, TransportHandoffScale {
     );
 
     try {
+      final enableWrite = _transport
+          .writeHexCommand(Uint8List.fromList(_enableCommand))
+          .then((_) {
+            if (!identical(_initialization, initialization)) return;
+            _enableWriteComplete = true;
+            _completeInitializationIfReady();
+          });
       await Future.wait<void>([
-        _transport.writeHexCommand(Uint8List.fromList(_enableCommand)),
+        enableWrite,
         initialization.future.timeout(
           _initializationTimeout,
-          onTimeout: () => throw const EndpointUnavailableException(
-            'HDS USB weight stream',
-            _initializationTimeout,
-          ),
+          onTimeout: () {
+            if (_initialWeightReceived) return initialization.future;
+            throw const EndpointUnavailableException(
+              'HDS USB weight stream',
+              _initializationTimeout,
+            );
+          },
         ),
       ], eagerError: true);
     } catch (_) {
@@ -147,6 +161,16 @@ class HDSSerial implements Scale, TransportHandoffScale {
     if (_initialization case final initialization?
         when !initialization.isCompleted) {
       initialization.completeError(error, stackTrace);
+    }
+  }
+
+  void _completeInitializationIfReady() {
+    final initialization = _initialization;
+    if (_enableWriteComplete &&
+        _initialWeightReceived &&
+        initialization != null &&
+        !initialization.isCompleted) {
+      initialization.complete();
     }
   }
 
@@ -274,10 +298,8 @@ class HDSSerial implements Scale, TransportHandoffScale {
     _ticksSinceLastData = 0;
     _retryAttempted = false;
     _validWeightFrames++;
-    if (_initialization case final initialization?
-        when !initialization.isCompleted) {
-      initialization.complete();
-    }
+    _initialWeightReceived = true;
+    _completeInitializationIfReady();
     final unsignedWeight = (data[2] << 8) | data[3];
     final signedWeight = unsignedWeight >= 0x8000
         ? unsignedWeight - 0x10000

--- a/lib/src/models/device/impl/decent_scale/scale_serial.dart
+++ b/lib/src/models/device/impl/decent_scale/scale_serial.dart
@@ -8,6 +8,7 @@ import 'package:reaprime/src/models/device/impl/decent_scale/protocol.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:reaprime/src/models/errors.dart';
 import 'package:rxdart/subjects.dart';
 
 class HDSSerial implements Scale, TransportHandoffScale {
@@ -46,7 +47,7 @@ class HDSSerial implements Scale, TransportHandoffScale {
 
   bool _isDisconnecting = false;
   Timer? _watchdogTimer;
-  Completer<bool>? _initialization;
+  Completer<void>? _initialization;
   int _ticksSinceLastData = 0;
   bool _retryAttempted = false;
   final List<int> _inputBuffer = [];
@@ -64,7 +65,7 @@ class HDSSerial implements Scale, TransportHandoffScale {
       _watchdogTimer = null;
       if (_initialization case final initialization?
           when !initialization.isCompleted) {
-        initialization.complete(false);
+        initialization.completeError(const DeviceNotConnectedException.scale());
       }
       _connectionSubject.add(ConnectionState.disconnected);
       _transportSubscription?.cancel();
@@ -100,33 +101,51 @@ class HDSSerial implements Scale, TransportHandoffScale {
     _inputBuffer.clear();
     _connectionSubject.add(ConnectionState.connecting);
     await _transport.connect();
-    final initialization = Completer<bool>();
+    final initialization = Completer<void>();
     _initialization = initialization;
     _transportSubscription = _transport.rawStream.listen(
       onData,
-      onError: (error) {
+      onError: (Object error, StackTrace stackTrace) {
+        _completeInitializationError(error, stackTrace);
         _log.warning("transport error", error);
         disconnect();
       },
       onDone: () {
+        _completeInitializationError(
+          StateError('HDS USB transport closed during initialization'),
+        );
         disconnect();
       },
     );
 
-    await _transport.writeHexCommand(Uint8List.fromList(_enableCommand));
-    final initialized = await initialization.future.timeout(
-      _initializationTimeout,
-      onTimeout: () => false,
-    );
+    try {
+      await _transport.writeHexCommand(Uint8List.fromList(_enableCommand));
+      await initialization.future.timeout(
+        _initializationTimeout,
+        onTimeout: () => throw const EndpointUnavailableException(
+          'HDS USB weight stream',
+          _initializationTimeout,
+        ),
+      );
+    } catch (_) {
+      if (identical(_initialization, initialization)) {
+        _initialization = null;
+      }
+      await disconnect();
+      rethrow;
+    }
     if (identical(_initialization, initialization)) {
       _initialization = null;
     }
-    if (!initialized) {
-      await disconnect();
-      throw TimeoutException('HDS USB weight stream initialization timed out');
-    }
     _startWatchdog();
     _connectionSubject.add(ConnectionState.connected);
+  }
+
+  void _completeInitializationError(Object error, [StackTrace? stackTrace]) {
+    if (_initialization case final initialization?
+        when !initialization.isCompleted) {
+      initialization.completeError(error, stackTrace);
+    }
   }
 
   int _watchdogTotalTicks = 0;
@@ -255,7 +274,7 @@ class HDSSerial implements Scale, TransportHandoffScale {
     _validWeightFrames++;
     if (_initialization case final initialization?
         when !initialization.isCompleted) {
-      initialization.complete(true);
+      initialization.complete();
     }
     final unsignedWeight = (data[2] << 8) | data[3];
     final signedWeight = unsignedWeight >= 0x8000

--- a/test/unit/devices/hds_serial_disconnect_test.dart
+++ b/test/unit/devices/hds_serial_disconnect_test.dart
@@ -105,7 +105,12 @@ void main() {
     });
 
     test('calls transport.disconnect() after onConnect', () async {
-      await hds.onConnect();
+      final connected = hds.onConnect();
+      await Future<void>.delayed(Duration.zero);
+      transport.emitRawData(
+        Uint8List.fromList([0x03, 0xCE, 0x00, 0x00, 0x00, 0x00, 0xCD]),
+      );
+      await connected;
       await hds.disconnect();
       expect(transport.disconnectCalled, isTrue);
     });

--- a/test/unit/devices/hds_serial_disconnect_test.dart
+++ b/test/unit/devices/hds_serial_disconnect_test.dart
@@ -62,6 +62,12 @@ class MockSerialTransport implements SerialTransport {
     _rawController.add(data);
   }
 
+  void emitRawError(Object error, [StackTrace? stackTrace]) {
+    _rawController.addError(error, stackTrace);
+  }
+
+  Future<void> closeRawStream() => _rawController.close();
+
   @override
   Future<void> dispose() async {
     _connectionSubject.close();

--- a/test/unit/devices/hds_serial_disconnect_test.dart
+++ b/test/unit/devices/hds_serial_disconnect_test.dart
@@ -9,6 +9,10 @@ import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:rxdart/subjects.dart';
 
 class MockSerialTransport implements SerialTransport {
+  MockSerialTransport({this.writeCompleter});
+
+  final Completer<void>? writeCompleter;
+
   final BehaviorSubject<ConnectionState> _connectionSubject =
       BehaviorSubject.seeded(ConnectionState.discovered);
 
@@ -56,6 +60,7 @@ class MockSerialTransport implements SerialTransport {
   @override
   Future<void> writeHexCommand(Uint8List command) async {
     writtenHexCommands.add(command);
+    await writeCompleter?.future;
   }
 
   void emitRawData(Uint8List data) {

--- a/test/unit/devices/hds_serial_watchdog_test.dart
+++ b/test/unit/devices/hds_serial_watchdog_test.dart
@@ -1,17 +1,119 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale_serial.dart';
 
 import 'hds_serial_disconnect_test.dart';
 
 Uint8List weightFrame(double weight) {
-  final raw = (weight * 10).toInt();
-  return Uint8List.fromList([0x03, 0xCE, (raw >> 8) & 0xFF, raw & 0xFF, 0x00]);
+  final raw = (weight * 10).toInt() & 0xFFFF;
+  final bytes = [0x03, 0xCE, (raw >> 8) & 0xFF, raw & 0xFF, 0x00, 0x00];
+  return Uint8List.fromList([...bytes, bytes.reduce((a, b) => a ^ b)]);
 }
 
 void main() {
+  group('HDSSerial protocol', () {
+    test('writes current enable and tare commands', () {
+      fakeAsync((async) {
+        final transport = MockSerialTransport();
+        final hds = HDSSerial(transport: transport);
+
+        hds.onConnect();
+        async.flushMicrotasks();
+        hds.tare();
+        async.flushMicrotasks();
+
+        expect(transport.writtenHexCommands, [
+          Uint8List.fromList([0x03, 0x20, 0x01, 0x01]),
+          Uint8List.fromList([0x03, 0x0F, 0x00, 0x00, 0x00, 0x01, 0x0D]),
+        ]);
+      });
+    });
+
+    test('stays connecting until a valid weight frame arrives', () {
+      fakeAsync((async) {
+        final transport = MockSerialTransport();
+        final hds = HDSSerial(transport: transport);
+        final states = <ConnectionState>[];
+        hds.connectionState.listen(states.add);
+
+        hds.onConnect();
+        async.flushMicrotasks();
+        expect(states.last, ConnectionState.connecting);
+
+        transport.emitRawData(weightFrame(42));
+        async.flushMicrotasks();
+        expect(states.last, ConnectionState.connected);
+      });
+    });
+
+    test('fails connection when no valid weight frame arrives', () {
+      fakeAsync((async) {
+        final transport = MockSerialTransport();
+        final hds = HDSSerial(transport: transport);
+        Object? error;
+
+        hds.onConnect().catchError((Object caught) {
+          error = caught;
+        });
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 3));
+        async.flushMicrotasks();
+
+        expect(error, isA<TimeoutException>());
+        expect(transport.disconnectCalled, isTrue);
+      });
+    });
+
+    test('decodes signed frames split and coalesced across chunks', () {
+      fakeAsync((async) {
+        final transport = MockSerialTransport();
+        final hds = HDSSerial(transport: transport);
+        final weights = <double>[];
+        hds.currentSnapshot.listen((snapshot) => weights.add(snapshot.weight));
+        hds.onConnect();
+        async.flushMicrotasks();
+
+        final positive = weightFrame(12.3);
+        transport.emitRawData(positive.sublist(0, 3));
+        transport.emitRawData(positive.sublist(3));
+        transport.emitRawData(
+          Uint8List.fromList([
+            ...utf8.encode('HDS log\n'),
+            ...weightFrame(-4.5),
+            ...weightFrame(6.7),
+          ]),
+        );
+        async.flushMicrotasks();
+
+        expect(weights, [12.3, -4.5, 6.7]);
+      });
+    });
+
+    test('ignores a bad checksum and resynchronizes to the next frame', () {
+      fakeAsync((async) {
+        final transport = MockSerialTransport();
+        final hds = HDSSerial(transport: transport);
+        final weights = <double>[];
+        hds.currentSnapshot.listen((snapshot) => weights.add(snapshot.weight));
+        hds.onConnect();
+        async.flushMicrotasks();
+        final invalid = weightFrame(10)..[6] ^= 0xFF;
+
+        transport.emitRawData(
+          Uint8List.fromList([...invalid, ...weightFrame(20)]),
+        );
+        async.flushMicrotasks();
+
+        expect(weights, [20]);
+      });
+    });
+  });
+
   group('HDSSerial watchdog', () {
     test('does not fire when data flows normally', () {
       fakeAsync((async) {
@@ -46,8 +148,29 @@ void main() {
         expect(
           transport.writtenHexCommands.length,
           greaterThan(initialCommands),
-          reason: 'Expected retry enable command after data gap',
         );
+        expect(
+          transport.writtenHexCommands.last,
+          Uint8List.fromList([0x03, 0x20, 0x01, 0x01]),
+        );
+      });
+    });
+
+    test('firmware text does not reset the watchdog', () {
+      fakeAsync((async) {
+        final transport = MockSerialTransport();
+        final hds = HDSSerial(transport: transport);
+        hds.onConnect();
+        async.flushMicrotasks();
+        transport.emitRawData(weightFrame(42));
+        async.flushMicrotasks();
+
+        for (var i = 0; i < 7; i++) {
+          transport.emitRawData(Uint8List.fromList(utf8.encode('log\n')));
+          async.elapse(const Duration(seconds: 2));
+        }
+
+        expect(transport.disconnectCalled, isTrue);
       });
     });
 
@@ -93,6 +216,8 @@ void main() {
         final hds = HDSSerial(transport: transport);
         hds.onConnect();
         async.elapse(Duration(milliseconds: 100));
+        transport.emitRawData(weightFrame(10));
+        async.flushMicrotasks();
 
         hds.disconnect();
         async.elapse(Duration(milliseconds: 100));

--- a/test/unit/devices/hds_serial_watchdog_test.dart
+++ b/test/unit/devices/hds_serial_watchdog_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -85,6 +86,29 @@ void main() {
 
         expect(error, same(transportError));
         expect(transport.disconnectCalled, isTrue);
+      });
+    });
+
+    test('handles a transport error while the enable write is pending', () {
+      fakeAsync((async) {
+        final writeCompleter = Completer<void>();
+        final transport = MockSerialTransport(writeCompleter: writeCompleter);
+        final hds = HDSSerial(transport: transport);
+        final transportError = StateError('USB removed during enable write');
+        Object? error;
+
+        hds.onConnect().catchError((Object caught) {
+          error = caught;
+        });
+        async.flushMicrotasks();
+        transport.emitRawError(transportError);
+        async.flushMicrotasks();
+
+        expect(error, same(transportError));
+        expect(transport.disconnectCalled, isTrue);
+
+        writeCompleter.complete();
+        async.flushMicrotasks();
       });
     });
 

--- a/test/unit/devices/hds_serial_watchdog_test.dart
+++ b/test/unit/devices/hds_serial_watchdog_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -6,6 +5,7 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale_serial.dart';
+import 'package:reaprime/src/models/errors.dart';
 
 import 'hds_serial_disconnect_test.dart';
 
@@ -64,7 +64,45 @@ void main() {
         async.elapse(const Duration(seconds: 3));
         async.flushMicrotasks();
 
-        expect(error, isA<TimeoutException>());
+        expect(error, isA<EndpointUnavailableException>());
+        expect(transport.disconnectCalled, isTrue);
+      });
+    });
+
+    test('preserves a transport error during initialization', () {
+      fakeAsync((async) {
+        final transport = MockSerialTransport();
+        final hds = HDSSerial(transport: transport);
+        final transportError = StateError('USB read failed');
+        Object? error;
+
+        hds.onConnect().catchError((Object caught) {
+          error = caught;
+        });
+        async.flushMicrotasks();
+        transport.emitRawError(transportError);
+        async.flushMicrotasks();
+
+        expect(error, same(transportError));
+        expect(transport.disconnectCalled, isTrue);
+      });
+    });
+
+    test('reports a closed transport during initialization', () {
+      fakeAsync((async) {
+        final transport = MockSerialTransport();
+        final hds = HDSSerial(transport: transport);
+        Object? error;
+
+        hds.onConnect().catchError((Object caught) {
+          error = caught;
+        });
+        async.flushMicrotasks();
+        transport.closeRawStream();
+        async.flushMicrotasks();
+
+        expect(error, isA<StateError>());
+        expect(error.toString(), contains('closed'));
         expect(transport.disconnectCalled, isTrue);
       });
     });
@@ -199,8 +237,14 @@ void main() {
 
         transport.emitRawData(weightFrame(10.0));
         async.elapse(Duration(milliseconds: 100));
+        final initialCommands = transport.writtenHexCommands.length;
 
-        async.elapse(Duration(seconds: 5));
+        async.elapse(Duration(seconds: 7));
+
+        expect(
+          transport.writtenHexCommands.length,
+          greaterThan(initialCommands),
+        );
 
         transport.emitRawData(weightFrame(20.0));
 

--- a/test/unit/devices/hds_serial_watchdog_test.dart
+++ b/test/unit/devices/hds_serial_watchdog_test.dart
@@ -112,6 +112,35 @@ void main() {
       });
     });
 
+    test('fails if transport errors after first frame but before enable', () {
+      fakeAsync((async) {
+        final writeCompleter = Completer<void>();
+        final transport = MockSerialTransport(writeCompleter: writeCompleter);
+        final hds = HDSSerial(transport: transport);
+        final transportError = StateError('USB removed before enable finished');
+        final states = <ConnectionState>[];
+        Object? error;
+        hds.connectionState.listen(states.add);
+
+        hds.onConnect().catchError((Object caught) {
+          error = caught;
+        });
+        async.flushMicrotasks();
+        transport.emitRawData(weightFrame(42));
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 3));
+        async.flushMicrotasks();
+        transport.emitRawError(transportError);
+        async.flushMicrotasks();
+        writeCompleter.complete();
+        async.flushMicrotasks();
+
+        expect(error, same(transportError));
+        expect(states, isNot(contains(ConnectionState.connected)));
+        expect(transport.disconnectCalled, isTrue);
+      });
+    });
+
     test('reports a closed transport during initialization', () {
       fakeAsync((async) {
         final transport = MockSerialTransport();


### PR DESCRIPTION
## Summary

What changed, and why?

- Send the OpenScale-compatible 10 Hz USB enable command and checksum-valid tare command.
- Keep HDS USB in `connecting` until a valid weight frame arrives, then parse fragmented/coalesced mixed serial input with checksum validation.
- Preserve USB read errors and early transport closure until both the enable write and first valid frame succeed, including when a frame arrives while the write is pending; report only a silent two-second readiness failure as `EndpointUnavailableException` rather than the connection manager's outer timeout.
- Refresh the watchdog only for valid weight frames and verify recovery after the retry threshold is reached.

## Linked Issue

Fixes #669

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- `flutter analyze` (passes)
- Focused HDS USB and shared BLE protocol tests: 61 tests pass
- VS2022 Windows debug build (passes)
- Physical HDS/OpenScale 3.1.13 or later verification on `COM5` (device advertised `FW: 3.1.13-dev-custom`): USB connected, weight frames arrived at about 10 Hz, tare returned 2.5 g to 0.0 g, and the connection remained healthy without initialization or watchdog errors
- Full `flutter test`: HDS tests pass; the repository suite retains unrelated Windows failures from CRLF-sensitive assertions, missing `quickjs_c_bridge.dll`, and local port collisions

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- Restores USB weight streaming and tare compatibility with HDS/OpenScale 3.1.13 or later.
- USB scales no longer appear connected before a validated weight stream is available.
- Initialization errors now retain their real cause and the two-second readiness timeout is no longer mislabeled as the connection manager's 30-second timeout.
- No API or migration impact.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
