### PR TITLE
feat(plugins): apply plugin settings immediately after save (gh-655)

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -2785,7 +2785,9 @@ paths:
       description: >
         Applies a settings patch. Omitted fields preserve the existing value;
         a null value clears the setting. For secure fields, an isSet state
-        object preserves the stored credential; null clears it. The response
+        object preserves the stored credential; null clears it. If the plugin
+        is loaded, it is reloaded so the running instance picks up the patch;
+        if it is unloaded, the patch is only persisted. The response
         is always redacted and never echoes a submitted credential.
       parameters:
         - name: id

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -288,7 +288,7 @@ Settings fields include: `gatewayMode`, `themeMode`, `logLevel`, `weightFlowMult
 |--------|------|-------------|---------|
 | GET | `/api/v1/plugins` | List all plugins (with `loaded`, `autoLoad`, `source`, `pendingUpdate` fields) | `plugins_handler.dart` |
 | GET | `/api/v1/plugins/:id/settings` | Get plugin settings; secure fields return `{isSet}` only | |
-| POST | `/api/v1/plugins/:id/settings` | Patch plugin settings (omitted preserves, `null` clears) and return a redacted result | |
+| POST | `/api/v1/plugins/:id/settings` | Patch plugin settings (omitted preserves, `null` clears), reload the plugin if loaded, and return a redacted result | |
 | POST | `/api/v1/plugins/:id/enable` | Load plugin + enable auto-load | |
 | POST | `/api/v1/plugins/:id/disable` | Unload plugin + disable auto-load | |
 | DELETE | `/api/v1/plugins/:id` | Remove plugin (unload + delete files) | |

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -586,7 +586,7 @@ Plugins can be managed via REST API:
 | POST | `/api/v1/plugins/update` | Check every GitHub-backed plugin for updates |
 | POST | `/api/v1/plugins/:id/update/approve` | Install an update that requests new permissions |
 | GET | `/api/v1/plugins/:id/settings` | Get plugin settings |
-| POST | `/api/v1/plugins/:id/settings` | Update plugin settings |
+| POST | `/api/v1/plugins/:id/settings` | Update plugin settings; reloads the plugin if it is loaded so the change applies immediately |
 
 `PUT /api/v1/plugins/:id/source` writes `manifest.json` and `plugin.js` for
 that id, creating the plugin if it is not installed yet:

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -527,41 +527,49 @@ class PluginLoaderService {
   Future<void> savePluginSettings(
     String pluginId,
     Map<String, dynamic> settings,
-  ) => _withPluginSettingsLock(pluginId, () async {
-    _ensureActive();
-    final manifest = _availablePluginsCache[pluginId];
-    if (manifest == null) {
-      throw Exception('Plugin not found: $pluginId');
+  ) async {
+    await _withPluginSettingsLock(pluginId, () async {
+      _ensureActive();
+      final manifest = _availablePluginsCache[pluginId];
+      if (manifest == null) {
+        throw Exception('Plugin not found: $pluginId');
+      }
+
+      _validateSettings(manifest, settings);
+      final stored = await _storedSettings(manifest);
+      final secureKeys = _secureSettingKeys(manifest);
+      final ordinaryPatch = Map.fromEntries(
+        settings.entries.where((entry) => !secureKeys.contains(entry.key)),
+      );
+      var secure = stored.secure;
+      for (final entry in settings.entries.where(
+        (entry) => secureKeys.contains(entry.key),
+      )) {
+        if (_isSecureState(entry.value)) continue;
+        secure = entry.value == null
+            ? Map.fromEntries(
+                secure.entries.where((current) => current.key != entry.key),
+              )
+            : {...secure, entry.key: entry.value};
+      }
+
+      final mergedOrdinary = {...stored.ordinary, ...ordinaryPatch};
+      for (final entry in ordinaryPatch.entries) {
+        if (entry.value == null) mergedOrdinary.remove(entry.key);
+      }
+
+      await _writeSecureSettings(pluginId, secure);
+      await _writeOrdinarySettings(pluginId, mergedOrdinary);
+
+      _log.fine('Settings saved for plugin: $pluginId');
+    });
+
+    // Reload only after the settings lock above is released: the load path
+    // re-reads settings under that same lock.
+    if (isPluginLoaded(pluginId)) {
+      await reloadPlugin(pluginId);
     }
-
-    _validateSettings(manifest, settings);
-    final stored = await _storedSettings(manifest);
-    final secureKeys = _secureSettingKeys(manifest);
-    final ordinaryPatch = Map.fromEntries(
-      settings.entries.where((entry) => !secureKeys.contains(entry.key)),
-    );
-    var secure = stored.secure;
-    for (final entry in settings.entries.where(
-      (entry) => secureKeys.contains(entry.key),
-    )) {
-      if (_isSecureState(entry.value)) continue;
-      secure = entry.value == null
-          ? Map.fromEntries(
-              secure.entries.where((current) => current.key != entry.key),
-            )
-          : {...secure, entry.key: entry.value};
-    }
-
-    final mergedOrdinary = {...stored.ordinary, ...ordinaryPatch};
-    for (final entry in ordinaryPatch.entries) {
-      if (entry.value == null) mergedOrdinary.remove(entry.key);
-    }
-
-    await _writeSecureSettings(pluginId, secure);
-    await _writeOrdinarySettings(pluginId, mergedOrdinary);
-
-    _log.fine('Settings saved for plugin: $pluginId');
-  });
+  }
 
   List<PluginManifest> get availablePlugins {
     return _availablePluginsCache.values.toList();

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -444,15 +444,22 @@ class PluginLoaderService {
       if (!isPluginLoaded(pluginId)) {
         throw Exception('Plugin not loaded: $pluginId');
       }
-
-      _log.info('Reloading plugin: $pluginId');
-
-      await _unloadPlugin(pluginId);
-
-      await _queuedLoad(pluginId);
-
-      _log.info('Plugin reloaded: $pluginId');
+      await _reloadPluginLocked(pluginId);
     });
+  }
+
+  Future<void> _reloadPluginIfLoaded(String pluginId) async {
+    return _withPluginMutationLock(pluginId, () async {
+      if (!isPluginLoaded(pluginId)) return;
+      await _reloadPluginLocked(pluginId);
+    });
+  }
+
+  Future<void> _reloadPluginLocked(String pluginId) async {
+    _log.info('Reloading plugin: $pluginId');
+    await _unloadPlugin(pluginId);
+    await _queuedLoad(pluginId);
+    _log.info('Plugin reloaded: $pluginId');
   }
 
   Future<void> setPluginAutoLoad(String pluginId, bool enabled) {
@@ -565,10 +572,11 @@ class PluginLoaderService {
     });
 
     // Reload only after the settings lock above is released: the load path
-    // re-reads settings under that same lock.
-    if (isPluginLoaded(pluginId)) {
-      await reloadPlugin(pluginId);
-    }
+    // re-reads settings under that same lock. The reload-if-loaded decision
+    // and the reload itself are one serialized mutation operation, so a
+    // concurrent unload cannot fail the save after the settings were
+    // persisted.
+    await _reloadPluginIfLoaded(pluginId);
   }
 
   List<PluginManifest> get availablePlugins {

--- a/lib/src/services/webserver/plugins_handler.dart
+++ b/lib/src/services/webserver/plugins_handler.dart
@@ -419,7 +419,6 @@ final class PluginsHandler {
       } on PluginSettingsValidationException catch (e) {
         return jsonBadRequest({'error': e.message});
       }
-      await pluginService.reloadPlugin(id);
       return jsonOk(await pluginService.pluginSettings(id));
     });
   }

--- a/test/plugin_loader_service_appstore_test.dart
+++ b/test/plugin_loader_service_appstore_test.dart
@@ -104,11 +104,26 @@ void main() {
     late Directory tempDir;
     late PluginLoaderService service;
     late FakeCredentialStore credentialStore;
+    late FakeKvStore kvStore;
     var sourceCounter = 0;
+
+    Future<Object?> waitForStorage(
+      String namespace,
+      String key,
+      Object? expected,
+    ) async {
+      for (var i = 0; i < 200; i++) {
+        final value = await kvStore.get(namespace: namespace, key: key);
+        if (value == expected) return value;
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      return kvStore.get(namespace: namespace, key: key);
+    }
 
     Directory makePluginSource(
       String id, {
       Map<String, Object> settings = const {},
+      List<String> permissions = const [],
       String? jsCode,
     }) {
       final dir = Directory('${tempDir.path}/source_${sourceCounter++}')
@@ -121,7 +136,7 @@ void main() {
           'description': 'Test plugin',
           'version': '1.0.0',
           'apiVersion': 1,
-          'permissions': <String>[],
+          'permissions': permissions,
           'settings': settings,
           'api': <Object>[],
         }),
@@ -146,8 +161,9 @@ function createPlugin() {
             (_) async => tempDir.path,
           );
       credentialStore = FakeCredentialStore();
+      kvStore = FakeKvStore();
       service = PluginLoaderService(
-        kvStore: FakeKvStore(),
+        kvStore: kvStore,
         credentialStore: credentialStore,
       );
       await service.initialize();
@@ -511,6 +527,127 @@ function createPlugin() {
         'Password': {'isSet': true},
       });
     });
+
+    test(
+      'saving settings for a loaded plugin reloads it with the new value',
+      () async {
+        const id = 'live-apply.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Mode': {'type': 'string'},
+            },
+            permissions: ['pluginStorage'],
+            jsCode:
+                '''
+function createPlugin(host) {
+  return {
+    id: "$id",
+    onLoad(settings) {
+      globalThis.__modeLoads = (globalThis.__modeLoads || 0) + 1;
+      host.storage({type: "write", key: "mode",
+        data: globalThis.__modeLoads + ":" + settings.Mode});
+    }
+  };
+}
+''',
+          ).path,
+        );
+
+        await service.savePluginSettings(id, {'Mode': 'off'});
+        await service.loadPlugin(id);
+        expect(await waitForStorage(id, 'mode', '1:off'), '1:off');
+
+        await service.savePluginSettings(id, {'Mode': 'auto'});
+
+        expect(service.isPluginLoaded(id), isTrue);
+        expect(
+          await waitForStorage(id, 'mode', '2:auto'),
+          '2:auto',
+          reason: 'save must reload the loaded plugin exactly once ',
+        );
+      },
+    );
+
+    test('saving settings for an unloaded plugin leaves it unloaded', () async {
+      const id = 'unloaded-save.reaplugin';
+      await service.addPlugin(
+        makePluginSource(
+          id,
+          settings: {
+            'Mode': {'type': 'string'},
+          },
+        ).path,
+      );
+
+      await service.savePluginSettings(id, {'Mode': 'auto'});
+
+      expect(service.isPluginLoaded(id), isFalse);
+      expect(await service.pluginSettings(id), {'Mode': 'auto'});
+    });
+
+    test(
+      'concurrent saves on a loaded plugin reload without deadlocking',
+      () async {
+        const id = 'concurrent-loaded.reaplugin';
+        const credentialKey = 'plugin.settings.secure.$id';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Username': {'type': 'string'},
+              'Password': {'type': 'string', 'secure': true},
+            },
+            jsCode:
+                '''
+function createPlugin() {
+  return { id: "$id", onLoad() {} };
+}
+''',
+          ).path,
+        );
+        credentialStore.values = {
+          credentialKey: jsonEncode({'Password': 'old-secret'}),
+        };
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString(
+          'plugin.settings.$id',
+          jsonEncode({'Username': 'old-user'}),
+        );
+        await service.loadPlugin(id);
+
+        final staleWriteStarted = Completer<void>();
+        final releaseStaleWrite = Completer<void>();
+        credentialStore.blockNextWrite(
+          staleWriteStarted,
+          releaseStaleWrite.future,
+        );
+
+        final usernameUpdate = service.savePluginSettings(id, {
+          'Username': 'new-user',
+        });
+        await staleWriteStarted.future;
+        final passwordUpdate = service.savePluginSettings(id, {
+          'Password': 'new-secret',
+        });
+        await Future<void>.delayed(Duration.zero);
+        releaseStaleWrite.complete();
+        await Future.wait([usernameUpdate, passwordUpdate]);
+
+        expect(service.isPluginLoaded(id), isTrue);
+        expect(jsonDecode(credentialStore.values[credentialKey]!), {
+          'Password': 'new-secret',
+        });
+        expect(jsonDecode(prefs.getString('plugin.settings.$id')!), {
+          'Username': 'new-user',
+        });
+        expect(await service.pluginSettings(id), {
+          'Username': 'new-user',
+          'Password': {'isSet': true},
+        });
+      },
+    );
 
     const unsafeIds = [
       '',

--- a/test/plugin_loader_service_appstore_test.dart
+++ b/test/plugin_loader_service_appstore_test.dart
@@ -54,6 +54,13 @@ class FakeCredentialStore implements CredentialStore {
 
 class FakeKvStore implements KeyValueStoreService {
   final Map<String, Map<String, Object>> _store = {};
+  Completer<void>? _nextWriteStarted;
+  Future<void>? _nextWriteRelease;
+
+  void blockNextWrite(Completer<void> started, Future<void> release) {
+    _nextWriteStarted = started;
+    _nextWriteRelease = release;
+  }
 
   @override
   Future<void> initialize() async {}
@@ -64,6 +71,14 @@ class FakeKvStore implements KeyValueStoreService {
     required String key,
     required Object value,
   }) async {
+    final started = _nextWriteStarted;
+    if (started != null) {
+      final release = _nextWriteRelease!;
+      _nextWriteStarted = null;
+      _nextWriteRelease = null;
+      started.complete();
+      await release;
+    }
     _store.putIfAbsent(namespace, () => {})[key] = value;
   }
 
@@ -648,6 +663,49 @@ function createPlugin() {
         });
       },
     );
+
+    test('a disable racing a settings save does not fail the save', () async {
+      const id = 'save-disable-race.reaplugin';
+      await service.addPlugin(
+        makePluginSource(
+          id,
+          settings: {
+            'Mode': {'type': 'string'},
+          },
+          permissions: ['pluginStorage'],
+          jsCode:
+              '''
+function createPlugin(host) {
+  return {
+    id: "$id",
+    onUnload() {
+      host.storage({type: "write", key: "unloaded", data: true});
+    }
+  };
+}
+''',
+        ).path,
+      );
+      await service.savePluginSettings(id, {'Mode': 'auto'});
+      await service.loadPlugin(id);
+
+      // Hold the mutation lock inside disable's unload (its onUnload storage
+      // write blocks) while the save persists and then attempts to apply.
+      final unloadStarted = Completer<void>();
+      final releaseUnload = Completer<void>();
+      kvStore.blockNextWrite(unloadStarted, releaseUnload.future);
+
+      final disable = service.disablePlugin(id);
+      await unloadStarted.future;
+      final save = service.savePluginSettings(id, {'Mode': 'fast'});
+      await Future<void>.delayed(Duration.zero);
+      releaseUnload.complete();
+
+      await Future.wait([save, disable]);
+
+      expect(service.isPluginLoaded(id), isFalse);
+      expect(await service.pluginSettings(id), {'Mode': 'fast'});
+    });
 
     const unsafeIds = [
       '',

--- a/test/services/webserver/plugins_handler_test.dart
+++ b/test/services/webserver/plugins_handler_test.dart
@@ -17,6 +17,7 @@ class _SettingsPluginLoaderService extends Fake implements PluginLoaderService {
     'Password': {'isSet': true},
   };
   Map<String, dynamic>? savedPatch;
+  int reloadCalls = 0;
 
   @override
   Future<Map<String, dynamic>> pluginSettings(String pluginId) async =>
@@ -31,7 +32,9 @@ class _SettingsPluginLoaderService extends Fake implements PluginLoaderService {
   }
 
   @override
-  Future<void> reloadPlugin(String pluginId) async {}
+  Future<void> reloadPlugin(String pluginId) async {
+    reloadCalls += 1;
+  }
 }
 
 void main() {
@@ -124,6 +127,30 @@ void main() {
       });
       expect(response.statusCode, 200);
     });
+
+    test(
+      'POST delegates the reload to the service instead of reloading',
+      () async {
+        final response = await app.call(
+          Request(
+            'POST',
+            Uri.parse('http://localhost/api/v1/plugins/$pluginId/settings'),
+            headers: {'content-type': 'application/json'},
+            body: jsonEncode({'Username': 'new-user'}),
+          ),
+        );
+
+        expect(response.statusCode, 200);
+        expect(pluginService.savedPatch, {'Username': 'new-user'});
+        expect(
+          pluginService.reloadCalls,
+          0,
+          reason:
+              'apply-on-save lives in savePluginSettings; the handler '
+              'must not reload as well',
+        );
+      },
+    );
   });
 
   test('synchronous plugin response completes the request directly', () async {

--- a/test/webserver/plugins_handler_update_test.dart
+++ b/test/webserver/plugins_handler_update_test.dart
@@ -16,6 +16,7 @@ void main() {
   group('PUT /api/v1/plugins/<id>/source', () {
     late Directory tempDir;
     late PluginLoaderService service;
+    late FakeKeyValueStoreService kvStore;
     late Handler handler;
 
     Map<String, dynamic> manifestJson(String id, {String version = '1.0.0'}) =>
@@ -40,10 +41,32 @@ function createPlugin() {
 
     const brokenJs = 'function createPlugin() { throw new Error("boom"); }';
 
+    Future<Object?> waitForStorage(
+      String namespace,
+      String key,
+      Object? expected,
+    ) async {
+      for (var i = 0; i < 200; i++) {
+        final value = await kvStore.get(namespace: namespace, key: key);
+        if (value == expected) return value;
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      return kvStore.get(namespace: namespace, key: key);
+    }
+
     Future<Response> put(String id, Object body) async => handler(
       Request(
         'PUT',
         Uri.parse('http://localhost/api/v1/plugins/$id/source'),
+        body: jsonEncode(body),
+        headers: {'content-type': 'application/json'},
+      ),
+    );
+
+    Future<Response> postSettings(String id, Object body) async => handler(
+      Request(
+        'POST',
+        Uri.parse('http://localhost/api/v1/plugins/$id/settings'),
         body: jsonEncode(body),
         headers: {'content-type': 'application/json'},
       ),
@@ -71,7 +94,8 @@ function createPlugin() {
             const MethodChannel('plugins.flutter.io/path_provider'),
             (_) async => tempDir.path,
           );
-      service = PluginLoaderService(kvStore: FakeKeyValueStoreService());
+      kvStore = FakeKeyValueStoreService();
+      service = PluginLoaderService(kvStore: kvStore);
       await service.initialize();
       final app = Router().plus;
       PluginsHandler(
@@ -303,6 +327,48 @@ function createPlugin() {
 
       expect(res.statusCode, 400);
       expect(Directory('${tempDir.parent.path}/escape').existsSync(), isFalse);
+    });
+
+    test('POST settings applies via a single service-level reload', () async {
+      const id = 'post-settings.reaplugin';
+      final dir = Directory('${tempDir.path}/source_post_settings')
+        ..createSync(recursive: true);
+      File('${dir.path}/manifest.json').writeAsStringSync(
+        jsonEncode({
+          ...manifestJson(id),
+          'permissions': ['pluginStorage'],
+          'settings': {
+            'Mode': {'type': 'string'},
+          },
+        }),
+      );
+      File('${dir.path}/plugin.js').writeAsStringSync('''
+function createPlugin(host) {
+  return {
+    id: "$id",
+    onLoad(settings) {
+      globalThis.__modeLoads = (globalThis.__modeLoads || 0) + 1;
+      host.storage({type: "write", key: "mode",
+        data: globalThis.__modeLoads + ":" + settings.Mode});
+    }
+  };
+}
+''');
+      await service.addPlugin(dir.path);
+      await service.savePluginSettings(id, {'Mode': 'off'});
+      await service.loadPlugin(id);
+      expect(await waitForStorage(id, 'mode', '1:off'), '1:off');
+
+      final res = await postSettings(id, {'Mode': 'auto'});
+
+      expect(res.statusCode, 200);
+      expect(jsonDecode(await res.readAsString()), {'Mode': 'auto'});
+      expect(service.isPluginLoaded(id), isTrue);
+      expect(
+        await waitForStorage(id, 'mode', '2:auto'),
+        '2:auto',
+        reason: 'REST save must reload the loaded plugin exactly once',
+      );
     });
   });
 }


### PR DESCRIPTION
Fixes #655

## Problem

Saving plugin settings from the in-app Settings UI persisted them to disk but left the already-running plugin on its stale in-memory settings. `POST /api/v1/plugins/<id>/settings` worked around this by reloading the plugin in the handler, so REST saves took effect immediately while native UI saves did not — until app restart or a manual unload/load.

## Change

Centralize the apply step in `PluginLoaderService.savePluginSettings`:

- Persist and validate settings exactly as before (unchanged, under the existing per-plugin settings lock).
- Only after the settings lock is fully released, reload the plugin if it is currently loaded, so the new instance receives the persisted settings. The reload happens exactly once and is awaited before the save reports success; reload failures propagate instead of silently claiming the new settings are active.
- An unloaded plugin stays unloaded — saving never implicitly enables or loads a plugin.

The REST handler no longer reloads explicitly; both the native Settings UI and the REST endpoint share the single service-level save-and-apply path.

Locking: the settings write releases the settings lock before the reload enters the load path (`_pluginSettingsForLoad` re-acquires that lock), preserving the existing serialization guarantees for ordinary/secure settings, concurrent patches, and plugin mutation/reload operations. No locks were weakened or bypassed.

## Out of scope (per #655)

- `DrainHistory` retry-after-connection, `shot-upload.reaplugin` backlog-drain, plugin log severity/visibility, and a new `settingsUpdated` event are separate concerns and are not included.

## Tests

- Loaded plugin: saving settings reloads it exactly once and the new instance receives the new value (JS load counter via plugin storage).
- Unloaded plugin: save persists but leaves it unloaded.
- Concurrent saves on a loaded plugin complete without deadlocking.
- REST POST settings applies via the service-level reload (no duplicate reload); handler-contract test pins that the handler does not call `reloadPlugin` itself.

Verification: `flutter analyze` clean; full `flutter test` 3337 pass (remaining failures are pre-existing on `main` in this environment — webui token-injection and a known `mmr_codec` parallel-run flake).