### PR TITLE
fix(de1): separate refill-kit detection from override

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -5541,13 +5541,18 @@ components:
             refillKit:
               type: boolean
               description: >
-                Whether an automatic refill kit is detected on this machine.
+                Whether an automatic refill kit was detected on this machine.
                 Bit 0 of the refill-kit register as read at connect, before
-                Decaid resets that register to auto. Use this, not
-                `refillKitSetting`, to decide whether a machine refills itself:
-                on a plumbed machine in auto mode a low-water check against
+                Decaid writes auto back to that register. This is machine
+                detection, not configuration: writing `refillKitSetting` does
+                not change it, and it is fixed for the lifetime of the
+                connection.
+
+                Use this, not `refillKitSetting`, to decide whether a machine
+                refills itself: on a plumbed machine a low-water check against
                 WaterLevels.refillLevel fires more or less continuously, and
-                this is the only field that tells the two cases apart.
+                this is the only field that tells that case apart from a
+                machine with no kit.
             voltage:
               type: integer
               description: Heater supply voltage in volts, as reported by the machine.
@@ -6134,15 +6139,19 @@ components:
           enum: [120, 230]
         refillKitSetting:
           description: |
-            Refill kit behaviour to write: `2` = auto (default), `1` = force on,
+            Refill kit override: `2` = auto (default), `1` = force on,
             `0` = force off.
 
-            This does not persist. Decaid writes `2` (auto) to the same register
-            on every connect, so a force-on or force-off selection is lost the
-            next time the machine reconnects.
+            Writes the value to the machine's refill-kit register and updates
+            the override Decaid reports back. It does not change
+            `MachineInfo.extra.refillKit`, which is what the machine detected
+            at connect.
 
-            Note that a write and a read do not mean the same thing — see the
-            same field on `De1AdvancedSettingsResponse`.
+            The override is not persisted. Decaid writes `2` (auto) at connect,
+            so a force-on or force-off selection lasts only until the machine is
+            discovered and connected again.
+
+            Any value other than `0`, `1` or `2` is rejected with `400`.
           type: integer
           nullable: true
           enum: [0, 1, 2]
@@ -6170,22 +6179,16 @@ components:
           enum: [120, 230, -1]
         refillKitSetting:
           description: |
-            Refill kit register as last read from the machine. A read is a
-            **detection result**, not the configuration that was written:
-            `1` = a kit is detected, `0` = no kit detected.
+            Refill kit override currently in effect: `2` = auto, `1` = force on,
+            `0` = force off.
 
-            Decaid writes `2` (auto) at connect and the firmware resolves it, so
-            a value read back after connect is the firmware's answer. `2` is
-            only ever returned when a client wrote it during this connection and
-            the register has not been re-read since.
+            This is the configuration, not a detection result. Decaid writes `2`
+            (auto) at connect, so a machine that has not been written to since
+            reports `2` whether or not it has a kit fitted. For detection, read
+            `MachineInfo.extra.refillKit`.
 
-            Building a settings UI that presents `0` / `1` / `2` as three
-            user-chosen modes therefore misrepresents what a read returns.
-            `MachineInfo.extra.refillKit` is the same register's bit 0 and is
-            the clearer field to read for detection.
-
-            A value the app does not recognise (including the register never
-            having been read) is reported as `2`.
+            The value is served from Decaid's cache of the last override
+            written; the register is not re-read.
           type: integer
           enum: [0, 1, 2]
     De1CalibrationRequest:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -5532,7 +5532,28 @@ components:
           description: Whether GroupHeadController is present and active
         extra:
           type: object
-          description: various extra information.
+          description: >
+            Machine details read from MMR once at connect. The object stays
+            open — a firmware or model may contribute keys not listed here —
+            but these two are always present for a DE1.
+          additionalProperties: true
+          properties:
+            refillKit:
+              type: boolean
+              description: >
+                Whether an automatic refill kit is detected on this machine.
+                Bit 0 of the refill-kit register as read at connect, before
+                Decaid resets that register to auto. Use this, not
+                `refillKitSetting`, to decide whether a machine refills itself:
+                on a plumbed machine in auto mode a low-water check against
+                WaterLevels.refillLevel fires more or less continuously, and
+                this is the only field that tells the two cases apart.
+            voltage:
+              type: integer
+              description: Heater supply voltage in volts, as reported by the machine.
+          example:
+            refillKit: true
+            voltage: 220
 
     MachineCapabilities:
       type: object
