### PR TITLE
fix(account): verify stored Decent credentials and invalidate stale auth state

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -5133,9 +5133,14 @@ paths:
 
   /api/v1/account/decent:
     get:
-      summary: Decent account link status
+      summary: Decent account auth status
       description: >
-        Reports whether a Decent Espresso account is currently linked.
+        Reports whether the linked Decent Espresso account is currently
+        authenticated. `loggedIn` is true only when the stored credentials
+        have been accepted by the Decent backend (validated via
+        `login_test` on first status read per session); a definitive upstream
+        401 invalidates the state until the next successful login or
+        re-validation. Stored credentials being present is not sufficient.
         Linking and unlinking are performed only through the app's native UI,
         not over the network, so no login/logout routes are exposed here. The
         linked email is deliberately omitted — it is PII and this endpoint is
@@ -5143,7 +5148,7 @@ paths:
       tags: [Account]
       responses:
         "200":
-          description: Current link status
+          description: Current auth status
           content:
             application/json:
               schema:
@@ -5152,7 +5157,7 @@ paths:
                 properties:
                   loggedIn:
                     type: boolean
-                    description: True if a Decent account is linked
+                    description: True if the linked Decent account is authenticated
 
   /api/v1/account/proxy/support/api/{endpoint}:
     get:

--- a/doc/AI_STORAGE_NOTES.md
+++ b/doc/AI_STORAGE_NOTES.md
@@ -51,6 +51,10 @@ Gotchas:
 
 Keep these stores independent. A settings reset must not clear account credentials unless explicitly requested.
 
+## Account Auth State (gh#696)
+
+`DecentAccountService` stores `email` + encrypted password (`cryptpw`, returned by `login_test`) in the secure store. Stored credentials mean **linked**, not **authenticated**: `hasLinkedAccount()` is the presence check; `isLoggedIn()` is auth-aware and returns a cached in-memory state, validated against `/support/api/login_test` (memoized while in flight; only definitive results are sticky — an indeterminate network/5xx outcome sets a 30s cooldown (`retryInterval`) so widget rebuilds and status polls cannot hammer `login_test`, and the next check after the cooldown retries). `login_test` accepts `pw` or `cryptpw` and returns `0` (body `"0\n"`, status 200 — always trim before comparing) on rejection, otherwise the cryptpw. A definitive rejection (401 or `"0"`) marks the account not authenticated; 5xx/network errors are indeterminate and leave the cached state untouched. `DecentProxyService` reports upstream 401s via `onAuthFailure` -> `reportAuthenticationFailure()`. Credentials are kept on 401 — a transient backend failure must not destroy the link; the next session re-validates. Auth state carries a generation counter: login success, logout, and reported auth failures bump it, and an in-flight validation only writes its result if its generation is still current, so a stale validation of old credentials cannot clobber a newer successful login (or resurrect auth after a 401). Failed `login()` attempts never touch stored credentials (a bad replacement login cannot erase a working link).
+
 Plugin settings marked `secure` in the manifest are stored through
 `CredentialStore` under a plugin-scoped key. Ordinary plugin settings remain in
 SharedPreferences. Reads exposed to UI and REST clients return only `{isSet}`

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -448,7 +448,7 @@ archive is also bounded by the 2 GiB import request limit.
 
 | Method | Path | Description | Handler |
 |--------|------|-------------|---------|
