### PR TITLE
fix(account): parse serial numbers tolerantly (SKU-annotated responses)

### DIFF
--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -1,6 +1,17 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 
+List<String> parseSerialNumbers(String body) {
+  return const LineSplitter()
+      .convert(body)
+      .map((line) => line.trim())
+      .where((line) => line.isNotEmpty)
+      .map((line) => line.split(RegExp(r'\s+')).first)
+      .where((serial) => serial.isNotEmpty)
+      .toSet()
+      .toList();
+}
+
 abstract class CredentialStore {
   Future<String?> read({required String key});
 
@@ -62,13 +73,17 @@ class DecentAccountService {
         'serial fetch failed (${response.statusCode}): ${response.body.trim()}',
       );
     }
-    if (response.body.trim() == '0') {
-      throw StateError("Unexpected response: ${response.body.trim()}");
+    final body = response.body.trim();
+
+    if (body == '0') {
+      throw StateError('Unexpected response: $body');
     }
-    if (response.body.isEmpty) {
+
+    if (body.isEmpty) {
       return [];
     }
-    return response.body.trim().split('\n');
+
+    return parseSerialNumbers(body);
   }
 
   Future<bool> verifyMachineSerial(String serial) async {

--- a/test/services/account/decent_account_service_test.dart
+++ b/test/services/account/decent_account_service_test.dart
@@ -254,6 +254,25 @@ void main() {
         expect(serials, ['DE1-0001', 'DE1-0042']);
       });
 
+      test('parses SKU-annotated response from the real backend', () async {
+        httpClient = _mockClient(
+          statusCode: 200,
+          body:
+              '1337 DE-BE1BENGLE220V_15A_3000W_B0-01101\n'
+              '1338 DE-DE1PRO220V7-00533',
+        );
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+        await store.write(key: 'email', value: 'test@example.com');
+        await store.write(key: 'password', value: 'cryptpw_abc123');
+
+        final serials = await service.fetchSerialNumbers();
+        expect(serials, ['1337', '1338']);
+      });
+
       test('returns empty list when API responds with empty body', () async {
         httpClient = _mockClient(statusCode: 200, body: '');
         service = DecentAccountService(
@@ -288,9 +307,52 @@ void main() {
       });
     });
 
+    group('parseSerialNumbers', () {
+      test('parses bare serial numbers', () {
+        expect(parseSerialNumbers('1337\n1338'), ['1337', '1338']);
+      });
+
+      test('parses serials with SKU metadata', () {
+        expect(
+          parseSerialNumbers(
+            '1337 DE-BE1BENGLE220V_15A_3000W_B0-01101\n'
+            '1338 DE-DE1PRO220V7-00533',
+          ),
+          ['1337', '1338'],
+        );
+      });
+
+      test('handles CRLF responses', () {
+        expect(parseSerialNumbers('1337\r\n1338\r\n'), ['1337', '1338']);
+      });
+
+      test('handles CR-only responses', () {
+        expect(parseSerialNumbers('1337\r1338\r'), ['1337', '1338']);
+      });
+
+      test('ignores blank lines and surrounding whitespace', () {
+        expect(
+          parseSerialNumbers(
+            '  1337   DE-BE1BENGLE220V_15A_3000W_B0-01101  \n\n'
+            '   1338   DE-DE1PRO220V7-00533   ',
+          ),
+          ['1337', '1338'],
+        );
+      });
+
+      test('deduplicates serial numbers', () {
+        expect(parseSerialNumbers('1337\n1337 DE-SOMETHING'), ['1337']);
+      });
+    });
+
     group('verifyMachineSerial', () {
       test('returns true when serial is in account serials', () async {
-        httpClient = _mockClient(statusCode: 200, body: 'DE1-0001\nDE1-0042');
+        httpClient = _mockClient(
+          statusCode: 200,
+          body:
+              '1337 DE-BE1BENGLE220V_15A_3000W_B0-01101\n'
+              '1338 DE-DE1PRO220V7-00533',
+        );
         service = DecentAccountService(
           httpClient: httpClient,
           credentialStore: store,
@@ -299,7 +361,7 @@ void main() {
         await store.write(key: 'email', value: 'test@example.com');
         await store.write(key: 'password', value: 'cryptpw_abc123');
 
-        final result = await service.verifyMachineSerial('DE1-0042');
+        final result = await service.verifyMachineSerial('1338');
         expect(result, isTrue);
       });
 


### PR DESCRIPTION
## Summary
The serial endpoint (`/support/api/sn?onlyespressomachines=1`) returns one machine record per line. Current parsing assumed each line was exactly a serial number, which breaks when the backend also returns SKU metadata per line, e.g.:

```
1337 DE-BE1BENGLE220V_15A_3000W_B0-01101
1338 DE-DE1PRO220V7-00533
```

Extract parsing into a pure `parseSerialNumbers()` helper: one machine record per line, first whitespace-delimited field is the serial. Tolerates LF/CRLF/CR line endings, surrounding whitespace, blank lines, and duplicate serials. The request URL is unchanged — this is defensive parsing, not a backend contract change.

## Verification
- Existing bare-serial responses continue to work
- SKU-annotated responses parse correctly
- `verifyMachineSerial('1338')` succeeds for both `1338` and `1338 DE-DE1PRO220V7-00533`
- HTTP/error handling unchanged
- Tests: 6 regression cases for the new helper + integration test using a real backend response shape (SKU-annotated)
- `flutter analyze` clean, full `flutter test` passes (3352 tests)

## Files
- `lib/src/services/account/decent_account_service.dart`
- `test/services/account/decent_account_service_test.dart`

Closes: none (hardening change)