@@ -6113,7 +6134,15 @@ components:
           enum: [120, 230]
         refillKitSetting:
           description: |
-            Refill kit behavior. `2` = auto (default), `1` = force on, `0` = force off.
+            Refill kit behaviour to write: `2` = auto (default), `1` = force on,
+            `0` = force off.
+
+            This does not persist. Decaid writes `2` (auto) to the same register
+            on every connect, so a force-on or force-off selection is lost the
+            next time the machine reconnects.
+
+            Note that a write and a read do not mean the same thing — see the
+            same field on `De1AdvancedSettingsResponse`.
           type: integer
           nullable: true
           enum: [0, 1, 2]
@@ -6141,7 +6170,22 @@ components:
           enum: [120, 230, -1]
         refillKitSetting:
           description: |
-            Refill kit behavior. `2` = auto, `1` = force on, `0` = force off.
+            Refill kit register as last read from the machine. A read is a
+            **detection result**, not the configuration that was written:
+            `1` = a kit is detected, `0` = no kit detected.
+
+            Decaid writes `2` (auto) at connect and the firmware resolves it, so
+            a value read back after connect is the firmware's answer. `2` is
+            only ever returned when a client wrote it during this connection and
+            the register has not been re-read since.
+
+            Building a settings UI that presents `0` / `1` / `2` as three
+            user-chosen modes therefore misrepresents what a read returns.
+            `MachineInfo.extra.refillKit` is the same register's bit 0 and is
+            the clearer field to read for detection.
+
+            A value the app does not recognise (including the register never
+            having been read) is reported as `2`.
           type: integer
           enum: [0, 1, 2]
     De1CalibrationRequest:

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -45,7 +45,7 @@ For browser clients on a different origin, `ETag` is exposed via `Access-Control
 | POST | `/api/v1/machine/settings` | Update machine settings (one grouped, serialized device write per request) | |
 | POST | `/api/v1/machine/shotSettings` | Update shot settings (steam temp, hot water, target volume, group temp) | |
 | GET | `/api/v1/machine/settings/advanced` | Advanced heater/phase settings | |
-| POST | `/api/v1/machine/settings/advanced` | Update advanced settings (heater phase flows/timeouts, idle temp, `heaterVoltage`, `refillKitSetting`). `refillKitSetting` does not persist — Decaid writes auto on every connect. Reading it back gives a detection result, not the written mode; `GET /api/v1/machine/info` -> `extra.refillKit` is the clearer detection field | |
+| POST | `/api/v1/machine/settings/advanced` | Update advanced settings (heater phase flows/timeouts, idle temp, `heaterVoltage`, `refillKitSetting`). `refillKitSetting` is an override (`0` force off, `1` force on, `2` auto) and is not persisted — Decaid writes auto at connect, so it lasts only for the current connection. It is not detection: `GET /api/v1/machine/info` -> `extra.refillKit` reports what the machine detected | |
 | DELETE | `/api/v1/machine/settings/reset` | Reset machine settings to defaults (fan, heater idle/phase flows + ph2 timeout, refill kit auto, flow multiplier 1.0, steam purge 0) — one grouped, serialized device write | |
 | GET | `/api/v1/machine/calibration` | Flow estimation calibration (`flowMultiplier`, calFlowEst MMR) | |
 | POST | `/api/v1/machine/calibration` | Update flow estimation calibration | |

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -45,7 +45,7 @@ For browser clients on a different origin, `ETag` is exposed via `Access-Control
 | POST | `/api/v1/machine/settings` | Update machine settings (one grouped, serialized device write per request) | |
 | POST | `/api/v1/machine/shotSettings` | Update shot settings (steam temp, hot water, target volume, group temp) | |
 | GET | `/api/v1/machine/settings/advanced` | Advanced heater/phase settings | |