-| GET | `/api/v1/account/decent` | Decent account link status: `{loggedIn}` | `account_handler.dart` |
+| GET | `/api/v1/account/decent` | Decent account auth status: `{loggedIn}` (true only when stored credentials are accepted by the backend) | `account_handler.dart` |
 | GET | `/api/v1/account/proxy/<path>` | Auth-enriching proxy to `decentespresso.com/<path>` | `account_proxy_handler.dart` |
 | POST | `/api/v1/account/proxy/<path>` | Auth-enriching write proxy (relays body) | `account_proxy_handler.dart` |
 | PUT | `/api/v1/account/proxy/<path>` | Auth-enriching write proxy (relays body) | `account_proxy_handler.dart` |

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -445,6 +445,7 @@ void main(List<String> args) async {
       credentialStore: credentialStore,
       requireConsent: gate.requireConsent,
       baseUrl: decentBaseUrl,
+      onAuthFailure: () => decentAccountService!.reportAuthenticationFailure(),
     );
     accountTokensController = AccountTokensController(
       tokenService: proxyTokenService,

--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -1,4 +1,6 @@
 import 'dart:convert';
+
+import 'package:clock/clock.dart';
 import 'package:http/http.dart' as http;
 
 List<String> parseSerialNumbers(String body) {
@@ -26,10 +28,18 @@ class DecentAccountService {
   final http.Client _httpClient;
   final CredentialStore _store;
   final String baseUrl;
+  final Duration retryInterval;
+
+  bool? _authenticated;
+  Future<bool>? _validationFuture;
+  DateTime? _cooldownUntil;
+  int _authGeneration = 0;
+
   DecentAccountService({
     required http.Client httpClient,
     required CredentialStore credentialStore,
     this.baseUrl = "https://decentespresso.com",
+    this.retryInterval = const Duration(seconds: 30),
   }) : _httpClient = httpClient,
        _store = credentialStore;
 
@@ -40,9 +50,11 @@ class DecentAccountService {
       '/support/api/login_test',
     );
 
-    if (response.statusCode == 200 && response.body != '0') {
+    if (response.statusCode == 200 && response.body.trim() != '0') {
       await _store.write(key: 'email', value: email);
       await _store.write(key: 'password', value: response.body.trim());
+      _authGeneration++;
+      _authenticated = true;
       return true;
     }
     return false;
@@ -51,9 +63,67 @@ class DecentAccountService {
   Future<void> logout() async {
     await _store.delete(key: 'email');
     await _store.delete(key: 'password');
+    _authGeneration++;
+    _authenticated = false;
   }
 
-  Future<bool> isLoggedIn() async => await _store.read(key: 'email') != null;
+  Future<bool> hasLinkedAccount() async =>
+      await _store.read(key: 'email') != null &&
+      await _store.read(key: 'password') != null;
+
+  Future<bool> isLoggedIn() async {
+    if (!await hasLinkedAccount()) return false;
+    final cached = _authenticated;
+    if (cached != null) return cached;
+    final pending = _validationFuture;
+    if (pending != null) return pending;
+    final cooldownUntil = _cooldownUntil;
+    if (cooldownUntil != null) {
+      if (clock.now().isBefore(cooldownUntil)) return false;
+      _cooldownUntil = null;
+    }
+    final future = verifyStoredCredentials();
+    _validationFuture = future;
+    future.whenComplete(() {
+      _validationFuture = null;
+      if (_authenticated == null) {
+        _cooldownUntil = clock.now().add(retryInterval);
+      }
+    });
+    return future;
+  }
+
+  Future<bool> verifyStoredCredentials() async {
+    final generation = _authGeneration;
+    final email = await _store.read(key: 'email');
+    final password = await _store.read(key: 'password');
+    if (email == null || password == null) {
+      _setAuthenticated(generation, false);
+      return false;
+    }
+    final http.Response response;
+    try {
+      response = await _authedGet(email, password, '/support/api/login_test');
+    } catch (_) {
+      return _authenticated ?? false;
+    }
+    final valid = response.statusCode == 200 && response.body.trim() != '0';
+    final rejected =
+        response.statusCode == 401 ||
+        (response.statusCode == 200 && response.body.trim() == '0');
+    if (!valid && !rejected) return _authenticated ?? false;
+    _setAuthenticated(generation, valid);
+    return _authenticated ?? false;
+  }
+
+  void _setAuthenticated(int generation, bool value) {
+    if (generation == _authGeneration) _authenticated = value;
+  }
+
+  void reportAuthenticationFailure() {
+    _authGeneration++;
+    _authenticated = false;
+  }
 
   Future<String?> getEmail() async => _store.read(key: 'email');
 

--- a/lib/src/services/account/decent_proxy_service.dart
+++ b/lib/src/services/account/decent_proxy_service.dart
@@ -46,6 +46,7 @@ class DecentProxyService {
   final CredentialStore _store;
   final RequireAccountConsent _requireConsent;
   final String baseUrl;
+  final void Function()? onAuthFailure;
 
   final Set<String> allowedPrefixes;
 
@@ -69,6 +70,7 @@ class DecentProxyService {
     required RequireAccountConsent requireConsent,
     this.baseUrl = 'https://decentespresso.com',
     this.allowedPrefixes = const {'support/api/'},
+    this.onAuthFailure,
   }) : _httpClient = httpClient,
        _store = credentialStore,
        _requireConsent = requireConsent;
@@ -138,6 +140,10 @@ class DecentProxyService {
 
     final response = await _httpClient.send(outbound);
     final responseBody = await response.stream.toBytes();
+
+    if (response.statusCode == 401) {
+      onAuthFailure?.call();
+    }
 
     _log.info(
       'caller=$callerId $normalizedMethod /$normalizedPath -> ${response.statusCode}',

--- a/test/account/account_page_test.dart
+++ b/test/account/account_page_test.dart
@@ -1,0 +1,153 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:reaprime/src/account/account_page.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class FakeCredentialStore implements CredentialStore {
+  final Map<String, String> _values = {};
+
+  @override
+  Future<String?> read({required String key}) async => _values[key];
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    _values.remove(key);
+  }
+}
+
+Widget buildTestApp(Widget child) => ShadApp(home: child);
+
+DecentAccountService buildService(
+  FakeCredentialStore store,
+  http_testing.MockClientHandler handler,
+) {
+  return DecentAccountService(
+    httpClient: http_testing.MockClient(handler),
+    credentialStore: store,
+  );
+}
+
+class _RebuildingHost extends StatefulWidget {
+  const _RebuildingHost(this.childBuilder);
+
+  final WidgetBuilder childBuilder;
+
+  @override
+  State<_RebuildingHost> createState() => _RebuildingHostState();
+}
+
+class _RebuildingHostState extends State<_RebuildingHost> {
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.childBuilder(context);
+}
+
+void main() {
+  testWidgets('shows Link Your Account for stored invalid credentials', (
+    tester,
+  ) async {
+    final store = FakeCredentialStore();
+    await store.write(key: 'email', value: 'user@example.com');
+    await store.write(key: 'password', value: 'stale_cryptpw');
+    final service = buildService(store, (_) async => http.Response('', 401));
+
+    await tester.pumpWidget(buildTestApp(AccountPage(accountService: service)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Logged In'), findsNothing);
+    expect(find.text('Link Your Account'), findsOneWidget);
+  });
+
+  testWidgets('shows Logged In for stored valid credentials', (tester) async {
+    final store = FakeCredentialStore();
+    await store.write(key: 'email', value: 'user@example.com');
+    await store.write(key: 'password', value: 'cryptpw_abc123');
+    final service = buildService(
+      store,
+      (_) async => http.Response('cryptpw_abc123', 200),
+    );
+
+    await tester.pumpWidget(buildTestApp(AccountPage(accountService: service)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Logged In'), findsOneWidget);
+    expect(find.text('Link Your Account'), findsNothing);
+  });
+
+  testWidgets('parent rebuilds during an outage do not hammer the backend', (
+    tester,
+  ) async {
+    final store = FakeCredentialStore();
+    await store.write(key: 'email', value: 'user@example.com');
+    await store.write(key: 'password', value: 'cryptpw_abc123');
+    var requests = 0;
+    final service = buildService(store, (_) async {
+      requests++;
+      return http.Response('', 500);
+    });
+
+    await tester.pumpWidget(
+      buildTestApp(
+        _RebuildingHost((_) => AccountPage(accountService: service)),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(requests, 1);
+
+    for (var i = 0; i < 10; i++) {
+      await tester.pump(const Duration(seconds: 1));
+    }
+    expect(requests, 1);
+
+    await tester.pump(const Duration(seconds: 25));
+    expect(requests, 2);
+    expect(find.text('Link Your Account'), findsOneWidget);
+  });
+
+  testWidgets('no longer shows Logged In after an upstream auth failure', (
+    tester,
+  ) async {
+    final store = FakeCredentialStore();
+    await store.write(key: 'email', value: 'user@example.com');
+    await store.write(key: 'password', value: 'cryptpw_abc123');
+    final service = buildService(
+      store,
+      (_) async => http.Response('cryptpw_abc123', 200),
+    );
+
+    await tester.pumpWidget(buildTestApp(AccountPage(accountService: service)));
+    await tester.pumpAndSettle();
+    expect(find.text('Logged In'), findsOneWidget);
+
+    service.reportAuthenticationFailure();
+
+    await tester.pumpWidget(buildTestApp(AccountPage(accountService: service)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Logged In'), findsNothing);
+    expect(find.text('Link Your Account'), findsOneWidget);
+  });
+}

--- a/test/services/account/decent_account_service_test.dart
+++ b/test/services/account/decent_account_service_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart' as http_testing;
@@ -42,7 +45,7 @@ void main() {
 
     setUp(() {
       store = FakeCredentialStore();
-      httpClient = _mockClient(statusCode: 200, body: 'cryptpw_abc123');
+      httpClient = _mockClient(statusCode: 200, body: 'cryptpw_abc123\n');
       service = DecentAccountService(
         httpClient: httpClient,
         credentialStore: store,
@@ -76,8 +79,9 @@ void main() {
         expect(result, isTrue);
       });
 
-      test('returns false when API responds with "0"', () async {
-        httpClient = _mockClient(statusCode: 200, body: '0');
+      test('returns false when API responds with "0" (real backend sends '
+          '"0\\n")', () async {
+        httpClient = _mockClient(statusCode: 200, body: '0\n');
         service = DecentAccountService(
           httpClient: httpClient,
           credentialStore: store,
@@ -86,6 +90,7 @@ void main() {
 
         final result = await service.login('test@example.com', 'wrong');
         expect(result, isFalse);
+        expect(store.hasCredentials, isFalse);
       });
 
       test('returns false when API returns non-200 status', () async {
@@ -123,7 +128,7 @@ void main() {
       });
 
       test('does NOT persist credentials on failed login', () async {
-        httpClient = _mockClient(statusCode: 200, body: '0');
+        httpClient = _mockClient(statusCode: 200, body: '0\n');
         service = DecentAccountService(
           httpClient: httpClient,
           credentialStore: store,
@@ -132,6 +137,30 @@ void main() {
 
         await service.login('test@example.com', 'wrong');
         expect(store.hasCredentials, isFalse);
+      });
+
+      test('failed replacement login preserves previously valid stored '
+          'credentials', () async {
+        await store.write(key: 'email', value: 'good@example.com');
+        await store.write(key: 'password', value: 'cryptpw_abc123');
+        final badAuth = base64Encode(utf8.encode('bad@example.com:wrongpw'));
+        httpClient = http_testing.MockClient((request) async {
+          if (request.headers['authorization'] == 'Basic $badAuth') {
+            return http.Response('0\n', 200);
+          }
+          return http.Response('cryptpw_abc123\n', 200);
+        });
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        final ok = await service.login('bad@example.com', 'wrongpw');
+        expect(ok, isFalse);
+        expect(await store.read(key: 'email'), 'good@example.com');
+        expect(await store.read(key: 'password'), 'cryptpw_abc123');
+        expect(await service.isLoggedIn(), isTrue);
       });
 
       test('sends correctly-encoded Basic Auth header', () async {
@@ -184,10 +213,42 @@ void main() {
         expect(await service.isLoggedIn(), isTrue);
       });
 
-      test('returns true when credentials are already stored from a '
-          'previous session', () async {
+      test(
+        'returns true when stored credentials validate against the backend',
+        () async {
+          await store.write(key: 'email', value: 'returning@example.com');
+          await store.write(key: 'password', value: 'cryptpw_abc123');
+          service = DecentAccountService(
+            httpClient: httpClient,
+            credentialStore: store,
+            baseUrl: _baseUrl,
+          );
+
+          expect(await service.isLoggedIn(), isTrue);
+        },
+      );
+
+      test('returns false when stored credentials are stale', () async {
         await store.write(key: 'email', value: 'returning@example.com');
-        await store.write(key: 'password', value: 'oldpassword');
+        await store.write(key: 'password', value: 'stale_cryptpw');
+        httpClient = _mockClient(statusCode: 401, body: '');
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        expect(await service.isLoggedIn(), isFalse);
+      });
+
+      test('validates only once per session', () async {
+        var calls = 0;
+        httpClient = http_testing.MockClient((request) async {
+          calls++;
+          return http.Response('cryptpw_abc123', 200);
+        });
+        await store.write(key: 'email', value: 'returning@example.com');
+        await store.write(key: 'password', value: 'cryptpw_abc123');
         service = DecentAccountService(
           httpClient: httpClient,
           credentialStore: store,
@@ -195,6 +256,234 @@ void main() {
         );
 
         expect(await service.isLoggedIn(), isTrue);
+        expect(await service.isLoggedIn(), isTrue);
+        expect(calls, 1);
+      });
+
+      test(
+        'retries validation after an indeterminate network failure',
+        () async {
+          var calls = 0;
+          httpClient = http_testing.MockClient((request) async {
+            calls++;
+            if (calls == 1) throw Exception('SocketException');
+            return http.Response('cryptpw_abc123\n', 200);
+          });
+          await store.write(key: 'email', value: 'returning@example.com');
+          await store.write(key: 'password', value: 'cryptpw_abc123');
+          service = DecentAccountService(
+            httpClient: httpClient,
+            credentialStore: store,
+            baseUrl: _baseUrl,
+            retryInterval: Duration.zero,
+          );
+
+          expect(await service.isLoggedIn(), isFalse);
+          expect(await service.isLoggedIn(), isTrue);
+          expect(calls, 2);
+        },
+      );
+
+      test('throttles retries after an indeterminate failure', () async {
+        var calls = 0;
+        httpClient = http_testing.MockClient((request) async {
+          calls++;
+          throw Exception('SocketException');
+        });
+        await store.write(key: 'email', value: 'returning@example.com');
+        await store.write(key: 'password', value: 'cryptpw_abc123');
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        expect(await service.isLoggedIn(), isFalse);
+        expect(await service.isLoggedIn(), isFalse);
+        expect(calls, 1);
+      });
+
+      test('does not retry after a definitive rejection', () async {
+        var calls = 0;
+        httpClient = http_testing.MockClient((request) async {
+          calls++;
+          return http.Response('0\n', 200);
+        });
+        await store.write(key: 'email', value: 'returning@example.com');
+        await store.write(key: 'password', value: 'stale_cryptpw');
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        expect(await service.isLoggedIn(), isFalse);
+        expect(await service.isLoggedIn(), isFalse);
+        expect(calls, 1);
+      });
+
+      test(
+        'returns false after reportAuthenticationFailure but keeps the link',
+        () async {
+          await service.login('test@example.com', 'hunter2');
+          expect(await service.isLoggedIn(), isTrue);
+
+          service.reportAuthenticationFailure();
+
+          expect(await service.isLoggedIn(), isFalse);
+          expect(await service.hasLinkedAccount(), isTrue);
+          expect(await store.read(key: 'email'), 'test@example.com');
+        },
+      );
+    });
+
+    group('hasLinkedAccount', () {
+      test('returns false when no credentials stored', () async {
+        expect(await service.hasLinkedAccount(), isFalse);
+      });
+
+      test('returns false when only an email is stored', () async {
+        await store.write(key: 'email', value: 'user@example.com');
+        expect(await service.hasLinkedAccount(), isFalse);
+      });
+
+      test('returns true when email and password are stored', () async {
+        await store.write(key: 'email', value: 'user@example.com');
+        await store.write(key: 'password', value: 'cryptpw_abc123');
+        expect(await service.hasLinkedAccount(), isTrue);
+      });
+
+      test('returns false after logout', () async {
+        await store.write(key: 'email', value: 'user@example.com');
+        await store.write(key: 'password', value: 'cryptpw_abc123');
+        await service.logout();
+        expect(await service.hasLinkedAccount(), isFalse);
+      });
+    });
+
+    group('verifyStoredCredentials', () {
+      test('returns true when backend accepts stored credentials', () async {
+        await store.write(key: 'email', value: 'user@example.com');
+        await store.write(key: 'password', value: 'cryptpw_abc123');
+
+        expect(await service.verifyStoredCredentials(), isTrue);
+        expect(await service.isLoggedIn(), isTrue);
+      });
+
+      test(
+        'returns false on a 401 and marks the account not authenticated',
+        () async {
+          httpClient = _mockClient(statusCode: 401, body: '');
+          await store.write(key: 'email', value: 'user@example.com');
+          await store.write(key: 'password', value: 'stale_cryptpw');
+          service = DecentAccountService(
+            httpClient: httpClient,
+            credentialStore: store,
+            baseUrl: _baseUrl,
+          );
+
+          expect(await service.verifyStoredCredentials(), isFalse);
+          expect(await service.isLoggedIn(), isFalse);
+          expect(await service.hasLinkedAccount(), isTrue);
+        },
+      );
+
+      test('returns false when login_test responds with "0"', () async {
+        httpClient = _mockClient(statusCode: 200, body: '0\n');
+        await store.write(key: 'email', value: 'user@example.com');
+        await store.write(key: 'password', value: 'stale_cryptpw');
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        expect(await service.verifyStoredCredentials(), isFalse);
+      });
+
+      test('does not clear auth state on a transient server error', () async {
+        await service.login('test@example.com', 'hunter2');
+        expect(await service.isLoggedIn(), isTrue);
+        httpClient = _mockClient(statusCode: 500, body: '');
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        expect(await service.verifyStoredCredentials(), isFalse);
+        expect(store.hasCredentials, isTrue);
+      });
+
+      test('does not clear auth state on a network error', () async {
+        await store.write(key: 'email', value: 'user@example.com');
+        await store.write(key: 'password', value: 'cryptpw_abc123');
+        httpClient = http_testing.MockClient(
+          (_) async => throw Exception('SocketException'),
+        );
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        expect(await service.verifyStoredCredentials(), isFalse);
+        expect(store.hasCredentials, isTrue);
+      });
+    });
+
+    group('concurrent auth updates', () {
+      test(
+        'stale validation does not clobber a newer successful login',
+        () async {
+          final completer = Completer<http.Response>();
+          final oldAuth = base64Encode(
+            utf8.encode('old@example.com:stale_cryptpw'),
+          );
+          httpClient = http_testing.MockClient((request) {
+            if (request.headers['authorization'] == 'Basic $oldAuth') {
+              return completer.future;
+            }
+            return Future.value(http.Response('newcryptpw\n', 200));
+          });
+          await store.write(key: 'email', value: 'old@example.com');
+          await store.write(key: 'password', value: 'stale_cryptpw');
+          service = DecentAccountService(
+            httpClient: httpClient,
+            credentialStore: store,
+            baseUrl: _baseUrl,
+          );
+
+          final staleValidation = service.verifyStoredCredentials();
+
+          expect(await service.login('new@example.com', 'goodpw'), isTrue);
+          expect(await service.isLoggedIn(), isTrue);
+
+          completer.complete(http.Response('0\n', 200));
+          expect(await staleValidation, isTrue);
+          expect(await service.isLoggedIn(), isTrue);
+          expect(await store.read(key: 'email'), 'new@example.com');
+        },
+      );
+
+      test('in-flight validation does not resurrect auth after an upstream '
+          'failure', () async {
+        final completer = Completer<http.Response>();
+        httpClient = http_testing.MockClient((_) => completer.future);
+        await store.write(key: 'email', value: 'user@example.com');
+        await store.write(key: 'password', value: 'cryptpw_abc123');
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        final validation = service.verifyStoredCredentials();
+        service.reportAuthenticationFailure();
+
+        completer.complete(http.Response('cryptpw_abc123\n', 200));
+        expect(await validation, isFalse);
+        expect(await service.isLoggedIn(), isFalse);
       });
     });
 

--- a/test/services/account/decent_proxy_service_test.dart
+++ b/test/services/account/decent_proxy_service_test.dart
@@ -42,12 +42,14 @@ void main() {
     http_testing.MockClientHandler handler, {
     String baseUrl = 'https://decentespresso.com',
     Future<bool> Function(String callerId) requireConsent = _allowConsent,
+    void Function()? onAuthFailure,
   }) {
     return DecentProxyService(
       httpClient: http_testing.MockClient(handler),
       credentialStore: store,
       requireConsent: requireConsent,
       baseUrl: baseUrl,
+      onAuthFailure: onAuthFailure,
     );
   }
 
@@ -473,5 +475,35 @@ void main() {
       ),
       isTrue,
     );
+  });
+
+  test('reports an upstream 401 to the auth-failure hook', () async {
+    await linkAccount();
+    var failures = 0;
+    final service = buildService(
+      (request) async => http.Response('unauthorized', 401),
+      onAuthFailure: () => failures++,
+    );
+
+    final response = await service.proxyGet(
+      callerId: 'skin',
+      path: 'support/api/sn',
+    );
+
+    expect(response.statusCode, 401);
+    expect(failures, 1);
+  });
+
+  test('does not call the auth-failure hook on non-401 responses', () async {
+    await linkAccount();
+    var failures = 0;
+    final service = buildService(
+      (request) async => http.Response('ok', 200),
+      onAuthFailure: () => failures++,
+    );
+
+    await service.proxyGet(callerId: 'skin', path: 'support/api/sn');
+
+    expect(failures, 0);
   });
 }

--- a/test/webserver/account_handler_test.dart
+++ b/test/webserver/account_handler_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
 import 'package:http/testing.dart' as http_testing;
 import 'package:reaprime/src/services/account/decent_account_service.dart';
 import 'package:reaprime/src/services/webserver_service.dart';
@@ -25,14 +26,17 @@ class FakeCredentialStore implements CredentialStore {
 
 void main() {
   late FakeCredentialStore store;
+  late DecentAccountService service;
+  late http_testing.MockClientHandler httpHandler;
   late Handler handler;
 
   setUp(() {
     store = FakeCredentialStore();
-    final service = DecentAccountService(
-      httpClient: http_testing.MockClient((request) async {
-        fail('AccountHandler must not make network requests: ${request.url}');
-      }),
+    httpHandler = (request) async {
+      fail('AccountHandler must not make network requests: ${request.url}');
+    };
+    service = DecentAccountService(
+      httpClient: http_testing.MockClient((request) => httpHandler(request)),
       credentialStore: store,
     );
     final app = Router().plus;
@@ -66,9 +70,10 @@ void main() {
     expect(body['loggedIn'], false);
   });
 
-  test('status reports a linked account without leaking the email', () async {
+  test('status reports authenticated for stored valid credentials', () async {
     await store.write(key: 'email', value: 'user@example.com');
     await store.write(key: 'password', value: 'cryptpw_abc123');
+    httpHandler = (request) async => http.Response('cryptpw_abc123', 200);
 
     final response = await sendGet('/api/v1/account/decent');
     expect(response.statusCode, 200);
@@ -76,6 +81,39 @@ void main() {
     expect(body['loggedIn'], true);
     expect(body.containsKey('email'), isFalse);
   });
+
+  test(
+    'status reports not authenticated for stale stored credentials',
+    () async {
+      await store.write(key: 'email', value: 'user@example.com');
+      await store.write(key: 'password', value: 'stale_cryptpw');
+      httpHandler = (request) async => http.Response('', 401);
+
+      final response = await sendGet('/api/v1/account/decent');
+      expect(response.statusCode, 200);
+      final body = jsonDecode(await response.readAsString()) as Map;
+      expect(body['loggedIn'], false);
+    },
+  );
+
+  test(
+    'status reports not authenticated after an upstream auth failure',
+    () async {
+      await store.write(key: 'email', value: 'user@example.com');
+      await store.write(key: 'password', value: 'cryptpw_abc123');
+      httpHandler = (request) async => http.Response('cryptpw_abc123', 200);
+      final first = jsonDecode(
+        await (await sendGet('/api/v1/account/decent')).readAsString(),
+      );
+      expect(first, containsPair('loggedIn', true));
+
+      service.reportAuthenticationFailure();
+
+      final response = await sendGet('/api/v1/account/decent');
+      final body = jsonDecode(await response.readAsString()) as Map;
+      expect(body['loggedIn'], false);
+    },
+  );
 
   test('login is not exposed over HTTP', () async {
     final response = await sendPost('/api/v1/account/decent/login', {


### PR DESCRIPTION
## Summary

Decaid previously treated the presence of a stored Decent account email as equivalent to being authenticated. `isLoggedIn()` only checked `store.read('email') != null`, so stale or invalid credentials left the UI and `/api/v1/account/decent` reporting **Logged In** indefinitely while authenticated API calls returned 401 (observed with `shot-upload.reaplugin`).

This PR separates *linked* from *authenticated*:

- `hasLinkedAccount()` — credentials present locally (email + encrypted password stored)
- `isLoggedIn()` — auth-aware: validates stored `email + cryptpw` against `login_test` once per session (memoized, so UI/REST polls never re-validate per request), then returns the cached in-memory state
- `verifyStoredCredentials()` — validation path; 200 + non-`0` = valid, 401 or `0` = definitively invalid, 5xx/network = indeterminate (state untouched)
- `reportAuthenticationFailure()` — `DecentProxyService` reports upstream 401s via a narrow `onAuthFailure` hook; auth state is invalidated centrally. Credentials are kept on 401 so a transient backend failure does not destroy the link; the next session re-validates
- Fixed `login()` accepting the backend's rejection body `"0\n"` (verified live: `login_test` returns `200` with body `0\n` for wrong credentials — the untrimmed `body != '0'` comparison treated it as success, storing wrong credentials and showing **Logged In**)

Failed replacement logins never touch stored credentials, so a bad re-login cannot erase a working link.

## Linked Issue

Fixes #696

## Verification

- Full suite: 3392 tests passed, 1 skipped; `flutter analyze` clean
- New/updated regression tests: no stored credentials, successful login persists + authenticates, stored valid credentials validate, stored stale credentials rejected, proxy 401 invalidates auth state, AccountPage no longer renders **Logged In** after a proxy 401, `/api/v1/account/decent` reports `loggedIn: false` after invalidation, failed replacement login preserves valid stored credentials, logout clears, one validation per session, real backend `"0\n"` rejection body; indeterminate (network/5xx) validation retries on the next check while definitive rejection stays sticky
- Manually verified against the live backend: wrong credentials via Basic auth and via the documented `email+cryptpw` param form both return `200 "0\n"`

## Impact

- REST contract unchanged in shape (`{loggedIn}`), semantics now auth-aware — `doc/Api.md` and `assets/api/rest_v1.yml` updated
- No credentials or auth material exposed to plugins/REST clients; proxy logging unchanged
- Rationale documented in `doc/AI_STORAGE_NOTES.md`

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->

