### PR TITLE
fix(plugins): reconcile persisted settings against the current manifest schema

### DIFF
--- a/doc/AI_STORAGE_NOTES.md
+++ b/doc/AI_STORAGE_NOTES.md
@@ -121,6 +121,50 @@ omissions — which offset paging cannot guarantee. The page functions are
 built in `main.dart` from the DAOs and carried by `BackupDataSources`; the
 storage service interfaces are unchanged.
 
+## Plugin Settings Schema Reconciliation (issue #655 follow-up)
+
+Persisted plugin settings are values of the **current manifest schema**, not
+an independent schema-less document. Every read path (Flutter settings UI,
+REST GET, plugin load/reload, future frontends) routes through
+`PluginLoaderService._storedSettings()`, which reconciles persisted ordinary
+and secure settings against the current `PluginManifest`:
+
+- Key no longer declared by the manifest -> dropped (a manifest with
+  `settings: {}` therefore drops every previously persisted value).
+- Enum value no longer in `values` -> reset to the manifest `default` when
+  that default is itself a declared value, otherwise dropped.
+- Value incompatible with the declared type (`string`/`number`/`boolean`) ->
+  reset to the manifest `default` when the default matches the type,
+  otherwise dropped.
+- Cleaned state is written back to storage (`plugin.settings.<id>` and the
+  secure store) so stale values do not return.
+- Settings whose schema has no usable `type` are left untouched (cannot be
+  judged).
+- **Secure values are not opaque**: the same enum/type reconciliation applies
+  to values in secure storage. Reconciliation always happens in secure
+  storage only — a value that no longer fits the schema is reset or dropped
+  and is never written to ordinary storage.
+- Keys that are `secure: true` in the current manifest are migrated out of
+  ordinary storage by the legacy migration path. A value whose secure flag
+  was removed is never copied back into plaintext and simply reverts to
+  unset.
+
+**`_validateSettings()` is unchanged**: caller-supplied keys are still
+validated strictly against the current manifest, including the existing
+empty-schema early return (a caller may still write to a plugin whose
+manifest declares no settings, but the next read reconciles those values
+away). Reconciliation only ever touches host-owned persisted state, never
+caller payloads.
+
+**Failed installs/updates are transactional**: `installPluginPackage()` and
+`updatePluginSource()` snapshot raw persisted settings (ordinary + secure)
+before mutating, and `_restorePersistedSettings()` restores them verbatim on
+rollback, before the previous version is reloaded. A failed update leaves
+both the previous plugin version and its settings exactly as they were
+before the attempt.
+
+Renames are not inferred: `OldName -> NewName` behaves as removed + added.
+
 ## Keeping Notes Fresh
 
 Add migration gotchas, storage ownership changes, and data integrity rules. Prune when schema versions are retired.

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -166,6 +166,8 @@ class PluginLoaderService {
         }
       } catch (e) {
         _log.warning('Rolling back failed install of plugin $pluginId', e);
+        // Restore settings before the previous version reloads: the reload
+        // re-reads reconciled settings under the settings lock.
         await _restorePersistedSettings(pluginId, settingsSnapshot);
         if (pluginDir.existsSync()) pluginDir.deleteSync(recursive: true);
         if (hadPrevious) {
@@ -269,6 +271,8 @@ class PluginLoaderService {
         _log.warning('Rolling back failed update of plugin $pluginId', e);
         _deleteQuietly(stagedManifest);
         _deleteQuietly(stagedSource);
+        // Restore settings before the previous version reloads: the reload
+        // re-reads reconciled settings under the settings lock.
         await _restorePersistedSettings(pluginId, settingsSnapshot);
         await _restorePluginSource(
           pluginId: pluginId,
@@ -713,10 +717,6 @@ class PluginLoaderService {
     return (ordinary: migratedOrdinary, secure: secure);
   }
 
-  // Persisted settings are values of the current manifest schema. Keys the
-  // manifest no longer declares are dropped, and values that no longer fit
-  // the schema are reset to a valid manifest default or removed. A manifest
-  // with no settings drops every previously persisted ordinary value.
   Map<String, dynamic> _reconcileOrdinarySettings(
     PluginManifest manifest,
     Map<String, dynamic> ordinary,
@@ -726,8 +726,6 @@ class PluginLoaderService {
     final reconciled = <String, dynamic>{};
     for (final entry in ordinary.entries) {
       if (secureKeys.contains(entry.key)) {
-        // Secure values are migrated to secure storage by the caller; keep
-        // them untouched here so the migration path is unchanged.
         reconciled[entry.key] = entry.value;
         continue;
       }
@@ -739,10 +737,6 @@ class PluginLoaderService {
     return reconciled;
   }
 
-  // Secure values also conform to the current schema (enum values, types).
-  // Reconciliation happens in secure storage only; a value that no longer
-  // fits the schema is reset to a valid manifest default or removed, and is
-  // never written to ordinary storage.
   Map<String, dynamic> _reconcileSecureSettings(
     PluginManifest manifest,
     Map<String, dynamic> secure,
@@ -860,9 +854,6 @@ class PluginLoaderService {
     );
   }
 
-  // Raw persisted settings, taken before an install/update can reconcile
-  // them against a new manifest. Restored verbatim on rollback so a failed
-  // update leaves settings exactly as they were before the attempt.
   Future<({Map<String, dynamic> ordinary, Map<String, dynamic> secure})>
   _capturePersistedSettings(String pluginId) =>
       _withPluginSettingsLock(pluginId, () async {

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -141,6 +141,7 @@ class PluginLoaderService {
     return _withPluginMutationLock(pluginId, () async {
       _ensureActive();
       if (!allowDowngrade) _ensureNotDowngrade(manifest);
+      final settingsSnapshot = await _capturePersistedSettings(pluginId);
 
       final pluginDir = Directory('${_pluginsDir.path}/$pluginId');
       final backupDir = Directory('${pluginDir.path}$_backupSuffix');
@@ -165,6 +166,7 @@ class PluginLoaderService {
         }
       } catch (e) {
         _log.warning('Rolling back failed install of plugin $pluginId', e);
+        await _restorePersistedSettings(pluginId, settingsSnapshot);
         if (pluginDir.existsSync()) pluginDir.deleteSync(recursive: true);
         if (hadPrevious) {
           backupDir.renameSync(pluginDir.path);
@@ -221,6 +223,7 @@ class PluginLoaderService {
     return _withPluginMutationLock(pluginId, () async {
       _ensureActive();
       _ensureNotDowngrade(manifest);
+      final settingsSnapshot = await _capturePersistedSettings(pluginId);
 
       final previousManifest = _availablePluginsCache[pluginId];
       final pluginDir = Directory('${_pluginsDir.path}/$pluginId');
@@ -266,6 +269,7 @@ class PluginLoaderService {
         _log.warning('Rolling back failed update of plugin $pluginId', e);
         _deleteQuietly(stagedManifest);
         _deleteQuietly(stagedSource);
+        await _restorePersistedSettings(pluginId, settingsSnapshot);
         await _restorePluginSource(
           pluginId: pluginId,
           pluginDir: pluginDir,
@@ -674,29 +678,110 @@ class PluginLoaderService {
 
   Future<({Map<String, dynamic> ordinary, Map<String, dynamic> secure})>
   _storedSettings(PluginManifest manifest) async {
-    final ordinary = _readOrdinarySettings(manifest.id);
     final secureKeys = _secureSettingKeys(manifest);
     final storedSecure = await _readSecureSettings(manifest.id);
-    final secure = Map.fromEntries(
+    final secureBase = Map.fromEntries(
       storedSecure.entries.where((entry) => secureKeys.contains(entry.key)),
     );
-    if (secure.length != storedSecure.length) {
-      await _writeSecureSettings(manifest.id, secure);
-    }
+
+    final storedOrdinary = _readOrdinarySettings(manifest.id);
+    final ordinary = _reconcileOrdinarySettings(manifest, storedOrdinary);
+
     final legacySecure = Map.fromEntries(
       ordinary.entries.where((entry) => secureKeys.contains(entry.key)),
     );
+    final secure = _reconcileSecureSettings(manifest, {
+      ...legacySecure,
+      ...secureBase,
+    });
+
     if (legacySecure.isEmpty) {
+      if (!mapEquals(storedSecure, secure)) {
+        await _writeSecureSettings(manifest.id, secure);
+      }
+      if (!mapEquals(storedOrdinary, ordinary)) {
+        await _writeOrdinarySettings(manifest.id, ordinary);
+      }
       return (ordinary: ordinary, secure: secure);
     }
 
-    final migratedSecure = {...legacySecure, ...secure};
     final migratedOrdinary = Map.fromEntries(
       ordinary.entries.where((entry) => !secureKeys.contains(entry.key)),
     );
-    await _writeSecureSettings(manifest.id, migratedSecure);
+    await _writeSecureSettings(manifest.id, secure);
     await _writeOrdinarySettings(manifest.id, migratedOrdinary);
-    return (ordinary: migratedOrdinary, secure: migratedSecure);
+    return (ordinary: migratedOrdinary, secure: secure);
+  }
+
+  // Persisted settings are values of the current manifest schema. Keys the
+  // manifest no longer declares are dropped, and values that no longer fit
+  // the schema are reset to a valid manifest default or removed. A manifest
+  // with no settings drops every previously persisted ordinary value.
+  Map<String, dynamic> _reconcileOrdinarySettings(
+    PluginManifest manifest,
+    Map<String, dynamic> ordinary,
+  ) {
+    final manifestSettings = manifest.settings;
+    final secureKeys = _secureSettingKeys(manifest);
+    final reconciled = <String, dynamic>{};
+    for (final entry in ordinary.entries) {
+      if (secureKeys.contains(entry.key)) {
+        // Secure values are migrated to secure storage by the caller; keep
+        // them untouched here so the migration path is unchanged.
+        reconciled[entry.key] = entry.value;
+        continue;
+      }
+      final schema = manifestSettings[entry.key];
+      if (schema == null) continue;
+      final value = _reconciledPersistedValue(entry.key, schema, entry.value);
+      if (value != null) reconciled[entry.key] = value;
+    }
+    return reconciled;
+  }
+
+  // Secure values also conform to the current schema (enum values, types).
+  // Reconciliation happens in secure storage only; a value that no longer
+  // fits the schema is reset to a valid manifest default or removed, and is
+  // never written to ordinary storage.
+  Map<String, dynamic> _reconcileSecureSettings(
+    PluginManifest manifest,
+    Map<String, dynamic> secure,
+  ) {
+    final manifestSettings = manifest.settings;
+    final reconciled = <String, dynamic>{};
+    for (final entry in secure.entries) {
+      final schema = manifestSettings[entry.key];
+      if (schema == null) continue;
+      final value = _reconciledPersistedValue(entry.key, schema, entry.value);
+      if (value != null) reconciled[entry.key] = value;
+    }
+    return reconciled;
+  }
+
+  dynamic _reconciledPersistedValue(String key, dynamic schema, dynamic value) {
+    if (value == null) return null;
+    if (schema is! Map) return value;
+    if (schema['type'] == 'enum') {
+      final enumValues = parsePluginEnumValues(key, schema);
+      if (enumValues.contains(value)) return value;
+      final defaultValue = schema['default'];
+      return enumValues.contains(defaultValue) ? defaultValue : null;
+    }
+    final compatible = switch (schema['type']) {
+      'string' => value is String,
+      'number' => value is num,
+      'boolean' => value is bool,
+      _ => true,
+    };
+    if (compatible) return value;
+    final defaultValue = schema['default'];
+    final defaultCompatible = switch (schema['type']) {
+      'string' => defaultValue is String,
+      'number' => defaultValue is num,
+      'boolean' => defaultValue is bool,
+      _ => false,
+    };
+    return defaultCompatible ? defaultValue : null;
   }
 
   Map<String, dynamic> _readOrdinarySettings(String pluginId) {
@@ -774,6 +859,26 @@ class PluginLoaderService {
       value: jsonEncode(settings),
     );
   }
+
+  // Raw persisted settings, taken before an install/update can reconcile
+  // them against a new manifest. Restored verbatim on rollback so a failed
+  // update leaves settings exactly as they were before the attempt.
+  Future<({Map<String, dynamic> ordinary, Map<String, dynamic> secure})>
+  _capturePersistedSettings(String pluginId) =>
+      _withPluginSettingsLock(pluginId, () async {
+        return (
+          ordinary: _readOrdinarySettings(pluginId),
+          secure: await _readSecureSettings(pluginId),
+        );
+      });
+
+  Future<void> _restorePersistedSettings(
+    String pluginId,
+    ({Map<String, dynamic> ordinary, Map<String, dynamic> secure}) settings,
+  ) => _withPluginSettingsLock(pluginId, () async {
+    await _writeOrdinarySettings(pluginId, settings.ordinary);
+    await _writeSecureSettings(pluginId, settings.secure);
+  });
 
   Future<void> _deleteSecureSettings(String pluginId) async {
     _volatileSecureSettings = Map.fromEntries(

--- a/test/plugin_loader_service_appstore_test.dart
+++ b/test/plugin_loader_service_appstore_test.dart
@@ -707,6 +707,616 @@ function createPlugin(host) {
       expect(await service.pluginSettings(id), {'Mode': 'fast'});
     });
 
+    group('settings schema evolution', () {
+      test('drops a removed setting and cleans it from storage', () async {
+        const id = 'evolve-remove.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'AutoUpload': {'type': 'boolean'},
+              'DrainHistory': {'type': 'boolean'},
+            },
+          ).path,
+        );
+        await service.savePluginSettings(id, {
+          'AutoUpload': true,
+          'DrainHistory': true,
+        });
+        final prefs = await SharedPreferences.getInstance();
+        expect(jsonDecode(prefs.getString('plugin.settings.$id')!), {
+          'AutoUpload': true,
+          'DrainHistory': true,
+        });
+
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'AutoUpload': {'type': 'boolean'},
+            },
+          ).path,
+        );
+
+        expect(await service.pluginSettings(id), {'AutoUpload': true});
+        expect(jsonDecode(prefs.getString('plugin.settings.$id')!), {
+          'AutoUpload': true,
+        });
+
+        await service.savePluginSettings(id, {'AutoUpload': false});
+        expect(await service.pluginSettings(id), {'AutoUpload': false});
+        expect(jsonDecode(prefs.getString('plugin.settings.$id')!), {
+          'AutoUpload': false,
+        });
+      });
+
+      test('reload after a schema change passes only current settings to the '
+          'plugin', () async {
+        const id = 'evolve-load.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Mode': {'type': 'string'},
+              'Legacy': {'type': 'string'},
+            },
+            permissions: ['pluginStorage'],
+            jsCode:
+                '''
+function createPlugin(host) {
+  return {
+    id: "$id",
+    onLoad(settings) {
+      host.storage({type: "write", key: "loads",
+        data: JSON.stringify(settings)});
+    }
+  };
+}
+''',
+          ).path,
+        );
+        await service.savePluginSettings(id, {'Mode': 'fast', 'Legacy': 'old'});
+        await service.loadPlugin(id);
+        expect(
+          await waitForStorage(id, 'loads', '{"Mode":"fast","Legacy":"old"}'),
+          '{"Mode":"fast","Legacy":"old"}',
+        );
+
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Mode': {'type': 'string'},
+            },
+            permissions: ['pluginStorage'],
+            jsCode:
+                '''
+function createPlugin(host) {
+  return {
+    id: "$id",
+    onLoad(settings) {
+      host.storage({type: "write", key: "loads",
+        data: JSON.stringify(settings)});
+    }
+  };
+}
+''',
+          ).path,
+        );
+
+        expect(service.isPluginLoaded(id), isTrue);
+        expect(
+          await waitForStorage(id, 'loads', '{"Mode":"fast"}'),
+          '{"Mode":"fast"}',
+          reason: 'the reload after the update must not see the removed key',
+        );
+      });
+
+      test('resets an obsolete enum value to a valid default', () async {
+        const id = 'evolve-enum.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Roast': {
+                'type': 'enum',
+                'values': ['Light', 'Medium', 'Dark'],
+                'default': 'Medium',
+              },
+            },
+          ).path,
+        );
+        await service.savePluginSettings(id, {'Roast': 'Medium'});
+
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Roast': {
+                'type': 'enum',
+                'values': ['Light', 'Dark'],
+                'default': 'Dark',
+              },
+            },
+          ).path,
+        );
+
+        expect(await service.pluginSettings(id), {'Roast': 'Dark'});
+        final prefs = await SharedPreferences.getInstance();
+        expect(jsonDecode(prefs.getString('plugin.settings.$id')!), {
+          'Roast': 'Dark',
+        });
+      });
+
+      test('removes an enum value with no valid default', () async {
+        const id = 'evolve-enum-null.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Roast': {
+                'type': 'enum',
+                'values': ['Light', 'Medium'],
+                'default': 'Medium',
+              },
+            },
+          ).path,
+        );
+        await service.savePluginSettings(id, {'Roast': 'Light'});
+
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Roast': {
+                'type': 'enum',
+                'values': ['Medium'],
+                'default': 'Light',
+              },
+            },
+          ).path,
+        );
+
+        expect(await service.pluginSettings(id), isEmpty);
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.containsKey('plugin.settings.$id'), isFalse);
+      });
+
+      test('converts an incompatible persisted type via the default', () async {
+        const id = 'evolve-type.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Enabled': {'type': 'string'},
+            },
+          ).path,
+        );
+        await service.savePluginSettings(id, {'Enabled': 'yes'});
+
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Enabled': {'type': 'boolean', 'default': true},
+            },
+          ).path,
+        );
+
+        expect(await service.pluginSettings(id), {'Enabled': true});
+        final prefs = await SharedPreferences.getInstance();
+        expect(jsonDecode(prefs.getString('plugin.settings.$id')!), {
+          'Enabled': true,
+        });
+      });
+
+      test('drops a value incompatible with the new type', () async {
+        const id = 'evolve-type-drop.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Level': {'type': 'string'},
+            },
+          ).path,
+        );
+        await service.savePluginSettings(id, {'Level': 'high'});
+
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Level': {'type': 'number'},
+            },
+          ).path,
+        );
+
+        expect(await service.pluginSettings(id), isEmpty);
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.containsKey('plugin.settings.$id'), isFalse);
+      });
+
+      test('still rejects unknown caller-provided keys', () async {
+        const id = 'evolve-reject.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'AutoUpload': {'type': 'boolean'},
+            },
+          ).path,
+        );
+
+        await expectLater(
+          service.savePluginSettings(id, {
+            'AutoUpload': true,
+            'DrainHistory': true,
+          }),
+          throwsA(isA<PluginSettingsValidationException>()),
+        );
+      });
+
+      test('migrates a setting that became secure', () async {
+        const id = 'evolve-secure.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Token': {'type': 'string'},
+            },
+          ).path,
+        );
+        await service.savePluginSettings(id, {'Token': 'secret'});
+
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Token': {'type': 'string', 'secure': true},
+            },
+          ).path,
+        );
+
+        expect(await service.pluginSettings(id), {
+          'Token': {'isSet': true},
+        });
+        expect(
+          credentialStore.values.values.single,
+          jsonEncode({'Token': 'secret'}),
+        );
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getString('plugin.settings.$id'), isNull);
+      });
+
+      test('never copies a former secret into ordinary storage', () async {
+        const id = 'evolve-secure-drop.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Token': {'type': 'string', 'secure': true},
+            },
+          ).path,
+        );
+        await service.savePluginSettings(id, {'Token': 'secret'});
+
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Token': {'type': 'string'},
+            },
+          ).path,
+        );
+
+        expect(await service.pluginSettings(id), isEmpty);
+        expect(credentialStore.values, isEmpty);
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getString('plugin.settings.$id'), isNull);
+      });
+
+      test('a manifest with no settings cleans persisted settings', () async {
+        const id = 'evolve-empty.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Mode': {'type': 'string'},
+            },
+          ).path,
+        );
+        await service.savePluginSettings(id, {'Mode': 'fast'});
+        final prefs = await SharedPreferences.getInstance();
+        expect(jsonDecode(prefs.getString('plugin.settings.$id')!), {
+          'Mode': 'fast',
+        });
+
+        await service.addPlugin(makePluginSource(id, settings: {}).path);
+
+        expect(await service.pluginSettings(id), isEmpty);
+        expect(prefs.containsKey('plugin.settings.$id'), isFalse);
+      });
+
+      test('a manifest with no settings loads the plugin with none', () async {
+        const id = 'evolve-empty-load.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Mode': {'type': 'string'},
+            },
+            permissions: ['pluginStorage'],
+            jsCode:
+                '''
+function createPlugin(host) {
+  return {
+    id: "$id",
+    onLoad(settings) {
+      host.storage({type: "write", key: "loads",
+        data: JSON.stringify(settings)});
+    }
+  };
+}
+''',
+          ).path,
+        );
+        await service.savePluginSettings(id, {'Mode': 'fast'});
+        await service.loadPlugin(id);
+        expect(
+          await waitForStorage(id, 'loads', '{"Mode":"fast"}'),
+          '{"Mode":"fast"}',
+        );
+
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {},
+            permissions: ['pluginStorage'],
+            jsCode:
+                '''
+function createPlugin(host) {
+  return {
+    id: "$id",
+    onLoad(settings) {
+      host.storage({type: "write", key: "loads",
+        data: JSON.stringify(settings)});
+    }
+  };
+}
+''',
+          ).path,
+        );
+
+        expect(service.isPluginLoaded(id), isTrue);
+        expect(
+          await waitForStorage(id, 'loads', '{}'),
+          '{}',
+          reason: 'the reload after the update must not see old settings',
+        );
+        expect(await service.pluginSettings(id), isEmpty);
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.containsKey('plugin.settings.$id'), isFalse);
+      });
+
+      test('a failed update restores the previous settings', () async {
+        const id = 'evolve-rollback.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'AutoUpload': {'type': 'boolean'},
+              'DrainHistory': {'type': 'boolean'},
+            },
+            permissions: ['pluginStorage'],
+            jsCode:
+                '''
+function createPlugin() {
+  return { id: "$id", onLoad() {} };
+}
+''',
+          ).path,
+        );
+        await service.savePluginSettings(id, {
+          'AutoUpload': true,
+          'DrainHistory': true,
+        });
+        await service.loadPlugin(id);
+        expect(service.isPluginLoaded(id), isTrue);
+
+        await expectLater(
+          service.addPlugin(
+            makePluginSource(
+              id,
+              settings: {
+                'AutoUpload': {'type': 'boolean'},
+              },
+              permissions: ['pluginStorage'],
+              jsCode: 'function createPlugin() { throw new Error("boom"); }',
+            ).path,
+          ),
+          throwsA(anything),
+        );
+
+        expect(service.isPluginLoaded(id), isTrue);
+        expect(await service.pluginSettings(id), {
+          'AutoUpload': true,
+          'DrainHistory': true,
+        });
+        final prefs = await SharedPreferences.getInstance();
+        expect(jsonDecode(prefs.getString('plugin.settings.$id')!), {
+          'AutoUpload': true,
+          'DrainHistory': true,
+        });
+      });
+
+      test(
+        'a failed update restores settings reconciled away by the new schema',
+        () async {
+          const id = 'evolve-rollback-schema.reaplugin';
+          await service.addPlugin(
+            makePluginSource(
+              id,
+              settings: {
+                'Level': {'type': 'string'},
+                'Roast': {
+                  'type': 'enum',
+                  'values': ['Light', 'Medium'],
+                  'default': 'Medium',
+                },
+              },
+              permissions: ['pluginStorage'],
+              jsCode:
+                  '''
+function createPlugin() {
+  return { id: "$id", onLoad() {} };
+}
+''',
+            ).path,
+          );
+          await service.savePluginSettings(id, {
+            'Level': 'high',
+            'Roast': 'Medium',
+          });
+          await service.loadPlugin(id);
+
+          await expectLater(
+            service.addPlugin(
+              makePluginSource(
+                id,
+                settings: {
+                  'Level': {'type': 'number'},
+                  'Roast': {
+                    'type': 'enum',
+                    'values': ['Light'],
+                    'default': 'Light',
+                  },
+                },
+                permissions: ['pluginStorage'],
+                jsCode: 'function createPlugin() { throw new Error("boom"); }',
+              ).path,
+            ),
+            throwsA(anything),
+          );
+
+          expect(await service.pluginSettings(id), {
+            'Level': 'high',
+            'Roast': 'Medium',
+          });
+        },
+      );
+
+      test('a failed update restores a secure migration', () async {
+        const id = 'evolve-rollback-secure.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Token': {'type': 'string'},
+            },
+            permissions: ['pluginStorage'],
+            jsCode:
+                '''
+function createPlugin() {
+  return { id: "$id", onLoad() {} };
+}
+''',
+          ).path,
+        );
+        await service.savePluginSettings(id, {'Token': 'secret'});
+        await service.loadPlugin(id);
+
+        await expectLater(
+          service.addPlugin(
+            makePluginSource(
+              id,
+              settings: {
+                'Token': {'type': 'string', 'secure': true},
+              },
+              permissions: ['pluginStorage'],
+              jsCode: 'function createPlugin() { throw new Error("boom"); }',
+            ).path,
+          ),
+          throwsA(anything),
+        );
+
+        expect(await service.pluginSettings(id), {'Token': 'secret'});
+        final prefs = await SharedPreferences.getInstance();
+        expect(jsonDecode(prefs.getString('plugin.settings.$id')!), {
+          'Token': 'secret',
+        });
+        expect(credentialStore.values, isEmpty);
+      });
+
+      test('reconciles a secure value that changed type', () async {
+        const id = 'evolve-secure-type.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Enabled': {'type': 'string'},
+            },
+          ).path,
+        );
+        await service.savePluginSettings(id, {'Enabled': 'yes'});
+
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Enabled': {'type': 'boolean', 'secure': true},
+            },
+          ).path,
+        );
+
+        expect(await service.pluginSettings(id), {
+          'Enabled': {'isSet': false},
+        });
+        expect(credentialStore.values, isEmpty);
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getString('plugin.settings.$id'), isNull);
+      });
+
+      test('resets a secure enum value removed from values', () async {
+        const id = 'evolve-secure-enum.reaplugin';
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Roast': {
+                'type': 'enum',
+                'secure': true,
+                'values': ['Light', 'Medium'],
+                'default': 'Medium',
+              },
+            },
+          ).path,
+        );
+        await service.savePluginSettings(id, {'Roast': 'Medium'});
+
+        await service.addPlugin(
+          makePluginSource(
+            id,
+            settings: {
+              'Roast': {
+                'type': 'enum',
+                'secure': true,
+                'values': ['Light', 'Dark'],
+                'default': 'Dark',
+              },
+            },
+          ).path,
+        );
+
+        expect(await service.pluginSettings(id), {
+          'Roast': {'isSet': true},
+        });
+        expect(
+          credentialStore.values.values.single,
+          jsonEncode({'Roast': 'Dark'}),
+        );
+      });
+    });
+
     const unsafeIds = [
       '',
       '.',

--- a/test/webserver/plugins_handler_update_test.dart
+++ b/test/webserver/plugins_handler_update_test.dart
@@ -370,5 +370,56 @@ function createPlugin(host) {
         reason: 'REST save must reload the loaded plugin exactly once',
       );
     });