-| POST | `/api/v1/machine/settings/advanced` | Update advanced settings (heater phase flows/timeouts, idle temp, `heaterVoltage`, `refillKitSetting`) | |
+| POST | `/api/v1/machine/settings/advanced` | Update advanced settings (heater phase flows/timeouts, idle temp, `heaterVoltage`, `refillKitSetting`). `refillKitSetting` does not persist — Decaid writes auto on every connect. Reading it back gives a detection result, not the written mode; `GET /api/v1/machine/info` -> `extra.refillKit` is the clearer detection field | |
 | DELETE | `/api/v1/machine/settings/reset` | Reset machine settings to defaults (fan, heater idle/phase flows + ph2 timeout, refill kit auto, flow multiplier 1.0, steam purge 0) — one grouped, serialized device write | |
 | GET | `/api/v1/machine/calibration` | Flow estimation calibration (`flowMultiplier`, calFlowEst MMR) | |
 | POST | `/api/v1/machine/calibration` | Update flow estimation calibration | |

--- a/lib/src/models/device/de1_interface.dart
+++ b/lib/src/models/device/de1_interface.dart
@@ -101,7 +101,10 @@ enum De1RefillKitSettings {
   final int hex;
   const De1RefillKitSettings(this.hex);
   factory De1RefillKitSettings.fromInt(int setting) {
-    return De1RefillKitSettings.values.firstWhere((e) => e.hex == setting);
+    return De1RefillKitSettings.values.firstWhere(
+      (e) => e.hex == setting,
+      orElse: () => De1RefillKitSettings.auto,
+    );
   }
 }
 

--- a/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
+++ b/lib/src/models/device/impl/de1/unified_de1/unified_de1.dart
@@ -239,7 +239,8 @@ class UnifiedDe1 implements De1Interface {
   @override
   String get name => "DE1";
   int _voltage = -1;
-  int _refillKit = -1;
+  int _refillKitDetected = -1;
+  De1RefillKitSettings _refillKitSetting = De1RefillKitSettings.auto;
   double? _cachedFlowEstimation;
   int? _connectedModelValue;
 
@@ -269,7 +270,9 @@ class UnifiedDe1 implements De1Interface {
     final serial = _unpackMMRInt(await _mmrRead(MMRItem.serialN));
     final firmware = _unpackMMRInt(await _mmrRead(MMRItem.cpuFirmwareBuild));
     _voltage = _unpackMMRInt(await _mmrRead(MMRItem.heaterV));
-    _refillKit = _unpackMMRInt(await _mmrRead(MMRItem.refillKitPresent));
+    _refillKitDetected = _unpackMMRInt(
+      await _mmrRead(MMRItem.refillKitPresent),
+    );
     try {
       _cachedFlowEstimation = await getFlowEstimation();
     } catch (e) {
@@ -281,12 +284,16 @@ class UnifiedDe1 implements De1Interface {
       model: DecentMachineModel.fromInt(model).name,
       serialNumber: "$serial",
       groupHeadControllerPresent: (ghcInfo & 0x04) > 1,
-      extra: {'refillKit': (_refillKit & 0x01) != 0, 'voltage': _voltage},
+      extra: {
+        'refillKit': (_refillKitDetected & 0x01) != 0,
+        'voltage': _voltage,
+      },
     );
 
     _log.info("Info: ${_info!.toJson()}");
 
-    await _mmrWrite(MMRItem.refillKitPresent, [0x02]);
+    await _mmrWrite(MMRItem.refillKitPresent, [De1RefillKitSettings.auto.hex]);
+    _refillKitSetting = De1RefillKitSettings.auto;
 
     await enableUserPresenceFeature();
   }
@@ -779,7 +786,7 @@ class UnifiedDe1 implements De1Interface {
 
   @override
   Future<De1RefillKitSettings> getRefillKitSettings() async {
-    return De1RefillKitSettings.fromInt(_refillKit);
+    return _refillKitSetting;
   }
 
   @override
@@ -791,6 +798,6 @@ class UnifiedDe1 implements De1Interface {
   @override
   Future<void> setRefillKitSettings(De1RefillKitSettings settings) async {
     await _writeMMRInt(MMRItem.refillKitPresent, settings.hex);
-    _refillKit = settings.hex;
+    _refillKitSetting = settings;
   }
 }

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -419,11 +419,20 @@ class De1Handler {
       final heaterVoltage = json['heaterVoltage'] == null
           ? null
           : De1HeaterVoltage.fromInt(parseInt(json['heaterVoltage']));
-      final refillKitSetting = json['refillKitSetting'] == null
+      final refillKitRaw = json['refillKitSetting'] == null
           ? null
-          : De1RefillKitSettings.values.firstWhere(
-              (e) => e.hex == parseInt(json['refillKitSetting']),
-            );
+          : parseInt(json['refillKitSetting']);
+      if (refillKitRaw != null &&
+          !De1RefillKitSettings.values.any((e) => e.hex == refillKitRaw)) {
+        return jsonBadRequest({
+          'error':
+              'refillKitSetting must be 0 (force off), 1 (force on) '
+              'or 2 (auto)',
+        });
+      }
+      final refillKitSetting = refillKitRaw == null
+          ? null
+          : De1RefillKitSettings.fromInt(refillKitRaw);
 
       return withQueuedDe1((de1) async {
         if (heaterPh1Flow != null) {

--- a/test/services/webserver/de1handler_settings_reset_test.dart
+++ b/test/services/webserver/de1handler_settings_reset_test.dart
@@ -141,6 +141,18 @@ void main() {
       },
     );
 
+    test('rejects a refillKitSetting outside 0/1/2 with 400', () async {
+      final de1 = MockDe1();
+      await wireWith(de1);
+
+      final res = await post('/api/v1/machine/settings/advanced', {
+        'refillKitSetting': 7,
+      });
+
+      expect(res.statusCode, 400);
+      expect(await de1.getRefillKitSettings(), De1RefillKitSettings.auto);
+    });
+
     test('returns 500 when no DE1 connected', () async {
       await wireWith(null);
       final res = await post('/api/v1/machine/settings/advanced', {

--- a/test/unit/models/device/impl/de1/unified_de1/refill_kit_semantics_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/refill_kit_semantics_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
+import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
+
+import '../../../../../../helpers/fake_ble_transport.dart';
+
+void main() {
+  group('refill kit detection vs configuration', () {
+    late FakeBleTransport transport;
+    late UnifiedDe1 de1;
+
+    Future<void> connect({required int detected}) async {
+      transport.queueOnConnectResponses(refillKitPresent: detected);
+      await de1.onConnect();
+    }
+
+    setUp(() {
+      transport = FakeBleTransport();
+      de1 = UnifiedDe1(transport: transport);
+    });
+
+    tearDown(() => transport.dispose());
+
+    test(
+      'a detected kit is published as machineInfo.extra.refillKit',
+      () async {
+        await connect(detected: 1);
+        expect(de1.machineInfo.extra['refillKit'], isTrue);
+      },
+    );
+
+    test(
+      'connect leaves the configuration at auto, not at the detected value',
+      () async {
+        await connect(detected: 1);
+        expect(
+          await de1.getRefillKitSettings(),
+          De1RefillKitSettings.auto,
+          reason:
+              'onConnect writes 0x02 to the register, so auto is what is set; '
+              'reporting forceOn here would be the detected value leaking out',
+        );
+      },
+    );
+
+    test('writing forceOff does not disturb the detected state', () async {
+      await connect(detected: 1);
+      await de1.setRefillKitSettings(De1RefillKitSettings.forceOff);
+
+      expect(await de1.getRefillKitSettings(), De1RefillKitSettings.forceOff);
+      expect(de1.machineInfo.extra['refillKit'], isTrue);
+    });
+
+    test('writing forceOn does not invent a detection', () async {
+      await connect(detected: 0);
+      await de1.setRefillKitSettings(De1RefillKitSettings.forceOn);
+
+      expect(await de1.getRefillKitSettings(), De1RefillKitSettings.forceOn);
+      expect(de1.machineInfo.extra['refillKit'], isFalse);
+    });
+
+    test('detection masks bit 0 while the configuration stays auto', () async {
+      await connect(detected: 0x81);
+
+      expect(de1.machineInfo.extra['refillKit'], isTrue);
+      expect(
+        await de1.getRefillKitSettings(),
+        De1RefillKitSettings.auto,
+        reason: 'a raw register value must never be parsed as a configuration',
+      );
+    });
+
+    test(
+      'the override survives a reconnect of the same device object',
+      () async {
+        await connect(detected: 1);
+        await de1.setRefillKitSettings(De1RefillKitSettings.forceOff);
+
+        await de1.onConnect();
+
+        expect(
+          await de1.getRefillKitSettings(),
+          De1RefillKitSettings.forceOff,
+          reason:
+              'onConnect returns early once _info is set, so no MMR write of '
+              'auto happens on a second connect of the same instance',
+        );
+      },
+    );
+
+    test('a freshly discovered device starts from auto again', () async {
+      await connect(detected: 1);
+      await de1.setRefillKitSettings(De1RefillKitSettings.forceOff);
+
+      final transport2 = FakeBleTransport();
+      addTearDown(transport2.dispose);
+      final de1b = UnifiedDe1(transport: transport2);
+      transport2.queueOnConnectResponses(refillKitPresent: 1);
+      await de1b.onConnect();
+
+      expect(await de1b.getRefillKitSettings(), De1RefillKitSettings.auto);
+      expect(de1b.machineInfo.extra['refillKit'], isTrue);
+    });
+
+    test('the connect-time write puts auto on the wire', () async {
+      await connect(detected: 1);
+
+      final addr = MMRItem.refillKitPresent.address;
+      final writes = transport.writes.where(
+        (w) => w.characteristicUUID == Endpoint.writeToMMR.uuid,
+      );
+      final refillWrites = writes.where((w) {
+        return w.data.length >= 5 &&
+            w.data[1] == (addr >> 16) & 0xFF &&
+            w.data[2] == (addr >> 8) & 0xFF &&
+            w.data[3] == addr & 0xFF;
+      }).toList();
+
+      expect(refillWrites, hasLength(1));
+      expect(refillWrites.single.data[4], 0x02);
+    });
+  });
+}

--- a/test/unit/models/device/refill_kit_settings_test.dart
+++ b/test/unit/models/device/refill_kit_settings_test.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:yaml/yaml.dart';
+
+YamlMap _schema(String name) {
+  final spec =
+      loadYaml(File('assets/api/rest_v1.yml').readAsStringSync()) as YamlMap;
+  return ((spec['components'] as YamlMap)['schemas'] as YamlMap)[name]
+      as YamlMap;
+}
+
+void main() {
+  group('De1RefillKitSettings.fromInt', () {
+    test('maps the three register values the machine defines', () {
+      expect(De1RefillKitSettings.fromInt(0), De1RefillKitSettings.forceOff);
+      expect(De1RefillKitSettings.fromInt(1), De1RefillKitSettings.forceOn);
+      expect(De1RefillKitSettings.fromInt(2), De1RefillKitSettings.auto);
+    });
+
+    test('falls back to auto instead of throwing on an unknown value', () {
+      // -1 is UnifiedDe1._refillKit before the connect-time MMR read lands, and
+      // the register can carry bits beyond the low one — extra.refillKit masks
+      // with 0x01 for exactly that reason. Neither may 500 GET
+      // /api/v1/machine/settings/advanced.
+      for (final raw in [-1, 3, 0x81, 255]) {
+        expect(
+          De1RefillKitSettings.fromInt(raw),
+          De1RefillKitSettings.auto,
+          reason: 'register value $raw must not throw',
+        );
+      }
+    });
+  });
+
+  test('MachineInfo.extra documents the refill-kit detection flag', () {
+    final extra =
+        (_schema('MachineInfo')['properties'] as YamlMap)['extra'] as YamlMap;
+    final properties = extra['properties'] as YamlMap;
+
+    expect(properties.keys, containsAll(<String>['refillKit', 'voltage']));
+    expect((properties['refillKit'] as YamlMap)['type'], 'boolean');
+    expect(
+      extra['additionalProperties'],
+      isTrue,
+      reason: 'extra stays open to keys this spec does not list',
+    );
+  });
+
+  test('a refillKitSetting read is documented as a detection result', () {
+    final response =
+        (_schema('De1AdvancedSettingsResponse')['properties']
+                as YamlMap)['refillKitSetting']
+            as YamlMap;
+
+    expect(response['description'], contains('detection result'));
+  });
+}

--- a/test/unit/models/device/refill_kit_settings_test.dart
+++ b/test/unit/models/device/refill_kit_settings_test.dart
@@ -20,10 +20,9 @@ void main() {
     });
 
     test('falls back to auto instead of throwing on an unknown value', () {
-      // -1 is UnifiedDe1._refillKit before the connect-time MMR read lands, and
-      // the register can carry bits beyond the low one — extra.refillKit masks
-      // with 0x01 for exactly that reason. Neither may 500 GET
-      // /api/v1/machine/settings/advanced.
+      // Configuration parsing only: the REST layer rejects an out-of-range
+      // refillKitSetting with 400 before this is reached, and detection never
+      // goes through here. The fallback keeps a stray value from throwing.
       for (final raw in [-1, 3, 0x81, 255]) {
         expect(
           De1RefillKitSettings.fromInt(raw),
@@ -48,12 +47,33 @@ void main() {
     );
   });
 
-  test('a refillKitSetting read is documented as a detection result', () {
+  test('refillKitSetting is documented as an override, not a detection', () {
     final response =
         (_schema('De1AdvancedSettingsResponse')['properties']
                 as YamlMap)['refillKitSetting']
             as YamlMap;
+    final description = response['description'] as String;
 
-    expect(response['description'], contains('detection result'));
+    expect(description, contains('override'));
+    expect(description, contains('not a detection result'));
+    expect(
+      description,
+      contains('MachineInfo.extra.refillKit'),
+      reason: 'a reader sent here for detection needs the field name',
+    );
+  });
+
+  test('MachineInfo.extra.refillKit is documented as detection', () {
+    final refillKit =
+        (((_schema('MachineInfo')['properties'] as YamlMap)['extra']
+                    as YamlMap)['properties']
+                as YamlMap)['refillKit']
+            as YamlMap;
+
+    expect(refillKit['description'], contains('detected'));
+    expect(
+      refillKit['description'],
+      contains('writing `refillKitSetting` does not change it'),
+    );
   });
 }


### PR DESCRIPTION
## Summary

What changed, and why?

Originally a docs-only PR. @tadelv's review was right that it documented an implementation ambiguity instead of fixing it, so the PR now fixes the model and the docs follow.

- `UnifiedDe1` kept two meanings in one field. `onConnect()` read MMR `refillKitPresent` into `_refillKit` and published bit 0 as `extra.refillKit`, then wrote auto back to the register **without** updating `_refillKit`; `setRefillKitSettings()` later overwrote the same field with the requested override. `getRefillKitSettings()` returned `De1RefillKitSettings.fromInt(_refillKit)`.

  The consequence was a wrong answer, not only unclear docs: straight after connect a machine with a kit reported `refillKitSetting: 1` (force on) and one without reported `0` (force off), while the register actually held `2` (auto, written at `unified_de1.dart:289`).

- Split along the `decentespresso/de1app` line between `refill_kit_detected` and `refill_kit_override`:

  ```dart
  int _refillKitDetected = -1;
  De1RefillKitSettings _refillKitSetting = De1RefillKitSettings.auto;
  ```

  - `_refillKitDetected` takes the connect-time MMR read and feeds `extra.refillKit` via `(_refillKitDetected & 0x01) != 0`. Nothing else writes it.
  - `_refillKitSetting` is set to `auto` right after the connect-time write, and updated by `setRefillKitSettings()`.
  - `getRefillKitSettings()` returns the override directly — no `fromInt` on a raw register value.

- `POST /api/v1/machine/settings/advanced` used `firstWhere` with no `orElse` on `refillKitSetting` (`de1handler.dart:424`) and threw a 500 on anything outside `0`/`1`/`2`. It now answers **400**. Not on the review list, but with `fromInt` falling back to `auto` an unvalidated boundary would silently turn `refillKitSetting: 7` into auto, so the two belong together.

- `De1RefillKitSettings.fromInt` keeps its `orElse: auto`, now reached only for configuration parsing. Detection never goes through it.

- Spec and `doc/Api.md` describe the two concepts separately. All "detection result" language is gone from `refillKitSetting`; `extra.refillKit` now states that writing `refillKitSetting` does not change it.

## Linked Issue

Fixes #671

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- New `test/unit/models/device/impl/de1/unified_de1/refill_kit_semantics_test.dart` — 8 tests driving `UnifiedDe1` through `FakeBleTransport`, as requested rather than enum conversion alone. `queueOnConnectResponses` already accepts `refillKitPresent`, so no new test harness was needed.

  | Test | Covers |
  |---|---|
  | a detected kit is published as `machineInfo.extra.refillKit` | detection reaches machine info |
  | connect leaves the configuration at auto, not at the detected value | **failed before the fix** (`forceOn`) |
  | writing `forceOff` does not disturb the detected state | review item 3 |
  | writing `forceOn` does not invent a detection | review item 4 |
  | detection masks bit 0 while the configuration stays auto | raw register never parsed as config |
  | the override survives a reconnect of the same device object | actual reconnect behaviour, see below |
  | a freshly discovered device starts from auto again | **failed before the fix** (`forceOn`) |
  | the connect-time write puts auto on the wire | asserts `0x02` on `writeToMMR` |

- Negative check: 2 of the 8 fail against the pre-fix code, both returning `forceOn` where `auto` is correct. The other 6 are regression guards for behaviour the split must not break.
- REST round-trip (review item 5) is already covered by the existing `round-trips through GET after write` in `de1handler_settings_reset_test.dart` — not duplicated. Added `rejects a refillKitSetting outside 0/1/2 with 400` there.
- `refill_kit_settings_test.dart` spec-contract assertions flipped from "documented as a detection result" to override wording, plus a new assertion that `extra.refillKit` is documented as detection.
- `flutter analyze` — `No issues found!`
- `flutter test` — `3341 passed, 6 failed`. The 6 are all in `test/webui_support/webui_token_injection_test.dart` (`getWifiIP` fallbacks), and the identical 6 fail on the base commit with the change stashed. Unrelated to this PR.
- Hardware evidence for the detection path unchanged from the original PR: a DE1XL over USB serial (2026-08-24 09:53) shows `mmr read: refillKitPresent` -> register `1` -> `extra: {refillKit: true, voltage: 220}` -> `mmr write: refillKitPresent`.

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- **Behaviour (bug fix):** `GET /api/v1/machine/settings/advanced` -> `refillKitSetting` now reports the override. Before the fix it reported the detected register value straight after connect, so a plumbed machine read back `1` (force on) although auto was in effect. A client that treated that GET as the current mode was reading detection.
- **Behaviour:** `GET .../advanced` no longer 500s when the register holds a value outside `0`/`1`/`2` (including `-1`, before the connect-time read lands).
- **API:** `POST .../advanced` with a `refillKitSetting` outside `0`/`1`/`2` now returns **400** instead of **500**. A client sending a valid value sees no change.
- **Spec:** `MachineInfo.extra` gains named `refillKit` and `voltage` properties (payload unchanged — Decaid already sends both), `additionalProperties: true`. Both `refillKitSetting` descriptions rewritten as override; enum values unchanged.
- **User-visible:** none directly. Enables skins to suppress spurious low-water warnings on plumbed machines — the Streamline case in decentespresso/streamline-js#60.
- **Docs:** `doc/Api.md` advanced-settings row rewritten.
- **Security:** none.

## Notes for the reviewer

**One correction to review item 7.** Reconnect does *not* return the configuration to auto. `onConnect()` has `if (_info != null) return;` at `unified_de1.dart:256`, so reconnecting the same device object skips the whole MMR block, including the write of auto — the override survives. Only a device discovered afresh starts from auto. Two tests pin both halves, and the spec says "lasts only until the machine is discovered and connected again" rather than "every connect". The original PR description claimed the latter; it was wrong.

Kept out of scope, per the review: no WebSocket refill-kit state, no persistence of the override across restarts, no new settings storage, no water-level API changes. The masking inconsistency I raised previously is resolved by construction — `fromInt` no longer sees raw register values at all, so there is nothing left to reconcile.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfCnQuQG7i7obdVdkCRG69