+
+    test(
+      'GET and POST settings after a schema change omit dropped keys',
+      () async {
+        const id = 'evolve-rest.reaplugin';
+        final dir = Directory('${tempDir.path}/source_evolve_rest')
+          ..createSync(recursive: true);
+        File('${dir.path}/manifest.json').writeAsStringSync(
+          jsonEncode({
+            ...manifestJson(id),
+            'settings': {
+              'AutoUpload': {'type': 'boolean'},
+              'DrainHistory': {'type': 'boolean'},
+            },
+          }),
+        );
+        File('${dir.path}/plugin.js').writeAsStringSync(pluginJs(id));
+        await service.addPlugin(dir.path);
+        await service.savePluginSettings(id, {
+          'AutoUpload': true,
+          'DrainHistory': true,
+        });
+
+        final putRes = await put(id, {
+          'manifest': {
+            ...manifestJson(id, version: '2.0.0'),
+            'settings': {
+              'AutoUpload': {'type': 'boolean'},
+            },
+          },
+          'plugin': pluginJs(id),
+        });
+        expect(putRes.statusCode, 200);
+
+        final getRes = await handler(
+          Request(
+            'GET',
+            Uri.parse('http://localhost/api/v1/plugins/$id/settings'),
+          ),
+        );
+        expect(getRes.statusCode, 200);
+        expect(jsonDecode(await getRes.readAsString()), {'AutoUpload': true});
+
+        final postRes = await postSettings(id, {'AutoUpload': false});
+        expect(postRes.statusCode, 200);
+        expect(jsonDecode(await postRes.readAsString()), {'AutoUpload': false});
+
+        final badRes = await postSettings(id, {'DrainHistory': true});
+        expect(badRes.statusCode, 400);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Plugin settings are persisted across plugin updates, but stale keys survived forever: a plugin that removed a setting from its manifest left the old value in storage, where it was exposed by `pluginSettings()`, passed into the plugin runtime on load/reload, and blocked every subsequent save (strict validation rejects keys the manifest no longer declares).

Persisted settings are now treated as values of the **current manifest schema**, not an opaque document. `PluginLoaderService._storedSettings()` reconciles persisted state on every read/save/load:

- Keys the manifest no longer declares are dropped; a manifest with `settings: {}` drops every previously persisted value.
- Enum values no longer in `values` are reset to a valid manifest default, else removed.
- Values incompatible with the declared type (`string`/`number`/`boolean`) are reset to a valid default, else removed.
- **Secure values are not opaque**: the same enum/type reconciliation applies in secure storage, and a value that no longer fits the schema is reset or dropped without ever being written to plaintext.
- Cleaned state is written back to storage so stale values cannot return.

**Failed installs/updates are transactional**: `installPluginPackage()` and `updatePluginSource()` snapshot raw persisted settings (ordinary + secure) before mutating and restore them verbatim on rollback — a failed update leaves both the previous plugin version and its settings exactly as they were before the attempt.

**Strict caller validation is unchanged**: unknown caller-supplied keys still fail with `PluginSettingsValidationException` (REST returns 400); reconciliation only ever repairs host-owned persisted state. Reconciliation stays centralized in `PluginLoaderService` — REST and Flutter observe the same behavior, and the earlier draft's Flutter-side stale-key filtering was removed as redundant.

## Linked Issue

N/A — no dedicated issue filed. Preserves the #655 settings save → reload-if-loaded behavior (covered by regression tests).

## Verification

- `flutter analyze` (affected files): clean.
- `flutter test` on plugin loader / settings suites: 137/137 passed, including 18 new regression tests:
  - removed-key lifecycle (reads, storage cleanup, save success, no resurrection);
  - reload after a schema change passes only current settings to the plugin runtime;
  - enum value → valid default / removed; incompatible type → default / removed;
  - caller unknown-key rejection (service + REST 400);
  - ordinary → secure migration; secure → ordinary never leaks to plaintext;
  - **empty-schema cleanup**: v1 settings → v2 `settings: {}` returns `{}`, clears SharedPreferences, and loads the plugin with no old settings;
  - **failed-update rollback**: removed key, type/enum reconciliation, and secure migration are all restored on rollback;
  - **secure reconciliation**: ordinary string → secure boolean dropped without leak; secure enum value removed from `values` reset to the valid default;
  - REST GET omits dropped keys, REST POST of current settings succeeds after a schema change;
  - existing secure-migration, concurrent-PATCH, and #655 save-and-reload tests remain green.
- Note: `test/plugins/shot_upload_*` and `plugins_settings_view_sources_test.dart` cannot run in this checkout (missing `assets/plugins/shot-upload.reaplugin/` directory, pre-existing, unrelated).

## Impact

Behavior change: on the first read after a plugin update, stale settings are dropped and cleaned from storage (existing valid values are preserved). A setting whose type changed without a usable default reverts to unset. Failed plugin updates no longer lose settings. No API shape changes; `doc/AI_STORAGE_NOTES.md` documents the reconciliation policy, the empty-schema semantics, the secure-value policy, and the rollback guarantee.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
